### PR TITLE
Add trailing slash to matrix job names for UI clarity

### DIFF
--- a/.github/workflows/full-sweep-1k1k-scheduler.yml
+++ b/.github/workflows/full-sweep-1k1k-scheduler.yml
@@ -37,7 +37,7 @@ jobs:
     benchmark-dsr1:
         needs: get-dsr1-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: dsr1 1k1k
+        name: dsr1 1k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -61,7 +61,7 @@ jobs:
     benchmark-gptoss:
         needs: get-gptoss-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: gptoss 1k1k
+        name: gptoss 1k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -85,7 +85,7 @@ jobs:
     # This is a workaround until we can integrate GB200 into master configs.
     benchmark-gb200:
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: gb200 1k1k sweep
+        name: gb200 1k1k sweep /
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/full-sweep-1k8k-scheduler.yml
+++ b/.github/workflows/full-sweep-1k8k-scheduler.yml
@@ -37,7 +37,7 @@ jobs:
     benchmark-dsr1:
         needs: get-dsr1-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: dsr1 1k8k
+        name: dsr1 1k8k /
         strategy:
             fail-fast: false
             matrix:
@@ -61,7 +61,7 @@ jobs:
     benchmark-gptoss:
         needs: get-gptoss-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: gptoss 1k8k
+        name: gptoss 1k8k /
         strategy:
             fail-fast: false
             matrix:
@@ -85,7 +85,7 @@ jobs:
     # This is a workaround until we can integrate GB200 into master configs.
     benchmark-gb200:
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: gb200 1k8k sweep
+        name: gb200 1k8k sweep /
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/full-sweep-8k1k-scheduler.yml
+++ b/.github/workflows/full-sweep-8k1k-scheduler.yml
@@ -37,7 +37,7 @@ jobs:
     benchmark-dsr1:
         needs: get-dsr1-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: dsr1 8k1k
+        name: dsr1 8k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -61,7 +61,7 @@ jobs:
     benchmark-gptoss:
         needs: get-gptoss-configs
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: gptoss 8k1k
+        name: gptoss 8k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -85,7 +85,7 @@ jobs:
     # This is a workaround until we can integrate GB200 into master configs.
     benchmark-gb200:
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: gb200 8k1k sweep
+        name: gb200 8k1k sweep /
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/full-sweep-test.yml
+++ b/.github/workflows/full-sweep-test.yml
@@ -110,6 +110,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.dsr1-1k1k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: dsr1 1k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -143,6 +144,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.gptoss-1k1k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: gptoss 1k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -176,6 +178,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.dsr1-8k1k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: dsr1 8k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -209,6 +212,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.gptoss-8k1k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: gptoss 8k1k /
         strategy:
             fail-fast: false
             matrix:
@@ -242,6 +246,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.dsr1-1k8k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: dsr1 1k8k /
         strategy:
             fail-fast: false
             matrix:
@@ -369,6 +374,7 @@ jobs:
         needs: get-configs
         if: ${{ needs.get-configs.outputs.gptoss-1k8k != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
+        name: gptoss 1k8k /
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Appends a trailing slash `/` to the `name` field for various benchmark jobs. This is a cosmetic update and does not affect workflow logic or execution.