### PR TITLE
[AMD] Update MI355x Deepseek-R1 FP4 SGLang Image to v0.5.7

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.6.post2-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.7-rocm700-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -156,3 +156,9 @@
     - "Add PD disaggregation (1P2D) for Mi355X"
     - "Includes with and without speculative decoding"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/348
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang
+  description:
+    - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.7"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/395


### PR DESCRIPTION
Updating the SGLang docker image to the SGLang community docker image
Image=lmsysorg/sglang:v0.5.7-rocm700-mi35x

Impacted configurations: MI355x Deepseek-R1 FP4

Link to the runs: TBD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates MI355x DeepSeek-R1 FP4 SGLang config to use the upstream v0.5.7 image and records the change.
> 
> - Bump `image` for `dsr1-fp4-mi355x-sglang` to `lmsysorg/sglang:v0.5.7-rocm700-mi35x` in `.github/configs/amd-master.yaml`
> - Add entry in `perf-changelog.yaml` documenting this update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc7f1a1c22f0efb267ff141548317b8a1f79e99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->