### PR TITLE
feat: input throughput per gpu

### DIFF
--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -12,6 +12,10 @@ precision = sys.argv[5]
 with open(f'{result_filename}.json') as f:
     bmk_result = json.load(f)
 
+tput_per_gpu = float(bmk_result['total_token_throughput']) / tp_size
+output_tput_per_gpu = float(bmk_result['output_throughput']) / tp_size
+input_tput_per_gpu = tput_per_gpu - output_tput_per_gpu
+
 data = {
     'hw': hw,
     'tp': tp_size,
@@ -19,8 +23,9 @@ data = {
     'model': bmk_result['model_id'],
     'framework': framework,
     'precision': precision,
-    'tput_per_gpu': float(bmk_result['total_token_throughput']) / tp_size,
-    'output_tput_per_gpu': float(bmk_result['output_throughput']) / tp_size
+    'tput_per_gpu': tput_per_gpu,
+    'output_tput_per_gpu': output_tput_per_gpu,
+    'input_tput_per_gpu': input_tput_per_gpu
 }
 
 if len(sys.argv) == 7:  # MTP


### PR DESCRIPTION
vllm `benchmark_serving.py` already benchmarks and collects the total & output throughput per sec but the middleware helper script for transforming the data didn't piping it through yet. (`input = total - output`)

added quick patch to `utils/process_result.py`

confirmed that no changes to `utils/collect_results.py` where needed

Validated changes here
https://github.com/InferenceMAX/InferenceMAX/actions/runs/18581713783

