### PR TITLE
[NVIDIA] Add DSR1 MTP

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Launch job script
         env:
           RUNNER_NAME: ${{ runner.name }}
-          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_tp${{ env.TP }}_conc${{ env.CONC }}_${{ runner.name }}
+          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_tp${{ env.TP }}_conc${{ env.CONC }}${{ env.MTP_MODE != 'off' && format('-mtp-{0}', runner.name) || format('_{0}', runner.name) }}
         run: |
           bash ./runners/launch_${RUNNER_NAME%%_*}.sh
           if [ -f "$RESULT_FILENAME.json" ]; then

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         tp: ${{ fromJson(inputs.tp-list) }}
         conc: ${{ fromJson(inputs.conc-list) }}
-    name: '${{ inputs.exp-name }} ${{ inputs.runner }} ${{ inputs.precision }} tp${{ matrix.tp }} conc${{ matrix.conc }}'
+    name: '${{ inputs.exp-name }} ${{ inputs.runner }} ${{ inputs.precision }} tp${{ matrix.tp }} conc${{ matrix.conc }}${{ inputs.mtp-mode == 'on' && ' mtp-on' || '' }}'
 
     env:
       TP: ${{ matrix.tp }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         tp: ${{ fromJson(inputs.tp-list) }}
         conc: ${{ fromJson(inputs.conc-list) }}
-    name: '${{ inputs.exp-name }} ${{ inputs.runner }} ${{ inputs.precision }} tp${{ matrix.tp }} conc${{ matrix.conc }}${{ inputs.mtp-mode == 'on' && ' mtp-on' || '' }}'
+    name: '${{ inputs.exp-name }} ${{ inputs.runner }} ${{ inputs.precision }} tp${{ matrix.tp }} conc${{ matrix.conc }}'
 
     env:
       TP: ${{ matrix.tp }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -38,6 +38,9 @@ on:
       conc-list:
         type: string
         default: '[4, 8, 16, 32, 64]'
+      mtp-mode:
+        type: string
+        default: 'off'
 
 env:
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -51,6 +54,7 @@ env:
   IMAGE: ${{ inputs.image }}
   FRAMEWORK: ${{ inputs.framework }}
   PRECISION: ${{ inputs.precision }}
+  MTP_MODE: ${{ inputs.mtp-mode }}
 
 jobs:
   benchmark:

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -108,6 +108,7 @@ jobs:
       random-range-ratio: ${{ inputs.random-range-ratio }}
       tp-list: '[8]'
       conc-list: '[4, 8, 16, 32, 64, 128]'
+      mtp-mode: 'off'
 
   bmk-mi300x-fp8:
     if: ${{ inputs.use_mi300x }}
@@ -187,7 +188,7 @@ jobs:
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
       model: 'nvidia/DeepSeek-R1-0528-FP4-v2'
       framework: 'trt'
-      precision: fp4
+      precision: 'fp4'
       exp-name: ${{ inputs.exp-name }}
       isl: ${{ inputs.isl }}
       osl: ${{ inputs.osl }}
@@ -195,6 +196,45 @@ jobs:
       random-range-ratio: ${{ inputs.random-range-ratio }}
       tp-list: '[4, 8]'
       conc-list: '[4, 8, 16, 32, 64, 128, 256]'  # DPA4EP4 is already 30 tok/s/user and DPA8EP8 is already 35tok/s/user. 512 conc would be too much so we skipping it
+      mtp-mode: 'off'
+
+  bmk-b200-trt-fp4-mtp:
+    if: ${{ inputs.use_b200 }}
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      runner: b200-trt
+      image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
+      model: 'nvidia/DeepSeek-R1-0528-FP4-v2'
+      framework: 'trt'
+      precision: 'fp4'
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      tp-list: '[4, 8]'
+      conc-list: '[4, 8, 16, 32, 64, 128, 256]'
+      mtp-mode: 'on'
+
+  bmk-b200-trt-fp8-mtp:
+    if: ${{ inputs.use_b200 }}
+    uses: ./.github/workflows/benchmark-tmpl.yml
+    secrets: inherit
+    with:
+      runner: b200-trt
+      image: 'nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2'
+      model: 'deepseek-ai/DeepSeek-R1-0528'
+      framework: 'trt'
+      precision: 'fp8'
+      exp-name: ${{ inputs.exp-name }}
+      isl: ${{ inputs.isl }}
+      osl: ${{ inputs.osl }}
+      max-model-len: ${{ inputs.max-model-len }}
+      random-range-ratio: ${{ inputs.random-range-ratio }}
+      tp-list: '[8]'
+      conc-list: '[4, 8, 16, 32, 64, 128]'
+      mtp-mode: 'on'
 
   bmk-mi355x-fp4:
     if: ${{ inputs.use_mi355x }}

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -107,6 +107,7 @@ jobs:
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
       tp-list: '[8]'
+      conc-list: '[4, 8, 16, 32, 64, 128]'
 
   bmk-mi300x-fp8:
     if: ${{ inputs.use_mi300x }}

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -100,6 +100,15 @@ on:
           - '70b_test'
           - 'dsr1_test'
           - 'gptoss_test'
+
+      mtp-mode:
+        description: 'MTP Mode'
+        required: true
+        type: choice
+        options:
+          - 'off'
+          - 'on'
+        default: 'off'
         
 jobs:
   runner-test:
@@ -118,6 +127,7 @@ jobs:
       random-range-ratio: 0.8
       tp-list: '[8]'
       conc-list: '[1]'
+      mtp-mode: ${{ inputs.mtp-mode }}
 
   collect-test-results:
     needs: runner-test

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -126,7 +126,7 @@ jobs:
       max-model-len: 2048
       random-range-ratio: 0.8
       tp-list: '[8]'
-      conc-list: '[1]'
+      conc-list: '[4,8,16,32]'
       mtp-mode: ${{ inputs.mtp-mode }}
 
   collect-test-results:

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -126,7 +126,7 @@ jobs:
       max-model-len: 2048
       random-range-ratio: 0.8
       tp-list: '[8]'
-      conc-list: '[4,8,16,32]'
+      conc-list: '[4,8,16,32,64]'
       mtp-mode: ${{ inputs.mtp-mode }}
 
   collect-test-results:

--- a/benchmarks/dsr1_fp4_b200_docker.sh
+++ b/benchmarks/dsr1_fp4_b200_docker.sh
@@ -8,6 +8,8 @@ else
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
+ps aux
+
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 \

--- a/benchmarks/dsr1_fp4_b200_trt_mtp_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_trt_mtp_slurm.sh
@@ -162,4 +162,5 @@ python3 bench_serving/benchmark_serving.py \
 --request-rate inf --ignore-eos \
 --save-result --percentile-metrics 'ttft,tpot,itl,e2el' \
 --result-dir /workspace/ \
+--use-chat-template \
 --result-filename $RESULT_FILENAME.json

--- a/benchmarks/dsr1_fp8_b200_docker.sh
+++ b/benchmarks/dsr1_fp8_b200_docker.sh
@@ -19,6 +19,7 @@ else
   SCHEDULER_RECV_INTERVAL=10
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+ps aux
 
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \

--- a/benchmarks/dsr1_fp8_b200_trt_mtp_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_trt_mtp_slurm.sh
@@ -123,4 +123,5 @@ python3 bench_serving/benchmark_serving.py \
 --request-rate inf --ignore-eos \
 --save-result --percentile-metrics 'ttft,tpot,itl,e2el' \
 --result-dir /workspace/ \
+--use-chat-template \
 --result-filename $RESULT_FILENAME.json

--- a/benchmarks/dsr1_fp8_h200_trt_mtp_slurm.sh
+++ b/benchmarks/dsr1_fp8_h200_trt_mtp_slurm.sh
@@ -82,7 +82,7 @@ fi
 MAX_NUM_TOKENS=$(( ((MTP+1)*MAX_BATCH_SIZE+ISL+64+63)/64*64 ))
 
 # Launch TRT-LLM server
-mpirun -n 1 --oversubscribe --allow-run-as-root \
+PYTHONNOUSERSITE=1 mpirun -n 1 --oversubscribe --allow-run-as-root \
     trtllm-serve $MODEL --port=$PORT \
     --trust_remote_code \
     --backend=pytorch \

--- a/benchmarks/dsr1_fp8_h200_trt_mtp_slurm.sh
+++ b/benchmarks/dsr1_fp8_h200_trt_mtp_slurm.sh
@@ -119,4 +119,5 @@ python3 bench_serving/benchmark_serving.py \
 --request-rate inf --ignore-eos \
 --save-result --percentile-metrics 'ttft,tpot,itl,e2el' \
 --result-dir /workspace/ \
+--use-chat-template \
 --result-filename $RESULT_FILENAME.json

--- a/benchmarks/dsr1_fp8_h200_trt_slurm.sh
+++ b/benchmarks/dsr1_fp8_h200_trt_slurm.sh
@@ -71,13 +71,20 @@ fi
 
 set -x
 
-MAX_NUM_TOKENS=$(( ($CONC+$ISL+64+63)/64*64 ))
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    MAX_BATCH_SIZE=$((CONC/TP))
+else
+    MAX_BATCH_SIZE=$CONC
+fi
+
+MAX_NUM_TOKENS=$(( (MAX_BATCH_SIZE+ISL+64+63)/64*64 ))
 
 # Launch TRT-LLM server
 mpirun -n 1 --oversubscribe --allow-run-as-root \
     trtllm-serve $MODEL --port=$PORT \
     --trust_remote_code \
     --backend=pytorch \
+    --max_batch_size=$MAX_BATCH_SIZE \
     --max_seq_len=$MAX_MODEL_LEN \
     --max_num_tokens=$MAX_NUM_TOKENS \
     --tp_size=$TP --ep_size=$EP_SIZE \

--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -5,6 +5,7 @@ export PORT_OFFSET=0  # Doesn't matter when --exclusive
 
 MODEL_CODE="${EXP_NAME%%_*}"
 FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
+MTP_SUFFIX=$([[ "$MTP_MODE" == "on" ]] && printf '_mtp' || printf '')
 
 PARTITION="dgx-b200"
 SQUASH_FILE="/raid/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
@@ -20,6 +21,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_slurm.sh
+bash benchmarks/${MODEL_CODE}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${MTP_SUFFIX}_slurm.sh
 
 scancel $JOB_ID

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -5,6 +5,7 @@ export PORT_OFFSET=0  # Doesn't matter when --exclusive
 
 MODEL_CODE="${EXP_NAME%%_*}"
 FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
+MTP_SUFFIX=$([[ "$MTP_MODE" == "on" ]] && printf '_mtp' || printf '')
 
 PARTITION="dgx-h200"
 SQUASH_FILE="/raid/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
@@ -20,6 +21,6 @@ srun --jobid=$JOB_ID \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash benchmarks/${MODEL_CODE}_${PRECISION}_h200${FRAMEWORK_SUFFIX}_slurm.sh
+bash benchmarks/${MODEL_CODE}_${PRECISION}_h200${FRAMEWORK_SUFFIX}${MTP_SUFFIX}_slurm.sh
 
 scancel $JOB_ID


### PR DESCRIPTION
As per guidance we've recvd, wanted to add MTP ON configs for single node after GB200 is merged. 
Only TRT MTP for now.

Changes:
1. Added benchmarks/dsr1_*_mtp_slurm.sh files for fp8 and fp4
2. modified dsr1-tmpl.yml to account for new runs.