### PR TITLE
chore: make enroot import idempotent

### DIFF
--- a/runners/launch_b200-nv.sh
+++ b/runners/launch_b200-nv.sh
@@ -15,6 +15,11 @@ JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
+    echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+    srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
+    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+fi
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_h100-cw.sh
+++ b/runners/launch_h100-cw.sh
@@ -11,6 +11,11 @@ SAGEMAKER_SHM_PATH=$(mktemp -d /mnt/vast/shm-XXXXXX)
 
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
+    echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+    srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
+    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+fi
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$SAGEMAKER_SHM_PATH:/dev/shm/sagemaker_sessions \

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -21,6 +21,11 @@ if [[ "$MODEL" == "openai/gpt-oss-120b" && "$FRAMEWORK" == "trt" ]]; then
     CONTAINER_IMAGE=$IMAGE
 else
     srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+    if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
+        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+        srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
+        srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+    fi
     CONTAINER_IMAGE=$(realpath $SQUASH_FILE)
 fi
 

--- a/runners/launch_h200-nb.sh
+++ b/runners/launch_h200-nb.sh
@@ -19,6 +19,11 @@ if [[ "$MODEL" == "openai/gpt-oss-120b" && "$FRAMEWORK" == "trt" ]]; then
     CONTAINER_IMAGE=$IMAGE
 else
     srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+    if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
+        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+        srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
+        srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+    fi
     CONTAINER_IMAGE=$(realpath $SQUASH_FILE)
 fi
 

--- a/runners/launch_h200-nv.sh
+++ b/runners/launch_h200-nv.sh
@@ -15,6 +15,11 @@ JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
 set -x
 srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
+    echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+    srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
+    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+fi
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -11,6 +11,11 @@ salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
 srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+if ! srun --jobid=$JOB_ID bash -c "sudo unsquashfs -l $SQUASH_FILE > /dev/null"; then
+    echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+    srun --jobid=$JOB_ID bash -c "sudo rm -f $SQUASH_FILE"
+    srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+fi
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_mi325x-amd.sh
+++ b/runners/launch_mi325x-amd.sh
@@ -11,6 +11,11 @@ salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no
 JOB_ID=$(squeue -u $USER -h -o %A | head -n1)
 
 srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+if ! srun --jobid=$JOB_ID bash -c "sudo unsquashfs -l $SQUASH_FILE > /dev/null"; then
+    echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+    srun --jobid=$JOB_ID bash -c "sudo rm -f $SQUASH_FILE"
+    srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+fi
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
 --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_mi355x-amd.sh
+++ b/runners/launch_mi355x-amd.sh
@@ -154,6 +154,11 @@ else
         srun --jobid=$JOB_ID bash -c "sudo rm $SQUASH_FILE"
     fi
     srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+    if ! srun --jobid=$JOB_ID bash -c "sudo unsquashfs -l $SQUASH_FILE > /dev/null"; then
+        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
+        srun --jobid=$JOB_ID bash -c "sudo rm -f $SQUASH_FILE"
+        srun --jobid=$JOB_ID bash -c "sudo enroot import -o $SQUASH_FILE docker://$IMAGE"
+    fi
     srun --jobid=$JOB_ID bash -c "sudo chmod -R a+rwX /hf-hub-cache/"
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \


### PR DESCRIPTION
For SLURM runners, in the case that the job is cancelled in the middle of `enroot import`, the squash file gets corrupted and the subsequent run on that node will fail to import immediately, forcing engineer to manually delete.

This should make the `enroot import` idempotent by checking it's validity prior to use.