### PR TITLE
chore: update vllm image to 11.0

### DIFF
--- a/.github/workflows/70b-tmpl.yml
+++ b/.github/workflows/70b-tmpl.yml
@@ -45,7 +45,7 @@ jobs:
     secrets: inherit
     with:
       runner: h100
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       framework: 'vllm'
       precision: 'fp8'
@@ -62,7 +62,7 @@ jobs:
     secrets: inherit
     with:
       runner: h200
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       framework: 'vllm'
       precision: 'fp8'
@@ -97,7 +97,7 @@ jobs:
     secrets: inherit
     with:
       runner: b200
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP8'
       framework: 'vllm'
       precision: 'fp8'
@@ -183,7 +183,7 @@ jobs:
     secrets: inherit
     with:
       runner: b200
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'nvidia/Llama-3.3-70B-Instruct-FP4'
       framework: 'vllm'
       precision: 'fp4'

--- a/.github/workflows/full-sweep-tmpl.yml
+++ b/.github/workflows/full-sweep-tmpl.yml
@@ -137,30 +137,30 @@ jobs:
     with:
       exp-name: '70b_8k1k'
 
-  dsr1-8k1k:
-    if: ${{ inputs.run_8k1k }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_8k1k'
-      isl: 8192
-      osl: 1024
-      max-model-len: 9216
-      random-range-ratio: 0.8
-      use_h200: ${{ inputs.use_h200 }}
-      use_b200: ${{ inputs.use_b200 }}
-      use_mi300x: ${{ inputs.use_mi300x }}
-      use_mi325x: ${{ inputs.use_mi325x }}
-      use_mi355x: ${{ inputs.use_mi355x }}
-      use_gb200: ${{ inputs.use_gb200 }}
+  # dsr1-8k1k:
+  #   if: ${{ inputs.run_8k1k }}
+  #   uses: ./.github/workflows/dsr1-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: 'dsr1_8k1k'
+  #     isl: 8192
+  #     osl: 1024
+  #     max-model-len: 9216
+  #     random-range-ratio: 0.8
+  #     use_h200: ${{ inputs.use_h200 }}
+  #     use_b200: ${{ inputs.use_b200 }}
+  #     use_mi300x: ${{ inputs.use_mi300x }}
+  #     use_mi325x: ${{ inputs.use_mi325x }}
+  #     use_mi355x: ${{ inputs.use_mi355x }}
+  #     use_gb200: ${{ inputs.use_gb200 }}
 
-  collect-dsr1-8k1k-results:
-    needs: dsr1-8k1k
-    if: ${{ inputs.run_8k1k && always() }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_8k1k'
+  # collect-dsr1-8k1k-results:
+  #   needs: dsr1-8k1k
+  #   if: ${{ inputs.run_8k1k && always() }}
+  #   uses: ./.github/workflows/collect-results.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: 'dsr1_8k1k'
 
   gptoss-8k1k:
     if: ${{ inputs.run_8k1k }}

--- a/.github/workflows/full-sweep-tmpl.yml
+++ b/.github/workflows/full-sweep-tmpl.yml
@@ -62,30 +62,30 @@ jobs:
     with:
       exp-name: '70b_1k1k'
 
-  dsr1-1k1k:
-    if: ${{ inputs.run_1k1k }}
-    uses: ./.github/workflows/dsr1-tmpl.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_1k1k'
-      isl: 1024
-      osl: 1024
-      max-model-len: 2048
-      random-range-ratio: 0.8
-      use_h200: ${{ inputs.use_h200 }}
-      use_b200: ${{ inputs.use_b200 }}
-      use_mi300x: ${{ inputs.use_mi300x }}
-      use_mi325x: ${{ inputs.use_mi325x }}
-      use_mi355x: ${{ inputs.use_mi355x }}
-      use_gb200: ${{ inputs.use_gb200 }}
+  # dsr1-1k1k:
+  #   if: ${{ inputs.run_1k1k }}
+  #   uses: ./.github/workflows/dsr1-tmpl.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: 'dsr1_1k1k'
+  #     isl: 1024
+  #     osl: 1024
+  #     max-model-len: 2048
+  #     random-range-ratio: 0.8
+  #     use_h200: ${{ inputs.use_h200 }}
+  #     use_b200: ${{ inputs.use_b200 }}
+  #     use_mi300x: ${{ inputs.use_mi300x }}
+  #     use_mi325x: ${{ inputs.use_mi325x }}
+  #     use_mi355x: ${{ inputs.use_mi355x }}
+  #     use_gb200: ${{ inputs.use_gb200 }}
 
-  collect-dsr1-1k1k-results:
-    needs: dsr1-1k1k
-    if: ${{ inputs.run_1k1k && always() }}
-    uses: ./.github/workflows/collect-results.yml
-    secrets: inherit
-    with:
-      exp-name: 'dsr1_1k1k'
+  # collect-dsr1-1k1k-results:
+  #   needs: dsr1-1k1k
+  #   if: ${{ inputs.run_1k1k && always() }}
+  #   uses: ./.github/workflows/collect-results.yml
+  #   secrets: inherit
+  #   with:
+  #     exp-name: 'dsr1_1k1k'
 
   gptoss-1k1k:
     if: ${{ inputs.run_1k1k }}
@@ -137,30 +137,30 @@ jobs:
     with:
       exp-name: '70b_8k1k'
 
-  # dsr1-8k1k:
-  #   if: ${{ inputs.run_8k1k }}
-  #   uses: ./.github/workflows/dsr1-tmpl.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: 'dsr1_8k1k'
-  #     isl: 8192
-  #     osl: 1024
-  #     max-model-len: 9216
-  #     random-range-ratio: 0.8
-  #     use_h200: ${{ inputs.use_h200 }}
-  #     use_b200: ${{ inputs.use_b200 }}
-  #     use_mi300x: ${{ inputs.use_mi300x }}
-  #     use_mi325x: ${{ inputs.use_mi325x }}
-  #     use_mi355x: ${{ inputs.use_mi355x }}
-  #     use_gb200: ${{ inputs.use_gb200 }}
+  dsr1-8k1k:
+    if: ${{ inputs.run_8k1k }}
+    uses: ./.github/workflows/dsr1-tmpl.yml
+    secrets: inherit
+    with:
+      exp-name: 'dsr1_8k1k'
+      isl: 8192
+      osl: 1024
+      max-model-len: 9216
+      random-range-ratio: 0.8
+      use_h200: ${{ inputs.use_h200 }}
+      use_b200: ${{ inputs.use_b200 }}
+      use_mi300x: ${{ inputs.use_mi300x }}
+      use_mi325x: ${{ inputs.use_mi325x }}
+      use_mi355x: ${{ inputs.use_mi355x }}
+      use_gb200: ${{ inputs.use_gb200 }}
 
-  # collect-dsr1-8k1k-results:
-  #   needs: dsr1-8k1k
-  #   if: ${{ inputs.run_8k1k && always() }}
-  #   uses: ./.github/workflows/collect-results.yml
-  #   secrets: inherit
-  #   with:
-  #     exp-name: 'dsr1_8k1k'
+  collect-dsr1-8k1k-results:
+    needs: dsr1-8k1k
+    if: ${{ inputs.run_8k1k && always() }}
+    uses: ./.github/workflows/collect-results.yml
+    secrets: inherit
+    with:
+      exp-name: 'dsr1_8k1k'
 
   gptoss-8k1k:
     if: ${{ inputs.run_8k1k }}

--- a/.github/workflows/gptoss-tmpl.yml
+++ b/.github/workflows/gptoss-tmpl.yml
@@ -50,7 +50,7 @@ jobs:
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
       runner: h100
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'openai/gpt-oss-120b'
       tp-list: '[2, 4, 8]'
       framework: 'vllm'
@@ -67,7 +67,7 @@ jobs:
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
       runner: h200
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'openai/gpt-oss-120b'
       tp-list: '[1, 2, 4, 8]'
       framework: 'vllm'
@@ -84,7 +84,7 @@ jobs:
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
       runner: b200
-      image: 'vllm/vllm-openai:v0.10.2'
+      image: 'vllm/vllm-openai:v0.11.0'
       model: 'openai/gpt-oss-120b'
       tp-list: '[1, 2, 4, 8]'
       framework: 'vllm'

--- a/.github/workflows/runner-model-sweep-test.yml
+++ b/.github/workflows/runner-model-sweep-test.yml
@@ -33,8 +33,8 @@ jobs:
           - 'h100-cw_0'
           - 'h100-cw_1'
         config:
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
 
     name: '${{ matrix.runner }}'
     uses: ./.github/workflows/benchmark-tmpl.yml
@@ -70,9 +70,9 @@ jobs:
           - 'h200-nv_2'
           - 'h200-nv_3'
         config:
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
           - { image: 'lmsysorg/sglang:v0.5.2rc2-cu126', model: 'deepseek-ai/DeepSeek-R1-0528', framework: 'sglang', precision: 'fp8', exp-name: 'dsr1_test' }
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
 
     name: '${{ matrix.runner }}'
     uses: ./.github/workflows/benchmark-tmpl.yml
@@ -140,11 +140,11 @@ jobs:
           - 'b200-nvd_2'
           - 'b200-nvd_3'
         config:
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'nvidia/Llama-3.3-70B-Instruct-FP4', framework: 'vllm', precision: 'fp4', exp-name: '70b_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'nvidia/Llama-3.3-70B-Instruct-FP8', framework: 'vllm', precision: 'fp8', exp-name: '70b_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'nvidia/Llama-3.3-70B-Instruct-FP4', framework: 'vllm', precision: 'fp4', exp-name: '70b_test' }
           - { image: 'lmsysorg/sglang:v0.5.3rc1-cu129-b200', model: 'deepseek-ai/DeepSeek-R1-0528', framework: 'sglang', precision: 'fp8', exp-name: 'dsr1_test' }
           - { image: 'lmsysorg/sglang:v0.5.3rc1-cu129-b200', model: 'nvidia/DeepSeek-R1-0528-FP4', framework: 'sglang', precision: 'fp4', exp-name: 'dsr1_test' }
-          - { image: 'vllm/vllm-openai:v0.10.2', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
+          - { image: 'vllm/vllm-openai:v0.11.0', model: 'openai/gpt-oss-120b', framework: 'vllm', precision: 'fp4', exp-name: 'gptoss_test' }
 
     name: '${{ matrix.runner }}'
     uses: ./.github/workflows/benchmark-tmpl.yml

--- a/.github/workflows/runner-sweep-test.yml
+++ b/.github/workflows/runner-sweep-test.yml
@@ -36,7 +36,7 @@ on:
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_sgl-dev-v0.5.2-rocm7.0-mi35x-20250915'
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250915'
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1'
-          - 'vllm/vllm-openai:v0.10.2'
+          - 'vllm/vllm-openai:v0.11.0'
 
       model:
         description: 'Model'

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -67,7 +67,7 @@ on:
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_sgl-dev-v0.5.2-rocm7.0-mi35x-20250915'
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250915'
           - 'rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1'
-          - 'vllm/vllm-openai:v0.10.2'
+          - 'vllm/vllm-openai:v0.11.0'
       model:
         description: 'Model'
         required: true

--- a/benchmarks/70b_fp8_h100_docker.sh
+++ b/benchmarks/70b_fp8_h100_docker.sh
@@ -22,7 +22,7 @@ EOF
 export PYTHONNOUSERSITE=1
 
 vllm serve $MODEL --host=0.0.0.0 --port=$PORT \
---config=config.yaml \
+--config config.yaml \
 --gpu-memory-utilization=0.9 \
 --tensor-parallel-size=$TP \
 --max-num-seqs=$CONC  \

--- a/benchmarks/70b_fp8_h100_slurm.sh
+++ b/benchmarks/70b_fp8_h100_slurm.sh
@@ -30,7 +30,7 @@ export TORCH_CUDA_ARCH_LIST="9.0"
 
 set -x
 PYTHONNOUSERSITE=1 vllm serve $MODEL --host=0.0.0.0 --port=$PORT \
---config=config.yaml \
+--config config.yaml \
 --gpu-memory-utilization=0.9 \
 --tensor-parallel-size=$TP \
 --max-num-seqs=$CONC  \

--- a/benchmarks/gptoss_fp4_h100_docker.sh
+++ b/benchmarks/gptoss_fp4_h100_docker.sh
@@ -9,9 +9,11 @@
 # CONC
 
 cat > config.yaml << EOF
+compilation-config: '{"cudagraph_mode":"PIECEWISE"}'
 async-scheduling: true
 no-enable-prefix-caching: true
 max-num-batched-tokens: 8192
+cuda-graph-sizes: 2048
 max-model-len: 10240
 EOF
 

--- a/benchmarks/gptoss_fp4_h100_docker.sh
+++ b/benchmarks/gptoss_fp4_h100_docker.sh
@@ -21,7 +21,7 @@ export PYTHONNOUSERSITE=1
 
 set -x
 vllm serve $MODEL --host=0.0.0.0 --port=$PORT \
---config=config.yaml \
+--config config.yaml \
 --gpu-memory-utilization=0.9 \
 --tensor-parallel-size=$TP \
 --max-num-seqs=$CONC  \

--- a/benchmarks/gptoss_fp4_h100_docker.sh
+++ b/benchmarks/gptoss_fp4_h100_docker.sh
@@ -12,8 +12,8 @@ cat > config.yaml << EOF
 compilation-config: '{"cudagraph_mode":"PIECEWISE"}'
 async-scheduling: true
 no-enable-prefix-caching: true
-max-num-batched-tokens: 8192
 cuda-graph-sizes: 2048
+max-num-batched-tokens: 8192
 max-model-len: 10240
 EOF
 

--- a/benchmarks/gptoss_fp4_h100_docker.sh
+++ b/benchmarks/gptoss_fp4_h100_docker.sh
@@ -11,7 +11,6 @@
 cat > config.yaml << EOF
 async-scheduling: true
 no-enable-prefix-caching: true
-cuda-graph-sizes: 2048
 max-num-batched-tokens: 8192
 max-model-len: 10240
 EOF

--- a/benchmarks/gptoss_fp4_h100_slurm.sh
+++ b/benchmarks/gptoss_fp4_h100_slurm.sh
@@ -20,8 +20,8 @@ cat > config.yaml << EOF
 compilation-config: '{"cudagraph_mode":"PIECEWISE"}'
 async-scheduling: true
 no-enable-prefix-caching: true
-max-num-batched-tokens: 8192
 cuda-graph-sizes: 2048
+max-num-batched-tokens: 8192
 max-model-len: 10240
 EOF
 

--- a/benchmarks/gptoss_fp4_h100_slurm.sh
+++ b/benchmarks/gptoss_fp4_h100_slurm.sh
@@ -17,9 +17,11 @@
 echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 
 cat > config.yaml << EOF
+compilation-config: '{"cudagraph_mode":"PIECEWISE"}'
 async-scheduling: true
 no-enable-prefix-caching: true
 max-num-batched-tokens: 8192
+cuda-graph-sizes: 2048
 max-model-len: 10240
 EOF
 

--- a/benchmarks/gptoss_fp4_h100_slurm.sh
+++ b/benchmarks/gptoss_fp4_h100_slurm.sh
@@ -30,7 +30,7 @@ export TORCH_CUDA_ARCH_LIST="9.0"
 
 set -x
 PYTHONNOUSERSITE=1 vllm serve $MODEL --host=0.0.0.0 --port=$PORT \
---config=config.yaml \
+--config config.yaml \
 --gpu-memory-utilization=0.9 \
 --tensor-parallel-size=$TP \
 --max-num-seqs=$CONC  \

--- a/benchmarks/gptoss_fp4_h100_slurm.sh
+++ b/benchmarks/gptoss_fp4_h100_slurm.sh
@@ -19,7 +19,6 @@ echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 cat > config.yaml << EOF
 async-scheduling: true
 no-enable-prefix-caching: true
-cuda-graph-sizes: 2048
 max-num-batched-tokens: 8192
 max-model-len: 10240
 EOF

--- a/benchmarks/gptoss_fp4_h200_slurm.sh
+++ b/benchmarks/gptoss_fp4_h200_slurm.sh
@@ -31,8 +31,10 @@ fi
 
 # Create config.yaml
 cat > config.yaml << EOF
+compilation-config: '{"cudagraph_mode":"PIECEWISE"}'
 async-scheduling: true
 no-enable-prefix-caching: true
+cuda-graph-sizes: 2048
 max-num-batched-tokens: 8192
 max-model-len: $CALCULATED_MAX_MODEL_LEN
 EOF

--- a/benchmarks/gptoss_fp4_h200_slurm.sh
+++ b/benchmarks/gptoss_fp4_h200_slurm.sh
@@ -33,7 +33,6 @@ fi
 cat > config.yaml << EOF
 async-scheduling: true
 no-enable-prefix-caching: true
-cuda-graph-sizes: 2048
 max-num-batched-tokens: 8192
 max-model-len: $CALCULATED_MAX_MODEL_LEN
 EOF


### PR DESCRIPTION
Update base vllm images from 10.2 to 11.0.
```
❯ git grep -nri 'vllm/vllm-openai:v0.10.2' | cat

```
Pending completion of: https://github.com/InferenceMAX/InferenceMAX/actions/runs/18477372794