### PR TITLE
[NVIDIA] chore: add b200 gptoss slurm

### DIFF
--- a/benchmarks/gptoss_fp4_b200_slurm.sh
+++ b/benchmarks/gptoss_fp4_b200_slurm.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# === Required Env Vars ===
+# MODEL
+# PORT_OFFSET
+# TP
+# CONC
+# ISL
+# OSL
+# MAX_MODEL_LEN
+# RANDOM_RANGE_RATIO
+# RESULT_FILENAME
+# NUM_PROMPTS
+
+echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+
+nvidia-smi
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=$((ISL + OSL + 20))
+elif [ "$ISL" = "8192" ] || [ "$OSL" = "8192" ]; then
+    CALCULATED_MAX_MODEL_LEN=$((ISL + OSL + 200))
+else
+    CALCULATED_MAX_MODEL_LEN=${MAX_MODEL_LEN:-10240}  
+fi
+
+cat > config.yaml << EOF
+kv-cache-dtype: fp8
+compilation-config: '{"pass_config":{"enable_fi_allreduce_fusion":true,"enable_noop":true}}'
+async-scheduling: true
+no-enable-prefix-caching: true
+max-cudagraph-capture-size: 2048
+max-num-batched-tokens: 8192
+max-model-len: $CALCULATED_MAX_MODEL_LEN
+EOF
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export PYTHONNOUSERSITE=1
+export VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1
+
+SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
+PORT=$(( 8888 + $PORT_OFFSET ))
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT --config config.yaml \
+--gpu-memory-utilization 0.9 --tensor-parallel-size $TP --max-num-seqs 512 \
+> $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Source benchmark utilities
+source "$(dirname "$0")/benchmark_lib.sh"
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$NUM_PROMPTS" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a Slurm-friendly benchmark runner for vLLM.
> 
> - Adds `benchmarks/gptoss_fp4_b200_slurm.sh` to start `vllm serve` and execute `run_benchmark_serving` with env-driven params
> - Generates `config.yaml` (e.g., `kv-cache-dtype: fp8`, async scheduling, cudagraph limits) and dynamically computes `max-model-len` from `ISL`/`OSL`
> - Handles server readiness via `benchmark_lib.sh`, sets CUDA/FlashInfer envs, installs minimal deps, and writes results to `/workspace/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf83681ef2ba32e341adadda9575122dec64026d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->