### PR TITLE
feat: output throughput per gpu 

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -137,12 +137,12 @@ jobs:
             exit 1
           fi
 
-      - name: Process result
-        run: |
-          python3 utils/process_result.py ${{ inputs.runner }} $TP $RESULT_FILENAME $FRAMEWORK $PRECISION
+      # - name: Process result
+      #   run: |
+      #     python3 utils/process_result.py ${{ inputs.runner }} $TP $RESULT_FILENAME $FRAMEWORK $PRECISION
 
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RESULT_FILENAME }}
-          path: agg_${{ env.RESULT_FILENAME }}.json
+          path: ${{ env.RESULT_FILENAME }}.json

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -137,12 +137,12 @@ jobs:
             exit 1
           fi
 
-      # - name: Process result
-      #   run: |
-      #     python3 utils/process_result.py ${{ inputs.runner }} $TP $RESULT_FILENAME $FRAMEWORK $PRECISION
+      - name: Process result
+        run: |
+          python3 utils/process_result.py ${{ inputs.runner }} $TP $RESULT_FILENAME $FRAMEWORK $PRECISION
 
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RESULT_FILENAME }}
-          path: ${{ env.RESULT_FILENAME }}.json
+          path: agg_${{ env.RESULT_FILENAME }}.json

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -19,7 +19,8 @@ data = {
     'model': bmk_result['model_id'],
     'framework': framework,
     'precision': precision,
-    'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size
+    'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size,
+    'output_tput_per_gpu': float(bmk_result['output_token_throughput']) / tp_size
 }
 
 if len(sys.argv) == 7:  # MTP

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -20,7 +20,7 @@ data = {
     'framework': framework,
     'precision': precision,
     'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size,
-    'output_tput_per_gpu': float(bmk_result['output_token_throughput']) / tp_size
+    'output_tput_per_gpu': float(bmk_result['output_throughput']) / tp_size
 }
 
 if len(sys.argv) == 7:  # MTP


### PR DESCRIPTION
vllm `benchmark_serving.py` already benchmarks and collects the output throughput per sec but the middleware helper script for transforming the data didn't piping it through yet. 

added quick patch to `utils/process_result.py`

confirmed that no changes to `utils/collect_results.py` where needed

here is the validation run: https://github.com/InferenceMAX/InferenceMAX/actions/runs/18542476169/job/52853541173

## per benchmark job artifact output
<img width="503" height="491" alt="image" src="https://github.com/user-attachments/assets/9e5e6219-4511-4879-b581-7a6d645a1418" />

## per workflow aggregration artifact
<img width="391" height="500" alt="image" src="https://github.com/user-attachments/assets/11c230b6-9109-4dfa-9409-6e0b055fb28d" />
