### PR TITLE
[nv] - h200 sglang disagg

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1880,4 +1880,160 @@ gptoss-fp4-gb200-dynamo-trt:
         - "DECODE_MAX_NUM_TOKENS=20000"
         - "DECODE_MAX_BATCH_SIZE=512"
         - "DECODE_GPU_MEM_FRACTION=0.9"
-        
+
+dsr1-fp8-h200-dynamo-sglang:
+  image: lmsysorg/sglang:v0.5.8-cu130-runtime
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: h200-multinode-slurm
+  precision: fp8
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    # Aggregated mode (single node TEP)
+    - conc-list: [1, 4, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/1k1k/bs128-agg-tp.yaml"
+      decode:
+        num-worker: 0
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # Low latency (1 prefill, 9 decode, TEP)
+    - conc-list: [1, 4, 8, 16, 32, 64, 128, 256]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/1k1k/low-latency-1p9d.yaml"
+      decode:
+        num-worker: 9
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # High throughput TEP (1 prefill, 6 decode)
+    - conc-list: [512, 1024, 2048]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/1k1k/bs256-1p6d-tp.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # High throughput DEP (1 prefill, 6 decode, dp-attention)
+    - conc-list: [128, 256, 512, 1024, 2048]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/1k1k/bs256-1p6d-dep.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 8
+        dp-attn: true
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # Aggregated mode (single node TEP)
+    - conc-list: [1, 4, 16, 32, 64, 128, 256]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs128-agg-tp.yaml"
+      decode:
+        num-worker: 0
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # Low latency TEP (1 prefill, 7 decode)
+    - conc-list: [1, 4, 8]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs4-1p7d.yaml"
+      decode:
+        num-worker: 7
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # TEP (1 prefill, 6 decode)
+    - conc-list: [4, 8, 16]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs8-1p6d.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # TEP (1 prefill, 3 decode)
+    - conc-list: [8, 16, 32]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs16-1p3d.yaml"
+      decode:
+        num-worker: 3
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # TEP (2 prefill, 3 decode)
+    - conc-list: [32, 64, 128]
+      prefill:
+        num-worker: 2
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs64-2p3d.yaml"
+      decode:
+        num-worker: 3
+        tp: 8
+        ep: 1
+        dp-attn: false
+    # High throughput DEP (1 prefill, 1 decode, dp-attention)
+    - conc-list: [64, 128, 256]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/8k1k/bs128-1p1d-dep.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -269,3 +269,15 @@
     - "Includes MTP and STP configurations for 1k1k and 8k1k sequence lengths"
     - "Concurrency levels: 4, 8, 16, 32, 64, 128, 256, 512"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/570
+
+- config-keys:
+    - dsr1-fp8-h200-dynamo-sglang
+  description:
+    - "Add DSR1 FP8 H200 Dynamo SGLang disaggregated multinode configuration"
+    - "Image: lmsysorg/sglang:v0.5.8-cu130-runtime"
+    - "Runner: h200-multinode-slurm with multinode and disagg enabled"
+    - "Recipes sourced from srtslurm repo (recipes/h200/)"
+    - "1k1k configs: aggregated, low-latency (1P9D), high-throughput TEP (1P6D), DEP (1P6D)"
+    - "8k1k configs: aggregated, TEP configs (1P7D, 1P6D, 1P3D, 2P3D), DEP (1P1D)"
+    - "Concurrency levels range from 1 to 2048 depending on configuration"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/TBD


### PR DESCRIPTION
Add H200 SGLang disaggregated multinode configurations, sourced from srtslurm recipes.

  Depends on #570

  Changes

  - Add dsr1-fp8-h200-dynamo-sglang config to nvidia-master.yaml
  - 1k1k: aggregated, low-latency (1P9D), high-throughput TEP/DEP (1P6D)
  - 8k1k: aggregated, TEP variants (1P7D, 1P6D, 1P3D, 2P3D), DEP (1P1D)
  - Add perf-changelog entry
  - Document recipe registration from srtslurm in AGENT.md