### PR TITLE
[NVIDIA] fix: H100+H200 CoreWeave fix

### DIFF
--- a/runners/launch_h100-cw.sh
+++ b/runners/launch_h100-cw.sh
@@ -7,17 +7,17 @@ SQUASH_FILE="/mnt/vast/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
-SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
+SAGEMAKER_SHM_PATH=$(mktemp -d /dev/shm/shm-XXXXXX)
 
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$SHM_PATH:/dev/shm/sagemaker_sessions \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$SAGEMAKER_SHM_PATH:/dev/shm/sagemaker_sessions \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL,PORT=8888 \
 bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_h100_slurm.sh
 
-rmdir $SHM_PATH
+rmdir $SAGEMAKER_SHM_PATH
 scancel $JOB_ID

--- a/runners/launch_h100-cw.sh
+++ b/runners/launch_h100-cw.sh
@@ -7,14 +7,17 @@ SQUASH_FILE="/mnt/vast/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
+SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
+
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$SHM_PATH:/dev/shm/sagemaker_sessions \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL,PORT=8888 \
 bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_h100_slurm.sh
 
+rmdir $SHM_PATH
 scancel $JOB_ID

--- a/runners/launch_h100-cw.sh
+++ b/runners/launch_h100-cw.sh
@@ -7,7 +7,7 @@ SQUASH_FILE="/mnt/vast/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
-SAGEMAKER_SHM_PATH=$(mktemp -d /dev/shm/shm-XXXXXX)
+SAGEMAKER_SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
 
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -9,6 +9,8 @@ FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PARTITION="h200"
 SQUASH_FILE="/mnt/vast/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 
+SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
+
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
@@ -25,10 +27,11 @@ fi
 # This seems to have been introduced in vLLM 0.11.2, but the issue is specific to CoreWeave runners.
 srun --jobid=$JOB_ID \
 --container-image=$CONTAINER_IMAGE \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$SHM_PATH:/dev/shm/sagemaker_sessions \
 --container-mount-home \
 --container-workdir=/workspace/ \
 --no-container-entrypoint --export=ALL \
-bash -c "bash benchmarks/${MODEL_CODE}_${PRECISION}_h200${FRAMEWORK_SUFFIX}_slurm.sh; rm -rf /dev/shm/sagemaker_sessions"
+bash benchmarks/${MODEL_CODE}_${PRECISION}_h200${FRAMEWORK_SUFFIX}_slurm.sh
 
+rmdir $SHM_PATH
 scancel $JOB_ID

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -9,7 +9,7 @@ FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
 PARTITION="h200"
 SQUASH_FILE="/mnt/vast/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 
-SAGEMAKER_SHM_PATH=$(mktemp -d /dev/shm/shm-XXXXXX)
+SAGEMAKER_SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
 
 salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)


### PR DESCRIPTION
After upgrade to vLLM 0.11.2, it appears the container tries to access `/dev/shm/sagemaker_sessions` (inside the container). For some reason, on CoreWeave cluster (H100 + H200), the same fs is being mounted each time, so between subsequent runs there are permission errors. Therefore, the workaround/solution is to just mount `dev/shm/sagemaker_sessions` to a temp directory on `/mnt/vast`. 