### PR TITLE
[NVIDIA] bug fix: add TP=2,4 to B200, just as mi355 has

### DIFF
--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -106,7 +106,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 8]'
+      tp-list: '[1, 2, 4, 8]' # fix: add TP=2,4 to B200, just as mi355 has
 
   bmk-b200-trt-fp8:
     if: ${{ inputs.use_b200 }}
@@ -123,7 +123,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 8]'  
+      tp-list: '[1, 2, 4, 8]' # fix: add TP=2,4 to B200, just as mi355 has
       conc-list: '[4, 8, 16, 32, 64, 128]'  # B200 can achieve TPS/User >= 30 with larger concurrency till 256
 
   bmk-mi300x-fp8:
@@ -192,7 +192,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 8]'  
+      tp-list: '[1, 2, 4, 8]'  # fix: add TP=2,4 to B200, just as mi355 has
 
   bmk-b200-trt-fp4:
     if: ${{ inputs.use_b200 }}
@@ -209,7 +209,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[1, 8]'  
+      tp-list: '[1, 2, 4, 8]' # fix: add TP=2,4 to B200, just as mi355 has
       conc-list: '[4, 8, 16, 32, 64, 128]'  # B200 can achieve TPS/User >= 30 with larger concurrency till 128
 
   bmk-mi355x-fp4:


### PR DESCRIPTION
To see full Pareto frontier and match behavior of AMD GPUs.
- https://github.com/InferenceMAX/InferenceMAX/blob/31af0fe22939a2b50823d3518a65a844e75c9dec/.github/workflows/70b-tmpl.yml#L144
- https://github.com/InferenceMAX/InferenceMAX/blob/31af0fe22939a2b50823d3518a65a844e75c9dec/.github/workflows/70b-tmpl.yml#L161
- https://github.com/InferenceMAX/InferenceMAX/blob/31af0fe22939a2b50823d3518a65a844e75c9dec/.github/workflows/70b-tmpl.yml#L178
- https://github.com/InferenceMAX/InferenceMAX/blob/31af0fe22939a2b50823d3518a65a844e75c9dec/.github/workflows/70b-tmpl.yml#L230
