### PR TITLE
[AMD] feat: update MI355X gptoss vLLM config to v0.14.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -175,7 +175,7 @@ gptoss-fp4-mi325x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi355x-vllm:
-  image: rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1
+  image: vllm/vllm-openai-rocm:v0.14.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x

--- a/benchmarks/gptoss_fp4_mi355x_docker.sh
+++ b/benchmarks/gptoss_fp4_mi355x_docker.sh
@@ -25,6 +25,11 @@ export VLLM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
 export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
 
+# Set HIP_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES=$ROCR_VISIBLE_DEVICES
+fi
+
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 
 set -x
@@ -32,12 +37,10 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---max-seq-len-to-capture $MAX_MODEL_LEN \
 --config config.yaml \
 --block-size=64 \
 --no-enable-prefix-caching \
---disable-log-requests \
---async-scheduling > $SERVER_LOG 2>&1 &
+--disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/gptoss_fp4_mi355x_slurm.sh
+++ b/benchmarks/gptoss_fp4_mi355x_slurm.sh
@@ -28,6 +28,11 @@ export VLLM_USE_AITER_UNIFIED_ATTENTION=1
 export VLLM_ROCM_USE_AITER_MHA=0
 export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
 
+# Set HIP_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES=$ROCR_VISIBLE_DEVICES
+fi
+
 #
 ## Start up vllm server
 set -x
@@ -35,12 +40,10 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---max-seq-len-to-capture $MAX_MODEL_LEN \
 --config config.yaml \
 --block-size=64 \
 --no-enable-prefix-caching \
---disable-log-requests \
---async-scheduling > $SERVER_LOG 2>&1 &
+--disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 


### PR DESCRIPTION
## Summary
- Update MI355X gptoss vLLM image from `rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1` to `vllm/vllm-openai-rocm:v0.14.0`
- Add `HIP_VISIBLE_DEVICES` env var for Ray compatibility in vLLM 0.14+
- Remove deprecated `--max-seq-len-to-capture` CLI arg
- Remove deprecated `--async-scheduling` CLI arg

## Test Plan
- [ ] Run benchmark with concurrency=4 to validate the new image works

Closes #492

🤖 Generated with [Claude Code](https://claude.ai/code)