### PR TITLE
feat: set default value for --runner-config flag; claude code shouldn't need to explicitly set the default runner yaml every time, it should be default

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,7 +32,7 @@ The `full-sweep` command generates benchmark configurations with optional filter
 ```
 usage: generate_sweep_configs.py full-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
-    --runner-config RUNNER_CONFIG
+    [--runner-config RUNNER_CONFIG]
     [--model-prefix MODEL_PREFIX [MODEL_PREFIX ...]]
     [--precision PRECISION [PRECISION ...]]
     [--framework FRAMEWORK [FRAMEWORK ...]]
@@ -84,7 +84,7 @@ The `runner-model-sweep` command validates that all runner nodes of a specific t
 ```
 usage: generate_sweep_configs.py runner-model-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
-    --runner-config RUNNER_CONFIG
+    [--runner-config RUNNER_CONFIG]
     --runner-type RUNNER_TYPE
     [--runner-node-filter RUNNER_NODE_FILTER]
     (--single-node | --multi-node)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,32 +49,32 @@ usage: generate_sweep_configs.py full-sweep
 
 **Test all single-node gptoss configurations on B200 with 1k1k sequence lengths:**
 ```
-full-sweep --single-node --model-prefix gptoss --runner-type b200 --seq-lens 1k1k --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --single-node --model-prefix gptoss --runner-type b200 --seq-lens 1k1k --config-files .github/configs/nvidia-master.yaml
 ```
 
 **Test all single-node fp8 precision configs for 1k8k workloads:**
 ```
-full-sweep --single-node --precision fp8 --seq-lens 1k8k --config-files .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --single-node --precision fp8 --seq-lens 1k8k --config-files .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml
 ```
 
 **Test all single-node TRT configs on H200 runners:**
 ```
-full-sweep --single-node --framework trt --runner-type h200 b200-trt --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --single-node --framework trt --runner-type h200 b200-trt --config-files .github/configs/nvidia-master.yaml
 ```
 
 **Test specific single-node model on specific hardware with specific sequence lengths:**
 ```
-full-sweep --single-node --model-prefix dsr1 --runner-type b200 --precision fp4 --framework sglang --seq-lens 1k1k 8k1k --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --single-node --model-prefix dsr1 --runner-type b200 --precision fp4 --framework sglang --seq-lens 1k1k 8k1k --config-files .github/configs/nvidia-master.yaml
 ```
 
 **Limit concurrency and parallelism for faster testing:**
 ```
-full-sweep --single-node --max-conc 64 --max-tp 4 --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --single-node --max-conc 64 --max-tp 4 --config-files .github/configs/nvidia-master.yaml
 ```
 
 **Test all multi-node configurations:**
 ```
-full-sweep --multi-node --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+full-sweep --multi-node --config-files .github/configs/nvidia-master.yaml
 ```
 
 ## `runner-model-sweep` Command
@@ -96,7 +96,7 @@ I just upgraded the CUDA drivers on all H200 runners and need to verify that all
 
 Go to the GitHub Actions UI, click on the `End-to-End Tests` workflow, and enter the following command as the text input:
 ```
-runner-model-sweep --single-node --runner-type h200 --config-files .github/configs/amd-master.yaml .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml
+runner-model-sweep --single-node --runner-type h200 --config-files .github/configs/amd-master.yaml .github/configs/nvidia-master.yaml
 ```
 
 This will run a test (just the highest available parallelism and lowest available concurrency) for each configuration that specifies the `h200` runner type, across all H200 runner nodes defined in `.github/configs/runners.yaml`.
@@ -112,7 +112,7 @@ This is particularly useful when:
 
 Use `--runner-node-filter` to only test a subset of runner nodes:
 ```
-runner-model-sweep --single-node --runner-type mi300x --runner-node-filter mi300x-amd --config-files .github/configs/amd-master.yaml --runner-config .github/configs/runners.yaml
+runner-model-sweep --single-node --runner-type mi300x --runner-node-filter mi300x-amd --config-files .github/configs/amd-master.yaml
 ```
 
 This will only include runner nodes whose names contain "mi300x-amd"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -90,22 +90,22 @@ jobs:
 
             **Filter by model prefix and Nvidia nodes:**
             ```
-            generate-cli-command: "full-sweep --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml --single-node --model-prefix dsr1"
+            generate-cli-command: "full-sweep --config-files .github/configs/nvidia-master.yaml --single-node --model-prefix dsr1"
             ```
 
             **Filter by framework and AMD nodes:**
             ```
-            generate-cli-command: "full-sweep --config-files .github/configs/amd-master.yaml --runner-config .github/configs/runners.yaml --single-node --framework sglang"
+            generate-cli-command: "full-sweep --config-files .github/configs/amd-master.yaml --single-node --framework sglang"
             ```
 
             **Filter by precision and runner type:**
             ```
-            generate-cli-command: "full-sweep --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml --single-node --precision fp8 --runner-type h200"
+            generate-cli-command: "full-sweep --config-files .github/configs/nvidia-master.yaml --single-node --precision fp8 --runner-type h200"
             ```
 
             **Test specific config keys:**
             ```
-            generate-cli-command: "test-config --config-files .github/configs/nvidia-master.yaml --runner-config .github/configs/runners.yaml --config-keys dsr1-fp4-b200-sglang"
+            generate-cli-command: "test-config --config-files .github/configs/nvidia-master.yaml --config-keys dsr1-fp4-b200-sglang"
             ```
 
             **IMPORTANT: Keep runs precise and efficient:**

--- a/AGENT.md
+++ b/AGENT.md
@@ -60,30 +60,30 @@ python -m pytest matrix_logic/ -v
 # Full sweep with all configs
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runners-config .github/configs/runners.yaml
+  --runner-config .github/configs/runners.yaml
 
 # Filter by model prefix (dsr1 or gptoss)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runners-config .github/configs/runners.yaml \
+  --runner-config .github/configs/runners.yaml \
   --model dsr1
 
 # Filter by framework (sglang, trt, vllm, atom, dynamo-trt, dynamo-sglang)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runners-config .github/configs/runners.yaml \
+  --runner-config .github/configs/runners.yaml \
   --framework sglang
 
 # Filter by precision (fp4, fp8)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runners-config .github/configs/runners.yaml \
+  --runner-config .github/configs/runners.yaml \
   --precision fp8
 
 # Filter by runner type (b200, h100, h200, gb200, mi300x, mi325x, mi355x)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runners-config .github/configs/runners.yaml \
+  --runner-config .github/configs/runners.yaml \
   --runner b200
 ```
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -59,31 +59,26 @@ python -m pytest matrix_logic/ -v
 ```bash
 # Full sweep with all configs
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --master-config .github/configs/nvidia-master.yaml \
-  --runner-config .github/configs/runners.yaml
+  --master-config .github/configs/nvidia-master.yaml
 
 # Filter by model prefix (dsr1 or gptoss)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runner-config .github/configs/runners.yaml \
   --model dsr1
 
 # Filter by framework (sglang, trt, vllm, atom, dynamo-trt, dynamo-sglang)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runner-config .github/configs/runners.yaml \
   --framework sglang
 
 # Filter by precision (fp4, fp8)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runner-config .github/configs/runners.yaml \
   --precision fp8
 
 # Filter by runner type (b200, h100, h200, gb200, mi300x, mi325x, mi355x)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --master-config .github/configs/nvidia-master.yaml \
-  --runner-config .github/configs/runners.yaml \
   --runner b200
 ```
 

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -508,8 +508,8 @@ def main():
     )
     parent_parser.add_argument(
         '--runner-config',
-        required=True,
-        help='Configuration file holding runner information (YAML format)'
+        default='.github/configs/runners.yaml',
+        help='Configuration file holding runner information (YAML format, defaults to .github/configs/runners.yaml)'
     )
 
     # Create main parser

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -946,3 +946,129 @@ class TestEdgeCases:
         assert result[0]["tp"] == 2
         assert result[0]["ep"] == 1
         assert result[0]["conc"] == 1
+
+
+# =============================================================================
+# Test argument parsing and defaults
+# =============================================================================
+
+class TestArgumentDefaults:
+    """Tests for command-line argument parsing and default values."""
+
+    def test_runner_config_default_value(self):
+        """Verify --runner-config defaults to .github/configs/runners.yaml."""
+        import sys
+        from generate_sweep_configs import main
+
+        # Save original sys.argv
+        original_argv = sys.argv
+
+        try:
+            # Simulate command-line args without --runner-config flag
+            sys.argv = [
+                'generate_sweep_configs.py',
+                'full-sweep',
+                '--config-files', 'dummy.yaml',
+                '--single-node'
+            ]
+
+            # Parse args using the ArgumentParser from main
+            # We need to access the parser directly
+            import argparse
+            from generate_sweep_configs import main
+
+            # Create the same parent parser as in main()
+            parent_parser = argparse.ArgumentParser(add_help=False)
+            parent_parser.add_argument(
+                '--config-files',
+                nargs='+',
+                required=True,
+                help='One or more configuration files (YAML format)'
+            )
+            parent_parser.add_argument(
+                '--runner-config',
+                default='.github/configs/runners.yaml',
+                help='Configuration file holding runner information (YAML format, defaults to .github/configs/runners.yaml)'
+            )
+
+            # Create main parser
+            parser = argparse.ArgumentParser(
+                description='Generate benchmark configurations from YAML config files'
+            )
+
+            # Create subparsers
+            subparsers = parser.add_subparsers(
+                dest='command',
+                required=True,
+                help='Available commands'
+            )
+
+            # Add full-sweep subparser
+            full_sweep_parser = subparsers.add_parser(
+                'full-sweep',
+                parents=[parent_parser],
+                add_help=False,
+                help='Generate full sweep configurations'
+            )
+            full_sweep_parser.add_argument('--single-node', action='store_true')
+            full_sweep_parser.add_argument('--multi-node', action='store_true')
+
+            # Parse the args
+            args = parser.parse_args(['full-sweep', '--config-files', 'dummy.yaml', '--single-node'])
+
+            # Verify the default value
+            assert args.runner_config == '.github/configs/runners.yaml'
+
+        finally:
+            # Restore original sys.argv
+            sys.argv = original_argv
+
+    def test_runner_config_explicit_value(self):
+        """Verify --runner-config can be explicitly set."""
+        import argparse
+
+        # Create the same parent parser as in main()
+        parent_parser = argparse.ArgumentParser(add_help=False)
+        parent_parser.add_argument(
+            '--config-files',
+            nargs='+',
+            required=True,
+            help='One or more configuration files (YAML format)'
+        )
+        parent_parser.add_argument(
+            '--runner-config',
+            default='.github/configs/runners.yaml',
+            help='Configuration file holding runner information (YAML format, defaults to .github/configs/runners.yaml)'
+        )
+
+        # Create main parser
+        parser = argparse.ArgumentParser(
+            description='Generate benchmark configurations from YAML config files'
+        )
+
+        # Create subparsers
+        subparsers = parser.add_subparsers(
+            dest='command',
+            required=True,
+            help='Available commands'
+        )
+
+        # Add full-sweep subparser
+        full_sweep_parser = subparsers.add_parser(
+            'full-sweep',
+            parents=[parent_parser],
+            add_help=False,
+            help='Generate full sweep configurations'
+        )
+        full_sweep_parser.add_argument('--single-node', action='store_true')
+
+        # Parse with explicit --runner-config
+        args = parser.parse_args([
+            'full-sweep',
+            '--config-files', 'dummy.yaml',
+            '--runner-config', 'custom/path/runners.yaml',
+            '--single-node'
+        ])
+
+        # Verify the explicit value
+        assert args.runner_config == 'custom/path/runners.yaml'

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -5,7 +5,7 @@ import subprocess
 from collections import defaultdict
 
 import yaml
-from constants import GENERATE_SWEEPS_PY_SCRIPT, MASTER_CONFIGS, RUNNER_CONFIG
+from constants import GENERATE_SWEEPS_PY_SCRIPT, MASTER_CONFIGS
 from matrix_logic.generate_sweep_configs import seq_len_to_str
 from matrix_logic.validation import (
     ChangelogEntry,
@@ -113,8 +113,6 @@ def main():
                     *configs_to_run,
                     "--config-files",
                     *MASTER_CONFIGS,
-                    "--runner-config",
-                    RUNNER_CONFIG,
                 ],
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Set --runner-config to default to .github/configs/runners.yaml in
generate_sweep_configs.py and remove explicit --runner-config flags
from all usage examples in claude.yml and README.md files.

There is no other runner.yaml that people have used. Hence the need to set it as default

Closes #464

Generated with [Claude Code](https://claude.ai/code)