### PR TITLE
Update max-num-batched-tokens parameter to 131072 to improve throughp…

### DIFF
--- a/benchmarks/70b_fp8_mi300x_docker.sh
+++ b/benchmarks/70b_fp8_mi300x_docker.sh
@@ -33,7 +33,7 @@ vllm serve $MODEL --port=$PORT \
 --max-model-len=$MAX_MODEL_LEN \
 --max-seq-len-to-capture=$MAX_MODEL_LEN \
 --max-num-seqs=$CONC \
---max-num-batched-tokens=$(( $CONC * 128 )) \
+--max-num-batched-tokens=131072 \
 --no-enable-prefix-caching \
 --async-scheduling \
 --disable-log-requests

--- a/benchmarks/70b_fp8_mi300x_slurm.sh
+++ b/benchmarks/70b_fp8_mi300x_slurm.sh
@@ -43,7 +43,7 @@ vllm serve $MODEL --port=$PORT \
 --max-model-len=$MAX_MODEL_LEN \
 --max-seq-len-to-capture=$MAX_MODEL_LEN \
 --max-num-seqs=$CONC \
---max-num-batched-tokens=$(( $CONC * 128 )) \
+--max-num-batched-tokens=131072 \
 --no-enable-prefix-caching \
 --async-scheduling \
 --disable-log-requests \

--- a/benchmarks/70b_fp8_mi325x_docker.sh
+++ b/benchmarks/70b_fp8_mi325x_docker.sh
@@ -33,7 +33,7 @@ vllm serve $MODEL --port=$PORT \
 --max-model-len=$MAX_MODEL_LEN \
 --max-seq-len-to-capture=$MAX_MODEL_LEN \
 --max-num-seqs=$CONC \
---max-num-batched-tokens=$(( $CONC * 128 )) \
+--max-num-batched-tokens=131072 \
 --no-enable-prefix-caching \
 --async-scheduling \
 --disable-log-requests

--- a/benchmarks/70b_fp8_mi325x_slurm.sh
+++ b/benchmarks/70b_fp8_mi325x_slurm.sh
@@ -45,7 +45,7 @@ vllm serve $MODEL --port=$PORT \
 --max-model-len=$MAX_MODEL_LEN \
 --max-seq-len-to-capture=$MAX_MODEL_LEN \
 --max-num-seqs=$CONC \
---max-num-batched-tokens=$(( $CONC * 128 )) \
+--max-num-batched-tokens=131072 \
 --no-enable-prefix-caching \
 --async-scheduling \
 --disable-log-requests \

--- a/benchmarks/70b_fp8_mi355x_slurm.sh
+++ b/benchmarks/70b_fp8_mi355x_slurm.sh
@@ -39,7 +39,7 @@ vllm serve $MODEL --port=$PORT \
 --max-model-len=$MAX_MODEL_LEN \
 --max-seq-len-to-capture=$MAX_MODEL_LEN \
 --max-num-seqs=$CONC \
---max-num-batched-tokens=$(( $CONC * 128 )) \
+--max-num-batched-tokens=131072 \
 --no-enable-prefix-caching \
 --async-scheduling \
 --disable-log-requests \


### PR DESCRIPTION
…ut and ttft.
Will provide an expected performance boost. For example for the 8K1K con 4 we are seeing ~29% boost on Mi300x.
Here are the runs: before https://github.com/InferenceMAX/InferenceMAX/actions/runs/17838687561/job/50722323101#step:4:575
and after
https://github.com/InferenceMAX/InferenceMAX/actions/runs/17838980169/job/50723297124#step:4:578