### PR TITLE
[AMD] fix: claude-knowledge-about-amd  gfx950

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -222,3 +222,7 @@ jobs:
             - sglang: https://docs.sglang.ai/
             - vllm: https://docs.vllm.ai/en/latest/
             - vllm optimized flags configs: https://github.com/vllm-project/recipes
+
+            ### Additional Knowledge
+            - MI355 is gfx950 not gfx1201
+


### PR DESCRIPTION
Added additional knowledge section with MI355 details.

claude thoguth mi355 was gfx1201...

<img width="237" height="109" alt="image" src="https://github.com/user-attachments/assets/ba02a38b-8e9f-4aff-bef2-36a14dc281a2" />
