### PR TITLE
feat: add --min-conc flag for narrower sweeps

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -109,7 +109,8 @@ jobs:
             ```
 
             **IMPORTANT: Keep runs precise and efficient:**
-            - Use `--max-conc` to limit concurrent jobs and avoid overwhelming runners
+            - Use `--min-conc` and `--max-conc` together to specify a range of concurrency values for targeted sweeps
+            - Use `--max-conc` alone to limit concurrent jobs and avoid overwhelming runners
             - Define specific config keys with `--config-keys` instead of running full sweeps
             - Filter by specific models, frameworks, or precision when possible
             - Consider runner availability before triggering large sweeps

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -133,6 +133,14 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             if conc > conc_end:
                                 conc = conc_end
 
+                    # Apply min-conc filter if specified
+                    if args.min_conc is not None:
+                        if args.min_conc <= 0:
+                            continue  # Skip if min_conc is not positive
+                        conc_values = [c for c in conc_values if c >= args.min_conc]
+                        if not conc_values:
+                            continue  # Skip if no values meet the min_conc requirement
+
                     # Apply max-conc filter if specified
                     # If max_conc is less than all values, use max_conc directly (if valid)
                     if args.max_conc is not None:
@@ -192,6 +200,15 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             continue  # Skip if max_ep is not positive
                         if ep is not None and ep > args.max_ep:
                             ep = args.max_ep
+
+                    # Apply min-conc filter if specified
+                    # If conc_end < min_conc, skip this config entirely
+                    if args.min_conc is not None:
+                        if args.min_conc <= 0:
+                            continue  # Skip if min_conc is not positive
+                        if conc_end < args.min_conc:
+                            continue  # Skip if entire range is below min_conc
+                        conc_start = max(conc_start, args.min_conc)
 
                     # Apply max-conc filter if specified
                     # If conc_start > max_conc, use max_conc as both start and end (if valid)
@@ -567,6 +584,12 @@ def main():
         type=int,
         default=2,
         help='Step size for concurrency values (default: 2)'
+    )
+    full_sweep_parser.add_argument(
+        '--min-conc',
+        type=int,
+        required=False,
+        help='Minimum concurrency value to include (filters out lower concurrency values)'
     )
     full_sweep_parser.add_argument(
         '--max-conc',

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -116,6 +116,7 @@ def full_sweep_args_single_node():
     args.runner_type = None
     args.seq_lens = None
     args.step_size = 2
+    args.min_conc = None
     args.max_conc = None
     args.max_tp = None
     args.max_ep = None
@@ -134,6 +135,7 @@ def full_sweep_args_multi_node():
     args.runner_type = None
     args.seq_lens = None
     args.step_size = 2
+    args.min_conc = None
     args.max_conc = None
     args.max_tp = None
     args.max_ep = None


### PR DESCRIPTION
Adds a `--min-conc` argument to the `full-sweep` subcommand to complement the existing `--max-conc` flag. This allows users to specify a range of concurrency values by using both flags together, enabling more targeted sweeps.

Closes #471

Generated with [Claude Code](https://claude.ai/claude-code)