### PR TITLE
Fix hardware label generation for runners with framework suffix in names

### DIFF
--- a/utils/plot_perf.py
+++ b/utils/plot_perf.py
@@ -23,7 +23,11 @@ for result_path in results_dir.rglob(f'*.json'):
         result = json.load(f)
     # Create combined hw+framework identifier for plotting
     if result.get('framework') == 'trt':
-        result['hw_label'] = f"{result['hw']}-trt"
+        # Check if hardware name already contains framework suffix
+        if result['hw'].endswith('-trt'):
+            result['hw_label'] = result['hw']
+        else:
+            result['hw_label'] = f"{result['hw']}-trt"
     else:
         result['hw_label'] = result['hw']
     results.append(result)


### PR DESCRIPTION
###  Problem
When using runner names that already include the framework suffix (e.g., b200-trt), the plotting script was incorrectly creating double suffixes in hardware labels, resulting in b200-trt-trt instead of the expected b200-trt.

### Root Cause
The plot_perf.py script was blindly appending -trt to any hardware name when the framework was 'trt', without checking if the hardware name already contained the framework suffix.

### Solution
Updated utils/plot_perf.py to check if the hardware name already ends with -trt before appending it:

<pre>
# Create combined hw+framework identifier for plotting
if result.get('framework') == 'trt':
    # Check if hardware name already contains framework suffix
    if result['hw'].endswith('-trt'):
        result['hw_label'] = result['hw']
    else:
        result['hw_label'] = f"{result['hw']}-trt"
else:
    result['hw_label'] = result['hw']
</pre>

### Impact
✅ Fixes plotting for runners with names like b200-trt
✅ Maintains backward compatibility for existing runners like b200 → b200-trt
✅ No changes needed to workflow templates or result processing
✅ Results now plot correctly with proper hardware labels and colors