### PR TITLE
chore: update dependabot to use grouping for actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
Instead of opening a PR for each individual instance of a change, just combine all actions updates into one PR.