### PR TITLE
[AMD] Add Atom inference support for MI355X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -176,3 +176,73 @@ gptoss-fp4-mi355x-vllm:
     - { tp: 1, conc-start: 4, conc-end: 128 }
     - { tp: 4, conc-start: 4, conc-end: 4 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
+
+dsr1-fp4-mi355x-atom:
+  image: rocm/atom:nightly_gfx950_202512241633
+  model: amd/DeepSeek-R1-0528-MXFP4-Preview
+  model-prefix: dsr1
+  runner: mi355x-m15-17
+  precision: fp4
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+
+dsr1-fp8-mi355x-atom:
+  image: rocm/atom:nightly_gfx950_202512241633
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: mi355x-m15-17
+  precision: fp8
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+
+gptoss-fp4-mi355x-atom:
+  image: rocm/atom:nightly_gfx950_202512241633
+  model: openai/gpt-oss-120b
+  model-prefix: gptoss
+  runner: mi355x-m15-17
+  precision: fp4
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }

--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -51,5 +51,8 @@ mi355x:
 - 'mi355x-amd_1'
 - 'mi355x-amd_2'
 - 'mi355x-amd_3'
+mi355x-m15-17:
+- 'mi355x-amdatom'
+- 'mi355x-amdatomtw'
 gb200:
 - gb200-nv_0

--- a/.github/workflows/full-sweep-1k1k-scheduler.yml
+++ b/.github/workflows/full-sweep-1k1k-scheduler.yml
@@ -179,7 +179,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "dsr1_1k1k"
+            result-prefix: "bmk_dsr1_1k1k"
 
     collect-gptoss-results:
         needs:
@@ -192,7 +192,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "gptoss_1k1k"
+            result-prefix: "bmk_gptoss_1k1k"
 
     calc-success-rate:
         needs: [collect-dsr1-results, collect-gptoss-results]

--- a/.github/workflows/full-sweep-1k8k-scheduler.yml
+++ b/.github/workflows/full-sweep-1k8k-scheduler.yml
@@ -179,7 +179,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "dsr1_1k8k"
+            result-prefix: "bmk_dsr1_1k8k"
 
     collect-gptoss-results:
         needs:
@@ -192,7 +192,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "gptoss_1k8k"
+            result-prefix: "bmk_gptoss_1k8k"
 
     calc-success-rate:
         needs: [collect-dsr1-results, collect-gptoss-results]

--- a/.github/workflows/full-sweep-8k1k-scheduler.yml
+++ b/.github/workflows/full-sweep-8k1k-scheduler.yml
@@ -179,7 +179,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "dsr1_8k1k"
+            result-prefix: "bmk_dsr1_8k1k"
 
     collect-gptoss-results:
         needs:
@@ -192,7 +192,7 @@ jobs:
         uses: ./.github/workflows/collect-results.yml
         secrets: inherit
         with:
-            exp-name: "gptoss_8k1k"
+            result-prefix: "bmk_gptoss_8k1k"
 
     calc-success-rate:
         needs: [collect-dsr1-results, collect-gptoss-results]

--- a/benchmarks/dsr1_fp4_mi355x_atom_docker.sh
+++ b/benchmarks/dsr1_fp4_mi355x_atom_docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# ========= Required Env Vars =========
+# HF_TOKEN
+# HF_HUB_CACHE
+# MODEL
+# PORT
+# TP
+# CONC
+# MAX_MODEL_LEN
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+set -x
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN

--- a/benchmarks/dsr1_fp8_mi355x_atom_docker.sh
+++ b/benchmarks/dsr1_fp8_mi355x_atom_docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# ========= Required Env Vars =========
+# HF_TOKEN
+# HF_HUB_CACHE
+# MODEL
+# PORT
+# TP
+# CONC
+# MAX_MODEL_LEN
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+set -x
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN \
+    --block-size 16

--- a/benchmarks/gptoss_fp4_mi355x_atom_docker.sh
+++ b/benchmarks/gptoss_fp4_mi355x_atom_docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# ========= Required Env Vars =========
+# HF_TOKEN
+# HF_HUB_CACHE
+# MODEL
+# PORT
+# TP
+# CONC
+# MAX_MODEL_LEN
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+set -x
+export HSA_NO_SCRATCH_RECLAIM=1
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN

--- a/runners/launch_mi355x-amdatom.sh
+++ b/runners/launch_mi355x-amdatom.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# === Workflow-defined Env Vars ===
+# IMAGE
+# MODEL
+# TP
+# HF_HUB_CACHE
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# CONC
+# GITHUB_WORKSPACE
+# RESULT_FILENAME
+# HF_TOKEN
+# FRAMEWORK
+
+HF_HUB_CACHE_MOUNT="/mnt/hf_hub_cache/"  # Temp solution
+PORT=8888
+
+# Determine framework suffix for benchmark script
+FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "atom" ]] && printf '_atom' || printf '')
+
+network_name="bmk-net"
+server_name="bmk-server"
+client_name="bmk-client"
+
+# Cleanup: stop server container and remove network
+docker stop $server_name 2>/dev/null || true
+docker rm $server_name 2>/dev/null || true
+docker network rm $network_name 2>/dev/null || true
+
+docker network create $network_name
+
+set -x
+docker pull $IMAGE
+DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+echo "The image digest is: $DIGEST"
+
+set -x
+docker run --rm -d --ipc=host --shm-size=16g --network=$network_name --name=$server_name \
+--privileged --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
+--cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+-v $HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+-v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
+-e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
+-e ISL -e OSL \
+--entrypoint=/bin/bash \
+$IMAGE \
+benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi355x${FRAMEWORK_SUFFIX}_docker.sh"
+
+set +x
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [[ "$line" =~ Application\ startup\ complete ]]; then
+        break
+    fi
+done < <(docker logs -f --tail=0 $server_name 2>&1)
+
+if [[ "$MODEL" == "amd/DeepSeek-R1-0528-MXFP4-Preview" || "$MODEL" == "deepseek-ai/DeepSeek-R1-0528" ]]; then
+  if [[ "$OSL" == "8192" ]]; then
+    #NUM_PROMPTS=$(( CONC * 20 ))
+    NUM_PROMPTS=$(( CONC * 2 )) # atom has no much compilation overhead for dsr1
+  else
+    #NUM_PROMPTS=$(( CONC * 50 ))
+    NUM_PROMPTS=$(( CONC * 10 )) # atom has no much compilation overhead for dsr1
+  fi
+else
+  if [[ "$OSL" == "8192" ]]; then
+    NUM_PROMPTS=$(( CONC * 2 ))
+  else
+    NUM_PROMPTS=$(( CONC * 10 ))
+  fi
+fi
+
+set -x
+echo $GITHUB_WORKSPACE
+git clone https://github.com/kimbochen/bench_serving.git
+git clone https://github.com/kimbochen/bench_serving.git $GITHUB_WORKSPACE/bench_serving
+
+sleep 5
+
+set -x
+docker run --rm --network=$network_name --name=$client_name \
+-v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
+-e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
+--entrypoint=/bin/bash \
+$(echo "$IMAGE" | sed 's/#/\//') \
+-lc "pip install -q datasets pandas && \
+python3 bench_serving/benchmark_serving.py \
+--model=$MODEL --backend=vllm --base-url="http://$server_name:$PORT" \
+--dataset-name=random \
+--random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
+--num-prompts=$NUM_PROMPTS \
+--max-concurrency=$CONC \
+--trust-remote-code \
+--request-rate=inf --ignore-eos \
+--save-result --percentile-metrics="ttft,tpot,itl,e2el" \
+--result-dir=/workspace/ --result-filename=$RESULT_FILENAME.json"
+
+if ls gpucore.* 1> /dev/null 2>&1; then
+  echo "gpucore files exist. not good"
+  rm -f gpucore.*
+fi
+
+
+# Cleanup: stop server container and remove network
+docker stop $server_name 2>/dev/null || true
+docker rm $server_name 2>/dev/null || true
+docker network rm $network_name 2>/dev/null || true

--- a/runners/launch_mi355x-amdatomtw.sh
+++ b/runners/launch_mi355x-amdatomtw.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# === Workflow-defined Env Vars ===
+# IMAGE
+# MODEL
+# TP
+# HF_HUB_CACHE
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# CONC
+# GITHUB_WORKSPACE
+# RESULT_FILENAME
+# HF_TOKEN
+# FRAMEWORK
+
+HF_HUB_CACHE_MOUNT="/mnt/hf_hub_cache/"  # Temp solution
+PORT=8888
+
+# Determine framework suffix for benchmark script
+FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "atom" ]] && printf '_atom' || printf '')
+
+network_name="bmk-net"
+server_name="bmk-server"
+client_name="bmk-client"
+
+# Cleanup: stop server container and remove network
+docker stop $server_name 2>/dev/null || true
+docker rm $server_name 2>/dev/null || true
+docker network rm $network_name 2>/dev/null || true
+
+docker network create $network_name
+
+set -x
+docker pull $IMAGE
+DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+echo "The image digest is: $DIGEST"
+
+set -x
+docker run --rm -d --ipc=host --shm-size=16g --network=$network_name --name=$server_name \
+--privileged --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
+--cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+-v $HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+-v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
+-e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
+-e ISL -e OSL \
+--entrypoint=/bin/bash \
+$IMAGE \
+benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi355x${FRAMEWORK_SUFFIX}_docker.sh"
+
+set +x
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [[ "$line" =~ Application\ startup\ complete ]]; then
+        break
+    fi
+done < <(docker logs -f --tail=0 $server_name 2>&1)
+
+if [[ "$MODEL" == "amd/DeepSeek-R1-0528-MXFP4-Preview" || "$MODEL" == "deepseek-ai/DeepSeek-R1-0528" ]]; then
+  if [[ "$OSL" == "8192" ]]; then
+    #NUM_PROMPTS=$(( CONC * 20 ))
+    NUM_PROMPTS=$(( CONC * 2 )) # atom has no much compilation overhead for dsr1
+  else
+    #NUM_PROMPTS=$(( CONC * 50 ))
+    NUM_PROMPTS=$(( CONC * 10 )) # atom has no much compilation overhead for dsr1
+  fi
+else
+  if [[ "$OSL" == "8192" ]]; then
+    NUM_PROMPTS=$(( CONC * 2 ))
+  else
+    NUM_PROMPTS=$(( CONC * 10 ))
+  fi
+fi
+
+set -x
+echo $GITHUB_WORKSPACE
+git clone https://github.com/kimbochen/bench_serving.git
+git clone https://github.com/kimbochen/bench_serving.git $GITHUB_WORKSPACE/bench_serving
+
+sleep 5
+
+set -x
+docker run --rm --network=$network_name --name=$client_name \
+-v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
+-e HF_TOKEN -e PYTHONPYCACHEPREFIX=/tmp/pycache/ \
+--entrypoint=/bin/bash \
+$(echo "$IMAGE" | sed 's/#/\//') \
+-lc "pip install -q datasets pandas && \
+python3 bench_serving/benchmark_serving.py \
+--model=$MODEL --backend=vllm --base-url="http://$server_name:$PORT" \
+--dataset-name=random \
+--random-input-len=$ISL --random-output-len=$OSL --random-range-ratio=$RANDOM_RANGE_RATIO \
+--num-prompts=$NUM_PROMPTS \
+--max-concurrency=$CONC \
+--trust-remote-code \
+--request-rate=inf --ignore-eos \
+--save-result --percentile-metrics="ttft,tpot,itl,e2el" \
+--result-dir=/workspace/ --result-filename=$RESULT_FILENAME.json"
+
+if ls gpucore.* 1> /dev/null 2>&1; then
+  echo "gpucore files exist. not good"
+  rm -f gpucore.*
+fi
+
+
+# Cleanup: stop server container and remove network
+docker stop $server_name 2>/dev/null || true
+docker rm $server_name 2>/dev/null || true
+docker network rm $network_name 2>/dev/null || true


### PR DESCRIPTION
  Description:
  ## Summary
  - Add Atom framework configs for MI355X (dsr1-fp4, dsr1-fp8, gptoss-fp4)
  - Add benchmark scripts and runner launch scripts for Atom
  - Add mi355x-m15-17 runner group with atom runners
  - Fix workflow startup failure by correcting `exp-name` to `result-prefix` parameter in collect-results calls

  ## Changes
  - `.github/configs/amd-master.yaml` - Added atom configs
  - `.github/configs/runners.yaml` - Added atom runner group
  - `.github/workflows/full-sweep-*-scheduler.yml` - Fixed parameter name for collect-results workflow
  - New benchmark scripts in `benchmarks/`
  - New runner launch scripts in `runners/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Atom-based MI355X benchmarking and fixes result collection wiring.
> 
> - **Configs:** Introduces Atom presets in `amd-master.yaml` for `dsr1` (FP4/FP8) and `gptoss` (FP4) on MI355X with expanded concurrency/Tensor Parallel search spaces; uses `rocm/atom:nightly_gfx950_*` images and new `runner` group `mi355x-m15-17`.
> - **Runners:** Adds `mi355x-m15-17` group in `runners.yaml` with `mi355x-amdatom` and `mi355x-amdatomtw`.
> - **Bench scripts:** New `benchmarks/*_mi355x_atom_docker.sh` start `atom.entrypoints.openai_server`, auto-set `--max-model-len` by ISL/OSL, and include minor flags (e.g., `--block-size 16`, `HSA_NO_SCRATCH_RECLAIM=1`).
> - **Launcher scripts:** New `runners/launch_mi355x-amdatom*.sh` orchestrate server/client Docker, compute `NUM_PROMPTS`, run `bench_serving.py`, and clean up.
> - **Workflows:** In `full-sweep-*-scheduler.yml`, switch collect-results input from `exp-name` to `result-prefix` for `dsr1` and `gptoss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f3f06007ca1f7cc71fac086ddf27a14298c7f0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->