### PR TITLE
fix: e2e tests didn't work without evals field marked

### DIFF
--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -244,6 +244,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                         Fields.MAX_MODEL_LEN.value: isl + osl + 200,
                         Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
                         Fields.DISAGG.value: disagg,
+                        Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
                     }
 
                     validate_matrix_entry(entry, is_multinode)
@@ -313,6 +314,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             Fields.SPEC_DECODING.value: spec_decoding,
                             Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
                             Fields.DISAGG.value: disagg,
+                            Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
                         }
 
                         if ep is not None:
@@ -427,6 +429,7 @@ def generate_runner_model_sweep_config(args, all_config_data, runner_data):
                     Fields.MAX_MODEL_LEN.value: 2048,
                     Fields.EXP_NAME.value: f"{model_code}_test",
                     Fields.DISAGG.value: disagg,
+                    Fields.RUN_EVAL.value: False,
                 }
                 matrix_values.append(validate_matrix_entry(entry, is_multinode=True))
         else:
@@ -458,6 +461,7 @@ def generate_runner_model_sweep_config(args, all_config_data, runner_data):
                     Fields.MAX_MODEL_LEN.value: 2048,
                     Fields.EXP_NAME.value: f"{model_code}_test",
                     Fields.DISAGG.value: disagg,
+                    Fields.RUN_EVAL.value: False,
                 }
                 matrix_values.append(validate_matrix_entry(entry, is_multinode=False))
 
@@ -537,6 +541,7 @@ def generate_test_config_sweep(args, all_config_data):
                         Fields.MAX_MODEL_LEN.value: isl + osl + 200,
                         Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
                         Fields.DISAGG.value: disagg,
+                        Fields.RUN_EVAL.value: False,
                     }
                     matrix_values.append(validate_matrix_entry(entry, is_multinode=True))
                 else:
@@ -580,6 +585,7 @@ def generate_test_config_sweep(args, all_config_data):
                             Fields.SPEC_DECODING.value: spec_decoding,
                             Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
                             Fields.DISAGG.value: disagg,
+                            Fields.RUN_EVAL.value: False,
                         }
                         matrix_values.append(validate_matrix_entry(entry, is_multinode=False))
 

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -43,6 +43,7 @@ def valid_single_node_matrix_entry():
         "max-model-len": 2248,
         "exp-name": "dsr1_1k1k",
         "disagg": False,
+        "run-eval": False,
     }
 
 
@@ -85,6 +86,7 @@ def valid_multinode_matrix_entry():
         "max-model-len": 2248,
         "exp-name": "dsr1_1k1k",
         "disagg": True,
+        "run-eval": False,
     }
 
 

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -88,7 +88,7 @@ class SingleNodeMatrixEntry(BaseModel):
     max_model_len: int = Field(alias=Fields.MAX_MODEL_LEN.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     disagg: bool
-    run_eval: bool = Field(alias=Fields.RUN_EVAL.value, default=False)
+    run_eval: bool = Field(alias=Fields.RUN_EVAL.value)
 
 
 class WorkerConfig(BaseModel):
@@ -125,7 +125,7 @@ class MultiNodeMatrixEntry(BaseModel):
     max_model_len: int = Field(alias=Fields.MAX_MODEL_LEN.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     disagg: bool
-    run_eval: bool = Field(alias=Fields.RUN_EVAL.value, default=False)
+    run_eval: bool = Field(alias=Fields.RUN_EVAL.value)
 
 
 def validate_matrix_entry(entry: dict, is_multinode: bool) -> dict:


### PR DESCRIPTION
<img width="972" height="519" alt="CleanShot 2026-01-22 at 10 54 18" src="https://github.com/user-attachments/assets/4ee49d85-93ba-459f-8f18-d3aea3b60ea7" />

The E2E tests workflow did not work following #258 was merged because of the lack of `run-eval: ${{ matrix.config.run-eval }}` input. Despite there being a default in `benchmark-*-tmpl.yml`, GitHub actions doesn't allow passing an empty string as input.

Demonstration of fix: https://github.com/InferenceMAX/InferenceMAX/actions/runs/21257189962