### PR TITLE
fix: temporary fix for tonights run

### DIFF
--- a/benchmarks/70b_fp4_b200_trt_slurm.sh
+++ b/benchmarks/70b_fp4_b200_trt_slurm.sh
@@ -56,12 +56,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --tp_size $T
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/70b_fp8_b200_trt_slurm.sh
+++ b/benchmarks/70b_fp8_b200_trt_slurm.sh
@@ -56,12 +56,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --tp_size $T
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/70b_fp8_h200_slurm.sh
+++ b/benchmarks/70b_fp8_h200_slurm.sh
@@ -50,13 +50,6 @@ PYTHONNOUSERSITE=1 vllm serve $MODEL --host 0.0.0.0 --port $PORT --config config
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    # Ignore intel_extension_for_pytorch import errors
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]] && [[ ! "$line" =~ "intel_extension_for_pytorch" ]]; then
-		sleep 5
-		tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/70b_fp8_h200_trt_slurm.sh
+++ b/benchmarks/70b_fp8_h200_trt_slurm.sh
@@ -51,12 +51,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --tp_size $T
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/70b_fp8_mi325x_slurm.sh
+++ b/benchmarks/70b_fp8_mi325x_slurm.sh
@@ -67,12 +67,6 @@ vllm serve $MODEL --port=$PORT \
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-		sleep 5
-		tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/dsr1_fp4_b200_trt_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_trt_slurm.sh
@@ -124,12 +124,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root \
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/dsr1_fp8_b200_trt_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_trt_slurm.sh
@@ -88,12 +88,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root \
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/dsr1_fp8_h200_slurm.sh
+++ b/benchmarks/dsr1_fp8_h200_slurm.sh
@@ -47,12 +47,6 @@ fi
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-		sleep 5
-		tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/dsr1_fp8_h200_trt_slurm.sh
+++ b/benchmarks/dsr1_fp8_h200_trt_slurm.sh
@@ -88,12 +88,6 @@ PYTHONNOUSERSITE=1 mpirun -n 1 --oversubscribe --allow-run-as-root \
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/dsr1_fp8_mi325x_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi325x_slurm.sh
@@ -26,12 +26,6 @@ python3 -m sglang.launch_server \
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 "$SERVER_LOG"
-        echo "JOB $SLURM_JOB_ID ran on $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"The server is fired up and ready to roll"* ]]; then
         break
     fi

--- a/benchmarks/gptoss_fp4_h200_slurm.sh
+++ b/benchmarks/gptoss_fp4_h200_slurm.sh
@@ -50,13 +50,6 @@ PYTHONNOUSERSITE=1 vllm serve $MODEL --host 0.0.0.0 --port $PORT --config config
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    # Ignore intel_extension_for_pytorch import errors
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]] && [[ ! "$line" =~ "intel_extension_for_pytorch" ]]; then
-		sleep 5
-		tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi

--- a/benchmarks/gptoss_fp4_h200_trt_slurm.sh
+++ b/benchmarks/gptoss_fp4_h200_trt_slurm.sh
@@ -50,12 +50,6 @@ mpirun -n 1 --oversubscribe --allow-run-as-root trtllm-serve $MODEL --max_batch_
 set +x
 while IFS= read -r line; do
     printf '%s\n' "$line"
-    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
-        sleep 5
-        tail -n100 $SERVER_LOG
-        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
-        exit 1
-    fi
     if [[ "$line" == *"Application startup complete"* ]]; then
         break
     fi


### PR DESCRIPTION
## Problem

The following logic is present in many of the benchmark scripts
```bash
set +x
while IFS= read -r line; do
    printf '%s\n' "$line"
    if [[ "$line" =~ [Ee][Rr][Rr][Oo][Rr] ]]; then
        sleep 5
        tail -n100 $SERVER_LOG
        echo "JOB $SLURM_JOB_ID ran on NODE $SLURMD_NODENAME"
        exit 1
    fi
    if [[ "$line" == *"Application startup complete"* ]]; then
        break
    fi
done < <(tail -F -n0 "$SERVER_LOG")
```
This is employed to wait for the server to run so that the client can begin sending requests. The problem arises when non-critical error messaged appear in the server logs, such as [this one ](https://github.com/InferenceMAX/InferenceMAX/actions/runs/18891674349/job/53920541131), which kills the entire process despite the fact the servers handle this 429 gracefully.

## Solution 

The temp fix for now is to just remove the error detection at the risk of a server waiting forever to start. A better solution is to just continuously poll the server til' some amount of time has passed, but I want to get this in before tonight's run and would want to test something like that.

More permanantly, @kimbochen has an even better solution that will be shipped within the next few weeks.
