### PR TITLE
Cursor bugbot instructions, resolves  #397

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,7 @@
+# Review Guidelines
+1. Ignore any problems in utils/evals/*
+2. If any code end up creating a directory in `/workspace`, it is a critical error and should have the title: "Potential EACCES Error". A file in `/workspace` is ok.
+3. If any changed file contains /(?:^|\s)(TODO|FIXME)(?:\s*:|\s+)/, then:
+    - Add a non-blocking Bug titled "TODO/FIXME comment found"
+    - Body: "Replace TODO/FIXME with a tracked issue reference, e.g., `TODO(#1234): ...`, or remove it."
+    - If the TODO already references an issue pattern /#\d+|[A-Z]+-\d+/, mark the Bug as resolved automatically.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -4,4 +4,4 @@
 3. If any changed file contains /(?:^|\s)(TODO|FIXME)(?:\s*:|\s+)/, then:
     - Add a non-blocking Bug titled "TODO/FIXME comment found"
     - Body: "Replace TODO/FIXME with a tracked issue reference, e.g., `TODO(#1234): ...`, or remove it."
-    - If the TODO already references an issue pattern /#\d+|[A-Z]+-\d+/, mark the Bug as resolved automatically.
+    - If the TODO or FIXME already references an issue pattern /#\d+|[A-Z]+-\d+/, mark the Bug as resolved automatically.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,7 @@
+# Review Guidelines
+1. Ignore any problems in utils/evals/*
+2. If any code end up creating a directory in `/workspace`, it is a critical error and should have the title: "Potential EACCES Error". A file in `/workspace` is ok.
+3. If any changed file contains /(?:^|\s)(TODO|FIXME)(?:\s*:|\s+)/, then:
+    - Add a non-blocking Bug titled "TODO/FIXME comment found"
+    - Body: "Replace TODO/FIXME with a tracked issue reference, e.g., `TODO(#1234): ...`, or remove it."
+    - If the TODO already references an issue pattern /#\d+|[A-Z]+-\d+/, mark the Bug as resolved automatically.


### PR DESCRIPTION
Current instructions:
```
# Review Guidelines
1. Ignore any problems in utils/evals/*
2. If any code end up creating a directory in `/workspace`, it is a critical error and should have the title: "Potential EACCES Error". A file in `/workspace` is ok.
3. If any changed file contains /(?:^|\s)(TODO|FIXME)(?:\s*:|\s+)/, then:
    - Add a non-blocking Bug titled "TODO/FIXME comment found"
    - Body: "Replace TODO/FIXME with a tracked issue reference, e.g., `TODO(#1234): ...`, or remove it."
    - If the TODO already references an issue pattern /#\d+|[A-Z]+-\d+/, mark the Bug as resolved.
```

Docs from https://cursor.com/docs/cookbook/bugbot-rules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise automated review guidelines for tooling.
> 
> - New `.cursor/BUGBOT.md` defining rules: ignore `utils/evals/*`, treat creating directories in `/workspace` as a critical "Potential EACCES Error", and flag `TODO`/`FIXME` comments with guidance on issue-linked formatting and auto-resolving when references exist
> - New `.gemini/styleguide.md` mirroring the same checks (with TODO reference wording) for Gemini-driven reviews
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76747e1ebef3ab207454483087972349d86e92c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->