### PR TITLE
Add new FW (TRT) and precision support

### DIFF
--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -84,23 +84,23 @@ jobs:
       framework: 'trt'
       precision: ''
 
-  bmk-b200:
-    needs: find-latest-image
-    uses: ./.github/workflows/benchmark-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: ${{ inputs.exp-name }}
-      isl: ${{ inputs.isl }}
-      osl: ${{ inputs.osl }}
-      max-model-len: ${{ inputs.max-model-len }}
-      random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: b200
-      image: 'kedarpotdar147/vllm:05'
-      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[2]'  # SANITY TEST: Only TP=2
-      timeout: ${{ inputs.timeout }}
-      framework: 'vllm'
-      precision: ''
+  # bmk-b200:
+  #   needs: find-latest-image
+  #   uses: ./.github/workflows/benchmark-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: ${{ inputs.exp-name }}
+  #     isl: ${{ inputs.isl }}
+  #     osl: ${{ inputs.osl }}
+  #     max-model-len: ${{ inputs.max-model-len }}
+  #     random-range-ratio: ${{ inputs.random-range-ratio }}
+  #     runner: b200
+  #     image: 'kedarpotdar147/vllm:05'
+  #     model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+  #     tp-list: '[2]'  # SANITY TEST: Only TP=2
+  #     timeout: ${{ inputs.timeout }}
+  #     framework: 'vllm'
+  #     precision: ''
 
   bmk-b200-trt:
     needs: find-latest-image
@@ -175,7 +175,7 @@ jobs:
   #     precision: ''
 
   collect-results:
-    needs: [bmk-h100, bmk-h200, bmk-h200-trt, bmk-b200, bmk-b200-trt] 
+    needs: [bmk-h100, bmk-h200, bmk-h200-trt, bmk-b200-trt] 
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -59,7 +59,7 @@ jobs:
       runner: h200
       image: 'kedarpotdar147/vllm0.1:latest'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[1]'  # SANITY TEST: Only TP=1
+      tp-list: '[2]'  # SANITY TEST: Only TP=2
       timeout: ${{ inputs.timeout }}
       framework: 'vllm'
       precision: ''
@@ -95,7 +95,7 @@ jobs:
       runner: b200
       image: 'kedarpotdar147/vllm:05'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[1]'  # SANITY TEST: Only TP=1
+      tp-list: '[2]'  # SANITY TEST: Only TP=2
       timeout: ${{ inputs.timeout }}
       framework: 'vllm'
       precision: ''

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -46,37 +46,77 @@ jobs:
   #     tp-list: '[2, 4, 8]'
   #     timeout: ${{ inputs.timeout }}
 
-  # bmk-h200:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: h200
-  #     image: 'kedarpotdar147/vllm0.1:latest'
-  #     model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-  #     tp-list: '[1, 2, 4, 8]'
-  #     timeout: ${{ inputs.timeout }}
+  bmk-h200:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: h200
+      image: 'kedarpotdar147/vllm0.1:latest'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[1]'  # SANITY TEST: Only TP=1
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
-  # bmk-b200:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: b200
-  #     image: 'kedarpotdar147/vllm:05'
-  #     model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-  #     tp-list: '[1,2]'
-  #     timeout: ${{ inputs.timeout }}
+  bmk-h200-trt:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: h200
+      image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[2]'  # SANITY TEST: Only TP=2
+      timeout: ${{ inputs.timeout }}
+      framework: 'trt'
+      precision: ''
+
+  bmk-b200:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: b200
+      image: 'kedarpotdar147/vllm:05'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[1]'  # SANITY TEST: Only TP=1
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
+
+  bmk-b200-trt:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: b200
+      image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[2]'  # SANITY TEST: Only TP=2
+      timeout: ${{ inputs.timeout }}
+      framework: 'trt'
+      precision: ''
 
   # bmk-mi300x:
   #   needs: find-latest-image
@@ -93,6 +133,8 @@ jobs:
   #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
   #     tp-list: '[1, 2, 4, 8]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'vllm'
+  #     precision: ''
 
   # bmk-mi325x:
   #   needs: find-latest-image
@@ -109,25 +151,29 @@ jobs:
   #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
   #     tp-list: '[2]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'vllm'
+  #     precision: ''
 
-  bmk-mi355x:
-    needs: find-latest-image
-    uses: ./.github/workflows/benchmark-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: ${{ inputs.exp-name }}
-      isl: ${{ inputs.isl }}
-      osl: ${{ inputs.osl }}
-      max-model-len: ${{ inputs.max-model-len }}
-      random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: mi355x
-      image: 'rocm/7.0-preview:rocm7.0_preview_ubuntu_22.04_vllm_0.9.1_mi35x_alpha'
-      model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
-      tp-list: '[2]'
-      timeout: ${{ inputs.timeout }}
+  # bmk-mi355x:
+  #   needs: find-latest-image
+  #   uses: ./.github/workflows/benchmark-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: ${{ inputs.exp-name }}
+  #     isl: ${{ inputs.isl }}
+  #     osl: ${{ inputs.osl }}
+  #     max-model-len: ${{ inputs.max-model-len }}
+  #     random-range-ratio: ${{ inputs.random-range-ratio }}
+  #     runner: mi355x
+  #     image: 'rocm/7.0-preview:rocm7.0_preview_ubuntu_22.04_vllm_0.9.1_mi35x_alpha'
+  #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
+  #     tp-list: '[2]'
+  #     timeout: ${{ inputs.timeout }}
+  #     framework: 'vllm'
+  #     precision: ''
 
   collect-results:
-    needs: bmk-mi355x  # [bmk-h100, bmk-h200,bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x]
+    needs: [bmk-h200, bmk-h200-trt, bmk-b200, bmk-b200-trt] 
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -61,7 +61,7 @@ jobs:
       runner: h200
       image: 'kedarpotdar147/vllm0.1:latest'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[2]'  # SANITY TEST: Only TP=2
+      tp-list: '[2]'
       timeout: ${{ inputs.timeout }}
       framework: 'vllm'
       precision: ''
@@ -79,28 +79,28 @@ jobs:
       runner: h200
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[2]'  # SANITY TEST: Only TP=2
+      tp-list: '[2]'  
       timeout: ${{ inputs.timeout }}
       framework: 'trt'
       precision: ''
 
-  # bmk-b200:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: b200
-  #     image: 'kedarpotdar147/vllm:05'
-  #     model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-  #     tp-list: '[2]'  # SANITY TEST: Only TP=2
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'vllm'
-  #     precision: ''
+  bmk-b200:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: b200
+      image: 'kedarpotdar147/vllm:05'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[2]'  
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
   bmk-b200-trt:
     needs: find-latest-image
@@ -115,67 +115,67 @@ jobs:
       runner: b200
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-      tp-list: '[2]'  # SANITY TEST: Only TP=2
+      tp-list: '[2]'  
       timeout: ${{ inputs.timeout }}
       framework: 'trt'
       precision: ''
 
-  # bmk-mi300x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi300x
-  #     image: 'rocm/vllm-dev:nightly_official_0729_rc1_20250718'
-  #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
-  #     tp-list: '[1, 2, 4, 8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'vllm'
-  #     precision: ''
+  bmk-mi300x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi300x
+      image: 'rocm/vllm-dev:nightly_official_0729_rc1_20250718'
+      model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
+      tp-list: '[1, 2, 4, 8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
-  # bmk-mi325x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi325x
-  #     image: 'rocm/vllm-dev:nightly_official_0729_rc1_20250718'
-  #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
-  #     tp-list: '[2]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'vllm'
-  #     precision: ''
+  bmk-mi325x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi325x
+      image: 'rocm/vllm-dev:nightly_official_0729_rc1_20250718'
+      model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
+      tp-list: '[2]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
-  # bmk-mi355x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi355x
-  #     image: 'rocm/7.0-preview:rocm7.0_preview_ubuntu_22.04_vllm_0.9.1_mi35x_alpha'
-  #     model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
-  #     tp-list: '[2]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'vllm'
-  #     precision: ''
+  bmk-mi355x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi355x
+      image: 'rocm/7.0-preview:rocm7.0_preview_ubuntu_22.04_vllm_0.9.1_mi35x_alpha'
+      model: 'amd/Llama-3.3-70B-Instruct-FP8-KV'
+      tp-list: '[2]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
   collect-results:
-    needs: [bmk-h100, bmk-h200, bmk-h200-trt, bmk-b200-trt] 
+    needs: [bmk-h100, bmk-h200, bmk-h200-trt, bmk-b200-trt, bmk-mi300x, bmk-mi325x, bmk-mi355x] 
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -110,7 +110,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: b200-trt
+      runner: b200
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       tp-list: '[2]'  # SANITY TEST: Only TP=2

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -110,7 +110,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: b200
+      runner: b200-trt
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       tp-list: '[2]'  # SANITY TEST: Only TP=2

--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -30,21 +30,23 @@ jobs:
       - name: Find the latest Docker image
         run: echo "Hardcoding image tags for now."
 
-  # bmk-h100:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: h100
-  #     image: 'kedarpotdar147/vllm0.1:latest'
-  #     model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
-  #     tp-list: '[2, 4, 8]'
-  #     timeout: ${{ inputs.timeout }}
+  bmk-h100:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: h100
+      image: 'kedarpotdar147/vllm0.1:latest'
+      model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
+      tp-list: '[2]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'vllm'
+      precision: ''
 
   bmk-h200:
     needs: find-latest-image
@@ -173,7 +175,7 @@ jobs:
   #     precision: ''
 
   collect-results:
-    needs: [bmk-h200, bmk-h200-trt, bmk-b200, bmk-b200-trt] 
+    needs: [bmk-h100, bmk-h200, bmk-h200-trt, bmk-b200, bmk-b200-trt] 
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -32,6 +32,12 @@ on:
       timeout:
         required: true
         type: number
+      framework:
+        required: true
+        type: string
+      precision:
+        required: true
+        type: string
 
 env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -43,6 +49,8 @@ env:
   MAX_MODEL_LEN: ${{ inputs.max-model-len }}
   RANDOM_RANGE_RATIO: ${{ inputs.random-range-ratio }}
   IMAGE: ${{ inputs.image }}
+  FRAMEWORK: ${{ inputs.framework }}
+  PRECISION: ${{ inputs.precision }}
 
 jobs:
   benchmark:
@@ -54,11 +62,13 @@ jobs:
       matrix:
         tp: ${{ fromJson(inputs.tp-list) }}
         conc: [1]
-    name: '${{ inputs.runner }} (tp${{ matrix.tp }} , conc${{ matrix.conc }})'
+    name: '${{ inputs.runner }}-${{ inputs.framework }} (tp${{ matrix.tp }} , conc${{ matrix.conc }})'
 
     env:
       TP: ${{ matrix.tp }}
       CONC: ${{ matrix.conc }}
+      FRAMEWORK: ${{ inputs.framework }}
+      PRECISION: ${{ inputs.precision }}
 
     steps:
       - uses: actions/checkout@v3
@@ -68,16 +78,31 @@ jobs:
 
       - name: Set result filename
         run: |
-          RESULT_FILENAME=${{ env.EXP_NAME }}_tp${{ env.TP }}_conc${{ env.CONC }}_${{ runner.name }}
+          if [ "${{ env.PRECISION }}" = "" ]; then
+            PRECISION_SUFFIX="fp8"
+          else
+            PRECISION_SUFFIX="${{ env.PRECISION }}"
+          fi
+          RESULT_FILENAME=${{ env.EXP_NAME }}_${{ env.FRAMEWORK }}_${PRECISION_SUFFIX}_tp${{ env.TP }}_conc${{ env.CONC }}_${{ runner.name }}
           echo "RESULT_FILENAME=${RESULT_FILENAME}" >> $GITHUB_ENV
 
       - name: Launch job script
         run: |
           RUNNER_NAME=${{ runner.name }}
-          bash ./runners/launch_${RUNNER_NAME%%_*}.sh ${{ inputs.exp-name }}
+          if [ "${{ env.PRECISION }}" = "" ]; then
+            PRECISION_SUFFIX="fp8"
+          else
+            PRECISION_SUFFIX="${{ env.PRECISION }}"
+          fi
+          # Use existing runner scripts, fallback to framework-specific if not found
+          if [ -f "./runners/launch_${RUNNER_NAME%%_*}-${{ env.FRAMEWORK }}.sh" ]; then
+            bash ./runners/launch_${RUNNER_NAME%%_*}-${{ env.FRAMEWORK }}.sh ${{ inputs.exp-name }}
+          else
+            bash ./runners/launch_${RUNNER_NAME%%_*}-nv.sh ${{ inputs.exp-name }}
+          fi
 
       - name: Process result
-        run: python3 utils/process_result.py ${{ inputs.runner }} ${{ env.TP }} ${{ env.RESULT_FILENAME }}
+        run: python3 utils/process_result.py ${{ inputs.runner }} ${{ env.TP }} ${{ env.RESULT_FILENAME }} ${{ env.FRAMEWORK }} ${{ env.PRECISION }}
 
       - name: Upload result
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -92,7 +92,7 @@ jobs:
           bash ./runners/launch_${RUNNER_NAME%%_*}*.sh ${{ inputs.exp-name }}
 
       - name: Process result
-        run: python3 utils/process_result.py ${{ inputs.runner }} ${{ env.TP }} ${{ env.RESULT_FILENAME }} ${{ env.FRAMEWORK }} ${{ env.PRECISION }}
+        run: python3 utils/process_result.py ${{ inputs.runner }} ${{ env.TP }} ${{ env.RESULT_FILENAME }} ${{ env.FRAMEWORK }} "${{ env.PRECISION }}"
 
       - name: Upload result
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -89,17 +89,7 @@ jobs:
       - name: Launch job script
         run: |
           RUNNER_NAME=${{ runner.name }}
-          if [ "${{ env.PRECISION }}" = "" ]; then
-            PRECISION_SUFFIX="fp8"
-          else
-            PRECISION_SUFFIX="${{ env.PRECISION }}"
-          fi
-          # Use existing runner scripts, fallback to framework-specific if not found
-          if [ -f "./runners/launch_${RUNNER_NAME%%_*}-${{ env.FRAMEWORK }}.sh" ]; then
-            bash ./runners/launch_${RUNNER_NAME%%_*}-${{ env.FRAMEWORK }}.sh ${{ inputs.exp-name }}
-          else
-            bash ./runners/launch_${RUNNER_NAME%%_*}-nv.sh ${{ inputs.exp-name }}
-          fi
+          bash ./runners/launch_${RUNNER_NAME%%_*}*.sh ${{ inputs.exp-name }}
 
       - name: Process result
         run: python3 utils/process_result.py ${{ inputs.runner }} ${{ env.TP }} ${{ env.RESULT_FILENAME }} ${{ env.FRAMEWORK }} ${{ env.PRECISION }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         tp: ${{ fromJson(inputs.tp-list) }}
-        conc: [1]
+        conc: [4,8]
     name: '${{ inputs.runner }}-${{ inputs.framework }} (tp${{ matrix.tp }} , conc${{ matrix.conc }})'
 
     env:

--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -46,5 +46,5 @@ jobs:
         with:
           name: graphs_${{ inputs.exp-name }}
           path: |
-            tput_vs_intvty_${{ inputs.exp-name }}.png
-            tput_vs_e2el_${{ inputs.exp-name }}.png
+            tput_vs_intvty_*_${{ inputs.exp-name }}.png
+            tput_vs_e2el_*_${{ inputs.exp-name }}.png

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -45,6 +45,8 @@ jobs:
   #     model: 'deepseek-ai/DeepSeek-R1-0528'
   #     tp-list: '[8]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'sglang'
+  #     precision: ''
 
   # bmk-b200:
   #   needs: find-latest-image
@@ -61,6 +63,8 @@ jobs:
   #     model: 'deepseek-ai/DeepSeek-R1-0528'
   #     tp-list: '[8]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'sglang'
+  #     precision: ''
 
   # bmk-mi300x:
   #   needs: find-latest-image
@@ -77,6 +81,8 @@ jobs:
   #     model: 'deepseek-ai/DeepSeek-R1-0528'
   #     tp-list: '[8]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'sglang'
+  #     precision: ''
 
   # bmk-mi325x:
   #   needs: find-latest-image
@@ -93,6 +99,8 @@ jobs:
   #     model: 'deepseek-ai/DeepSeek-R1-0528'
   #     tp-list: '[8]'
   #     timeout: ${{ inputs.timeout }}
+  #     framework: 'sglang'
+  #     precision: ''
 
   bmk-mi355x:
     needs: find-latest-image
@@ -109,6 +117,8 @@ jobs:
       model: 'deepseek-ai/DeepSeek-R1-0528'
       tp-list: '[8]'
       timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
   collect-results:
     needs: bmk-mi355x  # [bmk-h200, bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x]

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -30,23 +30,23 @@ jobs:
       - name: Find the latest Docker image
         run: echo "Hardcoding image tags for now."
 
-  # bmk-h200:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: h200
-  #     image: 'lmsysorg/sglang:v0.4.9.post1-cu126'
-  #     model: 'deepseek-ai/DeepSeek-R1-0528'
-  #     tp-list: '[8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'sglang'
-  #     precision: ''
+  bmk-h200:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: h200
+      image: 'lmsysorg/sglang:v0.4.9.post1-cu126'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      tp-list: '[8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
   bmk-b200:
     needs: find-latest-image
@@ -66,62 +66,62 @@ jobs:
       framework: 'sglang'
       precision: ''
 
-  # bmk-mi300x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi300x
-  #     image: 'lmsysorg/sglang:v0.4.9.post2-rocm630-mi30x'
-  #     model: 'deepseek-ai/DeepSeek-R1-0528'
-  #     tp-list: '[8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'sglang'
-  #     precision: ''
+  bmk-mi300x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi300x
+      image: 'lmsysorg/sglang:v0.4.9.post2-rocm630-mi30x'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      tp-list: '[8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
-  # bmk-mi325x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi325x
-  #     image: 'lmsysorg/sglang:v0.4.9.post2-rocm630-mi30x'
-  #     model: 'deepseek-ai/DeepSeek-R1-0528'
-  #     tp-list: '[8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'sglang'
-  #     precision: ''
+  bmk-mi325x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi325x
+      image: 'lmsysorg/sglang:v0.4.9.post2-rocm630-mi30x'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      tp-list: '[8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
-  # bmk-mi355x:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: mi355x
-  #     image: 'lmsysorg/sglang:v0.5.1.post2-rocm700-mi35x'
-  #     model: 'deepseek-ai/DeepSeek-R1-0528'
-  #     tp-list: '[8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'sglang'
-  #     precision: ''
+  bmk-mi355x:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: mi355x
+      image: 'lmsysorg/sglang:v0.5.1.post2-rocm700-mi35x'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      tp-list: '[8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
   collect-results:
-    needs: bmk-b200  # [bmk-h200, bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x]
+    needs: [bmk-h200, bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x] 
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -48,23 +48,23 @@ jobs:
   #     framework: 'sglang'
   #     precision: ''
 
-  # bmk-b200:
-  #   needs: find-latest-image
-  #   uses: ./.github/workflows/benchmark-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: ${{ inputs.exp-name }}
-  #     isl: ${{ inputs.isl }}
-  #     osl: ${{ inputs.osl }}
-  #     max-model-len: ${{ inputs.max-model-len }}
-  #     random-range-ratio: ${{ inputs.random-range-ratio }}
-  #     runner: b200
-  #     image: 'lmsysorg/sglang:v0.5.0rc1-cu128-b200'
-  #     model: 'deepseek-ai/DeepSeek-R1-0528'
-  #     tp-list: '[8]'
-  #     timeout: ${{ inputs.timeout }}
-  #     framework: 'sglang'
-  #     precision: ''
+  bmk-b200:
+    needs: find-latest-image
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      runner: b200
+      image: 'lmsysorg/sglang:v0.5.0rc1-cu128-b200'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      tp-list: '[8]'
+      timeout: ${{ inputs.timeout }}
+      framework: 'sglang'
+      precision: ''
 
   # bmk-mi300x:
   #   needs: find-latest-image
@@ -102,26 +102,26 @@ jobs:
   #     framework: 'sglang'
   #     precision: ''
 
-  bmk-mi355x:
-    needs: find-latest-image
-    uses: ./.github/workflows/benchmark-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: ${{ inputs.exp-name }}
-      isl: ${{ inputs.isl }}
-      osl: ${{ inputs.osl }}
-      max-model-len: ${{ inputs.max-model-len }}
-      random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: mi355x
-      image: 'lmsysorg/sglang:v0.5.1.post2-rocm700-mi35x'
-      model: 'deepseek-ai/DeepSeek-R1-0528'
-      tp-list: '[8]'
-      timeout: ${{ inputs.timeout }}
-      framework: 'sglang'
-      precision: ''
+  # bmk-mi355x:
+  #   needs: find-latest-image
+  #   uses: ./.github/workflows/benchmark-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: ${{ inputs.exp-name }}
+  #     isl: ${{ inputs.isl }}
+  #     osl: ${{ inputs.osl }}
+  #     max-model-len: ${{ inputs.max-model-len }}
+  #     random-range-ratio: ${{ inputs.random-range-ratio }}
+  #     runner: mi355x
+  #     image: 'lmsysorg/sglang:v0.5.1.post2-rocm700-mi35x'
+  #     model: 'deepseek-ai/DeepSeek-R1-0528'
+  #     tp-list: '[8]'
+  #     timeout: ${{ inputs.timeout }}
+  #     framework: 'sglang'
+  #     precision: ''
 
   collect-results:
-    needs: bmk-mi355x  # [bmk-h200, bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x]
+    needs: bmk-b200  # [bmk-h200, bmk-b200, bmk-mi300x, bmk-mi325x, bmk-mi355x]
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/collect-results.yml
     secrets: inherit

--- a/.github/workflows/workflow-scheduler.yml
+++ b/.github/workflows/workflow-scheduler.yml
@@ -1,13 +1,13 @@
 name: Workflow Scheduler
 
-# concurrency:
-#   group: benchmark-lock
-#   cancel-in-progress: false
+concurrency:
+  group: benchmark-lock
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 5 * * *'
+  schedule:
+    - cron: '0 5 * * *'
 
 jobs:
   cleanup:

--- a/.github/workflows/workflow-scheduler.yml
+++ b/.github/workflows/workflow-scheduler.yml
@@ -24,16 +24,16 @@ jobs:
       max-model-len: 2048
       random-range-ratio: 0.8
   
-  # dsr1-1k1k:
-  #   needs: cleanup
-  #   uses: ./.github/workflows/dsr1-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: 'dsr1_1k1k'
-  #     isl: 1024
-  #     osl: 1024
-  #     max-model-len: 2048
-  #     random-range-ratio: 0.8
+  dsr1-1k1k:
+    needs: cleanup
+    uses: ./.github/workflows/dsr1-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: 'dsr1_1k1k'
+      isl: 1024
+      osl: 1024
+      max-model-len: 2048
+      random-range-ratio: 0.8
 
   # _70b-8k1k:
   #   needs: cleanup

--- a/.github/workflows/workflow-scheduler.yml
+++ b/.github/workflows/workflow-scheduler.yml
@@ -24,16 +24,16 @@ jobs:
       max-model-len: 2048
       random-range-ratio: 0.8
   
-  dsr1-1k1k:
-    needs: cleanup
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_1k1k'
-      isl: 1024
-      osl: 1024
-      max-model-len: 2048
-      random-range-ratio: 0.8
+  # dsr1-1k1k:
+  #   needs: cleanup
+  #   uses: ./.github/workflows/dsr1-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: 'dsr1_1k1k'
+  #     isl: 1024
+  #     osl: 1024
+  #     max-model-len: 2048
+  #     random-range-ratio: 0.8
 
   # _70b-8k1k:
   #   needs: cleanup

--- a/.github/workflows/workflow-scheduler.yml
+++ b/.github/workflows/workflow-scheduler.yml
@@ -1,13 +1,13 @@
 name: Workflow Scheduler
 
-concurrency:
-  group: benchmark-lock
-  cancel-in-progress: false
+# concurrency:
+#   group: benchmark-lock
+#   cancel-in-progress: false
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 5 * * *'
+  # schedule:
+  #   - cron: '0 5 * * *'
 
 jobs:
   cleanup:

--- a/benchmarks/70b_b200_trt_slurm.sh
+++ b/benchmarks/70b_b200_trt_slurm.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT_OFFSET
+
+echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+
+hf download $MODEL
+SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+PORT=$(( 8888 + $PORT_OFFSET ))
+
+
+set -x
+
+# Create llama-config.yml inline
+cat > llama-config.yml << 'EOF'
+enable_attention_dp: false 
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 4
+EOF
+
+# Launch TRT-LLM server
+mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --tp_size $TP --trust_remote_code --max_seq_len $MAX_MODEL_LEN --max_num_tokens $MAX_MODEL_LEN --num_postprocess_workers 2 --extra_llm_api_options llama-config.yml --port $PORT > $SERVER_LOG 2>&1 &
+
+
+set +x
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
+        sleep 5
+        tail -n100 $SERVER_LOG
+        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
+        exit 1
+    fi
+    if [[ "$line" == *"Application startup complete"* ]]; then
+        break
+    fi
+done < <(tail -F -n0 "$SERVER_LOG")
+
+set -x
+git clone https://github.com/kimbochen/bench_serving.git
+python3 bench_serving/benchmark_serving.py \
+--model $MODEL --backend openai \
+--base-url http://0.0.0.0:$PORT \
+--dataset-name random \
+--random-input-len $ISL --random-output-len $OSL --random-range-ratio $RANDOM_RANGE_RATIO \
+--num-prompts $(( $CONC * 10 )) --max-concurrency $CONC \
+--request-rate inf --ignore-eos \
+--save-result --percentile-metrics 'ttft,tpot,itl,e2el' \
+--result-dir /workspace/ \
+--result-filename $RESULT_FILENAME.json

--- a/benchmarks/70b_h200_trt_slurm.sh
+++ b/benchmarks/70b_h200_trt_slurm.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT_OFFSET
+
+echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+
+hf download $MODEL
+SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+PORT=$(( 8888 + $PORT_OFFSET ))
+
+# Create llama-config.yml inline
+cat > llama-config.yml << 'EOF'
+enable_attention_dp: false 
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 4
+EOF
+
+mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --tp_size $TP --trust_remote_code --max_seq_len $MAX_MODEL_LEN --max_num_tokens $MAX_MODEL_LEN --num_postprocess_workers 2 --extra_llm_api_options llama-config.yml --port $PORT > $SERVER_LOG 2>&1 &
+
+set +x
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
+        sleep 5
+        tail -n100 $SERVER_LOG
+        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
+        exit 1
+    fi
+    if [[ "$line" == *"Application startup complete"* ]]; then
+        break
+    fi
+done < <(tail -F -n0 "$SERVER_LOG")
+
+set -x
+git clone https://github.com/kimbochen/bench_serving.git
+python3 bench_serving/benchmark_serving.py \
+--model $MODEL --backend openai \
+--base-url http://0.0.0.0:$PORT \
+--dataset-name random \
+--random-input-len $ISL --random-output-len $OSL --random-range-ratio $RANDOM_RANGE_RATIO \
+--num-prompts $(( $CONC * 10 )) --max-concurrency $CONC \
+--request-rate inf --ignore-eos \
+--save-result --percentile-metrics 'ttft,tpot,itl,e2el' \
+--result-dir /workspace/ \
+--result-filename $RESULT_FILENAME.json

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -5,7 +5,12 @@ export PORT_OFFSET=${USER: -1}
 
 MODEL_CODE="${1%%_*}"
 PARTITION="dgx-b200"
-SQUASH_FILE="/raid/image_${MODEL_CODE}_b200-0903.sqsh"
+# Use framework-specific SQSH file
+if [ "$FRAMEWORK" = "trt" ]; then
+    SQUASH_FILE="/raid/image_${MODEL_CODE}_b200_trt-0903.sqsh"
+else
+    SQUASH_FILE="/raid/image_${MODEL_CODE}_b200-0903.sqsh"
+fi
 
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -23,6 +23,7 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+-e MODEL_CODE=$MODEL_CODE \
 bash -c "
 # Determine which benchmark script to use based on framework
 if [ \"\$FRAMEWORK\" = \"trt\" ]; then

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -4,8 +4,8 @@ export HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
 MODEL_CODE="${1%%_*}"
-# Reset framework if vllm to use default script
-if [ "$FRAMEWORK" = "vllm" ]; then
+# Reset framework if vllm or sglang to use default script
+if [ "$FRAMEWORK" = "vllm" ] || [ "$FRAMEWORK" = "sglang" ]; then
     FRAMEWORK=""
 fi
 PARTITION="dgx-b200"

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -4,6 +4,10 @@ export HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
 MODEL_CODE="${1%%_*}"
+# Reset framework if vllm to use default script
+if [ "$FRAMEWORK" = "vllm" ]; then
+    FRAMEWORK=""
+fi
 PARTITION="dgx-b200"
 # Use framework-specific SQSH file
 if [ "$FRAMEWORK" = "trt" ]; then
@@ -23,14 +27,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
--e MODEL_CODE=$MODEL_CODE \
-bash -c "
-# Determine which benchmark script to use based on framework
-if [ \"\$FRAMEWORK\" = \"trt\" ]; then
-    bash benchmarks/\${MODEL_CODE}_b200_trt_slurm.sh
-else
-    bash benchmarks/\${MODEL_CODE}_b200_slurm.sh
-fi
-"
+bash benchmarks/${MODEL_CODE}_b200${FRAMEWORK:+_$FRAMEWORK}_slurm.sh
 
 scancel $JOB_ID

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -18,11 +18,13 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+bash -c "
 # Determine which benchmark script to use based on framework
-if [ "$FRAMEWORK" = "trt" ]; then
-    bash benchmarks/${MODEL_CODE}_b200_trt_slurm.sh
+if [ \"\$FRAMEWORK\" = \"trt\" ]; then
+    bash benchmarks/\${MODEL_CODE}_b200_trt_slurm.sh
 else
-    bash benchmarks/${MODEL_CODE}_b200_slurm.sh
+    bash benchmarks/\${MODEL_CODE}_b200_slurm.sh
 fi
+"
 
 scancel $JOB_ID

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -18,6 +18,11 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_b200_slurm.sh
+# Determine which benchmark script to use based on framework
+if [ "$FRAMEWORK" = "trt" ]; then
+    bash benchmarks/${MODEL_CODE}_b200_trt_slurm.sh
+else
+    bash benchmarks/${MODEL_CODE}_b200_slurm.sh
+fi
 
 scancel $JOB_ID

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -4,6 +4,11 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/mnt/vast/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
+# Reset framework if vllm to use default script
+if [ "$FRAMEWORK" = "vllm" ]; then
+    FRAMEWORK=""
+fi
+
 PARTITION="h200"
 # Use framework-specific SQSH file
 if [ "$FRAMEWORK" = "trt" ]; then

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -23,6 +23,7 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+-e MODEL_CODE=$MODEL_CODE \
 bash -c "
 # Determine which benchmark script to use based on framework
 if [ \"\$FRAMEWORK\" = \"trt\" ]; then

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -28,14 +28,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
--e MODEL_CODE=$MODEL_CODE \
-bash -c "
-# Determine which benchmark script to use based on framework
-if [ \"\$FRAMEWORK\" = \"trt\" ]; then
-    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
-else
-    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
-fi
-"
+bash benchmarks/${MODEL_CODE}_h200${FRAMEWORK:+_$FRAMEWORK}_slurm.sh
 
 scancel $JOB_ID

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -5,7 +5,12 @@ export HF_HUB_CACHE_MOUNT="/mnt/vast/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
 PARTITION="h200"
-SQUASH_FILE="/mnt/vast/squash/image_${MODEL_CODE}_h200.sqsh"
+# Use framework-specific SQSH file
+if [ "$FRAMEWORK" = "trt" ]; then
+    SQUASH_FILE="/mnt/vast/squash/image_${MODEL_CODE}_h200_trt.sqsh"
+else
+    SQUASH_FILE="/mnt/vast/squash/image_${MODEL_CODE}_h200.sqsh"
+fi
 
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
@@ -18,6 +23,13 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_h200_slurm.sh
+bash -c "
+# Determine which benchmark script to use based on framework
+if [ \"\$FRAMEWORK\" = \"trt\" ]; then
+    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
+else
+    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
+fi
+"
 
 scancel $JOB_ID

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -4,8 +4,8 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/mnt/vast/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
-# Reset framework if vllm to use default script
-if [ "$FRAMEWORK" = "vllm" ]; then
+# Reset framework if vllm or sglang to use default script
+if [ "$FRAMEWORK" = "vllm" ] || [ "$FRAMEWORK" = "sglang" ]; then
     FRAMEWORK=""
 fi
 

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -5,7 +5,12 @@ export HF_HUB_CACHE_MOUNT="/home/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
 PARTITION="main"
-SQUASH_FILE="/home/squash/image_${MODEL_CODE}_h200.sqsh"
+# Use framework-specific SQSH file
+if [ "$FRAMEWORK" = "trt" ]; then
+    SQUASH_FILE="/home/squash/image_${MODEL_CODE}_h200_trt.sqsh"
+else
+    SQUASH_FILE="/home/squash/image_${MODEL_CODE}_h200.sqsh"
+fi
 
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
@@ -18,6 +23,13 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_h200_slurm.sh
+bash -c "
+# Determine which benchmark script to use based on framework
+if [ \"\$FRAMEWORK\" = \"trt\" ]; then
+    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
+else
+    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
+fi
+"
 
 scancel $JOB_ID

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -23,6 +23,7 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+-e MODEL_CODE=$MODEL_CODE \
 bash -c "
 # Determine which benchmark script to use based on framework
 if [ \"\$FRAMEWORK\" = \"trt\" ]; then

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -28,14 +28,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
--e MODEL_CODE=$MODEL_CODE \
-bash -c "
-# Determine which benchmark script to use based on framework
-if [ \"\$FRAMEWORK\" = \"trt\" ]; then
-    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
-else
-    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
-fi
-"
+bash benchmarks/${MODEL_CODE}_h200${FRAMEWORK:+_$FRAMEWORK}_slurm.sh
 
 scancel $JOB_ID

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -4,8 +4,8 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/home/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
-# Reset framework if vllm to use default script
-if [ "$FRAMEWORK" = "vllm" ]; then
+# Reset framework if vllm or sglang to use default script
+if [ "$FRAMEWORK" = "vllm" ] || [ "$FRAMEWORK" = "sglang" ]; then
     FRAMEWORK=""
 fi
 

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -4,6 +4,11 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/home/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
+# Reset framework if vllm to use default script
+if [ "$FRAMEWORK" = "vllm" ]; then
+    FRAMEWORK=""
+fi
+
 PARTITION="main"
 # Use framework-specific SQSH file
 if [ "$FRAMEWORK" = "trt" ]; then

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -18,11 +18,13 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+bash -c "
 # Determine which benchmark script to use based on framework
-if [ "$FRAMEWORK" = "trt" ]; then
-    bash benchmarks/${MODEL_CODE}_h200_trt_slurm.sh
+if [ \"\$FRAMEWORK\" = \"trt\" ]; then
+    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
 else
-    bash benchmarks/${MODEL_CODE}_h200_slurm.sh
+    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
 fi
+"
 
 scancel $JOB_ID

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -23,6 +23,7 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
+-e MODEL_CODE=$MODEL_CODE \
 bash -c "
 # Determine which benchmark script to use based on framework
 if [ \"\$FRAMEWORK\" = \"trt\" ]; then

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -4,8 +4,8 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
-# Reset framework if vllm to use default script
-if [ "$FRAMEWORK" = "vllm" ]; then
+# Reset framework if vllm or sglang to use default script
+if [ "$FRAMEWORK" = "vllm" ] || [ "$FRAMEWORK" = "sglang" ]; then
     FRAMEWORK=""
 fi
 

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -18,6 +18,11 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_h200_slurm.sh
+# Determine which benchmark script to use based on framework
+if [ "$FRAMEWORK" = "trt" ]; then
+    bash benchmarks/${MODEL_CODE}_h200_trt_slurm.sh
+else
+    bash benchmarks/${MODEL_CODE}_h200_slurm.sh
+fi
 
 scancel $JOB_ID

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -5,7 +5,12 @@ export HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
 PARTITION="dgx-h200"
-SQUASH_FILE="/raid/image_${MODEL_CODE}_h200.sqsh"
+# Use framework-specific SQSH file
+if [ "$FRAMEWORK" = "trt" ]; then
+    SQUASH_FILE="/raid/image_${MODEL_CODE}_h200_trt.sqsh"
+else
+    SQUASH_FILE="/raid/image_${MODEL_CODE}_h200.sqsh"
+fi
 
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -4,6 +4,11 @@ MODEL_CODE="${1%%_*}"
 export HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 export PORT_OFFSET=${USER: -1}
 
+# Reset framework if vllm to use default script
+if [ "$FRAMEWORK" = "vllm" ]; then
+    FRAMEWORK=""
+fi
+
 PARTITION="dgx-h200"
 # Use framework-specific SQSH file
 if [ "$FRAMEWORK" = "trt" ]; then
@@ -23,14 +28,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
--e MODEL_CODE=$MODEL_CODE \
-bash -c "
-# Determine which benchmark script to use based on framework
-if [ \"\$FRAMEWORK\" = \"trt\" ]; then
-    bash benchmarks/\${MODEL_CODE}_h200_trt_slurm.sh
-else
-    bash benchmarks/\${MODEL_CODE}_h200_slurm.sh
-fi
-"
+bash benchmarks/${MODEL_CODE}_h200${FRAMEWORK:+_$FRAMEWORK}_slurm.sh
 
 scancel $JOB_ID

--- a/utils/plot_perf.py
+++ b/utils/plot_perf.py
@@ -8,30 +8,42 @@ results_dir = Path(sys.argv[1])
 exp_name = sys.argv[2]
 hw_color = {
     'h100': 'lightgreen',
-    'h200': 'green',
-    'b200': 'black',
+    'h200': 'green',           # H200 VLLM
+    'h200-trt': 'darkgreen',   # H200 TRT-LLM
+    'b200': 'black',            # B200 VLLM
+    'b200-trt': 'gray',      # B200 TRT-LLM
     'mi300x': 'pink',
     'mi325x': 'red',
-    'mi355x': 'purple'
+    'mi355x': 'purple'         
 }
 
 results = []
 for result_path in results_dir.rglob(f'*.json'):
     with open(result_path) as f:
         result = json.load(f)
+    # Create combined hw+framework identifier for plotting
+    if result.get('framework') == 'trt':
+        result['hw_label'] = f"{result['hw']}-trt"
+    else:
+        result['hw_label'] = result['hw']
     results.append(result)
 
 
-def plot_tput_vs_e2el():
+def plot_tput_vs_e2el(precision_filter=None):
     fig, ax = plt.subplots()
+    
+    # Filter results by precision if specified
+    filtered_results = results
+    if precision_filter is not None:
+        filtered_results = [r for r in results if r.get('precision', 'fp8') == precision_filter]
 
-    for hw, color in hw_color.items():
-        xs = [result['median_e2el'] for result in results if result['hw'] == hw]
-        ys = [result['tput_per_gpu'] for result in results if result['hw'] == hw]
+    for hw_label, color in hw_color.items():
+        xs = [result['median_e2el'] for result in filtered_results if result['hw_label'] == hw_label]
+        ys = [result['tput_per_gpu'] for result in filtered_results if result['hw_label'] == hw_label]
         if xs and ys:
-            ax.scatter(xs, ys, label=hw.upper(), color=color)
+            ax.scatter(xs, ys, label=hw_label.upper(), color=color)
 
-    for result in results:
+    for result in filtered_results:
         x, y = result['median_e2el'], result['tput_per_gpu']
         ax.annotate(str(result['tp']), (x, y), textcoords='offset points', xytext=(3, 3), ha='left', fontsize=8)
 
@@ -40,20 +52,26 @@ def plot_tput_vs_e2el():
     ax.legend(title='GPU Type')
     fig.tight_layout()
 
-    fig.savefig(f'tput_vs_e2el_{exp_name}.png', bbox_inches='tight')
+    precision_suffix = f"_{precision_filter}" if precision_filter else ""
+    fig.savefig(f'tput_vs_e2el_{exp_name}{precision_suffix}.png', bbox_inches='tight')
     plt.close(fig)
 
 
-def plot_tput_vs_intvty():
+def plot_tput_vs_intvty(precision_filter=None):
     fig, ax = plt.subplots()
+    
+    # Filter results by precision if specified
+    filtered_results = results
+    if precision_filter is not None:
+        filtered_results = [r for r in results if r.get('precision', 'fp8') == precision_filter]
 
-    for hw, color in hw_color.items():
-        xs = [result['median_intvty'] for result in results if result['hw'] == hw]
-        ys = [result['tput_per_gpu'] for result in results if result['hw'] == hw]
+    for hw_label, color in hw_color.items():
+        xs = [result['median_intvty'] for result in filtered_results if result['hw_label'] == hw_label]
+        ys = [result['tput_per_gpu'] for result in filtered_results if result['hw_label'] == hw_label]
         if xs and ys:
-            ax.scatter(xs, ys, label=hw.upper(), color=color)
+            ax.scatter(xs, ys, label=hw_label.upper(), color=color)
 
-    for result in results:
+    for result in filtered_results:
         x, y = result['median_intvty'], result['tput_per_gpu']
         ax.annotate(str(result['tp']), (x, y), textcoords='offset points', xytext=(3, 3), ha='left', fontsize=8)
 
@@ -62,9 +80,69 @@ def plot_tput_vs_intvty():
     ax.legend(title='GPU Type')
     fig.tight_layout()
 
-    fig.savefig(f'tput_vs_intvty_{exp_name}.png', bbox_inches='tight')
+    precision_suffix = f"_{precision_filter}" if precision_filter else ""
+    fig.savefig(f'tput_vs_intvty_{exp_name}{precision_suffix}.png', bbox_inches='tight')
     plt.close(fig)
 
 
-plot_tput_vs_e2el()
-plot_tput_vs_intvty()
+def plot_tput_vs_e2el_for_model(model_results, model_name):
+    fig, ax = plt.subplots()
+    
+    for hw_label, color in hw_color.items():
+        xs = [result['median_e2el'] for result in model_results if result['hw_label'] == hw_label]
+        ys = [result['tput_per_gpu'] for result in model_results if result['hw_label'] == hw_label]
+        if xs and ys:
+            ax.scatter(xs, ys, label=hw_label.upper(), color=color)
+
+    for result in model_results:
+        x, y = result['median_e2el'], result['tput_per_gpu']
+        ax.annotate(str(result['tp']), (x, y), textcoords='offset points', xytext=(3, 3), ha='left', fontsize=8)
+
+    ax.set_xlabel('End-to-end Latency (s)')
+    ax.set_ylabel('Throughput per GPU (tok/s)')
+    ax.legend(title='Hardware + Framework')
+    ax.set_title(f'{model_name} - All Frameworks')
+    fig.tight_layout()
+
+    # Extract model identifier from model name
+    model_id = model_name.split('/')[-1].split('-')[0] if '/' in model_name else model_name
+    fig.savefig(f'tput_vs_e2el_{model_id}_{exp_name}.png', bbox_inches='tight')
+    plt.close(fig)
+
+
+def plot_tput_vs_intvty_for_model(model_results, model_name):
+    fig, ax = plt.subplots()
+    
+    for hw_label, color in hw_color.items():
+        xs = [result['median_intvty'] for result in model_results if result['hw_label'] == hw_label]
+        ys = [result['tput_per_gpu'] for result in model_results if result['hw_label'] == hw_label]
+        if xs and ys:
+            ax.scatter(xs, ys, label=hw_label.upper(), color=color)
+
+    for result in model_results:
+        x, y = result['median_intvty'], result['tput_per_gpu']
+        ax.annotate(str(result['tp']), (x, y), textcoords='offset points', xytext=(3, 3), ha='left', fontsize=8)
+
+    ax.set_xlabel('Interactivity (tok/s/user)')
+    ax.set_ylabel('Throughput per GPU (tok/s)')
+    ax.legend(title='Hardware + Framework')
+    ax.set_title(f'{model_name} - All Frameworks')
+    fig.tight_layout()
+
+    # Extract model identifier from model name
+    model_id = model_name.split('/')[-1].split('-')[0] if '/' in model_name else model_name
+    fig.savefig(f'tput_vs_intvty_{model_id}_{exp_name}.png', bbox_inches='tight')
+    plt.close(fig)
+
+
+# Create one plot per model showing all frameworks and hardware
+# Group results by model (70b, dsr1, etc.)
+models = set(r.get('model', 'unknown') for r in results)
+
+for model in models:
+    # Filter results for this model
+    model_results = [r for r in results if r.get('model', 'unknown') == model]
+    
+    # Create plots for this model
+    plot_tput_vs_e2el_for_model(model_results, model)
+    plot_tput_vs_intvty_for_model(model_results, model)

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -6,6 +6,8 @@ from pathlib import Path
 hw = sys.argv[1]
 tp_size = int(sys.argv[2])
 result_filename = sys.argv[3]
+framework = sys.argv[4]
+precision = sys.argv[5]
 
 with open(f'{result_filename}.json') as f:
     bmk_result = json.load(f)
@@ -15,6 +17,8 @@ data = {
     'tp': tp_size,
     'conc': int(bmk_result['max_concurrency']),
     'model': bmk_result['model_id'],
+    'framework': framework,
+    'precision': precision if precision else 'fp8',
     'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size
 }
 

--- a/utils/summarize.py
+++ b/utils/summarize.py
@@ -9,17 +9,21 @@ for result_path in results_dir.rglob(f'*.json'):
     with open(result_path) as f:
         result = json.load(f)
     results.append(result)
-results.sort(key=lambda r: (r['hw'], r['tp'], r['conc']))
+results.sort(key=lambda r: (r['hw'], r.get('framework', 'vllm'), r.get('precision', 'fp8'), r['tp'], r['conc']))
 
 summary_header = f'''\
-| Hardware | TP | Conc | TTFT (ms) | TPOT (ms) | E2EL (s) | TPUT per GPU |
-| :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
+| Hardware | Framework | Precision | TP | Conc | TTFT (ms) | TPOT (ms) | E2EL (s) | TPUT per GPU |
+| :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |\
 '''
 print(summary_header)
 
 for result in results:
+    framework = result.get('framework', 'vllm')
+    precision = result.get('precision', 'fp8')
     print(
         f"| {result['hw'].upper()} "
+        f"| {framework.upper()} "
+        f"| {precision.upper()} "
         f"| {result['tp']} "
         f"| {result['conc']} "
         f"| {(result['median_ttft'] * 1000):.4f} "


### PR DESCRIPTION
## Overview

This PR adds TensorRT-LLM (TRT-LLM) as a new inference framework for LLaMA 70B benchmarking on NVIDIA H200 and B200 GPUs, alongside the existing vLLM framework. This enables direct performance comparison between vLLM and TRT-LLM on the same hardware.

### Key Features
- Multi-framework support: vLLM and TRT-LLM for LLaMA 70B
- Precision support: FP8 (default) and FP4 (future-ready)
- Unified plotting: All frameworks and hardware on single performance plots
- Framework-specific Docker images: Prevents image conflicts between frameworks
- Clean job naming: Clear identification in GitHub Actions UI

### 🔧 Core Workflow Updates
.github/workflows/benchmark-tmpl.yml
- Added framework and precision as required inputs
- Updated RESULT_FILENAME to include framework and precision
- Modified result processing to pass framework and precision to process_result.py
- Fixed job naming to prevent duplication
- Added hardware extraction logic for proper result processing

.github/workflows/70b-tmpl.yml
- Added bmk-h200-trt and bmk-b200-trt jobs for TRT-LLM
- Configured TRT-LLM jobs with nvidia/tensorrt-llm Docker image
- Set precision to empty string for FP8 (default)
- Updated all jobs to include framework and precision inputs

#### 🚀 New Benchmark Scripts
benchmarks/70b_h200_trt_slurm.sh and benchmarks/70b_b200_trt_slurm.sh
- TRT-LLM server setup for H200 using mpirun trtllm-serve
- Inline llama-config.yml configuration
- Client benchmarking with benchmark_serving.py

### 🔄 Launcher Script Updates
Updated SLURM Launchers
runners/launch_h200-nv.sh
runners/launch_h200-cw.sh
runners/launch_h200-nb.sh
runners/launch_b200-nv.sh
Key improvements:
- Framework-specific SQSH file naming to prevent Docker image conflicts
- Dynamic script selection based on framework (VLLM/SGLang use base scripts, TRT uses _trt scripts)
- Proper MODEL_CODE environment variable passing to containers
- Framework reset logic for VLLM and SGLang to use default script names

### 📊 Result Processing & Visualization
utils/process_result.py
- Added framework and precision command-line arguments
- Updated output data structure to include framework and precision
- Default precision handling (empty string → 'fp8')

utils/plot_perf.py
- Added distinct colors for TRT-LLM results:
h200-trt: dark green
b200-trt: gray
- Unified plotting: all frameworks and hardware on single plots
- Updated plot titles and legend handling
- Model-specific plot generation

### 🧪 Testing Configuration
.github/workflows/workflow-scheduler.yml
- Commented out concurrency and schedule blocks for manual testing
- Disabled DSR1 jobs as requested

