### PR TITLE
[NVIDIA] Reduce B200 Runs & add B200 FP4 Docker Script

### DIFF
--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -106,7 +106,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 2]'  
+      tp-list: '[1, 8]'  
 
   bmk-b200-trt-fp8:
     if: ${{ inputs.use_b200 }}
@@ -123,7 +123,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 2, 4, 8]'  
+      tp-list: '[1, 8]'  
       conc-list: '[4, 8, 16, 32, 64, 128, 256]'  # B200 can achieve TPS/User >= 30 with larger concurrency till 256
 
   bmk-mi300x-fp8:
@@ -192,7 +192,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 2]'  
+      tp-list: '[1, 8]'  
 
   bmk-b200-trt-fp4:
     if: ${{ inputs.use_b200 }}
@@ -209,7 +209,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 2, 4, 8]'  
+      tp-list: '[1, 8]'  
       conc-list: '[4, 8, 16, 32, 64, 128, 256]'  # B200 can achieve TPS/User >= 30 with larger concurrency till 256
 
   bmk-mi355x-fp4:

--- a/.github/workflows/gptoss-tmpl.yml
+++ b/.github/workflows/gptoss-tmpl.yml
@@ -69,7 +69,7 @@ jobs:
       runner: b200
       image: 'vllm/vllm-openai:v0.10.2'
       model: 'openai/gpt-oss-120b'
-      tp-list: '[1, 2, 4, 8]'
+      tp-list: '[1, 8]'
       framework: 'vllm'
       precision: 'fp4'
 
@@ -86,7 +86,7 @@ jobs:
       runner: b200-trt
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
       model: 'openai/gpt-oss-120b'
-      tp-list: '[1, 2, 4, 8]'
+      tp-list: '[1, 8]'
       framework: 'trt'
       precision: 'fp4'
 

--- a/benchmarks/70b_fp4_b200_docker.sh
+++ b/benchmarks/70b_fp4_b200_docker.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT_OFFSET
+
+
+cat > config.yaml << EOF
+kv-cache-dtype: fp8
+compilation-config: '{"pass_config":{"enable_fi_allreduce_fusion":true,"enable_attn_fusion":true,"enable_noop":true},"custom_ops":["+quant_fp8","+rms_norm"],"cudagraph_mode":"FULL_DECODE_ONLY","splitting_ops":[]}'
+async-scheduling: true
+no-enable-prefix-caching: true
+max-num-batched-tokens: 8192
+max-model-len: 10240
+EOF
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export VLLM_FLASHINFER_ALLREDUCE_FUSION_THRESHOLDS_MB='{"2":32,"4":32,"8":8}'
+export PYTHONNOUSERSITE=1
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT --config config.yaml \
+--gpu-memory-utilization 0.9 --tensor-parallel-size $TP --max-num-seqs 512 \
+--disable-log-requests

--- a/benchmarks/dsr1_fp4_b200_docker.sh
+++ b/benchmarks/dsr1_fp4_b200_docker.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--cuda-graph-max-bs 256 --max-running-requests 256 --mem-fraction-static 0.85 --kv-cache-dtype fp8_e4m3 \
+--chunked-prefill-size 16384 \
+--enable-ep-moe --quantization modelopt_fp4 --enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--enable-symm-mem --disable-radix-cache --attention-backend trtllm_mla --enable-flashinfer-trtllm-moe --stream-interval 10

--- a/benchmarks/gptoss_fp4_b200_docker.sh
+++ b/benchmarks/gptoss_fp4_b200_docker.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars === 
+# HF_TOKEN
+# HF_HUB_CACHE
+# IMAGE
+# MODEL
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# TP
+# CONC
+# RESULT_FILENAME
+# PORT_OFFSET
+
+cat > config.yaml << EOF
+compilation-config: '{"pass_config":{"enable_fi_allreduce_fusion":true,"enable_attn_fusion":true,"enable_noop":true},"custom_ops":["+rms_norm"],"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+async-scheduling: true
+no-enable-prefix-caching: true
+cuda-graph-sizes: 2048
+max-num-batched-tokens: 8192
+max-model-len: 10240
+EOF
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export VLLM_FLASHINFER_ALLREDUCE_FUSION_THRESHOLDS_MB='{"2":32,"4":32,"8":8}'
+export PYTHONNOUSERSITE=1
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT --config config.yaml \
+--gpu-memory-utilization 0.9 --tensor-parallel-size $TP --max-num-seqs 512 \
+--disable-log-requests


### PR DESCRIPTION
- Copied commands from non-TRT slurm scripts for docker scripts
- Reduced B200 TP lists to `[1, 8]` for baseline and low latency scenarios
- Removed b200 labels from the NV slurm runners
- Validating the B200 run [here](https://github.com/InferenceMAX/InferenceMAX/actions/runs/17897804541)