### PR TITLE
[AMD] feat: support multiple cluster for mi355x DI CI workflow

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -251,7 +251,7 @@ dsr1-fp8-mi355x-atom:
     - { tp: 8, conc-start: 4, conc-end: 128 }
 
 dsr1-fp8-mi355x-sglang-disagg:
-  image: rocm/sgl-dev:sglang-0.5.6.post1-rocm700-mi35x-mori-1224
+  image: rocm/sgl-dev:sglang-0.5.6.post1-rocm700-mi35x-mori-0113
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   # NOTE: Until this cluster has more nodes, switch to a single runner because

--- a/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
+++ b/benchmarks/dsr1_fp8_mi355x_sglang-disagg_slurm.sh
@@ -28,7 +28,7 @@ check_env_vars \
 # git clone --branch cam/sa-251219 https://github.com/cquil11/sglang_disagg.git
 
 # Switch to origin repo url for supporting wide ep configs
-git clone --branch sa-260107 https://github.com/billishyahao/sglang_disagg.git
+git clone --branch sa-260114 https://github.com/billishyahao/sglang_disagg.git
 
 cd "$SGL_SLURM_JOBS_PATH" || exit 1
 
@@ -58,11 +58,18 @@ fi
 # Replace ' ' in CONC_LIST with 'x' such that the concurrency list is represented
 # by a list of numbers delimited by 'x'. This is because of how the underlying launch script
 # expects the concurrencies.
-bash ./submit_disagg.sh $PREFILL_NODES \
+JOB_ID=$(bash ./submit_disagg.sh $PREFILL_NODES \
     $PREFILL_NUM_WORKERS \
     $DECODE_NODES \
     $DECODE_NUM_WORKERS \
     $ISL $OSL "${CONC_LIST// /x}" inf \
     ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
     ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
-    ${RANDOM_RANGE_RATIO}
+    ${RANDOM_RANGE_RATIO})
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to submit job" >&2
+    exit 1
+fi
+
+echo "$JOB_ID"

--- a/runners/launch_mi355x-amd.sh
+++ b/runners/launch_mi355x-amd.sh
@@ -38,15 +38,25 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
 
     export MODEL_NAME="DeepSeek-R1"
     export MODEL_PATH="/nfsdata"
+
+    NODENAME=$(sinfo -N -h -t idle,mix -o "%N" | head -1)
+    if [[ $node == GPU* ]]; then
+        export MODEL_PATH="/nfsdata"
+    elif [[ $node == mia1* ]]; then
+        export MODEL_PATH="/it-share/data"
+    else
+        echo "[Error] No available nodes for launching slurm jobs"
+        exit 1
+    fi
+
     export ISL="$ISL"
     export OSL="$OSL"
 
     sudo rm -rf "$SGL_SLURM_JOBS_PATH/logs" 2>/dev/null || true
 
-    bash benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi355x_${FRAMEWORK}_slurm.sh"
+    JOB_ID=$(bash benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi355x_${FRAMEWORK}_slurm.sh")
 
     # Wait for job to complete
-    JOB_ID=$(squeue -u $USER --noheader --format='%i')
     LOG_FILE="$SGL_SLURM_JOBS_PATH/slurm_job-${JOB_ID}.out"
 
     # Give slurm time to start the job and create log file

--- a/runners/launch_mi355x-amd.sh
+++ b/runners/launch_mi355x-amd.sh
@@ -40,9 +40,9 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
     export MODEL_PATH="/nfsdata"
 
     NODENAME=$(sinfo -N -h -t idle,mix -o "%N" | head -1)
-    if [[ $node == GPU* ]]; then
+    if [[ $NODENAME == GPU* ]]; then
         export MODEL_PATH="/nfsdata"
-    elif [[ $node == mia1* ]]; then
+    elif [[ $NODENAME == mia1* ]]; then
         export MODEL_PATH="/it-share/data"
     else
         echo "[Error] No available nodes for launching slurm jobs"


### PR DESCRIPTION
This patch is to support multiple cluster for MI355X distributed inference CI workflow.
This patch co-work with the branch sa-260114 of recipe  https://github.com/billishyahao/sglang_disagg.git
The main change of recipe between sa-260107 and sa-260114 is as https://github.com/billishyahao/sglang_disagg/compare/sa-260107...sa-260114

Key features and bug fixes of sa-260114 are as below
- [Return jobid to caller](https://github.com/billishyahao/sglang_disagg/commit/c389d98af2b1808044a39a8b6cbaa662795496e2)
- [Add TC mapping check](https://github.com/billishyahao/sglang_disagg/commit/b22722dbf9d833876eb513c3abc563772a529377)
- [Mount nicctl to fetch NIC QoS and Priorities](https://github.com/billishyahao/sglang_disagg/commit/b22722dbf9d833876eb513c3abc563772a529377)
- [Auto select HCA](https://github.com/billishyahao/sglang_disagg/commit/9344a1c849dbd55bb17ef7a4812f1387b25eaa6d)
- [Remove hardcode nodelist](https://github.com/billishyahao/sglang_disagg/commit/1985f508a6908b898be106329033f952e140d04c)

Co-author: [@ichbinblau](https://github.com/ichbinblau)

Validated through sweep https://github.com/InferenceMAX/InferenceMAX/actions/runs/21025811633

