### PR TITLE
[AMD] Use upstream SGLang images on mi300, mi325 and mi355 for dsr1fp8

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -22,7 +22,7 @@ dsr1-fp4-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi300x-sglang:
-  image: rocm/7.0:rocm7.0_ubuntu_22.04_sgl-dev-v0.5.2-rocm7.0-mi30x-20250915
+  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x
@@ -44,7 +44,7 @@ dsr1-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi325x-sglang:
-  image: rocm/7.0:rocm7.0_ubuntu_22.04_sgl-dev-v0.5.2-rocm7.0-mi30x-20250915
+  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi325x
@@ -66,7 +66,7 @@ dsr1-fp8-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi355x-sglang:
-  image: rocm/7.0:rocm7.0_ubuntu_22.04_sgl-dev-v0.5.2-rocm7.0-mi35x-20250915
+  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi35x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x

--- a/benchmarks/dsr1_fp8_mi355x_docker.sh
+++ b/benchmarks/dsr1_fp8_mi355x_docker.sh
@@ -17,7 +17,6 @@ export SGLANG_USE_AITER=1
 export RCCL_MSCCL_ENABLE=0
 export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
-
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 
 python3 -m sglang.launch_server \

--- a/benchmarks/dsr1_fp8_mi355x_docker.sh
+++ b/benchmarks/dsr1_fp8_mi355x_docker.sh
@@ -14,10 +14,14 @@
 # https://rocm.docs.amd.com/en/docs-7.0-docker/benchmark-docker/inference-sglang-deepseek-r1-fp8.html
 
 export SGLANG_USE_AITER=1
+export RCCL_MSCCL_ENABLE=0
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 
 python3 -m sglang.launch_server \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -27,6 +31,7 @@ python3 -m sglang.launch_server \
     --mem-fraction-static 0.8 --disable-radix-cache \
     --num-continuous-decode-steps 4 \
     --max-prefill-tokens 196608 \
+    --enable-torch-compile \
     --cuda-graph-max-bs 128 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/dsr1_fp8_mi355x_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_slurm.sh
@@ -12,11 +12,14 @@
 
 export HF_MODULES_CACHE="/tmp/hf_modules_cache/"
 export SGLANG_USE_AITER=1
+export RCCL_MSCCL_ENABLE=0
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 
 set -x
 python3 -m sglang.launch_server \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -27,7 +30,8 @@ python3 -m sglang.launch_server \
     --disable-radix-cache \
     --num-continuous-decode-steps 4 \
     --max-prefill-tokens 196608 \
-    --cuda-graph-max-bs 128 > $SERVER_LOG 2>&1 &
+    --cuda-graph-max-bs 128 \
+    --enable-torch-compile > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 


### PR DESCRIPTION
1. Use upstream SGLang image "lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x" for MI300X
2. Use upstream SGLang Image "lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x" for MI325X
3. Use upstream SGLang Image "lmsysorg/sglang:v0.5.5.post3-rocm700-mi35x" for MI355X
4. MI355X launch scripts updated,

This PR addresses:
https://github.com/InferenceMAX/InferenceMAX/issues/292
https://github.com/InferenceMAX/InferenceMAX/issues/291
and
https://github.com/InferenceMAX/InferenceMAX/pull/295