### PR TITLE
feat: use opus model by default for PR reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -35,12 +35,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: opus
           trigger_phrase: "@pr-claude"
           track_progress: true
           allowed_bots: ''
           
           claude_args: |
+            --model 'claude-opus-4-5-20251101'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: opus
           trigger_phrase: "@pr-claude"
           track_progress: true
           allowed_bots: ''


### PR DESCRIPTION
Resolves #461

Adds `model: opus` to the PR review workflow so it uses Claude Opus 4.5 by default.

Generated with [Claude Code](https://claude.ai/code)