### PR TITLE
[AMD] Update MI355x Deepseek-R1 FP4 SGLang Image to v0.5.6.post2

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.6.post1-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.6.post2-rocm700-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -111,8 +111,8 @@
     - "fix: Pruning unnecessary concurrencies "
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/358
 
-  - config-keys:
+- config-keys:
     - dsr1-fp4-mi355x-sglang
-  description: 
-    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2"
-    pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369
+  description:
+    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2 "
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -114,5 +114,5 @@
 - config-keys:
     - dsr1-fp4-mi355x-sglang
   description:
-    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2 "
+    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -114,5 +114,5 @@
   - config-keys:
     - dsr1-fp4-mi355x-sglang
   description: 
-    - Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2 
-    PR: https://github.com/InferenceMAX/InferenceMAX/pull/369
+    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2"
+    pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -110,3 +110,9 @@
   description:
     - "fix: Pruning unnecessary concurrencies "
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/358
+
+  - config-keys:
+    - dsr1-fp4-mi355x-sglang
+  description: 
+    - Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2 
+    PR: https://github.com/InferenceMAX/InferenceMAX/pull/369


### PR DESCRIPTION
Updating the SGLang docker image to the SGLang community docker image
Image=`lmsysorg/sglang:v0.5.6.post2-rocm700-mi35x`

Impacted configurations: MI355x Deepseek-R1 FP4

Link to the runs: `https://github.com/InferenceMAX/InferenceMAX/actions/runs/20436306629/`