### PR TITLE
[AMD] fix: add appropriate random range ratio to Mi355X disagg

### DIFF
--- a/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
@@ -7,13 +7,13 @@ source "$(dirname "$0")/benchmark_lib.sh"
 check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING MODEL_PATH \
     PREFILL_NUM_WORKERS PREFILL_TP PREFILL_EP PREFILL_DP_ATTN \
     DECODE_NUM_WORKERS DECODE_TP DECODE_EP DECODE_DP_ATTN \
-    PREFILL_NODES DECODE_NODES SGL_SLURM_JOBS_PATH # SGL_SLURM_JOBS_PATH FIXME
+    PREFILL_NODES DECODE_NODES SGL_SLURM_JOBS_PATH RANDOM_RANGE_RATIO SGL_SLURM_JOBS_PATH
 
 # Always clone and setup sglang_disagg
 # git clone --branch cam/sa-251219 https://github.com/cquil11/sglang_disagg.git
 
 # Switch to origin repo url for supporting wide ep configs
-git clone --branch sa-260107 https://github.com/billishyahao/sglang_disagg.git
+git clone --branch sa-260107 https://github.com/cquil11/sglang_disagg.git
 
 cd "$SGL_SLURM_JOBS_PATH" || exit 1
 
@@ -49,4 +49,5 @@ bash ./submit_disagg.sh $PREFILL_NODES \
     $DECODE_NUM_WORKERS \
     $ISL $OSL "${CONC_LIST// /x}" inf \
     ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
-    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP}
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
+    ${RANDOM_RANGE_RATIO}


### PR DESCRIPTION
This is a followup to #348 .

This PR referenced another repo that called the benchmark serving script without the appropriate random range ratio. Here are the associated changes (comparing to the original branch): https://github.com/billishyahao/sglang_disagg/pull/8/changes. Note that since I do not have write access to the upstream `sglang_disagg` repository, I changed to my fork in this PR. But you can see the changes above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Mi355X disagg benchmark script to correctly wire through random range ratio and use the intended repo.
> 
> - Adds `RANDOM_RANGE_RATIO` to `check_env_vars` and forwards it to `submit_disagg.sh`
> - Switches `sglang_disagg` clone URL to `cquil11/sglang_disagg.git` on branch `sa-260107`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e555f6798a6288df827017264eaf1271d6fa92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->