### PR TITLE
[NVIDIA] Fix GB200 Integration

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -57,23 +57,12 @@ jobs:
     steps:
       - name: Resource cleanup
         run: |
-          if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-            echo "[Docker] Cleaning up resources ..."
-            docker ps -aq | xargs -r docker rm -f
-            docker network prune -f
-            while [ -n "$(docker ps -aq)" ]; do
-              docker ps -a
-              sleep 5
-            done
-          fi
-          if command -v squeue >/dev/null 2>&1; then
-            echo "[Slurm] Cleaning up resources ..."
-            scancel -u $USER
-            while [ -n "$(squeue -u $USER --noheader --format='%i')" ]; do
-              squeue -u $USER
-              sleep 5
-            done
-          fi
+          echo "[Slurm] Cleaning up resources ..."
+          scancel -u $USER
+          while [ -n "$(squeue -u $USER --noheader --format='%i')" ]; do
+            squeue -u $USER
+            sleep 5
+          done
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Launch multi-node job script
         env:
           RUNNER_NAME: ${{ runner.name }}
-          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_${{ runner.name }}
+          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_mtp-${{ env.MTP_MODE }}_${{ runner.name }}
         run: |
           bash ./runners/launch_${RUNNER_NAME%%_*}.sh
           # Check if at least one result file was created

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -93,7 +93,7 @@ jobs:
               # Extract GPU count from filename for tp_size calculation
               gpus=$(echo "$result_file" | sed "s/.*_gpus\([0-9]*\)\.json/\1/")
               if [ -n "$gpus" ]; then
-                python3 utils/process_result.py ${{ inputs.runner }} $gpus ${result_file%.json} $FRAMEWORK $PRECISION
+                python3 utils/process_result.py ${{ inputs.runner }} $gpus ${result_file%.json} $FRAMEWORK $PRECISION $MTP_MODE
               fi
             fi
           done

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -38,10 +38,6 @@ on:
         type: boolean
         required: false
         default: false
-      mtp-mode:
-        type: string
-        required: false
-        default: 'off'
 
 jobs:
   bmk-h200-fp8:
@@ -214,9 +210,9 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[4,8]'
+      tp-list: '[4, 8]'
 
-  bmk-gb200-fp4-multinode:
+  bmk-gb200-fp4-multinode-mtp-off:
     if: ${{ inputs.use_gb200 }}
     uses: ./.github/workflows/benchmark-multinode-tmpl.yml
     secrets: inherit
@@ -231,4 +227,21 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      mtp-mode: ${{ inputs.mtp-mode }}
+      mtp-mode: 'off'
+
+  bmk-gb200-fp4-multinode-mtp-on:
+    if: ${{ inputs.use_gb200 }}
+    uses: ./.github/workflows/benchmark-multinode-tmpl.yml
+    secrets: inherit
+    with:
+      runner: gb200
+      image: 'nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1-rc0.pre3'
+      model: 'deepseek-r1-fp4'
+      framework: 'dynamo-trtllm'
+      precision: 'fp4'
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      mtp-mode: 'on'

--- a/.github/workflows/full-sweep-tmpl.yml
+++ b/.github/workflows/full-sweep-tmpl.yml
@@ -86,58 +86,6 @@ jobs:
     with:
       exp-name: 'dsr1_1k1k'
 
-  dsr1-multinode-1k1k-mtp-off:
-    if: ${{ inputs.run_1k1k && inputs.use_gb200 }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_1k1k_mtp_off'
-      isl: 1024
-      osl: 1024
-      max-model-len: 2048
-      random-range-ratio: 0.8
-      use_h200: false
-      use_b200: false
-      use_mi300x: false
-      use_mi325x: false
-      use_mi355x: false
-      use_gb200: ${{ inputs.use_gb200 }}
-      mtp-mode: 'off'
-
-  collect-dsr1-multinode-1k1k-mtp-off-results:
-    needs: dsr1-multinode-1k1k-mtp-off
-    if: ${{ inputs.run_1k1k && inputs.use_gb200 && (success() || failure()) }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_1k1k_mtp_off'
-
-  dsr1-multinode-1k1k-mtp-on:
-    if: ${{ inputs.run_1k1k && inputs.use_gb200 }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_1k1k_mtp_on'
-      isl: 1024
-      osl: 1024
-      max-model-len: 2048
-      random-range-ratio: 0.8
-      use_h200: false
-      use_b200: false
-      use_mi300x: false
-      use_mi325x: false
-      use_mi355x: false
-      use_gb200: ${{ inputs.use_gb200 }}
-      mtp-mode: 'on'
-
-  collect-dsr1-multinode-1k1k-mtp-on-results:
-    needs: dsr1-multinode-1k1k-mtp-on
-    if: ${{ inputs.run_1k1k && inputs.use_gb200 && (success() || failure()) }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_1k1k_mtp_on'
-
   gptoss-1k1k:
     if: ${{ inputs.run_1k1k }}
     uses: ./.github/workflows/gptoss-tmpl.yml
@@ -211,58 +159,6 @@ jobs:
     secrets: inherit
     with:
       exp-name: 'dsr1_8k1k'
-
-  dsr1-multinode-8k1k-mtp-off:
-    if: ${{ inputs.run_8k1k && inputs.use_gb200 }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_8k1k_mtp_off'
-      isl: 8192
-      osl: 1024
-      max-model-len: 9216
-      random-range-ratio: 0.8
-      use_h200: false
-      use_b200: false
-      use_mi300x: false
-      use_mi325x: false
-      use_mi355x: false
-      use_gb200: ${{ inputs.use_gb200 }}
-      mtp-mode: 'off'
-
-  collect-dsr1-multinode-8k1k-mtp-off-results:
-    needs: dsr1-multinode-8k1k-mtp-off
-    if: ${{ inputs.run_8k1k && inputs.use_gb200 && (success() || failure()) }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_8k1k_mtp_off'
-
-  dsr1-multinode-8k1k-mtp-on:
-    if: ${{ inputs.run_8k1k && inputs.use_gb200 }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_8k1k_mtp_on'
-      isl: 8192
-      osl: 1024
-      max-model-len: 9216
-      random-range-ratio: 0.8
-      use_h200: false
-      use_b200: false
-      use_mi300x: false
-      use_mi325x: false
-      use_mi355x: false
-      use_gb200: ${{ inputs.use_gb200 }}
-      mtp-mode: 'on'
-
-  collect-dsr1-multinode-8k1k-mtp-on-results:
-    needs: dsr1-multinode-8k1k-mtp-on
-    if: ${{ inputs.run_8k1k && inputs.use_gb200 && (success() || failure()) }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_multinode_8k1k_mtp_on'
 
   gptoss-8k1k:
     if: ${{ inputs.run_8k1k }}

--- a/.github/workflows/full-sweep-tmpl.yml
+++ b/.github/workflows/full-sweep-tmpl.yml
@@ -77,6 +77,7 @@ jobs:
       use_mi300x: ${{ inputs.use_mi300x }}
       use_mi325x: ${{ inputs.use_mi325x }}
       use_mi355x: ${{ inputs.use_mi355x }}
+      use_gb200: ${{ inputs.use_gb200 }}
 
   collect-dsr1-1k1k-results:
     needs: dsr1-1k1k
@@ -151,6 +152,7 @@ jobs:
       use_mi300x: ${{ inputs.use_mi300x }}
       use_mi325x: ${{ inputs.use_mi325x }}
       use_mi355x: ${{ inputs.use_mi355x }}
+      use_gb200: ${{ inputs.use_gb200 }}
 
   collect-dsr1-8k1k-results:
     needs: dsr1-8k1k
@@ -225,6 +227,7 @@ jobs:
       use_mi300x: ${{ inputs.use_mi300x }}
       use_mi325x: ${{ inputs.use_mi325x }}
       use_mi355x: ${{ inputs.use_mi355x }}
+      use_gb200: ${{ inputs.use_gb200 }}
 
   collect-dsr1-1k8k-results:
     needs: dsr1-1k8k

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -22,6 +22,9 @@ data = {
     'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size
 }
 
+if len(sys.argv) == 7:  # MTP
+    data['mtp'] = sys.argv[6]
+
 for key, value in bmk_result.items():
     if key.endswith('ms'):
         data[key.replace('_ms', '')] = float(value) / 1000.0


### PR DESCRIPTION
Original GB200 creates a separate result artifact instead of being in the dsr1 results.  
This PR fixes the issue and integrates it back.
- Removed multinode template calls from full sweep template
- Use the same exp-name as other runs
- Added MTP config into result file name
- Added MTP config into result file