### PR TITLE
[AMD] Adjust the threshold for when to have AITER MHA enabled

### DIFF
--- a/benchmarks/70b_fp4_mi355x_docker.sh
+++ b/benchmarks/70b_fp4_mi355x_docker.sh
@@ -26,7 +26,7 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
 		export VLLM_TRITON_FP4_GEMM_USE_ASM=1
 	fi
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-	if [[ "$CONC" -gt "16" ]]; then
+	if [[ "$CONC" -ge "16" ]]; then
 		export VLLM_ROCM_USE_AITER_MHA=1
 	else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp4_mi355x_slurm.sh
+++ b/benchmarks/70b_fp4_mi355x_slurm.sh
@@ -33,7 +33,7 @@ elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
                 export VLLM_TRITON_FP4_GEMM_USE_ASM=1
         fi
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-	if [[ "$CONC" -gt "16" ]]; then
+	if [[ "$CONC" -ge "16" ]]; then
 		export VLLM_ROCM_USE_AITER_MHA=1
 	else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi300x_docker.sh
+++ b/benchmarks/70b_fp8_mi300x_docker.sh
@@ -34,7 +34,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if [[ "$CONC" -gt "16" ]]; then
+    if [[ "$CONC" -ge "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi300x_slurm.sh
+++ b/benchmarks/70b_fp8_mi300x_slurm.sh
@@ -45,7 +45,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if [[ "$CONC" -gt "16" ]]; then
+    if [[ "$CONC" -ge "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi325x_docker.sh
+++ b/benchmarks/70b_fp8_mi325x_docker.sh
@@ -22,7 +22,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if [[ "$CONC" -gt "16" ]]; then
+    if [[ "$CONC" -ge "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi325x_slurm.sh
+++ b/benchmarks/70b_fp8_mi325x_slurm.sh
@@ -33,7 +33,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-	if [[ "$CONC" -gt "16" ]]; then
+	if [[ "$CONC" -ge "16" ]]; then
 		export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi355x_docker.sh
+++ b/benchmarks/70b_fp8_mi355x_docker.sh
@@ -26,7 +26,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if [[ "$CONC" -gt "16" ]]; then
+    if [[ "$CONC" -ge "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0

--- a/benchmarks/70b_fp8_mi355x_slurm.sh
+++ b/benchmarks/70b_fp8_mi355x_slurm.sh
@@ -29,7 +29,7 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
     export VLLM_ROCM_USE_AITER_MHA=0
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if [[ "$CONC" -gt "16" ]]; then
+    if [[ "$CONC" -ge "16" ]]; then
         export VLLM_ROCM_USE_AITER_MHA=1
     else
 		export VLLM_ROCM_USE_AITER_MHA=0


### PR DESCRIPTION
Internal tests have shown improved results with VLLM_ROCM_USE_AITER_MHA=1 for ISL=8k / OSL=1k / concurrency 16.