### PR TITLE
[NVIDIA] fix: gptoss h100 docker bug

### DIFF
--- a/benchmarks/gptoss_fp4_h100_docker.sh
+++ b/benchmarks/gptoss_fp4_h100_docker.sh
@@ -48,6 +48,6 @@ run_benchmark_serving \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
     --num-prompts $(( $CONC * 10 )) \
-    --max-concurrency 512 \
+    --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/


### PR DESCRIPTION
A bug was introduced in #227 where `benchmarks/gptoss_fp4_h100_docker.sh` has `--max-concurrency` hard-coded to 512 instead of `$CONC`. This fixes that regression.

Smoke test: https://github.com/InferenceMAX/InferenceMAX/actions/runs/20041264142