### PR TITLE
[NVIDIA] Update dsr1-fp8-h200-sglang to SGLang v0.5.7

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -205,7 +205,7 @@ dsr1-fp8-b200-trt-mtp:
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-h200-sglang:
-  image: lmsysorg/sglang:v0.5.6-cu129-amd64
+  image: lmsysorg/sglang:v0.5.7-cu129-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -200,4 +200,4 @@
     - dsr1-fp8-h200-sglang
   description:
     - "Update H200 DeepSeek R1 FP8 SGLang image from v0.5.6 to v0.5.7"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/538

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -195,3 +195,9 @@
     - "Remove deprecated --max-seq-len-to-capture flag"
     - "Add HIP_VISIBLE_DEVICES env var for Ray compatibility in vLLM 0.14+"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/496
+
+- config-keys:
+    - dsr1-fp8-h200-sglang
+  description:
+    - "Update H200 DeepSeek R1 FP8 SGLang image from v0.5.6 to v0.5.7"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX


### PR DESCRIPTION
## Summary
- Update H200 DeepSeek R1 FP8 SGLang image from `v0.5.6-cu129-amd64` to `v0.5.7-cu129-amd64`
- Added entry to `perf-changelog.yaml`

## E2E Test Results (Attempt #2)

**Workflow Run:** [#567](https://github.com/InferenceMAX/InferenceMAX/actions/runs/21269952049)

| Configuration | Concurrency | Throughput/GPU (tok/s) | Mean TTFT (s) | Mean TPOT (ms) |
|---------------|-------------|------------------------|---------------|----------------|
| 1k1k | 16 | 234.65 | 0.224 | 16.58 |
| 1k1k | 32 | 300.66 | 0.430 | 25.64 |
| 1k8k | 8 | 88.45 | 0.284 | 12.37 |
| 1k8k | 16 | 135.22 | 0.233 | 16.24 |
| 1k8k | 32 | 181.58 | 0.415 | 24.23 |
| 8k1k | 4 | 350.93 | 0.458 | 12.03 |
| 8k1k | 32 | 982.02 | 1.041 | 34.60 |

**Result:** All benchmark jobs succeeded. SGLang v0.5.7 works correctly on H200 with good performance across all tested configurations.

Closes #389

---
Generated with [Claude Code](https://claude.ai/code)