### PR TITLE
[AMD] bug fix: remove unnecessary tp's from mi355x dsr1 fp4 runs

### DIFF
--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -210,7 +210,8 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      tp-list: '[4, 8]'
+      tp-list: ${{ inputs.isl == 1024 && inputs.osl == 1024 && '[4, 8]' || '[8]' }}
+
 
   bmk-gb200-fp4-multinode-mtp-off:
     if: ${{ inputs.use_gb200 && !(inputs.isl == '1024' && inputs.osl == '8192') }}

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -210,6 +210,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
+      # These tensor parallelism settings are not necessary as they cannot mathematically fall on the Pareto frontier - we remove them to save CI time.
       tp-list: ${{ inputs.isl == 1024 && inputs.osl == 1024 && '[4, 8]' || '[8]' }}
 
   bmk-gb200-fp4-multinode-mtp-off:

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -212,7 +212,6 @@ jobs:
       random-range-ratio: ${{ inputs.random-range-ratio }}
       tp-list: ${{ inputs.isl == 1024 && inputs.osl == 1024 && '[4, 8]' || '[8]' }}
 
-
   bmk-gb200-fp4-multinode-mtp-off:
     if: ${{ inputs.use_gb200 && !(inputs.isl == '1024' && inputs.osl == '8192') }}
     uses: ./.github/workflows/benchmark-multinode-tmpl.yml

--- a/.github/workflows/dsr1-tmpl.yml
+++ b/.github/workflows/dsr1-tmpl.yml
@@ -210,7 +210,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      # These tensor parallelism settings are not necessary as they cannot mathematically fall on the Pareto frontier - we remove them to save CI time.
+      # These tensor parallelism settings are not necessary as they cannot fall on the Pareto frontier with this particular container - we remove them to save CI time.
       tp-list: ${{ inputs.isl == 1024 && inputs.osl == 1024 && '[4, 8]' || '[8]' }}
 
   bmk-gb200-fp4-multinode-mtp-off:


### PR DESCRIPTION
These tensor parallelism settings are not necessary as they cannot fall on the Pareto frontier with this particular container - we remove them to save CI time.

<img width="922" height="575" alt="image" src="https://github.com/user-attachments/assets/b66560ea-c73e-444b-9e4e-1dbee1c088ba" />

<img width="972" height="577" alt="image" src="https://github.com/user-attachments/assets/1f84b2ba-2e97-42bb-b1a2-d388cc02f373" />



This modified sweep verifies that it works: https://github.com/InferenceMAX/InferenceMAX/actions/runs/18297920860/job/52100050029