### PR TITLE
[AMD] chore: add temp mi355x runners and disable mi355x nodes 0-3 temporarily

### DIFF
--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -39,9 +39,12 @@ mi325x:
 - 'mi325x-tw_2'
 - 'mi325x-tw_3'
 mi355x:
-- 'mi355x-amd_0'
-- 'mi355x-amd_1'
-- 'mi355x-amd_2'
-- 'mi355x-amd_3'
+# 0-3 undergoing maintenance, 4-5 are temporary nodes
+# - 'mi355x-amd_0'
+# - 'mi355x-amd_1'
+# - 'mi355x-amd_2'
+# - 'mi355x-amd_3'
+- 'mi355x-amd_4'
+- 'mi355x-amd_5'
 gb200:
 - gb200-nv_0


### PR DESCRIPTION
@japarada @ChrisMasonAMD @araslanix 

Nodes `mi355x-amd_{0,1,2,3}` are being validated. Two new MI355X nodes have been supplied for the time being.

- Setup `mi355x-amd_4` as `GPU3DBD`
- Setup `mi355x-amd_5` as `GPU3D32`
- Disable `mi355x-amd_{0,1,2,3}`

Run the following for verification that runs all configs on both new nodes: https://github.com/InferenceMAX/InferenceMAX/actions/runs/19213616451