### PR TITLE
[AMD] Deal with weird strings from `amdgpu-arch`

### DIFF
--- a/benchmarks/70b_fp8_mi325x_docker.sh
+++ b/benchmarks/70b_fp8_mi325x_docker.sh
@@ -22,6 +22,12 @@ elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     fi
 fi
 
+# Patch the aiter config script to deal
+# with weird strings reported by /opt/rocm/llvm/bin/amdgpu-arch.
+file_to_patch='/opt/venv/lib/python3.10/site-packages/aiter_meta/csrc/cpp_itfs/utils.py'
+sed -i'' -e 's#archs = \[arch.strip() for arch in archs\]#archs = \[arch.strip().split(":")\[0\] for arch in archs\]#'  $file_to_patch
+
+
 # In this specific case, float16 performs better than the datatype
 # picked by vllm when using auto for --dtype (bfloat16).
 set -x

--- a/benchmarks/70b_fp8_mi325x_slurm.sh
+++ b/benchmarks/70b_fp8_mi325x_slurm.sh
@@ -34,6 +34,12 @@ elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
 	fi
 fi
 
+# Patch the aiter config script to deal
+# with weird strings reported by /opt/rocm/llvm/bin/amdgpu-arch.
+file_to_patch='/opt/venv/lib/python3.10/site-packages/aiter_meta/csrc/cpp_itfs/utils.py'
+sed -i'' -e 's#archs = \[arch.strip() for arch in archs\]#archs = \[arch.strip().split(":")\[0\] for arch in archs\]#'  $file_to_patch
+
+
 # In this specific case, float16 performs better than the datatype
 # picked by vllm when using auto for --dtype (bfloat16).
 set -x


### PR DESCRIPTION
On certain mi325 nodes the reported architecture comes with a bunch of features separated by a `:`.

This was not expected by the aiter config script.

Hot patch the script in the docker to fix the problem. The fix will be rolled into the next docker.

Note: we observed this weird strings only on the tensorwave nodes, so only fixing the 325 configs.