### PR TITLE
fix: get rid of sudo rm rf in cleanup jobs

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -130,8 +130,6 @@ jobs:
             sleep 5
           done
 
-          sudo find . -not -user $USER -exec rm -rf {} +
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           token: ${{ secrets.REPO_PAT }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -138,8 +138,6 @@ jobs:
             done
           fi
 
-          sudo find . -not -user $USER -exec rm -rf {} +
-
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           token: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
Having `sudo` in the top level workflow jobs assumes gharunners have `sudo` on all the nodes, which is not true per se.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the privileged filesystem cleanup from benchmark workflows to avoid sudo assumptions and risky recursive deletes.
> 
> - Delete `sudo find . -not -user $USER -exec rm -rf {} +` from `benchmark-tmpl.yml` and `benchmark-multinode-tmpl.yml`
> - Retain existing Slurm/Docker cleanup, checkout, and job launch logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0af63bcbd048fd464851d125156454022c96f291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->