### PR TITLE
prompt engineering claude to stop generating wrong CI commands

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -104,7 +104,12 @@ jobs:
             )
             ```
 
-            The `generate-cli-command` input accepts arguments for `generate_sweep_configs.py`. Examples:
+            The `generate-cli-command` input accepts arguments for `generate_sweep_configs.py`.
+
+            usage: `generate_sweep_configs.py` `[-h]`
+                                 `{full-sweep,runner-model-sweep,test-config}`
+            
+            Examples:
 
             **Filter by model prefix and Nvidia nodes:**
             ```


### PR DESCRIPTION
generate_sweep_configs.py: error: unrecognized arguments: --min-conc 4 --max-conc 4 --seq-len 1024:1024

<img width="935" height="233" alt="image" src="https://github.com/user-attachments/assets/3c61cb33-5408-4235-bcdf-f09120a13ad7" />


+viz @Oseltamivir 