### PR TITLE
chore: allow dsr1 sglang to run on slurm nodes

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2,7 +2,7 @@ dsr1-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.5-cu129-amd64
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
-  runner: b200
+  runner: b200-nb
   precision: fp4
   framework: sglang
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2,7 +2,7 @@ dsr1-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.5-cu129-amd64
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
-  runner: b200-nb
+  runner: b200
   precision: fp4
   framework: sglang
   multinode: false

--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -20,12 +20,18 @@ b200-trt:
 - 'b200-nb_0'
 - 'b200-nb_1'
 b200:
+# Docker-only nodes
 - 'b200-nvd_0'
 - 'b200-nvd_1'
 - 'b200-nvd_2'
 - 'b200-nvd_3'
 - 'b200-dgxc_1'
 - 'b200-dgxc_2'
+# Slurm nodes (also have b200 label, can run docker workloads)
+- 'b200-nv_0'
+- 'b200-nv_1'
+- 'b200-nb_0'
+- 'b200-nb_1'
 mi300x:
 - 'mi300x-amd_0'
 - 'mi300x-amd_1'

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -28,8 +28,6 @@ else
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 \

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars ===
+# MODEL
+# PORT
+# TP
+# CONC
+# ISL
+# OSL
+# RANDOM_RANGE_RATIO
+# RESULT_FILENAME
+# EP_SIZE
+# NUM_PROMPTS
+
+echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+
+nvidia-smi
+
+
+# To improve CI stability, we patch this helper function to prevent a race condition that
+# happens 1% of the time. ref: https://github.com/flashinfer-ai/flashinfer/pull/1779
+sed -i '102,108d' /usr/local/lib/python3.12/dist-packages/flashinfer/jit/cubin_loader.py
+
+SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+
+# Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+ps aux
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--cuda-graph-max-bs 256 --max-running-requests 256 --mem-fraction-static 0.85 --kv-cache-dtype fp8_e4m3 \
+--chunked-prefill-size 16384 \
+--ep-size $EP_SIZE --quantization modelopt_fp4 --enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--enable-symm-mem --disable-radix-cache --attention-backend trtllm_mla --moe-runner-backend flashinfer_trtllm --stream-interval 10 > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Source benchmark utilities
+source "$(dirname "$0")/benchmark_lib.sh"
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$NUM_PROMPTS" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -2,7 +2,7 @@
 
 # === Required Env Vars ===
 # MODEL
-# PORT
+# PORT_OFFSET
 # TP
 # CONC
 # ISL
@@ -22,6 +22,7 @@ nvidia-smi
 sed -i '102,108d' /usr/local/lib/python3.12/dist-packages/flashinfer/jit/cubin_loader.py
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+PORT=$(( 8888 + $PORT_OFFSET ))
 
 # Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
 if [[ $CONC -ge 16 ]]; then

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -16,7 +16,6 @@ echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 
 nvidia-smi
 
-
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=$(( 8888 + $PORT_OFFSET ))
 

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -17,10 +17,6 @@ echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 nvidia-smi
 
 
-# To improve CI stability, we patch this helper function to prevent a race condition that
-# happens 1% of the time. ref: https://github.com/flashinfer-ai/flashinfer/pull/1779
-sed -i '102,108d' /usr/local/lib/python3.12/dist-packages/flashinfer/jit/cubin_loader.py
-
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=$(( 8888 + $PORT_OFFSET ))
 

--- a/benchmarks/dsr1_fp4_b200_slurm.sh
+++ b/benchmarks/dsr1_fp4_b200_slurm.sh
@@ -55,7 +55,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts "$NUM_PROMPTS" \
+    --num-prompts $(( $CONC * 10 )) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/

--- a/benchmarks/dsr1_fp8_b200_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_slurm.sh
@@ -33,8 +33,6 @@ else
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --tensor-parallel-size=$TP --data-parallel-size=1 \

--- a/benchmarks/dsr1_fp8_b200_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_slurm.sh
@@ -60,7 +60,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts "$NUM_PROMPTS" \
+    --num-prompts $(( $CONC * 10 )) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/

--- a/benchmarks/dsr1_fp8_b200_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_slurm.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars ===
+# MODEL
+# PORT_OFFSET
+# TP
+# CONC
+# ISL
+# OSL
+# RANDOM_RANGE_RATIO
+# RESULT_FILENAME
+# EP_SIZE
+# NUM_PROMPTS
+
+echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+
+nvidia-smi
+
+# To improve CI stability, we patch this helper function to prevent a race condition that
+# happens 1% of the time. ref: https://github.com/flashinfer-ai/flashinfer/pull/1779
+sed -i '102,108d' /usr/local/lib/python3.12/dist-packages/flashinfer/jit/cubin_loader.py
+
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+PORT=$(( 8888 + $PORT_OFFSET ))
+
+# Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+ps aux
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--cuda-graph-max-bs 128 --max-running-requests 128 \
+--mem-fraction-static 0.82 --kv-cache-dtype fp8_e4m3 --chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL --disable-radix-cache \
+--attention-backend trtllm_mla --stream-interval 30 --ep-size $EP_SIZE --moe-runner-backend flashinfer_trtllm --quantization fp8 > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Source benchmark utilities
+source "$(dirname "$0")/benchmark_lib.sh"
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$NUM_PROMPTS" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/

--- a/benchmarks/dsr1_fp8_b200_slurm.sh
+++ b/benchmarks/dsr1_fp8_b200_slurm.sh
@@ -16,10 +16,6 @@ echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 
 nvidia-smi
 
-# To improve CI stability, we patch this helper function to prevent a race condition that
-# happens 1% of the time. ref: https://github.com/flashinfer-ai/flashinfer/pull/1779
-sed -i '102,108d' /usr/local/lib/python3.12/dist-packages/flashinfer/jit/cubin_loader.py
-
 export SGL_ENABLE_JIT_DEEPGEMM=false
 export SGLANG_ENABLE_FLASHINFER_GEMM=true
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)


### PR DESCRIPTION
For some reason, we currently separate B200 TRT (SLURM) nodes from B200 SGLang (Docker) nodes. There is no reason SGLang cannot run on the SLURM nodes (although the reverse is not true).

This PR adds the infrastructure changes to allow for B200 SGLang to run on SLURM runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables running SGLang benchmarks on B200 Slurm nodes and updates runner targeting.
> 
> - Updates `.github/configs/runners.yaml` to include Slurm-labeled B200 nodes (`b200-nv_*`, `b200-nb_*`) under `b200` alongside Docker-only nodes
> - Adds `benchmarks/dsr1_fp4_b200_slurm.sh` and `benchmarks/dsr1_fp8_b200_slurm.sh` to launch SGLang on Slurm (TRT-LLM MLA, FlashInfer, FP4/FP8 configs) and run `run_benchmark_serving` after readiness checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1dcbda1a1955c17575b6b952a86e4dd4479f031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->