### PR TITLE
[NVIDIA] Update B200 SGL FP8 and add FP4 TP4

### DIFF
--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -84,7 +84,7 @@ jobs:
     secrets: inherit
     with:
       runner: b200
-      image: 'lmsysorg/sglang:v0.5.0rc1-cu128-b200'
+      image: 'lmsysorg/sglang:v0.5.3rc1-cu129-b200'
       model: 'deepseek-ai/DeepSeek-R1-0528'
       framework: 'sglang'
       precision: 'fp8'
@@ -178,7 +178,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[8]'
+      tp-list: '[4,8]'
       conc-list: '[4, 8, 16, 32, 64, 128]'  # Custom concurrency values for this job
 
   bmk-b200-trt-fp4:

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -121,8 +121,8 @@ jobs:
       osl: 1024
       max-model-len: 2048
       random-range-ratio: 0.8
-      tp-list: '[4]'
-      conc-list: '[4,8,16]'
+      tp-list: '[8]'
+      conc-list: '[1]'
 
   collect-test-results:
     needs: runner-test

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -121,8 +121,8 @@ jobs:
       osl: 1024
       max-model-len: 2048
       random-range-ratio: 0.8
-      tp-list: '[8]'
-      conc-list: '[4,8,16,32,64]'
+      tp-list: '[4]'
+      conc-list: '[4,8,16]'
 
   collect-test-results:
     needs: runner-test

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -122,7 +122,7 @@ jobs:
       max-model-len: 2048
       random-range-ratio: 0.8
       tp-list: '[8]'
-      conc-list: '[1]'
+      conc-list: '[4,8,16,32,64]'
 
   collect-test-results:
     needs: runner-test

--- a/benchmarks/dsr1_fp8_b200_docker.sh
+++ b/benchmarks/dsr1_fp8_b200_docker.sh
@@ -9,12 +9,21 @@
 # CONC
 # MAX_MODEL_LEN
 
-export SGL_ENABLE_JIT_DEEPGEMM=0
-export SGLANG_ENABLE_FLASHINFER_GEMM=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+
+# Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 set -x
-python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT --trust-remote-code \
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --tensor-parallel-size=$TP --data-parallel-size=1 \
---kv-cache-dtype=fp8_e4m3 --mem-fraction-static=0.82 \
---max-prefill-tokens=32768 --chunked-prefill-size=32768 --cuda-graph-max-bs=128 --max-running-requests=128 \
---disable-radix-cache --enable-flashinfer-trtllm-moe --attention-backend=trtllm_mla --stream-interval=1
+--cuda-graph-max-bs 128 --max-running-requests 128 \
+--mem-fraction-static 0.82 --kv-cache-dtype fp8_e4m3 --chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL --disable-radix-cache \
+--attention-backend trtllm_mla --stream-interval 30 --enable-flashinfer-trtllm-moe --quantization fp8

--- a/runners/launch_b200-nvd.sh
+++ b/runners/launch_b200-nvd.sh
@@ -28,9 +28,9 @@ done < <(docker logs -f --tail=0 $server_name 2>&1)
 
 git clone https://github.com/kimbochen/bench_serving.git
 
-# warmup for JIT kernels - only for DeepSeek-R1-0528-FP4 model
-if [[ "$MODEL" == "nvidia/DeepSeek-R1-0528-FP4" ]]; then
-    echo "Running warmup for DeepSeek-R1-0528-FP4 model..."
+# warmup for JIT kernels - only for DeepSeek-R1-0528 models
+if [[ "$MODEL" == "nvidia/DeepSeek-R1-0528-FP4" || "$MODEL" == "deepseek-ai/DeepSeek-R1-0528" ]]; then
+    echo "Running JIT kernel warmup for DeepSeek-R1-0528 model..."
     WARMUP_PROMPTS=$(( $CONC * 10 ))
     echo "Warmup prompts: $WARMUP_PROMPTS"
     docker run --rm --network host --name warmup-client \


### PR DESCRIPTION
1. Use latest sgl container for FP8 B200
2. Add TP4 concurrency in FP4 B200 sgl


TODO for later: update slurm script with latest flags

See runs: 
https://github.com/InferenceMAX/InferenceMAX/actions/runs/17950828777/job/51049377968 
https://github.com/InferenceMAX/InferenceMAX/actions/runs/17952378910/job/51054958566