### PR TITLE
chore: add evals only option to perf changelog

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -116,7 +116,7 @@
   description:
     - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369
-
+    
 - config-keys:
     - dsr1-fp4-b200-sglang
     - dsr1-fp8-b200-sglang
@@ -124,12 +124,12 @@
   description:
     - "Update NVIDIA DeepSeek sglang Docker image from v0.5.5 to v0.5.6"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/276
-
+  
 - config-keys:
     - gptoss-fp4-b200-vllm
     - gptoss-fp4-h100-vllm
     - gptoss-fp4-h200-vllm
-  description:
+  description: 
     - "Update vLLM image from v0.11.2 to v0.13.0"
     - "Add VLLM_MXFP4_USE_MARLIN=1 to H100 and H200 benchmark scripts"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/327
@@ -168,7 +168,7 @@
   description:
     - "Adds TP4 configurations to DSR1-FP8 B200 SGLang deployment experiments"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/411
-
+  
 - config-keys:
     - dsr1-fp4-b200-trt-mtp
     - dsr1-fp8-b200-trt-mtp
@@ -177,7 +177,7 @@
     - Add MTP (Multi-Token Prediction) support for single-node TRT configs
     - Add spec-decoding field to config entries and update launch scripts to select MTP benchmark scripts
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/392
-
+  
 - config-keys:
     - dsr1-fp8-mi355x-atom
     - dsr1-fp4-mi355x-atom
@@ -211,6 +211,7 @@
     - "Set --attention-backend aiter for AMD aiter attention backend"
     - "Update chunked-prefill-size and max-prefill-tokens from 196608 to 131072"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/544
+
 - config-keys:
     - dsr1-fp8-mi325x-sglang
   description:
@@ -225,6 +226,6 @@
 - config-keys:
     - dsr1-fp8-h200-sglang
   description:
-    - "Some change - evals only, no performance collection"
+    - test
   pr-link: test
   evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -116,7 +116,7 @@
   description:
     - "Updating MI355x Deepseek-R1 FP4 SGLang Image to upstream v0.5.6.post2"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/369
-    
+
 - config-keys:
     - dsr1-fp4-b200-sglang
     - dsr1-fp8-b200-sglang
@@ -124,12 +124,12 @@
   description:
     - "Update NVIDIA DeepSeek sglang Docker image from v0.5.5 to v0.5.6"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/276
-  
+
 - config-keys:
     - gptoss-fp4-b200-vllm
     - gptoss-fp4-h100-vllm
     - gptoss-fp4-h200-vllm
-  description: 
+  description:
     - "Update vLLM image from v0.11.2 to v0.13.0"
     - "Add VLLM_MXFP4_USE_MARLIN=1 to H100 and H200 benchmark scripts"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/327
@@ -168,7 +168,7 @@
   description:
     - "Adds TP4 configurations to DSR1-FP8 B200 SGLang deployment experiments"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/411
-  
+
 - config-keys:
     - dsr1-fp4-b200-trt-mtp
     - dsr1-fp8-b200-trt-mtp
@@ -177,7 +177,7 @@
     - Add MTP (Multi-Token Prediction) support for single-node TRT configs
     - Add spec-decoding field to config entries and update launch scripts to select MTP benchmark scripts
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/392
-  
+
 - config-keys:
     - dsr1-fp8-mi355x-atom
     - dsr1-fp4-mi355x-atom
@@ -221,3 +221,10 @@
     - "Reduce chunked-prefill-size from 196608 to 131072"
     - "Reduce max-prefill-tokens from 196608 to 131072"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/545
+
+- config-keys:
+    - dsr1-fp8-h200-sglang
+  description:
+    - "Some change - evals only, no performance collection"
+  pr-link: test
+  evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -211,7 +211,6 @@
     - "Set --attention-backend aiter for AMD aiter attention backend"
     - "Update chunked-prefill-size and max-prefill-tokens from 196608 to 131072"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/544
-
 - config-keys:
     - dsr1-fp8-mi325x-sglang
   description:
@@ -222,10 +221,3 @@
     - "Reduce chunked-prefill-size from 196608 to 131072"
     - "Reduce max-prefill-tokens from 196608 to 131072"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/545
-
-- config-keys:
-    - dsr1-fp8-h200-sglang
-  description:
-    - test
-  pr-link: test
-  evals-only: true

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -337,6 +337,7 @@ class ChangelogEntry(BaseModel):
     config_keys: list[str] = Field(alias="config-keys", min_length=1)
     description: list[str] = Field(min_length=1)
     pr_link: str = Field(alias="pr-link")
+    evals_only: bool = Field(alias="evals-only", default=False)
 
 
 class ChangelogMetadata(BaseModel):

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -103,6 +103,9 @@ def main():
             continue
         all_configs_to_run.update(configs_to_run)
 
+        # Use --evals-only if specified in changelog entry, otherwise --run-evals
+        eval_flag = "--evals-only" if entry.evals_only else "--run-evals"
+
         try:
             result = subprocess.run(
                 [
@@ -113,7 +116,7 @@ def main():
                     *configs_to_run,
                     "--config-files",
                     *MASTER_CONFIGS,
-                    "--run-evals"
+                    eval_flag
                 ],
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Add option to perf changelog that specifies to run evals only.