### PR TITLE
[AMD] Update MI300X SGLang to v0.5.7 with MLA persist and fp8 KV cache optimizations

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -47,7 +47,7 @@ dsr1-fp4-mi355x-atom:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
 
 dsr1-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.7-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x

--- a/benchmarks/dsr1_fp8_mi300x.sh
+++ b/benchmarks/dsr1_fp8_mi300x.sh
@@ -31,6 +31,7 @@ if [[ "$version" == "" || $version -lt 177 ]]; then
 fi
 
 export SGLANG_USE_AITER=1
+export SGLANG_AITER_MLA_PERSIST=1
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=${PORT:-8888}
@@ -41,9 +42,11 @@ python3 -m sglang.launch_server \
 --tensor-parallel-size=$TP \
 --mem-fraction-static=0.8 \
 --cuda-graph-max-bs=128 \
---chunked-prefill-size=196608 \
+--chunked-prefill-size=131072 \
 --num-continuous-decode-steps=4 \
---max-prefill-tokens=196608 \
+--max-prefill-tokens=131072 \
+--kv-cache-dtype fp8_e4m3 \
+--attention-backend aiter \
 --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -210,4 +210,4 @@
     - "Set --kv-cache-dtype fp8_e4m3 for fp8 KV cache"
     - "Set --attention-backend aiter for AMD aiter attention backend"
     - "Update chunked-prefill-size and max-prefill-tokens from 196608 to 131072"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/544

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -201,3 +201,13 @@
   description:
     - "Update H200 DeepSeek R1 FP8 SGLang image from v0.5.6 to v0.5.7"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/538
+
+- config-keys:
+    - dsr1-fp8-mi300x-sglang
+  description:
+    - "Update MI300X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.7"
+    - "Add SGLANG_AITER_MLA_PERSIST=1 for persistent MLA kernel optimization"
+    - "Set --kv-cache-dtype fp8_e4m3 for fp8 KV cache"
+    - "Set --attention-backend aiter for AMD aiter attention backend"
+    - "Update chunked-prefill-size and max-prefill-tokens from 196608 to 131072"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX


### PR DESCRIPTION
## Summary

- Update MI300X DeepSeek R1 FP8 SGLang image from `v0.5.5.post3-rocm700-mi30x` to `v0.5.7-rocm700-mi30x`
- Add `SGLANG_AITER_MLA_PERSIST=1` environment variable for persistent MLA (Multi-head Latent Attention) kernel optimization
- Set `--kv-cache-dtype fp8_e4m3` for FP8 KV cache
- Set `--attention-backend aiter` for AMD aiter attention backend
- Update `--chunked-prefill-size` and `--max-prefill-tokens` from 196608 to 131072

### What is `SGLANG_AITER_MLA_PERSIST`?

The `SGLANG_AITER_MLA_PERSIST` flag controls persistent kernel design for MLA (Multi-head Latent Attention) decoding with AMD's aiter library. When enabled, it optimizes the MLA attention mechanism for better performance on AMD GPUs, particularly when using fp8 KV cache configurations. This is particularly beneficial for DeepSeek models which use MLA attention architecture.

## Test plan

- [x] E2E benchmark workflow triggered: [Run #21273800781](https://github.com/InferenceMAX/InferenceMAX/actions/runs/21273800781)
- [ ] Verify benchmark results show no regression
- [ ] Review perf-changelog.yaml entry

## Files changed

1. `.github/configs/amd-master.yaml` - Updated image version
2. `benchmarks/dsr1_fp8_mi300x.sh` - Added env var and new server flags, updated prefill sizes
3. `perf-changelog.yaml` - Added changelog entry

Closes #539

---

cc @pr-claude for review

🤖 Generated with [Claude Code](https://claude.ai/code)