### PR TITLE
[NVIDIA] GPTOSS GB200 DISAGG Configurations + Assign EP explicitly for AGG

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -180,30 +180,29 @@ gptoss-fp4-b200-trt:
   precision: fp4
   framework: trt
   multinode: false
-  # For all sequence lengths, if CONC >= 256, then EP=TP and DP_ATTN=true
+  # DP Attn at higher concurrencies, TP attn at middle to lower. TP=1 turns out to be highest as artifact of concurrency limit=128
   seq-len-configs:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, dp-attn: true, conc-start: 32, conc-end: 128 }
-    - { tp: 4, dp-attn: true, conc-start: 32, conc-end: 64 }
-    - { tp: 1, conc-start: 64, conc-end: 128 }
-    - { tp: 2, conc-start: 4, conc-end: 32 }
-    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 1, conc-start: 128, conc-end: 128 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
+    - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 64 }
+    - { tp: 2, conc-start: 8, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 1, conc-start: 64, conc-end: 128 }
-    - { tp: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
-    - { tp: 2, conc-start: 4, conc-end: 128 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
+    - { tp: 2, conc-start: 4, conc-end: 16 }
     - { tp: 4, conc-start: 4, conc-end: 128 }
-    - { tp: 8, conc-start: 4, conc-end: 16 }
+    - { tp: 8, conc-start: 4, conc-end: 8 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 64, conc-end: 128 }
-    - { tp: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
+    - { tp: 1, conc-start: 128, conc-end: 128 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
     - { tp: 2, conc-start: 4, conc-end: 128 }
     - { tp: 4, conc-start: 4, conc-end: 32 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
@@ -1047,3 +1046,296 @@ dsr1-fp4-gb200-dynamo-sglang:
         dp-attn: true
         additional-settings:
         - "DECODE_NODES=8"
+
+gptoss-fp4-gb200-dynamo-trt:
+  image: jwillthomson/dynamo-trtllm-1.2.0rc2-min-tokens-fix-v2
+  model: openai/gpt-oss-120b
+  model-prefix: gptoss
+  runner: gb200
+  precision: fp4
+  framework: dynamo-trt
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    #Right of pareto
+    #P: 1xTP1   D:1xTP4
+    - spec-decoding: "none"
+      conc-list: [ 1, 2, 4, 16, 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=256"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# P: 1xTP1   D:4xTP2
+    - spec-decoding: "none"
+      conc-list: [ 16 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 4
+        tp: 2
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=32"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+  # P: 1xTP1   D:1xDEP2
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024, 2048, 2560 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1
+        tp: 2
+        ep: 2
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=1536"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+  # P: 1xTP1   D:2xDEP2
+    - spec-decoding: "none"
+      conc-list: [ 512, 1024, 2048, 2560 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 2
+        tp: 2
+        ep: 2
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=1536"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+  # P: 1xTP1   D:1xDEP4
+    - spec-decoding: "none"
+      conc-list: [ 256, 1024, 1536 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=512"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# P: 1xTP1   D:3xDEP4
+    - spec-decoding: "none"
+      conc-list: [ 3072 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 3
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=1024"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # Right side of pareto
+    - spec-decoding: "none"
+      conc-list: [1]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1  # TODO: Adjust num-worker
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=4"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+    - spec-decoding: "none"
+      conc-list: [2, 4, 8, 16, 32, 64]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1  # TODO: Adjust num-worker
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=128"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# Middle of pareto
+# P: 2xTP1   D:1xTP4
+    - spec-decoding: "none"
+      conc-list: [128, 512]
+      prefill:
+        num-worker: 2
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1  # TODO: Adjust num-worker
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=1024"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# P: 2xTP1   D:1xTP2
+    - spec-decoding: "none"
+      conc-list: [256, 384]
+      prefill:
+        num-worker: 2
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1  # TODO: Adjust num-worker
+        tp: 2
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=512"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# P: 2xTP1   D:1xDEP2
+    - spec-decoding: "none"
+      conc-list: [128, 512]
+      prefill:
+        num-worker: 2
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 1
+        tp: 2
+        ep: 2
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=512"
+        - "DECODE_GPU_MEM_FRACTION=0.9"
+
+# P: 2xTP1   D:2xDEP2
+    - spec-decoding: "none"
+      conc-list: [256, 384]
+      prefill:
+        num-worker: 2
+        tp: 1
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+        - "PREFILL_MAX_NUM_TOKENS=20000"
+        - "PREFILL_MAX_BATCH_SIZE=32"
+      decode:
+        num-worker: 2 
+        tp: 2
+        ep: 2
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=1"
+        - "DECODE_MAX_NUM_TOKENS=20000"
+        - "DECODE_MAX_BATCH_SIZE=512"
+        - "DECODE_GPU_MEM_FRACTION=0.9"

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -180,15 +180,15 @@ gptoss-fp4-b200-trt:
   precision: fp4
   framework: trt
   multinode: false
-  # DP Attn at higher concurrencies, TP attn at middle to lower. TP=1 turns out to be highest as artifact of concurrency limit=128
   seq-len-configs:
+  # DP Attn at higher concurrencies, TP attn at middle to lower. TP=1 turns out to be highest as artifact of concurrency limit=128
   - isl: 1024
     osl: 1024
     search-space:
     - { tp: 1, conc-start: 128, conc-end: 128 }
     - { tp: 2, ep: 2, dp-attn: true, conc-start: 64, conc-end: 128 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 64 }
-    - { tp: 2, conc-start: 8, conc-end: 64 }
+    - { tp: 2, conc-start: 8, conc-end: 32 }
     - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
   - isl: 1024
@@ -198,6 +198,7 @@ gptoss-fp4-b200-trt:
     - { tp: 2, conc-start: 4, conc-end: 16 }
     - { tp: 4, conc-start: 4, conc-end: 128 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
+  # DP Attn at higher concurrencies, TP attn at middle to lower. TP=1 turns out to be highest as artifact of concurrency limit=128
   - isl: 8192
     osl: 1024
     search-space:
@@ -1308,29 +1309,6 @@ gptoss-fp4-gb200-dynamo-trt:
         - "PREFILL_MAX_BATCH_SIZE=32"
       decode:
         num-worker: 1
-        tp: 2
-        ep: 2
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=1"
-        - "DECODE_MAX_NUM_TOKENS=20000"
-        - "DECODE_MAX_BATCH_SIZE=512"
-        - "DECODE_GPU_MEM_FRACTION=0.9"
-
-# P: 2xTP1   D:2xDEP2
-    - spec-decoding: "none"
-      conc-list: [256, 384]
-      prefill:
-        num-worker: 2
-        tp: 1
-        ep: 1
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
-        - "PREFILL_MAX_NUM_TOKENS=20000"
-        - "PREFILL_MAX_BATCH_SIZE=32"
-      decode:
-        num-worker: 2 
         tp: 2
         ep: 2
         dp-attn: true

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1049,7 +1049,7 @@ dsr1-fp4-gb200-dynamo-sglang:
         - "DECODE_NODES=8"
 
 gptoss-fp4-gb200-dynamo-trt:
-  image: jwillthomson/dynamo-trtllm-1.2.0rc2-min-tokens-fix-v2
+  image: nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.7.0.post2
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: gb200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1216,7 +1216,7 @@ gptoss-fp4-gb200-dynamo-trt:
         - "PREFILL_MAX_NUM_TOKENS=20000"
         - "PREFILL_MAX_BATCH_SIZE=32"
       decode:
-        num-worker: 1  # TODO: Adjust num-worker
+        num-worker: 1  
         tp: 8
         ep: 1
         dp-attn: false
@@ -1238,7 +1238,7 @@ gptoss-fp4-gb200-dynamo-trt:
         - "PREFILL_MAX_NUM_TOKENS=20000"
         - "PREFILL_MAX_BATCH_SIZE=32"
       decode:
-        num-worker: 1  # TODO: Adjust num-worker
+        num-worker: 1  
         tp: 4
         ep: 1
         dp-attn: false
@@ -1262,7 +1262,7 @@ gptoss-fp4-gb200-dynamo-trt:
         - "PREFILL_MAX_NUM_TOKENS=20000"
         - "PREFILL_MAX_BATCH_SIZE=32"
       decode:
-        num-worker: 1  # TODO: Adjust num-worker
+        num-worker: 1  
         tp: 4
         ep: 1
         dp-attn: false
@@ -1285,7 +1285,7 @@ gptoss-fp4-gb200-dynamo-trt:
         - "PREFILL_MAX_NUM_TOKENS=20000"
         - "PREFILL_MAX_BATCH_SIZE=32"
       decode:
-        num-worker: 1  # TODO: Adjust num-worker
+        num-worker: 1  
         tp: 2
         ep: 1
         dp-attn: false
@@ -1317,3 +1317,4 @@ gptoss-fp4-gb200-dynamo-trt:
         - "DECODE_MAX_NUM_TOKENS=20000"
         - "DECODE_MAX_BATCH_SIZE=512"
         - "DECODE_GPU_MEM_FRACTION=0.9"
+        

--- a/benchmarks/gptoss_fp4_b200_trt_slurm.sh
+++ b/benchmarks/gptoss_fp4_b200_trt_slurm.sh
@@ -49,9 +49,16 @@ moe_config:
 EOF
 
 if [[ "$DP_ATTENTION" == "true" ]]; then
-    export TRTLLM_MOE_ALLTOALL_BACKEND="mnnvlthroughput"
-    export TRTLLM_FORCE_ALLTOALL_METHOD="MNNVL"
-    export TRTLLM_MOE_A2A_WORKSPACE_MB="2048"
+    # DISABLE All2All for MoE TP
+    if [[ "$EP_SIZE" -eq 1 ]]; then
+        # DTP Alltoall Environment variables for EP_SIZE == 1
+        export TRTLLM_FORCE_ALLTOALL_METHOD="NotEnabled"
+    elif [[ "$EP_SIZE" -gt 1 ]]; then
+        # DEP
+        export TRTLLM_MOE_ALLTOALL_BACKEND="mnnvlthroughput"
+        export TRTLLM_FORCE_ALLTOALL_METHOD="MNNVL"
+        export TRTLLM_MOE_A2A_WORKSPACE_MB="2048"
+    fi
     cat << EOF >> $EXTRA_CONFIG_FILE
 attention_dp_config:
     enable_balance: true

--- a/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
+++ b/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/bash
+
+set -x
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING \
+    PREFILL_NUM_WORKERS PREFILL_TP PREFILL_EP PREFILL_DP_ATTN \
+    DECODE_NUM_WORKERS DECODE_TP DECODE_EP DECODE_DP_ATTN \
+    PREFILL_MAX_NUM_TOKENS PREFILL_MAX_BATCH_SIZE DECODE_MAX_NUM_TOKENS \
+    DECODE_MAX_BATCH_SIZE DECODE_GPU_MEM_FRACTION
+
+if [ "$SPEC_DECODING" == "mtp" ]; then
+    check_env_vars DECODE_MTP_SIZE
+else
+    DECODE_MTP_SIZE="0"
+fi
+
+PERFORMANCE_SWEEPS_PATH="components/backends/trtllm/performance_sweeps"
+
+echo "Cloning Dynamo repository..."
+git clone https://github.com/ai-dynamo/dynamo.git
+cd dynamo
+git checkout jthomson04/gpt-oss-disagg-slurm-v2
+git submodule update --init --recursive
+
+cd "$PERFORMANCE_SWEEPS_PATH"
+
+# Set up environment variables based on ISL/OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    export CACHE_TRANSCEIVER_MAX_NUM_TOKENS=1024
+elif [ "$ISL" = "8192" ] && [ "$OSL" = "1024" ]; then
+    export CACHE_TRANSCEIVER_MAX_NUM_TOKENS=8448
+else
+    echo "Unsupported ISL/OSL combination: $ISL/$OSL"
+    exit 1
+fi
+
+kind=dynamo_disagg
+additional_slurm_args="--time=04:00:00"
+ntasks_per_node=4
+
+gen_nodes=$(((DECODE_TP + 3)/4 * DECODE_NUM_WORKERS))
+total_nodes=$((PREFILL_NUM_WORKERS + gen_nodes))
+total_tasks=$((total_nodes * ntasks_per_node))
+
+decode_eplb_num_slots=0
+
+sbatch --nodes=${total_nodes} \
+    --ntasks=${total_tasks} \
+    --ntasks-per-node=${ntasks_per_node} \
+    --segment=${total_nodes} ${additional_slurm_args} \
+    benchmark_disagg.slurm \
+    ${PREFILL_NUM_WORKERS} ${PREFILL_TP} \
+    ${PREFILL_MAX_BATCH_SIZE} ${PREFILL_MAX_NUM_TOKENS} \
+    ${PREFILL_DP_ATTN} ${DECODE_NUM_WORKERS} \
+    ${DECODE_TP} ${DECODE_EP} ${DECODE_MAX_BATCH_SIZE} \
+    ${DECODE_MAX_NUM_TOKENS} ${DECODE_DP_ATTN} \
+    ${DECODE_GPU_MEM_FRACTION} ${decode_eplb_num_slots} \
+    ${DECODE_MTP_SIZE} "${CONC_LIST}" \
+    ${gen_nodes} ${kind} \
+    ${MODEL_PATH} ${SERVED_MODEL_NAME} \
+    ${IMAGE} ${ISL} ${OSL}

--- a/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
+++ b/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
@@ -10,7 +10,7 @@ check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING \
     PREFILL_MAX_NUM_TOKENS PREFILL_MAX_BATCH_SIZE DECODE_MAX_NUM_TOKENS \
     DECODE_MAX_BATCH_SIZE DECODE_GPU_MEM_FRACTION
 
-if [ "$SPEC_DECODING" == "mtp" ]; then
+if [[ "$SPEC_DECODING" == "mtp" ]]; then
     check_env_vars DECODE_MTP_SIZE
 else
     DECODE_MTP_SIZE="0"
@@ -61,3 +61,4 @@ sbatch --nodes=${total_nodes} \
     ${gen_nodes} ${kind} \
     ${MODEL_PATH} ${SERVED_MODEL_NAME} \
     ${IMAGE} ${ISL} ${OSL}
+    

--- a/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
+++ b/benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh
@@ -21,7 +21,7 @@ PERFORMANCE_SWEEPS_PATH="components/backends/trtllm/performance_sweeps"
 echo "Cloning Dynamo repository..."
 git clone https://github.com/ai-dynamo/dynamo.git
 cd dynamo
-git checkout jthomson04/gpt-oss-disagg-slurm-v2
+git checkout release/0.5.1-rc0.20260105
 git submodule update --init --recursive
 
 cd "$PERFORMANCE_SWEEPS_PATH"
@@ -61,4 +61,3 @@ sbatch --nodes=${total_nodes} \
     ${gen_nodes} ${kind} \
     ${MODEL_PATH} ${SERVED_MODEL_NAME} \
     ${IMAGE} ${ISL} ${OSL}
-    

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -141,3 +141,11 @@
   description:
     - Use upstream SGLang images on mi300, mi325 and mi355 for dsr1fp8
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/332
+
+- config-keys:
+    - gptoss-fp4-gb200-dynamo-trt
+    - gptoss-fp4-b200-trt
+  description:
+    - Explicitly add EP=TP for DP attention configs. Multinode Refactor inadvertently changed default EP=1
+    - Add GPTOSS DISAGG configurations for GB200 and B200
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -146,6 +146,6 @@
     - gptoss-fp4-gb200-dynamo-trt
     - gptoss-fp4-b200-trt
   description:
-    - Explicitly add EP=TP for DP attention configs. Multinode Refactor inadvertently changed default EP=1
-    - Add GPTOSS DISAGG configurations for GB200 and B200
+    - Explicitly add EP=TP for DP attention configs for B200 AGG nvidia-master file. Multinode Refactor inadvertently changed default EP=1
+    - Add GPTOSS DISAGG configurations for GB200 1k1k and 8k1k.
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/387

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -148,4 +148,4 @@
   description:
     - Explicitly add EP=TP for DP attention configs. Multinode Refactor inadvertently changed default EP=1
     - Add GPTOSS DISAGG configurations for GB200 and B200
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/387

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -29,12 +29,12 @@ elif [[ $FRAMEWORK == "dynamo-trt" ]]; then
     if [[ $MODEL_PREFIX == "gptoss" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/gpt-oss-120b"
         export SERVED_MODEL_NAME="gpt-oss-120b"
+    elif [[ $MODEL_PREFIX == "dsr1" ]]; then
+        export SERVED_MODEL_NAME="deepseek-r1-fp4"
     else
         echo "Unsupported model prefix: $MODEL_PREFIX. Supported prefixes are: gptoss"
         exit 1
     fi
-else
-    export SERVED_MODEL_NAME="deepseek-r1-fp4"
 fi
 
 export ISL="$ISL"

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -25,6 +25,14 @@ export MODEL_PATH=$MODEL
 if [[ $FRAMEWORK == "dynamo-sglang" ]]; then
     export CONFIG_DIR="/mnt/lustre01/artifacts/sglang-configs/1k1k"
     export SGL_SLURM_JOBS_PATH="dynamo/examples/backends/sglang/slurm_jobs"
+elif [[ $FRAMEWORK == "dynamo-trt" ]]; then
+    if [[ $MODEL_PREFIX == "gptoss" ]]; then
+        export MODEL_PATH="/mnt/lustre01/models/gpt-oss-120b"
+        export SERVED_MODEL_NAME="gpt-oss-120b"
+    else
+        echo "Unsupported model prefix: $MODEL_PREFIX. Supported prefixes are: gptoss"
+        exit 1
+    fi
 else
     export SERVED_MODEL_NAME="deepseek-r1-fp4"
 fi
@@ -59,7 +67,7 @@ if [[ $FRAMEWORK == "dynamo-trt" ]]; then
     echo "Found logs directory: $LOGS_DIR"
 
     # Find all result subdirectories in this logs directory
-    RESULT_SUBDIRS=$(find "$LOGS_DIR" -name "ctx*_gen*_[td]ep*_batch*_eplb*_mtp*" -type d)
+    RESULT_SUBDIRS=$(find "$LOGS_DIR" -name "ctx*_gen*_[td]p*_ep*_batch*_eplb*_mtp*" -type d)
 
     if [ -z "$RESULT_SUBDIRS" ]; then
         echo "No result subdirectories found in $LOGS_DIR"

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -67,7 +67,7 @@ if [[ $FRAMEWORK == "dynamo-trt" ]]; then
     echo "Found logs directory: $LOGS_DIR"
 
     # Find all result subdirectories in this logs directory
-    RESULT_SUBDIRS=$(find "$LOGS_DIR" -name "ctx*_gen*_[td]p*_ep*_batch*_eplb*_mtp*" -type d)
+    RESULT_SUBDIRS=$(find "$LOGS_DIR" -name "ctx*_gen*_*_batch*_eplb*_mtp*" -type d)
 
     if [ -z "$RESULT_SUBDIRS" ]; then
         echo "No result subdirectories found in $LOGS_DIR"


### PR DESCRIPTION
1) Adds GPTOSS GB200 DISAGG configurations for 1k1k and 8k1k workloads
2) Explicitly assign EP in nvidia master file for AGG in order to correctly run DP attention with MoE EP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces multi-node DISAGG benchmarking for GPT-OSS on GB200 and fixes explicit EP settings for DP-attention on B200 TRT.
> 
> - Adds `gptoss-fp4-gb200-dynamo-trt` to `nvidia-master.yaml` with 1k1k and 8k1k search spaces (prefill/decode worker counts, TP/EP, DP-attn, conc-lists, and token/batch/mem settings)
> - Updates `gptoss-fp4-b200-trt` search-space to explicitly set `ep: tp` for DP-attn configs and adjust concurrency ranges
> - Enhances `benchmarks/gptoss_fp4_b200_trt_slurm.sh` to conditionally configure MoE AllToAll: disable when `EP_SIZE=1`, use `MNNVL` when `EP_SIZE>1`
> - Adds `benchmarks/gptoss_fp4_gb200_dynamo-trt_slurm.sh` to clone/run Dynamo TRT DISAGG sweeps and submit SLURM jobs
> - Updates `runners/launch_gb200-nv.sh` for `dynamo-trt` (GPT-OSS model path/served name) and broadens result directory matching
> - Records changes in `perf-changelog.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b011864396c99319caea685466552cb709ba18fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->