### PR TITLE
[AMD/BUGFIX] Add env var for atom/gptoss

### DIFF
--- a/benchmarks/gptoss_fp4_mi355x_atom_slurm.sh
+++ b/benchmarks/gptoss_fp4_mi355x_atom_slurm.sh
@@ -38,6 +38,7 @@ fi
 set -x
 
 BLOCK_SIZE=${BLOCK_SIZE:-16}
+export ATOM_GPT_OSS_MODEL=1 #TODO remove this
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
     --server-port $PORT \


### PR DESCRIPTION
Hi @cquil11 

Can you please review & merge this ? gptoss needs this env var for the target docker img. 

Regards, 
Seungrok 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AMD ATOM backend support for MI355x experiments and integrates it into configs, benchmarks, runner, and perf changelog.
> 
> - Introduces `dsr1-fp4-mi355x-atom`, `dsr1-fp8-mi355x-atom`, and `gptoss-fp4-mi355x-atom` in `amd-master.yaml` with corresponding seq-len search spaces and ATOM images
> - New benchmark scripts: `dsr1_fp4_mi355x_atom_slurm.sh`, `dsr1_fp8_mi355x_atom_slurm.sh`, `gptoss_fp4_mi355x_atom_slurm.sh` launching `atom.entrypoints.openai_server`, handling `--max-model-len`, EP enablement, and (for GPT-OSS) setting `ATOM_GPT_OSS_MODEL=1`
> - Updates `launch_mi355x-amd.sh` to route to `*_atom` scripts via `FRAMEWORK_SUFFIX`, clear/import container squash for ATOM, and preserve NUM_PROMPTS logic
> - Appends perf entry documenting new ATOM configs (PR #383)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1815c25020583386b78765a5cb103b6411cf3171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->