### PR TITLE
Allows for workflow files on other branchs (not forks) to be used by slash command

### DIFF
--- a/.github/workflows/pr-comment-sweep.yml
+++ b/.github/workflows/pr-comment-sweep.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   get-jobs:
@@ -21,6 +22,7 @@ jobs:
       author-can-bypass: ${{ steps.auth.outputs.can-bypass }}
       # Immutable ref (commit SHA) to prevent TOCTOU on refs/pull/<n>/head
       ref: ${{ steps.ref_comment.outputs.ref }}
+      branch: ${{ steps.ref_comment.outputs.branch }}
     steps:
       - name: Parse PR comment (/sweep ...)
         id: parse
@@ -79,8 +81,10 @@ jobs:
             const pr = context.issue.number;
             const res = await github.rest.pulls.get({ owner, repo, pull_number: pr });
             const sha = res.data.head.sha;
+            const branch = res.data.head.ref;
             core.info(`Resolved PR #${pr} head SHA: ${sha}`);
             core.setOutput('ref', sha);
+            core.setOutput('branch', branch);
 
       - name: Reply with run link
         if: ${{ github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/sweep') && github.repository_owner == 'InferenceMAX' }}
@@ -117,19 +121,74 @@ jobs:
     steps:
       - run: echo "approved"
 
-  validate:
+  dispatch:
     needs: [get-jobs, approval]
     # always() is required to evaluate this condition when 'approval' is skipped (trusted author)
     if: ${{ always() && needs.get-jobs.result == 'success' && needs.get-jobs.outputs.pr-number != '' && needs.get-jobs.outputs.generator-args != '' && (needs.get-jobs.outputs.author-can-bypass == 'true' || needs.approval.result == 'success') }}
-    # Concurrency at job level so non-/sweep comments don't cancel active runs
-    concurrency:
-      group: "sweep-PR#${{ needs.get-jobs.outputs.pr-number }}"
-      cancel-in-progress: true
-    uses: ./.github/workflows/e2e-tests.yml
-    name: validate
-    secrets: inherit
-    with:
-      generate-cli-command: ${{ needs.get-jobs.outputs.generator-args }}
-      test-name: PR #${{ needs.get-jobs.outputs.pr-number }} sweep
-      # Use pinned SHA to prevent TOCTOU on refs/pull/<n>/head
-      ref: ${{ needs.get-jobs.outputs.ref }}
+    runs-on: ubuntu-latest
+    name: dispatch e2e-tests on PR branch
+    steps:
+      - name: Dispatch e2e-tests workflow on PR head branch
+        id: dispatch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          WORKFLOW_FILE: .github/workflows/e2e-tests.yml
+          REF_BRANCH: ${{ needs.get-jobs.outputs.branch }}
+          GEN_CMD: ${{ needs.get-jobs.outputs.generator-args }}
+          PINNED_REF: ${{ needs.get-jobs.outputs.ref }}
+          PR_NUMBER: ${{ needs.get-jobs.outputs.pr-number }}
+        with:
+          github-token: ${{ secrets.REPO_PAT || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflow_id = process.env.WORKFLOW_FILE;
+            const ref = process.env.REF_BRANCH;
+            const genCmd = process.env.GEN_CMD;
+            const pinned = process.env.PINNED_REF;
+            const prNum = process.env.PR_NUMBER;
+
+            if (!ref) {
+              core.setFailed('Missing PR head branch ref');
+              return;
+            }
+
+            // Kick off workflow_dispatch on the PR branch so its YAML is used
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id,
+              ref, // branch name for YAML resolution
+              inputs: {
+                'generate-cli-command': genCmd,
+                'test-name': `PR #${prNum} sweep`,
+                // Pinned SHA used by e2e-tests for checkout of code, independent of YAML ref
+                'ref': pinned || ''
+              }
+            });
+
+            // Try to find the run URL to post back
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            let runUrl = '';
+            for (let i = 0; i < 10; i++) {
+              const runs = await github.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, event: 'workflow_dispatch', branch: ref, per_page: 10 });
+              const match = runs.data.workflow_runs.find(r => r.head_branch === ref && (!pinned || r.head_sha === pinned));
+              if (match) { runUrl = match.html_url; break; }
+              await sleep(3000);
+            }
+            core.setOutput('run-url', runUrl);
+
+      - name: Reply with dispatched run link
+        if: ${{ steps.dispatch.outputs.run-url != '' && github.repository_owner == 'InferenceMAX' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RUN_URL: ${{ steps.dispatch.outputs.run-url }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const url = process.env.RUN_URL || '';
+            const body = url ? `Dispatched PR-branch workflow: ${url}` : 'Dispatched PR-branch workflow.';
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });


### PR DESCRIPTION
Currently, the slash command workflow uses workflows on `main`. This PR allows for workflow files on the PR branch to be used. This does not work for forks.

For example, for the evals PR, if I ran a slash command with `--evals-only`, only the few number of eval runs are done. This is correct as the number of runs are determined by `utils/matrix_logic/generate_sweep_configs.py`. However, each run will not run evals as the `main` branch's `.github/workflows/benchmark-tmpl.yml` does not pass the env var to the runners, as the workflows files on `main` are used only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables using the PR branch’s workflow YAML when triggering e2e tests via `/sweep`.
> 
> - Adds `actions: write` permission and captures PR head `branch` alongside pinned `ref` (SHA)
> - Replaces in-repo workflow call with a `workflow_dispatch` to `.github/workflows/e2e-tests.yml` on the PR head branch, passing `generate-cli-command`, `test-name`, and pinned `ref`
> - Finds and posts the dispatched run URL back to the PR comment
> - Keeps approval gate for outside collaborators; trusted collaborators bypass as before
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be8a11c4f5ac50a03043d941cc6846d2c2e42d75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->