### PR TITLE
[NVIDIA] Fix Docker Networking and Image Name Issues for B200 Launch Scripts

### DIFF
--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/benchmark-tmpl.yml
     secrets: inherit
     with:
-      runner: b200-trt
+      runner: b200
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       framework: 'trt'
@@ -199,7 +199,7 @@ jobs:
     uses: ./.github/workflows/benchmark-tmpl.yml
     secrets: inherit
     with:
-      runner: b200-trt
+      runner: b200
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP4'
       framework: 'trt'

--- a/benchmarks/70b_fp4_b200_trt_docker.sh
+++ b/benchmarks/70b_fp4_b200_trt_docker.sh
@@ -42,5 +42,5 @@ fi
 
 set -x
 # Launch TRT-LLM server
-trtllm-serve $MODEL --tp_size $TP --trust_remote_code \
+mpirun -n 1 --allow-run-as-root --oversubscribe trtllm-serve $MODEL --tp_size $TP --trust_remote_code \
 --max_seq_len $MAX_MODEL_LEN --max_num_tokens 16384 --extra_llm_api_options llama-config.yml --port $PORT

--- a/benchmarks/70b_fp4_b200_trt_docker.sh
+++ b/benchmarks/70b_fp4_b200_trt_docker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT
+
+# Create llama-config.yml inline
+# For 1k/1k, use batch_wait_max_tokens_ratio and batch_wait_timeout_iters will improve the performance, by default they are all zeros
+if [[ "$ISL" == "1024" && "$OSL" == "1024" && ${TP} -lt 8 ]]; then
+cat > llama-config.yml << 'EOF'
+batch_wait_max_tokens_ratio: 0.9
+batch_wait_timeout_iters: 20
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 10
+EOF
+else 
+cat > llama-config.yml << 'EOF'
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 10
+EOF
+fi
+
+set -x
+# Launch TRT-LLM server
+trtllm-serve $MODEL --tp_size $TP --trust_remote_code \
+--max_seq_len $MAX_MODEL_LEN --max_num_tokens 16384 --extra_llm_api_options llama-config.yml --port $PORT

--- a/benchmarks/70b_fp8_b200_trt_docker.sh
+++ b/benchmarks/70b_fp8_b200_trt_docker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT
+
+# Create llama-config.yml inline
+# For 1k/1k, use batch_wait_max_tokens_ratio and batch_wait_timeout_iters will improve the performance, by default they are all zeros
+if [[ "$ISL" == "1024" && "$OSL" == "1024" && ${TP} -lt 8 ]]; then
+cat > llama-config.yml << 'EOF'
+batch_wait_max_tokens_ratio: 0.9
+batch_wait_timeout_iters: 20
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 10
+EOF
+else 
+cat > llama-config.yml << 'EOF'
+cuda_graph_config: 
+  enable_padding: true 
+  max_batch_size: 1024 
+kv_cache_config: 
+  dtype: fp8 
+  enable_block_reuse: false 
+stream_interval: 10
+EOF
+fi
+
+set -x
+# Launch TRT-LLM server
+mpirun -n 1 --allow-run-as-root --oversubscribe trtllm-serve $MODEL --tp_size $TP --trust_remote_code \
+--max_seq_len $MAX_MODEL_LEN --max_num_tokens 16384 --extra_llm_api_options llama-config.yml --port $PORT

--- a/runners/launch_b200-nvd.sh
+++ b/runners/launch_b200-nvd.sh
@@ -17,7 +17,7 @@ docker run --rm -d --network $network_name --name $server_name \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
-$IMAGE \
+${IMAGE/\#/\/} \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200_docker.sh"
 
 set +x
@@ -35,7 +35,7 @@ docker run --rm --network $network_name --name $client_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
 --entrypoint=/bin/bash \
-$IMAGE \
+${IMAGE/\#/\/} \
 -lc "pip install -q datasets pandas && \
 python3 bench_serving/benchmark_serving.py \
 --model $MODEL  --backend vllm --base-url http://$server_name:$PORT \

--- a/runners/launch_b200-nvd.sh
+++ b/runners/launch_b200-nvd.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
+FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PORT=8888
 
 network_name="bmk-net"
@@ -18,7 +19,7 @@ docker run --rm -d --network $network_name --name $server_name \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
 ${IMAGE/\#/\/} \
-benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200_docker.sh"
+benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_docker.sh"
 
 set +x
 while IFS= read -r line; do

--- a/runners/launch_b200-nvd.sh
+++ b/runners/launch_b200-nvd.sh
@@ -18,7 +18,7 @@ docker run --rm -d --network $network_name --name $server_name \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
-${IMAGE/\#/\/} \
+$(echo "$IMAGE" | sed 's/#/\//') \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_docker.sh"
 
 set +x
@@ -36,7 +36,7 @@ docker run --rm --network $network_name --name $client_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
 --entrypoint=/bin/bash \
-${IMAGE/\#/\/} \
+$(echo "$IMAGE" | sed 's/#/\//') \
 -lc "pip install -q datasets pandas && \
 python3 bench_serving/benchmark_serving.py \
 --model $MODEL  --backend vllm --base-url http://$server_name:$PORT \

--- a/runners/launch_b200-nvd.sh
+++ b/runners/launch_b200-nvd.sh
@@ -4,14 +4,11 @@ HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PORT=8888
 
-network_name="bmk-net"
 server_name="bmk-server"
 client_name="bmk-client"
 
-docker network create $network_name
-
 set -x
-docker run --rm -d --network $network_name --name $server_name \
+docker run --rm -d --network host --name $server_name \
 --runtime nvidia --gpus all --ipc host --privileged --shm-size=16g --ulimit memlock=-1 --ulimit stack=67108864 \
 -v $HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
@@ -32,14 +29,14 @@ done < <(docker logs -f --tail=0 $server_name 2>&1)
 git clone https://github.com/kimbochen/bench_serving.git
 
 set -x
-docker run --rm --network $network_name --name $client_name \
+docker run --rm --network host --name $client_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
 --entrypoint=/bin/bash \
 $(echo "$IMAGE" | sed 's/#/\//') \
 -lc "pip install -q datasets pandas && \
 python3 bench_serving/benchmark_serving.py \
---model $MODEL  --backend vllm --base-url http://$server_name:$PORT \
+--model $MODEL  --backend vllm --base-url http://localhost:$PORT \
 --dataset-name random \
 --random-input-len $ISL --random-output-len $OSL --random-range-ratio $RANDOM_RANGE_RATIO \
 --num-prompts $(( $CONC * 10 )) \
@@ -50,6 +47,5 @@ python3 bench_serving/benchmark_serving.py \
 
 while [ -n "$(docker ps -aq)" ]; do
     docker stop $server_name
-    docker network rm $network_name
     sleep 5
 done

--- a/runners/launch_b200-tg.sh
+++ b/runners/launch_b200-tg.sh
@@ -4,21 +4,18 @@ HF_HUB_CACHE_MOUNT="/dev/shm/hf_hub_cache/"
 FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PORT=8888
 
-network_name="bmk-net"
 server_name="bmk-server"
 client_name="bmk-client"
 
-docker network create $network_name
-
 set -x
-docker run --rm -d --network $network_name --name $server_name \
+docker run --rm -d --network host --name $server_name \
 --runtime nvidia --gpus all --ipc host --privileged --shm-size=16g --ulimit memlock=-1 --ulimit stack=67108864 \
 -v $HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
-${IMAGE/\#/\/} \
+$(echo "$IMAGE" | sed 's/#/\//') \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_docker.sh"
 
 set +x
@@ -32,14 +29,14 @@ done < <(docker logs -f --tail=0 $server_name 2>&1)
 git clone https://github.com/kimbochen/bench_serving.git
 
 set -x
-docker run --rm --network $network_name --name $client_name \
+docker run --rm --network host --name $client_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
 --entrypoint=/bin/bash \
-${IMAGE/\#/\/} \
+$(echo "$IMAGE" | sed 's/#/\//') \
 -lc "pip install -q datasets pandas && \
 python3 bench_serving/benchmark_serving.py \
---model $MODEL  --backend vllm --base-url http://$server_name:$PORT \
+--model $MODEL  --backend vllm --base-url http://localhost:$PORT \
 --dataset-name random \
 --random-input-len $ISL --random-output-len $OSL --random-range-ratio $RANDOM_RANGE_RATIO \
 --num-prompts $(( $CONC * 10 )) \
@@ -50,6 +47,5 @@ python3 bench_serving/benchmark_serving.py \
 
 while [ -n "$(docker ps -aq)" ]; do
     docker stop $server_name
-    docker network rm $network_name
     sleep 5
 done

--- a/runners/launch_b200-tg.sh
+++ b/runners/launch_b200-tg.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 HF_HUB_CACHE_MOUNT="/dev/shm/hf_hub_cache/"
+FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PORT=8888
 
 network_name="bmk-net"
@@ -18,7 +19,7 @@ docker run --rm -d --network $network_name --name $server_name \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
 ${IMAGE/\#/\/} \
-benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200_docker.sh"
+benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_docker.sh"
 
 set +x
 while IFS= read -r line; do

--- a/runners/launch_b200-tg.sh
+++ b/runners/launch_b200-tg.sh
@@ -17,7 +17,7 @@ docker run --rm -d --network $network_name --name $server_name \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 --entrypoint=/bin/bash \
-$IMAGE \
+${IMAGE/\#/\/} \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200_docker.sh"
 
 set +x
@@ -35,7 +35,7 @@ docker run --rm --network $network_name --name $client_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
 --entrypoint=/bin/bash \
-$IMAGE \
+${IMAGE/\#/\/} \
 -lc "pip install -q datasets pandas && \
 python3 bench_serving/benchmark_serving.py \
 --model $MODEL  --backend vllm --base-url http://$server_name:$PORT \


### PR DESCRIPTION
### 🐛 Problem

The B200 Docker launch scripts had two critical issues:
1. Docker image name parsing failure: The bash parameter expansion ${IMAGE/\#/\/} was incorrectly escaping forward slashes, causing Docker to fail with "invalid reference format" errors
2. custom Docker networking: Using custom Docker networks (bmk-net) was causing connection issues and DNS resolution failures between containers


### 🔧 Solution

1. Fixed Image Name Transformation
Before: ${IMAGE/\#/\/} → nvcr.io\/nvidia/tensorrt-llm/ (incorrect escaping)
After: $(echo "$IMAGE" | sed 's/#/\//') → nvcr.io/nvidia/tensorrt-llm/ (correct format)
2. Simplified Docker Networking
Removed: Custom Docker network creation and management
Added: --network host for both server and client containers
Updated: Client base URL from http://$server_name:$PORT to http://localhost:$PORT
3. Updated vLLM Server Configuration
Fixed: vLLM server binding from --host=0.0.0.0 to --host=127.0.0.1 for host networking compatibility


Also added 70b fp8 trt b200 docker script :) 