### PR TITLE
[AMD] feat: Add mi355x distributed inference test CI workflow

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -176,3 +176,384 @@ gptoss-fp4-mi355x-vllm:
     - { tp: 1, conc-start: 4, conc-end: 128 }
     - { tp: 4, conc-start: 4, conc-end: 4 }
     - { tp: 8, conc-start: 4, conc-end: 8 }
+
+
+dsr1-fp8-mi355x-sglang-disagg:
+  image: rocm/sgl-dev:sglang-0.5.6.post1-rocm700-mi35x-mori-1224
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  # NOTE: Until this cluster has more nodes, switch to a single runner because
+  # no oversubscription is needed.
+  runner: mi355x-amd_0
+  precision: fp8
+  framework: sglang-disagg
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    # MTP configurations
+    # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
+    - spec-decoding: "mtp"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # MTP configurations
+    # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
+    - spec-decoding: "mtp"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+
+  - isl: 1024
+    osl: 8192
+    search-space:
+    # MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+
+    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -253,307 +253,307 @@ dsr1-fp8-mi355x-sglang-disagg:
         - "DECODE_NODES=2"
         - "DECODE_MTP_SIZE=2"
 
-    # # non-MTP configurations
-    # # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-    # - spec-decoding: "none"
-    #   conc-list: [ 2048 ]
-    #   prefill:
-    #     num-worker: 1
-    #     tp: 1
-    #     ep: 8
-    #     dp-attn: true
-    #     additional-settings:
-    #     - "PREFILL_NODES=1"
-    #   decode:
-    #     num-worker: 1
-    #     tp: 1
-    #     ep: 16
-    #     dp-attn: true
-    #     additional-settings:
-    #     - "DECODE_NODES=2"
-    #     - "DECODE_MTP_SIZE=0"
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
 
-    # # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-    # - spec-decoding: "none"
-    #   conc-list: [ 256, 512, 1024 ]
-    #   prefill:
-    #     num-worker: 1
-    #     tp: 1
-    #     ep: 8
-    #     dp-attn: true
-    #     additional-settings:
-    #     - "PREFILL_NODES=1"
-    #   decode:
-    #     num-worker: 2
-    #     tp: 1
-    #     ep: 8
-    #     dp-attn: true
-    #     additional-settings:
-    #     - "DECODE_NODES=2"
-    #     - "DECODE_MTP_SIZE=0"
-
-
-    # # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    # - spec-decoding: "none"
-    #   conc-list: [ 32, 64, 128 ]
-    #   prefill:
-    #     num-worker: 1
-    #     tp: 8
-    #     ep: 8
-    #     dp-attn: false
-    #     additional-settings:
-    #     - "PREFILL_NODES=1"
-
-    #   decode:
-    #     num-worker: 2
-    #     tp: 8
-    #     ep: 8
-    #     dp-attn: false
-    #     additional-settings:
-    #     - "DECODE_NODES=2"
-    #     - "DECODE_MTP_SIZE=0"
-
-  # - isl: 8192
-  #   osl: 1024
-  #   search-space:
-  #   # MTP configurations
-  #   # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 2048 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 16
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
-
-  #   # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 256, 512, 1024 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 2
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
 
 
-  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 32, 64, 128 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
 
-  #     decode:
-  #       num-worker: 2
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
 
-  #   # non-MTP configurations
-  #   # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 2048 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 16
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # MTP configurations
+    # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
+    - spec-decoding: "mtp"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
 
-  #   # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 256, 512, 1024 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 2
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
-
-  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 32, 64, 128 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-
-  #     decode:
-  #       num-worker: 2
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
+    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
 
 
-  # - isl: 1024
-  #   osl: 8192
-  #   search-space:
-  #   # MTP configurations
-  #   # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 2048 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 16
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
 
 
-  #   # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 256, 512, 1024 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 2
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
+  - isl: 1024
+    osl: 8192
+    search-space:
+    # MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
 
 
-  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-  #   - spec-decoding: "mtp"
-  #     conc-list: [ 32, 64, 128 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
+    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
 
-  #     decode:
-  #       num-worker: 2
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=2"
 
-  #   # non-MTP configurations
-  #   # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 2048 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 16
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
 
-  #   # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 256, 512, 1024 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 2
-  #       tp: 1
-  #       ep: 8
-  #       dp-attn: true
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
 
-  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-  #   - spec-decoding: "none"
-  #     conc-list: [ 32, 64, 128 ]
-  #     prefill:
-  #       num-worker: 1
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "PREFILL_NODES=1"
-  #     decode:
-  #       num-worker: 2
-  #       tp: 8
-  #       ep: 8
-  #       dp-attn: false
-  #       additional-settings:
-  #       - "DECODE_NODES=2"
-  #       - "DECODE_MTP_SIZE=0"
+    # non-MTP configurations
+    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    - spec-decoding: "none"
+      conc-list: [ 2048 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 1
+        tp: 1
+        ep: 16
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    - spec-decoding: "none"
+      conc-list: [ 256, 512, 1024 ]
+      prefill:
+        num-worker: 1
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 1
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -253,307 +253,307 @@ dsr1-fp8-mi355x-sglang-disagg:
         - "DECODE_NODES=2"
         - "DECODE_MTP_SIZE=2"
 
-    # non-MTP configurations
-    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-    - spec-decoding: "none"
-      conc-list: [ 2048 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 1
-        tp: 1
-        ep: 16
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+    # # non-MTP configurations
+    # # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+    # - spec-decoding: "none"
+    #   conc-list: [ 2048 ]
+    #   prefill:
+    #     num-worker: 1
+    #     tp: 1
+    #     ep: 8
+    #     dp-attn: true
+    #     additional-settings:
+    #     - "PREFILL_NODES=1"
+    #   decode:
+    #     num-worker: 1
+    #     tp: 1
+    #     ep: 16
+    #     dp-attn: true
+    #     additional-settings:
+    #     - "DECODE_NODES=2"
+    #     - "DECODE_MTP_SIZE=0"
 
-    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-    - spec-decoding: "none"
-      conc-list: [ 256, 512, 1024 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
-
-
-    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    - spec-decoding: "none"
-      conc-list: [ 32, 64, 128 ]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
-
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
-
-  - isl: 8192
-    osl: 1024
-    search-space:
-    # MTP configurations
-    # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
-    - spec-decoding: "mtp"
-      conc-list: [ 2048 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 1
-        tp: 1
-        ep: 16
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
-
-    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
-    - spec-decoding: "mtp"
-      conc-list: [ 256, 512, 1024 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
+    # # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+    # - spec-decoding: "none"
+    #   conc-list: [ 256, 512, 1024 ]
+    #   prefill:
+    #     num-worker: 1
+    #     tp: 1
+    #     ep: 8
+    #     dp-attn: true
+    #     additional-settings:
+    #     - "PREFILL_NODES=1"
+    #   decode:
+    #     num-worker: 2
+    #     tp: 1
+    #     ep: 8
+    #     dp-attn: true
+    #     additional-settings:
+    #     - "DECODE_NODES=2"
+    #     - "DECODE_MTP_SIZE=0"
 
 
-    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    - spec-decoding: "mtp"
-      conc-list: [ 32, 64, 128 ]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
+    # # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    # - spec-decoding: "none"
+    #   conc-list: [ 32, 64, 128 ]
+    #   prefill:
+    #     num-worker: 1
+    #     tp: 8
+    #     ep: 8
+    #     dp-attn: false
+    #     additional-settings:
+    #     - "PREFILL_NODES=1"
 
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
+    #   decode:
+    #     num-worker: 2
+    #     tp: 8
+    #     ep: 8
+    #     dp-attn: false
+    #     additional-settings:
+    #     - "DECODE_NODES=2"
+    #     - "DECODE_MTP_SIZE=0"
 
-    # non-MTP configurations
-    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-    - spec-decoding: "none"
-      conc-list: [ 2048 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 1
-        tp: 1
-        ep: 16
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+  # - isl: 8192
+  #   osl: 1024
+  #   search-space:
+  #   # MTP configurations
+  #   # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
 
-    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-    - spec-decoding: "none"
-      conc-list: [ 256, 512, 1024 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
-
-    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    - spec-decoding: "none"
-      conc-list: [ 32, 64, 128 ]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
-
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+  #   # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
 
 
-  - isl: 1024
-    osl: 8192
-    search-space:
-    # MTP configurations
-    # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-    - spec-decoding: "mtp"
-      conc-list: [ 2048 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 1
-        tp: 1
-        ep: 16
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
+
+  #   # non-MTP configurations
+  #   # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
 
 
-    # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
-    - spec-decoding: "mtp"
-      conc-list: [ 256, 512, 1024 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
+  # - isl: 1024
+  #   osl: 8192
+  #   search-space:
+  #   # MTP configurations
+  #   # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
 
 
-    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    - spec-decoding: "mtp"
-      conc-list: [ 32, 64, 128 ]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
+  #   # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
 
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=2"
 
-    # non-MTP configurations
-    # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
-    - spec-decoding: "none"
-      conc-list: [ 2048 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 1
-        tp: 1
-        ep: 16
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
 
-    # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
-    - spec-decoding: "none"
-      conc-list: [ 256, 512, 1024 ]
-      prefill:
-        num-worker: 1
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 1
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=2"
 
-    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
-    - spec-decoding: "none"
-      conc-list: [ 32, 64, 128 ]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "PREFILL_NODES=1"
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: false
-        additional-settings:
-        - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=0"
+  #   # non-MTP configurations
+  #   # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"

--- a/benchmarks/dsr1_fp8_gb200_dynamo-sglang_slurm.sh
+++ b/benchmarks/dsr1_fp8_gb200_dynamo-sglang_slurm.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 
 set -x

--- a/benchmarks/dsr1_fp8_gb200_dynamo-sglang_slurm.sh
+++ b/benchmarks/dsr1_fp8_gb200_dynamo-sglang_slurm.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -x

--- a/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
@@ -13,7 +13,7 @@ check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING MODEL_PATH \
 # git clone --branch cam/sa-251219 https://github.com/cquil11/sglang_disagg.git
 
 # Switch to origin repo url for supporting wide ep configs
-git clone --branch sa-260107 https://github.com/cquil11/sglang_disagg.git
+git clone --branch sa-260107 https://github.com/billishyahao/sglang_disagg.git
 
 cd "$SGL_SLURM_JOBS_PATH" || exit 1
 

--- a/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -x
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING MODEL_PATH \
+    PREFILL_NUM_WORKERS PREFILL_TP PREFILL_EP PREFILL_DP_ATTN \
+    DECODE_NUM_WORKERS DECODE_TP DECODE_EP DECODE_DP_ATTN \
+    PREFILL_NODES DECODE_NODES SGL_SLURM_JOBS_PATH # SGL_SLURM_JOBS_PATH FIXME
+
+# Always clone and setup sglang_disagg
+# git clone --branch cam/sa-251219 https://github.com/cquil11/sglang_disagg.git
+
+# Switch to origin repo url for supporting wide ep configs
+git clone --branch sa-260107 https://github.com/billishyahao/sglang_disagg.git
+
+cd "$SGL_SLURM_JOBS_PATH" || exit 1
+
+# Set up SGL launch script-specific environment variables
+export TIME_LIMIT="08:00:00"
+export MODEL_PATH=$MODEL_PATH
+export MODEL_NAME="DeepSeek-R1"
+export CONTAINER_IMAGE=$IMAGE
+
+
+export PREFILL_ENABLE_EP=true
+if [[ "$PREFILL_DP_ATTN" == "true" ]]; then
+export PREFILL_ENABLE_DP=true
+else
+export PREFILL_ENABLE_DP=false
+fi
+
+export DECODE_ENABLE_EP=true
+if [[ "$DECODE_DP_ATTN" == "true" ]]; then
+export DECODE_ENABLE_DP=true
+else
+export DECODE_ENABLE_DP=false
+fi
+
+
+# Launch jobs based on ISL/OSL
+# Replace ' ' in CONC_LIST with 'x' such that the concurrency list is represented
+# by a list of numbers delimited by 'x'. This is because of how the underlying launch script
+# expects the concurrencies.
+bash ./submit_disagg.sh $PREFILL_NODES \
+    $PREFILL_NUM_WORKERS \
+    $DECODE_NODES \
+    $DECODE_NUM_WORKERS \
+    $ISL $OSL "${CONC_LIST// /x}" inf \
+    ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP}

--- a/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
@@ -7,13 +7,13 @@ source "$(dirname "$0")/benchmark_lib.sh"
 check_env_vars CONC_LIST ISL OSL IMAGE SPEC_DECODING MODEL_PATH \
     PREFILL_NUM_WORKERS PREFILL_TP PREFILL_EP PREFILL_DP_ATTN \
     DECODE_NUM_WORKERS DECODE_TP DECODE_EP DECODE_DP_ATTN \
-    PREFILL_NODES DECODE_NODES SGL_SLURM_JOBS_PATH # SGL_SLURM_JOBS_PATH FIXME
+    PREFILL_NODES DECODE_NODES SGL_SLURM_JOBS_PATH RANDOM_RANGE_RATIO SGL_SLURM_JOBS_PATH
 
 # Always clone and setup sglang_disagg
 # git clone --branch cam/sa-251219 https://github.com/cquil11/sglang_disagg.git
 
 # Switch to origin repo url for supporting wide ep configs
-git clone --branch sa-260107 https://github.com/billishyahao/sglang_disagg.git
+git clone --branch sa-260107 https://github.com/cquil11/sglang_disagg.git
 
 cd "$SGL_SLURM_JOBS_PATH" || exit 1
 
@@ -49,4 +49,5 @@ bash ./submit_disagg.sh $PREFILL_NODES \
     $DECODE_NUM_WORKERS \
     $ISL $OSL "${CONC_LIST// /x}" inf \
     ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
-    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP}
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
+    ${RANDOM_RANGE_RATIO}

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -149,3 +149,10 @@
     - Explicitly add EP=TP for DP attention configs for B200 AGG nvidia-master file. Multinode Refactor inadvertently changed default EP=1
     - Add GPTOSS DISAGG configurations for GB200 1k1k and 8k1k.
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/387
+
+- config-keys:
+    - dsr1-fp8-mi355x-sglang-disagg
+  description:
+    - "Add PD disaggregation (1P2D) for Mi355X"
+    - "Includes with and without speculative decoding"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/348

--- a/runners/launch_mi355x-amd.sh
+++ b/runners/launch_mi355x-amd.sh
@@ -1,42 +1,169 @@
 #!/usr/bin/env bash
 
-export HF_HUB_CACHE_MOUNT="/hf-hub-cache"
-export PORT_OFFSET=${USER: -1}
+scancel_sync() {
+    local jobid=$1
+    local timeout=${2:-600}
+    local interval=10
+    local start
+    start=$(date +%s)
 
-PARTITION="compute"
-SQUASH_FILE="/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    echo "[scancel_sync] Requesting cancel of job $jobid"
+    scancel "$jobid" || true
 
-if [[ "$MODEL" == "amd/DeepSeek-R1-0528-MXFP4-Preview" || "$MODEL" == "deepseek-ai/DeepSeek-R1-0528" ]]; then
-  if [[ "$OSL" == "8192" ]]; then
-    export NUM_PROMPTS=$(( CONC * 20 ))
-  else
-    export NUM_PROMPTS=$(( CONC * 50 ))
-  fi
+    while [[ -n "$(squeue -j "$jobid" --noheader 2>/dev/null)" ]]; do
+        local now
+        now=$(date +%s)
+        if (( now - start >= timeout )); then
+            echo "[scancel_sync][WARN] job $jobid still present after ${timeout}s"
+            return 1
+        fi
+        echo "[scancel_sync] waiting for job $jobid to exit. $((timeout-(now-start))) secs remaining..."
+        sleep "$interval"
+    done
+    echo "[scancel_sync] job $jobid exited"
+    return 0
+}
+
+if [[ "$IS_MULTINODE" == "true" ]]; then
+    # This sets up the environment and launches multi-node benchmarks
+
+    set -x
+
+    # Set up environment variables for SLURM
+    export SLURM_ACCOUNT="$USER"
+    export SLURM_PARTITION="compute"
+    export SLURM_JOB_NAME="benchmark-sglang-disagg.job"
+
+    export SGL_SLURM_JOBS_PATH="sglang_disagg"
+
+    export MODEL_NAME="DeepSeek-R1"
+    export MODEL_PATH="/nfsdata"
+    export ISL="$ISL"
+    export OSL="$OSL"
+
+    sudo rm -rf "$SGL_SLURM_JOBS_PATH/logs" 2>/dev/null || true
+
+    bash benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi355x_${FRAMEWORK}_slurm.sh"
+
+    # Wait for job to complete
+    JOB_ID=$(squeue -u $USER --noheader --format='%i')
+    LOG_FILE="$SGL_SLURM_JOBS_PATH/slurm_job-${JOB_ID}.out"
+
+    # Give slurm time to start the job and create log file
+    sleep 10
+
+    # Wait for log file to appear (also check job is still alive)
+    while ! ls "$LOG_FILE" &>/dev/null; do
+        if ! squeue -u "$USER" --noheader --format='%i' | grep -q "$JOB_ID"; then
+            echo "ERROR: Job $JOB_ID failed before creating log file"
+            scontrol show job "$JOB_ID"
+            exit 1
+        fi
+        sleep 5
+    done
+
+    set +x
+
+    # Poll for job completion in background
+    (
+        while squeue -u $USER --noheader --format='%i' | grep -q "$JOB_ID"; do
+            sleep 10
+        done
+    ) &
+    POLL_PID=$!
+
+    # Tail the log file until job completes (-F follows by name, polls instead of inotify for NFS)
+    tail -F -s 2 -n+1 "$LOG_FILE" --pid=$POLL_PID 2>/dev/null
+
+    wait $POLL_PID
+
+    set -x
+
+    # FIXME: The below is bad and is a result of the indirection of the ways in which
+    # Dynamo jobs are launched. In a follow-up PR, the location of the result file should not
+    # depend on the runner, it should always be in the same spot in the GH workspace.
+
+    # Process results from all configurations
+
+    # search for "FRAMEWORK_DIFF_IF_STATEMENT #3" for this if-statement
+    # Find the latest log directory that contains the data
+
+    cat > collect_latest_results.py <<'PY'
+import os, sys
+sgl_job_dir, isl, osl, nexp = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+for path in sorted([f"{sgl_job_dir}/logs/{name}/sglang_isl_{isl}_osl_{osl}" for name in os.listdir(f"{sgl_job_dir}/logs/") if os.path.isdir(f"{sgl_job_dir}/logs/{name}/sglang_isl_{isl}_osl_{osl}")], key=os.path.getmtime, reverse=True)[:nexp]:
+    print(path)
+PY
+
+    LOGS_DIR=$(python3 collect_latest_results.py "$SGL_SLURM_JOBS_PATH" "$ISL" "$OSL" 1)
+    if [ -z "$LOGS_DIR" ]; then
+        echo "No logs directory found for ISL=${ISL}, OSL=${OSL}"
+        exit 1
+    fi
+
+    echo "Found logs directory: $LOGS_DIR"
+    ls -la "$LOGS_DIR"
+
+    # Result JSON are contained within the result directory
+    for result_file in $(find $LOGS_DIR -type f); do
+        # result_file should directly be isl_ISL_osl_OSL_concurrency_CONC_req_rate_R_gpus_N_ctx_M_gen_N.json
+        file_name=$(basename $result_file)
+        if [ -f $result_file ]; then
+            # Copy the result file to workspace with a unique name
+            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${file_name}"
+            echo "Found result file ${result_file}. Copying it to ${WORKSPACE_RESULT_FILE}"
+            cp $result_file $WORKSPACE_RESULT_FILE
+        fi
+    done
+
+    echo "All result files processed"
+    # Use sync scancel to ensure nfs file handle is released in time
+    set +x
+    scancel_sync $JOB_ID
+    set -x
+    echo "Canceled the slurm job $JOB_ID"
+
+    sudo rm -rf "$SGL_SLURM_JOBS_PATH/logs" 2>/dev/null || true
+
 else
-  export NUM_PROMPTS=$(( CONC * 10 ))
+
+    export HF_HUB_CACHE_MOUNT="/hf-hub-cache"
+    export PORT_OFFSET=${USER: -1}
+
+    PARTITION="compute"
+    SQUASH_FILE="/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+
+    if [[ "$MODEL" == "amd/DeepSeek-R1-0528-MXFP4-Preview" || "$MODEL" == "deepseek-ai/DeepSeek-R1-0528" ]]; then
+        if [[ "$OSL" == "8192" ]]; then
+            export NUM_PROMPTS=$(( CONC * 20 ))
+        else
+            export NUM_PROMPTS=$(( CONC * 50 ))
+        fi
+    else
+        export NUM_PROMPTS=$(( CONC * 10 ))
+    fi
+
+    export ENROOT_RUNTIME_PATH=/tmp
+
+    set -x
+    salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell
+    JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
+
+    srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+    srun --jobid=$JOB_ID bash -c "sudo chmod -R a+rwX /hf-hub-cache/"
+    srun --jobid=$JOB_ID \
+        --container-image=$SQUASH_FILE \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mount-home \
+        --container-writable \
+        --container-workdir=/workspace/ \
+        --no-container-entrypoint --export=ALL \
+        bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_mi355x_slurm.sh
+
+    scancel $JOB_ID
+
+    if ls gpucore.* 1> /dev/null 2>&1; then
+        echo "gpucore files exist. not good"
+        rm -f gpucore.*
+    fi
 fi
-
-export ENROOT_RUNTIME_PATH=/tmp
-
-set -x
-salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell
-JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
-
-srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
-srun --jobid=$JOB_ID bash -c "sudo chmod -R a+rwX /hf-hub-cache/"
-srun --jobid=$JOB_ID \
---container-image=$SQUASH_FILE \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
---container-mount-home \
---container-writable \
---container-workdir=/workspace/ \
---no-container-entrypoint --export=ALL \
-bash benchmarks/${EXP_NAME%%_*}_${PRECISION}_mi355x_slurm.sh
-
-scancel $JOB_ID
-
-if ls gpucore.* 1> /dev/null 2>&1; then
-  echo "gpucore files exist. not good"
-  rm -f gpucore.*
-fi
-


### PR DESCRIPTION
This patch is to add mi355x distributed inference test CI workflow and integrate recipes https://github.com/billishyahao/sglang_disagg into inferencemax github action

>
> Co-authored-by: billishyahao <bill.he@amd.com>
> Co-authored-by: ichbinblau <Theresa.Shan@amd.com>
> Co-authored-by: Duyi-Wang <duyi.wang@amd.com>
> Co-authored-by: inkcherry <mingzhi.liu@amd.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds distributed prefill/decode disaggregation benchmarking for MI355x FP8 DeepSeek-R1 and integrates it into CI.
> 
> - New `dsr1-fp8-mi355x-sglang-disagg` config in `.github/configs/amd-master.yaml` with multi-node settings (1P/2D), MTP and non-MTP variants across `isl`/`osl` combos, and explicit `tp/ep/dp-attn` plus node/worker counts
> - New SLURM launcher `benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh` that clones `sglang_disagg`, sets env, and submits disagg jobs
> - Update `runners/launch_mi355x-amd.sh` to support `IS_MULTINODE`: add `scancel_sync`, set SLURM env, invoke framework-specific launcher, tail logs, collect result JSONs, cancel/cleanup; retain single-node path
> - Update `perf-changelog.yaml` with the new MI355x disagg config entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0b94149e3eefd44604231db536880c11c0de58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->