### PR TITLE
Update 70b fp8 docker and slurm scripts

### DIFF
--- a/benchmarks/70b_fp8_mi300x_docker.sh
+++ b/benchmarks/70b_fp8_mi300x_docker.sh
@@ -31,6 +31,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$CONC" -gt "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
     fi
 fi
 

--- a/benchmarks/70b_fp8_mi300x_slurm.sh
+++ b/benchmarks/70b_fp8_mi300x_slurm.sh
@@ -42,6 +42,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$CONC" -gt "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
     fi
 fi
 

--- a/benchmarks/70b_fp8_mi325x_docker.sh
+++ b/benchmarks/70b_fp8_mi325x_docker.sh
@@ -19,6 +19,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$CONC" -gt "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
     fi
 fi
 

--- a/benchmarks/70b_fp8_mi325x_slurm.sh
+++ b/benchmarks/70b_fp8_mi325x_slurm.sh
@@ -31,6 +31,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
 	if [[ "$CONC" -gt "16" ]]; then
 		export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
 	fi
 fi
 

--- a/benchmarks/70b_fp8_mi355x_docker.sh
+++ b/benchmarks/70b_fp8_mi355x_docker.sh
@@ -21,6 +21,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$CONC" -gt "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
     fi
 fi
 

--- a/benchmarks/70b_fp8_mi355x_slurm.sh
+++ b/benchmarks/70b_fp8_mi355x_slurm.sh
@@ -27,6 +27,8 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$CONC" -gt "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
+    else
+		export VLLM_ROCM_USE_AITER_MHA=0
     fi
 fi
 


### PR DESCRIPTION
This PR updates an environment variable for Llama70b FP8 configs.
Note: Acknowledged that repo is softlocked. This change is to ensure that this additional variable is not overlooked in future runs.

validated the following:

https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208430731 Mi355  Con4
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208465822 Mi355  Con8
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208513929 Mi355  Con16


https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208438235 Mi325  Con4
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208497912 Mi325  Con8
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208517178 Mi325  Con16


https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208445597 Mi300  Con4
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208479829 Mi300  Con8
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18208522263 Mi300  Con16
