### PR TITLE
[AMD] bug fix: add back correct launch script for new mi325x slurm cluster

### DIFF
--- a/runners/launch_mi325x-amd.sh
+++ b/runners/launch_mi325x-amd.sh
@@ -1,56 +1,24 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
-sudo sh -c 'echo 0 > /proc/sys/kernel/numa_balancing'
+export HF_HUB_CACHE_MOUNT="/nfsdata/sa/hf_hub_cache-${USER: -1}/"
+export PORT_OFFSET=${USER: -1}
 
-HF_HUB_CACHE_MOUNT="/home/kimbosemianalysis/hf_hub_cache/"
-PORT=8888
-
-network_name="bmk-net"
-server_name="bmk-server"
-client_name="bmk-client"
-
-docker network create $network_name
+PARTITION="compute"
+SQUASH_FILE="/nfsdata/sa/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 
 set -x
-docker run --rm -d --ipc=host --shm-size=16g --network=$network_name --name=$server_name \
---privileged --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
---cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
--v $HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
--v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
--e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
--e ISL -e OSL \
---entrypoint=/bin/bash \
-$IMAGE \
-benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi325x_docker.sh"
+salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell
+JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
-set +x
-while IFS= read -r line; do
-    printf '%s\n' "$line"
-    if [[ "$line" =~ Application\ startup\ complete ]]; then
-        break
-    fi
-done < <(docker logs -f --tail=0 $server_name 2>&1)
+srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+srun --jobid=$JOB_ID \
+--container-image=$SQUASH_FILE \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+--container-mount-home \
+--container-writable \
+--container-remap-root \
+--container-workdir=/workspace/ \
+--no-container-entrypoint --export=ALL \
+bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_mi325x_slurm.sh
 
-git clone https://github.com/kimbochen/bench_serving.git
-
-set -x
-docker run --rm --network=$network_name --name=$client_name \
--v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
--e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
---entrypoint=python3 \
-$IMAGE \
-bench_serving/benchmark_serving.py \
---model=$MODEL --backend=vllm --base-url=http://$server_name:$PORT \
---dataset-name=random \
---random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
---num-prompts=$(( $CONC * 10 )) \
---max-concurrency=$CONC \
---request-rate=inf --ignore-eos \
---save-result --percentile-metrics="ttft,tpot,itl,e2el" \
---result-dir=/workspace/ --result-filename=$RESULT_FILENAME.json
-
-while [ -n "$(docker ps -aq)" ]; do
-    docker stop $server_name
-    docker network rm $network_name
-    sleep 5
-done
+scancel $JOB_ID


### PR DESCRIPTION
PR #224 adde new Mi325X SLURM cluster runners, but somewhere in rebasing the branch before merge, the actual new logic to launch SLURM jobs in `runners/launch_mi325x-amd.sh` was deleted and the Docker logic still made it into the merge. Oops.