### PR TITLE
feat: set opus as default model in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,7 @@ jobs:
           track_progress: true
           allowed_bots: ''
           claude_args: |
-            --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude opus') && 'claude-opus-4-5-20251101' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-sonnet-4-5-20250929' }}
+            --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude sonnet') && 'claude-sonnet-4-5-20250929' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-opus-4-5-20251101' }}
             --allowedTools "Write,Edit,Read,Glob,Grep,mcp__github__*,mcp__github_inline_comment__create_inline_comment,Bash(*,timeout=28800000)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Changed the default model from Sonnet to Opus (claude-opus-4-5-20251101).
Users can now explicitly use @claude sonnet or @claude haiku if needed.

Fixes #466

Generated with [Claude Code](https://claude.ai/code)