### PR TITLE
[NVIDIA]  Update runner for GPTOSS to b200-trt & update docker flag

### DIFF
--- a/.github/workflows/gptoss-tmpl.yml
+++ b/.github/workflows/gptoss-tmpl.yml
@@ -100,7 +100,7 @@ jobs:
       osl: ${{ inputs.osl }}
       max-model-len: ${{ inputs.max-model-len }}
       random-range-ratio: ${{ inputs.random-range-ratio }}
-      runner: b200-nvs
+      runner: b200-trt
       image: 'nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc0.post1'
       model: 'openai/gpt-oss-120b'
       tp-list: '[1, 2, 4, 8]'

--- a/runners/launch_b200-nb.sh
+++ b/runners/launch_b200-nb.sh
@@ -9,7 +9,7 @@ srun --partition=$PARTITION --gres=gpu:$TP --exclusive \
 --container-image=$IMAGE \
 --container-name=$(echo "$IMAGE" | sed 's/[\/:@#]/_/g')-${USER: -1} \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
---container-mount-home \
+--no-container-mount-home --container-writable \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL,PORT_OFFSET=${USER: -1} \
 bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}_slurm.sh


### PR DESCRIPTION
Updating docker arg and changing runner back to b200-trt for GPTOSS. 
Test job: https://github.com/InferenceMAX/InferenceMAX/actions/runs/18859399299

@kedarpotdar-nv 