### PR TITLE
MCP for sglang/vllm codebase for additional context

### DIFF
--- a/.claude/mcp/__init__.py
+++ b/.claude/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server for vLLM and SGLang repository access."""

--- a/.claude/mcp/mcp_utils.py
+++ b/.claude/mcp/mcp_utils.py
@@ -1,0 +1,365 @@
+"""Utility functions for MCP server - version detection, repo management, and filtering."""
+
+import os
+import re
+import logging
+import fnmatch
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+import yaml
+import git
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+def get_config_paths() -> List[str]:
+    """Get paths to InferenceMAX config files."""
+    root = Path(os.getenv('INFERENCEMAX_ROOT', Path.cwd()))
+    return [
+        str(root / '.github/configs/amd-master.yaml'),
+        str(root / '.github/configs/nvidia-master.yaml'),
+    ]
+
+
+def get_clone_dir() -> Path:
+    """Get directory for repository clones."""
+    return Path('/tmp/inferencemax-mcp')
+
+
+# ============================================================================
+# Version Detection
+# ============================================================================
+
+# Regex patterns for version extraction
+VLLM_PATTERNS = [
+    r'vllm/vllm-openai:v?([\d.]+(?:rc\d+)?)',  # vllm/vllm-openai:v0.13.0
+    r'vllm_([\d.]+)',                           # vllm_0.10.1
+]
+
+SGLANG_PATTERNS = [
+    r'lmsysorg/sglang:v?([\d.]+(?:\.post\d+)?)',   # lmsysorg/sglang:v0.5.7
+    r'sglang[:-](\d+\.\d+\.\d+(?:\.post\d+)?)',    # sglang-0.5.6.post1
+]
+
+
+def extract_version(image: str, patterns: List[str]) -> Optional[str]:
+    """
+    Extract version from Docker image tag using regex patterns.
+
+    Args:
+        image: Docker image string (e.g., "vllm/vllm-openai:v0.13.0")
+        patterns: List of regex patterns to try
+
+    Returns:
+        Extracted version string or None if not found
+    """
+    for pattern in patterns:
+        match = re.search(pattern, image, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return None
+
+
+def select_primary_version(versions: Set[str]) -> str:
+    """
+    Select primary version from a set using semantic versioning.
+
+    Args:
+        versions: Set of version strings
+
+    Returns:
+        Latest version by semantic versioning, or 'main' if empty
+    """
+    if not versions:
+        return 'main'
+
+    def parse_version(v: str) -> tuple:
+        """Parse version string into tuple for comparison."""
+        v_clean = v.lstrip('v')
+        # Handle post-releases and rc versions
+        v_clean = v_clean.replace('.post', '.').replace('rc', '.')
+        parts = v_clean.split('.')
+        return tuple(int(p) if p.isdigit() else 0 for p in parts)
+
+    return max(versions, key=parse_version)
+
+
+def detect_versions(config_paths: List[str]) -> Dict[str, Set[str]]:
+    """
+    Parse config files and extract vLLM and SGLang versions.
+
+    Args:
+        config_paths: Paths to YAML config files
+
+    Returns:
+        Dictionary mapping framework names to sets of detected versions:
+        {'vllm': {'0.13.0', '0.10.1'}, 'sglang': {'0.5.7', ...}}
+    """
+    versions = {'vllm': set(), 'sglang': set()}
+
+    for config_path in config_paths:
+        if not os.path.exists(config_path):
+            logger.warning(f"Config file not found: {config_path}")
+            continue
+
+        try:
+            with open(config_path, 'r') as f:
+                config = yaml.safe_load(f)
+
+            if not config:
+                continue
+
+            for config_name, config_data in config.items():
+                if not isinstance(config_data, dict) or 'image' not in config_data:
+                    continue
+
+                image = config_data['image']
+                framework = config_data.get('framework', '')
+
+                # Detect vLLM version
+                if 'vllm' in framework.lower() or 'vllm' in image.lower():
+                    version = extract_version(image, VLLM_PATTERNS)
+                    if version:
+                        versions['vllm'].add(version)
+                        logger.debug(f"Detected vLLM version {version} from {config_name}")
+
+                # Detect SGLang version
+                if 'sglang' in framework.lower() or 'sglang' in image.lower():
+                    version = extract_version(image, SGLANG_PATTERNS)
+                    if version:
+                        versions['sglang'].add(version)
+                        logger.debug(f"Detected SGLang version {version} from {config_name}")
+
+        except Exception as e:
+            logger.error(f"Error parsing config file {config_path}: {e}")
+
+    return versions
+
+
+# ============================================================================
+# Repository Management
+# ============================================================================
+
+REPO_URLS = {
+    'vllm': 'https://github.com/vllm-project/vllm.git',
+    'sglang': 'https://github.com/sgl-project/sglang.git',
+}
+
+
+def initialize_repo(name: str, url: str, path: Path) -> git.Repo:
+    """
+    Clone or update a repository.
+
+    Args:
+        name: Repository name (for logging)
+        url: Git repository URL
+        path: Local path for repository
+
+    Returns:
+        GitPython Repo object
+    """
+    if path.exists():
+        # Repository exists, update it
+        logger.info(f"Updating {name} repository at {path}")
+        repo = git.Repo(path)
+        try:
+            origin = repo.remotes.origin
+            origin.fetch()
+        except Exception as e:
+            logger.warning(f"Failed to fetch updates for {name}: {e}")
+    else:
+        # Clone repository
+        logger.info(f"Cloning {name} from {url}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        repo = git.Repo.clone_from(url, path)
+
+    return repo
+
+
+def fuzzy_match_tag(repo: git.Repo, version: str) -> Optional[str]:
+    """
+    Find best matching tag for a version using fuzzy matching.
+
+    Args:
+        repo: GitPython Repo object
+        version: Version string to match
+
+    Returns:
+        Matching tag name or None
+    """
+    all_tags = [tag.name for tag in repo.tags]
+
+    # Try exact matches with different prefixes
+    tag_candidates = [
+        f'v{version}',      # v0.5.7
+        version,            # 0.5.7
+        f'{version}.0',     # 0.5.7.0
+    ]
+
+    for candidate in tag_candidates:
+        if candidate in all_tags:
+            return candidate
+
+    # Fuzzy match: find tags containing version digits
+    version_digits = version.replace('.', '')
+    matching_tags = [t for t in all_tags if version_digits in t.replace('.', '')]
+
+    if matching_tags:
+        # Return the first match (usually the most specific)
+        return matching_tags[0]
+
+    return None
+
+
+def checkout_version(repo: git.Repo, framework: str, version: str) -> bool:
+    """
+    Checkout a specific version with fuzzy matching.
+
+    Args:
+        repo: GitPython Repo object
+        framework: Framework name (for logging)
+        version: Version string to checkout
+
+    Returns:
+        True if checkout successful, False otherwise
+    """
+    # Try to find matching tag
+    tag = fuzzy_match_tag(repo, version)
+
+    if tag:
+        try:
+            repo.git.checkout(tag)
+            logger.info(f"Checked out {framework} at {tag}")
+            return True
+        except git.GitCommandError as e:
+            logger.warning(f"Failed to checkout {tag} for {framework}: {e}")
+    else:
+        logger.warning(f"Could not find tag for version {version} in {framework}")
+
+    # Fallback to main/master
+    for branch in ['main', 'master']:
+        try:
+            repo.git.checkout(branch)
+            logger.info(f"Checked out {framework} at {branch} (fallback)")
+            return True
+        except git.GitCommandError as e:
+            logger.debug(f"Branch {branch} not available: {e}")
+
+    logger.error(f"Failed to checkout any branch for {framework}")
+    return False
+
+
+# ============================================================================
+# Path Filtering
+# ============================================================================
+
+EXCLUDE_PATTERNS = [
+    # Test directories
+    '**/tests/**',
+    '**/test/**',
+    '**/*_test.py',
+    '**/testing/**',
+
+    # Documentation
+    '**/docs/**',
+    '**/doc/**',
+    '**/*.md',  # Exclude markdown files (except root README)
+    '**/examples/**',
+
+    # Build artifacts
+    '**/build/**',
+    '**/dist/**',
+    '**/__pycache__/**',
+    '**/*.pyc',
+    '**/*.pyo',
+    '**/.git/**',
+
+    # IDE and config
+    '**/.vscode/**',
+    '**/.idea/**',
+    '**/.github/**',
+
+    # Large binary/data files
+    '**/*.so',
+    '**/*.whl',
+    '**/*.egg-info/**',
+]
+
+INCLUDE_PATTERNS = [
+    # Core Python source
+    '**/*.py',
+
+    # Configuration files
+    '**/pyproject.toml',
+    '**/setup.py',
+    '**/requirements*.txt',
+]
+
+# Special case: allow root-level README.md
+ROOT_ALLOWED_FILES = ['README.md', 'LICENSE']
+
+
+def should_include_file(file_path: Path, repo_path: Path) -> bool:
+    """
+    Determine if a file should be included in MCP resources.
+
+    Args:
+        file_path: Absolute path to file
+        repo_path: Repository root path
+
+    Returns:
+        True if file should be included
+    """
+    try:
+        rel_path = file_path.relative_to(repo_path)
+    except ValueError:
+        # File is not inside repo_path
+        return False
+
+    rel_path_str = str(rel_path)
+
+    # Check if it's a root-level allowed file
+    if rel_path.name in ROOT_ALLOWED_FILES and len(rel_path.parts) == 1:
+        return True
+
+    # Check exclude patterns first
+    for pattern in EXCLUDE_PATTERNS:
+        if fnmatch.fnmatch(rel_path_str, pattern):
+            return False
+
+    # Check include patterns
+    for pattern in INCLUDE_PATTERNS:
+        if fnmatch.fnmatch(rel_path_str, pattern):
+            return True
+
+    return False
+
+
+def list_filtered_files(repo_path: Path) -> List[Path]:
+    """
+    List all files in repository that pass the filter.
+
+    Args:
+        repo_path: Repository root path
+
+    Returns:
+        List of absolute file paths that should be exposed
+    """
+    if not repo_path.exists():
+        logger.warning(f"Repository path does not exist: {repo_path}")
+        return []
+
+    filtered_files = []
+
+    try:
+        for file_path in repo_path.rglob('*'):
+            if file_path.is_file() and should_include_file(file_path, repo_path):
+                filtered_files.append(file_path)
+    except Exception as e:
+        logger.error(f"Error listing files in {repo_path}: {e}")
+
+    return filtered_files

--- a/.claude/mcp/mcp_utils.py
+++ b/.claude/mcp/mcp_utils.py
@@ -264,12 +264,6 @@ EXCLUDE_PATTERNS = [
     '**/*_test.py',
     '**/testing/**',
 
-    # Documentation
-    '**/docs/**',
-    '**/doc/**',
-    '**/*.md',  # Exclude markdown files (except root README)
-    '**/examples/**',
-
     # Build artifacts
     '**/build/**',
     '**/dist/**',

--- a/.claude/mcp/server.py
+++ b/.claude/mcp/server.py
@@ -1,0 +1,313 @@
+"""MCP Server for vLLM and SGLang repository access."""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+import sys
+
+# Add parent directory to path to allow imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# Import MCP SDK
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Resource, Tool, TextContent
+
+# Import utility functions - use absolute import path
+try:
+    # Try relative import first (when run as module)
+    from .mcp_utils import (
+        get_config_paths,
+        get_clone_dir,
+        detect_versions,
+        select_primary_version,
+        initialize_repo,
+        checkout_version,
+        list_filtered_files,
+        REPO_URLS,
+    )
+except ImportError:
+    # Fall back to direct import (when run as script)
+    import importlib.util
+    mcp_utils_path = Path(__file__).parent / 'mcp_utils.py'
+    spec = importlib.util.spec_from_file_location('mcp_utils', mcp_utils_path)
+    mcp_utils = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mcp_utils)
+
+    get_config_paths = mcp_utils.get_config_paths
+    get_clone_dir = mcp_utils.get_clone_dir
+    detect_versions = mcp_utils.detect_versions
+    select_primary_version = mcp_utils.select_primary_version
+    initialize_repo = mcp_utils.initialize_repo
+    checkout_version = mcp_utils.checkout_version
+    list_filtered_files = mcp_utils.list_filtered_files
+    REPO_URLS = mcp_utils.REPO_URLS
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    stream=sys.stderr,  # Log to stderr so it doesn't interfere with stdio MCP communication
+)
+logger = logging.getLogger(__name__)
+
+
+class InferenceMAXMCPServer:
+    """MCP Server for vLLM and SGLang source code access."""
+
+    def __init__(self):
+        self.server = Server("inferencemax-repos")
+        self.repos = {}  # {framework: git.Repo}
+        self.resource_cache = {}  # {framework: List[Path]}
+
+        # Register MCP handlers
+        @self.server.list_resources()
+        async def handle_list_resources() -> List[Resource]:
+            return await self.list_resources()
+
+        @self.server.read_resource()
+        async def handle_read_resource(uri: str) -> str:
+            return await self.read_resource(uri)
+
+        @self.server.list_tools()
+        async def handle_list_tools() -> List[Tool]:
+            return await self.list_tools()
+
+        @self.server.call_tool()
+        async def handle_call_tool(name: str, arguments: dict) -> List[TextContent]:
+            return await self.call_tool(name, arguments)
+
+    async def initialize(self):
+        """Initialize repositories and detect versions."""
+        logger.info("Initializing InferenceMAX MCP Server...")
+
+        try:
+            # Detect versions from config files
+            config_paths = get_config_paths()
+            logger.info(f"Reading configs from: {config_paths}")
+            versions = detect_versions(config_paths)
+            logger.info(f"Detected versions: {versions}")
+
+            # Initialize repositories
+            clone_dir = get_clone_dir()
+            clone_dir.mkdir(parents=True, exist_ok=True)
+
+            for framework, url in REPO_URLS.items():
+                repo_path = clone_dir / framework
+                logger.info(f"Initializing {framework} repository...")
+
+                # Clone or update repository
+                repo = initialize_repo(framework, url, repo_path)
+                self.repos[framework] = repo
+
+                # Checkout appropriate version
+                framework_versions = versions.get(framework, set())
+                if framework_versions:
+                    primary_version = select_primary_version(framework_versions)
+                    logger.info(f"Checking out {framework} version {primary_version}")
+                    checkout_version(repo, framework, primary_version)
+                else:
+                    logger.warning(f"No versions detected for {framework}, using default branch")
+
+                # Build resource cache
+                logger.info(f"Building resource cache for {framework}...")
+                self.resource_cache[framework] = list_filtered_files(repo_path)
+                logger.info(f"Found {len(self.resource_cache[framework])} files for {framework}")
+
+            logger.info("Initialization complete!")
+
+        except Exception as e:
+            logger.error(f"Initialization failed: {e}", exc_info=True)
+            raise
+
+    async def list_resources(self) -> List[Resource]:
+        """List all available MCP resources."""
+        resources = []
+
+        for framework, files in self.resource_cache.items():
+            repo_path = get_clone_dir() / framework
+
+            for file_path in files:
+                try:
+                    rel_path = file_path.relative_to(repo_path)
+                    uri = f"{framework}:///{rel_path}"
+
+                    resources.append(Resource(
+                        uri=uri,
+                        name=str(rel_path),
+                        mimeType="text/plain",
+                        description=f"{framework} source file: {rel_path}",
+                    ))
+                except Exception as e:
+                    logger.warning(f"Error creating resource for {file_path}: {e}")
+
+        logger.info(f"Listed {len(resources)} total resources")
+        return resources
+
+    async def read_resource(self, uri: str) -> str:
+        """Read a specific resource by URI."""
+        logger.info(f"Reading resource: {uri}")
+
+        # Parse URI: vllm:///path/to/file.py
+        if uri.startswith('vllm:///'):
+            framework = 'vllm'
+            rel_path = uri[8:]  # Remove 'vllm:///'
+        elif uri.startswith('sglang:///'):
+            framework = 'sglang'
+            rel_path = uri[10:]  # Remove 'sglang:///'
+        else:
+            error_msg = f"Unknown URI scheme: {uri}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        if framework not in self.repos:
+            error_msg = f"Framework not available: {framework}"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
+
+        # Construct file path
+        repo_path = get_clone_dir() / framework
+        file_path = repo_path / rel_path
+
+        # Validate file exists and is in cache
+        if not file_path.exists():
+            error_msg = f"File not found: {rel_path}"
+            logger.error(error_msg)
+            raise FileNotFoundError(error_msg)
+
+        if file_path not in self.resource_cache.get(framework, []):
+            error_msg = f"File is filtered out: {rel_path}"
+            logger.error(error_msg)
+            raise PermissionError(error_msg)
+
+        # Read and return file contents
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            logger.info(f"Successfully read {len(content)} bytes from {uri}")
+            return content
+        except Exception as e:
+            error_msg = f"Error reading file {rel_path}: {e}"
+            logger.error(error_msg)
+            raise IOError(error_msg)
+
+    async def list_tools(self) -> List[Tool]:
+        """List available MCP tools."""
+        return [
+            Tool(
+                name="switch_version",
+                description="Switch to a different version of vLLM or SGLang",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "framework": {
+                            "type": "string",
+                            "enum": ["vllm", "sglang"],
+                            "description": "Framework to switch version for"
+                        },
+                        "version": {
+                            "type": "string",
+                            "description": "Version to switch to (e.g., '0.5.7', 'v0.13.0')"
+                        }
+                    },
+                    "required": ["framework", "version"]
+                }
+            ),
+            Tool(
+                name="list_versions",
+                description="List all detected versions from InferenceMAX configs",
+                inputSchema={
+                    "type": "object",
+                    "properties": {}
+                }
+            ),
+        ]
+
+    async def call_tool(self, name: str, arguments: dict) -> List[TextContent]:
+        """Handle tool calls."""
+        logger.info(f"Tool call: {name} with args: {arguments}")
+
+        if name == "switch_version":
+            framework = arguments["framework"]
+            version = arguments["version"]
+
+            if framework not in self.repos:
+                return [TextContent(
+                    type="text",
+                    text=f"Error: Framework '{framework}' not available"
+                )]
+
+            # Checkout version
+            repo = self.repos[framework]
+            success = checkout_version(repo, framework, version)
+
+            if success:
+                # Rebuild resource cache
+                repo_path = get_clone_dir() / framework
+                logger.info(f"Rebuilding resource cache for {framework}...")
+                self.resource_cache[framework] = list_filtered_files(repo_path)
+                logger.info(f"Found {len(self.resource_cache[framework])} files after version switch")
+
+                return [TextContent(
+                    type="text",
+                    text=f"Successfully switched {framework} to version {version}\n"
+                         f"Found {len(self.resource_cache[framework])} source files"
+                )]
+            else:
+                return [TextContent(
+                    type="text",
+                    text=f"Failed to switch {framework} to version {version}\n"
+                         f"Check logs for details"
+                )]
+
+        elif name == "list_versions":
+            config_paths = get_config_paths()
+            versions = detect_versions(config_paths)
+
+            result_lines = ["Detected versions from InferenceMAX configs:", ""]
+            for framework, version_set in versions.items():
+                if version_set:
+                    versions_str = ', '.join(sorted(version_set))
+                    result_lines.append(f"  {framework}: {versions_str}")
+                else:
+                    result_lines.append(f"  {framework}: (none detected)")
+
+            return [TextContent(
+                type="text",
+                text="\n".join(result_lines)
+            )]
+
+        else:
+            return [TextContent(
+                type="text",
+                text=f"Error: Unknown tool '{name}'"
+            )]
+
+    async def run(self):
+        """Run the MCP server."""
+        # Initialize repositories
+        await self.initialize()
+
+        # Start stdio server
+        logger.info("Starting MCP server on stdio...")
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                self.server.create_initialization_options()
+            )
+
+
+async def main():
+    """Main entry point."""
+    try:
+        server = InferenceMAXMCPServer()
+        await server.run()
+    except Exception as e:
+        logger.error(f"Server error: {e}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.claude/requirements-mcp.txt
+++ b/.claude/requirements-mcp.txt
@@ -1,0 +1,3 @@
+mcp>=0.9.0
+gitpython>=3.1.40
+pyyaml>=6.0

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -35,17 +35,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup MCP Server
+        run: |
+          pip install -r .claude/requirements-mcp.txt
+          mkdir -p /tmp/inferencemax-mcp
+
       - name: PR Review with Claude
         uses: anthropics/claude-code-action@v1
+        env:
+          INFERENCEMAX_ROOT: ${{ github.workspace }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@pr-claude"
           track_progress: true
           allowed_bots: ''
-          
+
           claude_args: |
             --model 'claude-opus-4-5-20251101'
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__inferencemax_repos__*,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -109,6 +116,27 @@ jobs:
             - Format: "Master config files were modified but `perf-changelog.yaml` was not updated. When changing `.github/configs/amd-master.yaml` or `.github/configs/nvidia-master.yaml`, you must add a corresponding entry to `perf-changelog.yaml` documenting the changes."
 
             Remember: Silence is golden. No comment is better than a low-value comment.
+
+            ## vLLM and SGLang Source Code Access:
+            You have access to vLLM and SGLang source code via the inferencemax-repos MCP server:
+            - Use `mcp__inferencemax_repos__*` tools to access repository source code
+            - Resources are available via URIs: `vllm:///path/to/file.py` and `sglang:///path/to/file.py`
+            - The server automatically detects and checks out the version matching InferenceMAX configs
+            - Use the `list_versions` tool to see detected versions
+            - Use the `switch_version` tool to switch to a different version if needed
+
+            **When to use this:**
+            - When reviewing changes that interact with vLLM/SGLang APIs or internals
+            - To verify that code correctly uses vLLM/SGLang features
+            - To check if assumptions about vLLM/SGLang behavior are accurate
+            - To understand how vLLM/SGLang implements features being used/modified
+            - To cross-reference documentation claims with actual implementation
+
+            **Example use cases:**
+            - PR modifies vLLM scheduler usage → Check actual vLLM scheduler implementation
+            - PR adds SGLang integration → Verify SGLang API matches the PR's usage
+            - PR claims feature X works a certain way → Read the source to confirm
+            - PR has a bug related to KV cache → Look at vLLM's KV cache implementation
 
             ## Line Count Report for generate_sweep_configs.py:
             If `utils/matrix_logic/generate_sweep_configs.py` was modified in this PR:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,10 +43,6 @@ jobs:
           pip install -r .claude/requirements-mcp.txt
           mkdir -p /tmp/inferencemax-mcp
 
-      - name: Setup MCP Server
-        run: |
-          pip install -r .claude/requirements-mcp.txt
-          mkdir -p /tmp/inferencemax-mcp
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,7 +69,7 @@ jobs:
 
           claude_args: |
             --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude sonnet') && 'claude-sonnet-4-5-20250929' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-opus-4-5-20251101' }}
-            --allowedTools "Write,Edit,Read,Glob,Grep,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__inferencemax_repos__*,Bash(*,timeout=28800000)"
+            --allowedTools "Write,Edit,Read,Glob,Grep,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__inferencemax_repos__*,mcp__fetch__*,Bash(*,timeout=28800000)"
           prompt: |
             REPO: ${{ github.repository }}
             PR/ISSUE NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,11 +38,22 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Setup MCP Server
+        run: |
+          pip install -r .claude/requirements-mcp.txt
+          mkdir -p /tmp/inferencemax-mcp
+
+      - name: Setup MCP Server
+        run: |
+          pip install -r .claude/requirements-mcp.txt
+          mkdir -p /tmp/inferencemax-mcp
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          INFERENCEMAX_ROOT: ${{ github.workspace }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -62,7 +73,7 @@ jobs:
 
           claude_args: |
             --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude sonnet') && 'claude-sonnet-4-5-20250929' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-opus-4-5-20251101' }}
-            --allowedTools "Write,Edit,Read,Glob,Grep,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__fetch__*,Bash(*,timeout=28800000)"
+            --allowedTools "Write,Edit,Read,Glob,Grep,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__inferencemax_repos__*,Bash(*,timeout=28800000)"
           prompt: |
             REPO: ${{ github.repository }}
             PR/ISSUE NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
@@ -150,6 +161,17 @@ jobs:
             - After reviewing code changes that might affect performance
 
             After triggering, monitor the workflow run using the returned run_id.
+
+            ## vLLM and SGLang Source Code Access
+
+            You have access to vLLM and SGLang source code via the inferencemax-repos MCP server:
+            - Use `mcp__inferencemax_repos__*` tools to access repository source code
+            - Resources are available via URIs: `vllm:///path/to/file.py` and `sglang:///path/to/file.py`
+            - The server automatically detects and checks out the version matching InferenceMAX configs
+            - Use the `list_versions` tool to see detected versions
+            - Use the `switch_version` tool to switch to a different version if needed
+
+            This gives you deep context about vLLM and SGLang internals when debugging issues or explaining behavior.
 
             Focus on: code quality, benchmark config changes, and performance impact.
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "inferencemax-repos": {
+      "command": "python",
+      "args": ["-m", ".claude.mcp.server"],
+      "env": {
+        "PYTHONPATH": "."
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,23 +9,3 @@
     }
   }
 }
-  "mcpServers": {
-    "inferencemax-repos": {
-      "command": "python",
-{
-  "mcpServers": {
-    "inferencemax-repos": {
-      "command": "python",
-      "args": [".claude/mcp/server.py"],
-      "env": {
-        "PYTHONPATH": "."
-      }
-    }
-  }
-}
-      "env": {
-        "PYTHONPATH": "."
-      }
-    }
-  }
-}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,6 +2,16 @@
   "mcpServers": {
     "inferencemax-repos": {
       "command": "python",
+      "args": [".claude/mcp/server.py"],
+      "env": {
+        "PYTHONPATH": "."
+      }
+    }
+  }
+}
+  "mcpServers": {
+    "inferencemax-repos": {
+      "command": "python",
 {
   "mcpServers": {
     "inferencemax-repos": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,17 @@
   "mcpServers": {
     "inferencemax-repos": {
       "command": "python",
-      "args": ["-m", ".claude.mcp.server"],
+{
+  "mcpServers": {
+    "inferencemax-repos": {
+      "command": "python",
+      "args": [".claude/mcp/server.py"],
+      "env": {
+        "PYTHONPATH": "."
+      }
+    }
+  }
+}
       "env": {
         "PYTHONPATH": "."
       }

--- a/test_mcp_server.py
+++ b/test_mcp_server.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Test script for InferenceMAX MCP Server."""
+
+import asyncio
+import sys
+from pathlib import Path
+import importlib.util
+
+# Load the server module directly
+server_path = Path(__file__).parent / '.claude' / 'mcp' / 'server.py'
+spec = importlib.util.spec_from_file_location('mcp_server', server_path)
+mcp_server = importlib.util.module_from_spec(spec)
+sys.modules['mcp_server'] = mcp_server
+spec.loader.exec_module(mcp_server)
+
+InferenceMAXMCPServer = mcp_server.InferenceMAXMCPServer
+
+async def test_initialization():
+    """Test MCP server initialization."""
+    print("=" * 60)
+    print("Testing InferenceMAX MCP Server")
+    print("=" * 60)
+
+    try:
+        print("\n1. Creating server instance...")
+        server = InferenceMAXMCPServer()
+
+        print("2. Initializing (this will clone repos, may take 2-3 minutes)...")
+        await server.initialize()
+
+        print("\n" + "=" * 60)
+        print("✓ Initialization complete!")
+        print("=" * 60)
+
+        print(f"\nvLLM resources: {len(server.resource_cache.get('vllm', []))} files")
+        print(f"SGLang resources: {len(server.resource_cache.get('sglang', []))} files")
+
+        # Show sample resources
+        print("\nSample vLLM files:")
+        vllm_files = server.resource_cache.get('vllm', [])
+        for file in vllm_files[:5]:
+            print(f"  - {file.relative_to(file.parent.parent.parent)}")
+
+        print("\nSample SGLang files:")
+        sglang_files = server.resource_cache.get('sglang', [])
+        for file in sglang_files[:5]:
+            print(f"  - {file.relative_to(file.parent.parent.parent)}")
+
+        print("\n" + "=" * 60)
+        print("✓ All tests passed!")
+        print("=" * 60)
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(test_initialization())


### PR DESCRIPTION
Clones the sglang/vllm codebase with ability to switch branch.

Tries to parse version from image name from `.github/configs/*-master.yaml`, then matches from list of branches in vllm/sglang repo.

Clones and works in `/tmp/inferencemax-mcp` 