### PR TITLE
[AMD] feat(mi325x): Update SGLang to v0.5.7 with aiter optimizations

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -69,7 +69,7 @@ dsr1-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.7-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi325x

--- a/benchmarks/dsr1_fp8_mi325x.sh
+++ b/benchmarks/dsr1_fp8_mi325x.sh
@@ -24,6 +24,7 @@ hf download $MODEL
 # https://rocm.docs.amd.com/en/docs-7.0-rc1/preview/benchmark-docker/inference-sglang-deepseek-r1-fp8.html#run-the-inference-benchmark
 
 export SGLANG_USE_AITER=1
+export SGLANG_AITER_MLA_PERSIST=1
 
 set -x
 python3 -m sglang.launch_server \
@@ -31,9 +32,11 @@ python3 -m sglang.launch_server \
 --tensor-parallel-size=$TP \
 --mem-fraction-static=0.8 \
 --cuda-graph-max-bs=128 \
---chunked-prefill-size=196608 \
+--chunked-prefill-size=131072 \
 --num-continuous-decode-steps=4 \
---max-prefill-tokens=196608 \
+--max-prefill-tokens=131072 \
+--kv-cache-dtype fp8_e4m3 \
+--attention-backend aiter \
 --disable-radix-cache \
 > $SERVER_LOG 2>&1 &
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -211,4 +211,4 @@
     - "Add --attention-backend aiter for AMD aiter attention backend"
     - "Reduce chunked-prefill-size from 196608 to 131072"
     - "Reduce max-prefill-tokens from 196608 to 131072"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/545

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -201,3 +201,14 @@
   description:
     - "Update H200 DeepSeek R1 FP8 SGLang image from v0.5.6 to v0.5.7"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/538
+
+- config-keys:
+    - dsr1-fp8-mi325x-sglang
+  description:
+    - "Update MI325X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.7"
+    - "Add SGLANG_AITER_MLA_PERSIST=1 for persistent MLA kernel with fp8 KV cache"
+    - "Add --kv-cache-dtype fp8_e4m3 for explicit FP8 KV cache"
+    - "Add --attention-backend aiter for AMD aiter attention backend"
+    - "Reduce chunked-prefill-size from 196608 to 131072"
+    - "Reduce max-prefill-tokens from 196608 to 131072"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX


### PR DESCRIPTION
## Summary

- Update MI325X DeepSeek R1 FP8 SGLang image from `v0.5.5.post3` to `v0.5.7`
- Add `SGLANG_AITER_MLA_PERSIST=1` for persistent MLA kernel with fp8 KV cache
- Add `--kv-cache-dtype fp8_e4m3` for explicit FP8 KV cache
- Add `--attention-backend aiter` for AMD aiter attention backend
- Reduce `--chunked-prefill-size` from 196608 to 131072
- Reduce `--max-prefill-tokens` from 196608 to 131072

**This is an MI325X-only change; MI300X remains unchanged.**

### Research Findings

`SGLANG_AITER_MLA_PERSIST` controls the persistent MLA (Multi-head Latent Attention) kernel design for FP8 KV cache in SGLang's aiter backend. When enabled (`=1`), it uses persistent scheduling for MLA decode operations which can improve throughput for DeepSeek models with FP8 KV cache.

Closes #542

@pr-claude please review

---
Generated with [Claude Code](https://claude.ai/code)