### PR TITLE
chore: use pull_request_target instead of pull_request as trigger

### DIFF
--- a/.github/workflows/label-validation.yml
+++ b/.github/workflows/label-validation.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - id: get-jobs
         shell: python


### PR DESCRIPTION
This will allow the validation workflow to be run from forked PRs.