### PR TITLE
[AMD] Chun reima/sglang fp8 v0.5.8 mi355

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -91,7 +91,7 @@ dsr1-fp8-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.5.post3-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.8-rocm700-mi35x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x

--- a/benchmarks/dsr1_fp8_mi355x.sh
+++ b/benchmarks/dsr1_fp8_mi355x.sh
@@ -23,7 +23,6 @@ hf download "$MODEL"
 export SGLANG_USE_AITER=1
 export RCCL_MSCCL_ENABLE=0
 export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-export SGLANG_AITER_MLA_PERSIST=1
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=${PORT:-8888}
@@ -40,7 +39,6 @@ python3 -m sglang.launch_server \
     --num-continuous-decode-steps 4 \
     --max-prefill-tokens 196608 \
     --enable-torch-compile \
-    --kv-cache-dtype fp8_e4m3 \
     --cuda-graph-max-bs 128 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/dsr1_fp8_mi355x.sh
+++ b/benchmarks/dsr1_fp8_mi355x.sh
@@ -23,6 +23,7 @@ hf download "$MODEL"
 export SGLANG_USE_AITER=1
 export RCCL_MSCCL_ENABLE=0
 export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export SGLANG_AITER_MLA_PERSIST=1
 
 SERVER_LOG=$(mktemp /tmp/server-XXXXXX.log)
 PORT=${PORT:-8888}
@@ -39,6 +40,7 @@ python3 -m sglang.launch_server \
     --num-continuous-decode-steps 4 \
     --max-prefill-tokens 196608 \
     --enable-torch-compile \
+    --kv-cache-dtype fp8_e4m3 \
     --cuda-graph-max-bs 128 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -265,4 +265,5 @@
     - dsr1-fp8-mi355x-sglang
   description:
     - "Update MI355X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.8"
+    - "Key fix: Disables mla persistent kernel when not using fp8 kv_cache (https://github.com/sgl-project/sglang/pull/17327)"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/572

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -260,3 +260,9 @@
     - Add official GSM8k eval results to GPT-OSS and DeepSeek R1 scenarios
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/558
   evals-only: true
+
+- config-keys:
+    - dsr1-fp8-mi355x-sglang
+  description:
+    - "Update MI355X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.8"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/572


### PR DESCRIPTION
Update MI355X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.8

Key fix: Disable mla persistent kernel when not using fp8 kv_cache (https://github.com/sgl-project/sglang/pull/17327)

Contributor list:
- 1am9trash
- HaiShaw
- chunfangamd
- rkarhila-amd