### PR TITLE
[AMD] feat: update MI355X GPT-OSS vLLM to v0.14.0 upstream

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -175,7 +175,7 @@ gptoss-fp4-mi325x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi355x-vllm:
-  image: rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1
+  image: vllm/vllm-openai-rocm:v0.14.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x

--- a/benchmarks/gptoss_fp4_mi355x_docker.sh
+++ b/benchmarks/gptoss_fp4_mi355x_docker.sh
@@ -14,16 +14,25 @@ check_env_vars \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 
-cat > config.yaml << EOF
-compilation-config: '{"compile_sizes":[1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116,118,120,122,124,126,128,256,512,1024,2048,8192] , "cudagraph_capture_sizes":[1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116,118,120,122,124,126,128,136,144,152,160,168,176,184,192,200,208,216,224,232,240,248,256,264,272,280,288,296,304,312,320,328,336,344,352,360,368,376,384,392,400,408,416,424,432,440,448,456,464,472,480,488,496,504,512,520,528,536,544,552,560,568,576,584,592,600,608,616,624,632,640,648,656,664,672,680,688,696,704,712,720,728,736,744,752,760,768,776,784,792,800,808,816,824,832,840,848,856,864,872,880,888,896,904,912,920,928,936,944,952,960,968,976,984,992,1000,1008,1016,1024,2048,4096,8192] , "cudagraph_mode": "FULL_AND_PIECEWISE"}' 
-EOF
+# If the machine runs a MEC FW older than 177, RCCL
+# cannot reclaim some memory.
+# Disable that features to avoid crashes.
+# This is related to the changes in the driver at:
+# https://rocm.docs.amd.com/en/docs-6.4.3/about/release-notes.html#amdgpu-driver-updates
+version=`rocm-smi --showfw | grep MEC | head -n 1 |  awk '{print $NF}'`
+if [[ "$version" == "" || $version -lt 177 ]]; then
+  export HSA_NO_SCRATCH_RECLAIM=1
+fi
 
-sleep 5
-cat config.yaml
+# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
 
 export VLLM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
-export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
+export VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 
@@ -32,12 +41,10 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---max-seq-len-to-capture $MAX_MODEL_LEN \
---config config.yaml \
+--compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
 --block-size=64 \
 --no-enable-prefix-caching \
---disable-log-requests \
---async-scheduling > $SERVER_LOG 2>&1 &
+--disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/gptoss_fp4_mi355x_slurm.sh
+++ b/benchmarks/gptoss_fp4_mi355x_slurm.sh
@@ -17,16 +17,25 @@ check_env_vars \
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=$(( 8888 + $PORT_OFFSET ))
 
-cat > config.yaml << EOF
-compilation-config: '{"compile_sizes":[1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116,118,120,122,124,126,128,256,512,1024,2048,8192] , "cudagraph_capture_sizes":[1,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116,118,120,122,124,126,128,136,144,152,160,168,176,184,192,200,208,216,224,232,240,248,256,264,272,280,288,296,304,312,320,328,336,344,352,360,368,376,384,392,400,408,416,424,432,440,448,456,464,472,480,488,496,504,512,520,528,536,544,552,560,568,576,584,592,600,608,616,624,632,640,648,656,664,672,680,688,696,704,712,720,728,736,744,752,760,768,776,784,792,800,808,816,824,832,840,848,856,864,872,880,888,896,904,912,920,928,936,944,952,960,968,976,984,992,1000,1008,1016,1024,2048,4096,8192] , "cudagraph_mode": "FULL_AND_PIECEWISE"}' 
-EOF
+# If the machine runs a MEC FW older than 177, RCCL
+# cannot reclaim some memory.
+# Disable that features to avoid crashes.
+# This is related to the changes in the driver at:
+# https://rocm.docs.amd.com/en/docs-6.4.3/about/release-notes.html#amdgpu-driver-updates
+version=`rocm-smi --showfw | grep MEC | head -n 1 |  awk '{print $NF}'`
+if [[ "$version" == "" || $version -lt 177 ]]; then
+  export HSA_NO_SCRATCH_RECLAIM=1
+fi
 
-sleep 5
-cat config.yaml
+# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
 
 export VLLM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
-export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
+export VLLM_ROCM_USE_AITER_TRITON_BF16_GEMM=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 #
 ## Start up vllm server
@@ -35,12 +44,11 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---max-seq-len-to-capture $MAX_MODEL_LEN \
---config config.yaml \
+--compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
 --block-size=64 \
 --no-enable-prefix-caching \
 --disable-log-requests \
---async-scheduling > $SERVER_LOG 2>&1 &
+> $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -195,3 +195,14 @@
     - "Remove deprecated --max-seq-len-to-capture flag"
     - "Add HIP_VISIBLE_DEVICES env var for Ray compatibility in vLLM 0.14+"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/496
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Update AMD MI355X GPT-OSS 120B vLLM to use upstream ROCm image vllm/vllm-openai-rocm:v0.14.0"
+    - "Remove deprecated --async-scheduling flag (now enabled by default in vLLM v0.14.0)"
+    - "Remove deprecated --max-seq-len-to-capture flag"
+    - "Add HIP_VISIBLE_DEVICES env var for Ray compatibility in vLLM 0.14+"
+    - "Add MEC firmware check and HSA_NO_SCRATCH_RECLAIM fix for RCCL memory reclaim"
+    - "Add VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 for MI3* quick allreduce optimization"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX


### PR DESCRIPTION
## Summary
- Update AMD MI355X GPT-OSS 120B vLLM to use upstream ROCm image `vllm/vllm-openai-rocm:v0.14.0`
- Remove deprecated CLI args (`--async-scheduling`, `--max-seq-len-to-capture`)
- Add `HIP_VISIBLE_DEVICES` env var for Ray compatibility in vLLM 0.14+
- Add MEC firmware check and `HSA_NO_SCRATCH_RECLAIM` fix
- Add `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4` for MI3* quick allreduce optimization

Fixes #492

## Test plan
- [ ] Run single concurrency test for `gptoss-fp4-mi355x-vllm`
- [ ] Verify vLLM server starts successfully with v0.14.0 image
- [ ] Verify benchmark completes without errors

Generated with [Claude Code](https://claude.ai/code)