### PR TITLE
[NVIDIA] fix: after refactor gb200 1k8k still doesnt exist

### DIFF
--- a/.github/workflows/full-sweep-1k8k-scheduler.yml
+++ b/.github/workflows/full-sweep-1k8k-scheduler.yml
@@ -82,53 +82,8 @@ jobs:
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
 
-    # This is a workaround until we can integrate GB200 into master configs.
-    benchmark-gb200:
-        uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: gb200 1k8k sweep
-        strategy:
-            fail-fast: false
-            matrix:
-                config:
-                    - {
-                          "image": "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1-rc0.pre3",
-                          "model": "deepseek-r1-fp4",
-                          "model-prefix": "dsr1",
-                          "precision": "fp4",
-                          "framework": "dynamo-trtllm",
-                          "mtp": "off",
-                      }
-                    - {
-                          "image": "nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.5.1-rc0.pre3",
-                          "model": "deepseek-r1-fp4",
-                          "model-prefix": "dsr1",
-                          "precision": "fp4",
-                          "framework": "dynamo-trtllm",
-                          "mtp": "on",
-                      }
-                    - {
-                          "image": "nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.5.1-rc0.pre1",
-                          "model": "deepseek-ai/DeepSeek-R1-0528",
-                          "model-prefix": "dsr1",
-                          "precision": "fp8",
-                          "framework": "dynamo-sglang",
-                          "mtp": "off",
-                      }
-        secrets: inherit
-        with:
-            runner: gb200
-            image: ${{ matrix.config.image }}
-            model: ${{ matrix.config.model }}
-            framework: ${{ matrix.config.framework }}
-            precision: ${{ matrix.config.precision }}
-            exp-name: ${{ matrix.config.model-prefix }}_1k8k
-            isl: 1024
-            osl: 8192
-            max-model-len: 9216
-            mtp-mode: ${{ matrix.config.mtp }}
-
     collect-dsr1-results:
-        needs: [benchmark-dsr1, benchmark-gb200]
+        needs: benchmark-dsr1
         if: ${{ always() }}
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit


### PR DESCRIPTION
after refactor gb200 1k8k was add back even tho it wasnt submitted yet, created https://github.com/InferenceMAX/InferenceMAX/issues/158 to track adding it. 