### PR TITLE
Add container image accessibility validation to PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -125,6 +125,24 @@ jobs:
 
             Remember: Silence is golden. No comment is better than a low-value comment.
 
+            ## Container Image Accessibility Validation:
+            When reviewing changes to `.github/configs/*-master.yaml` files, verify that ALL `image:` values are publicly accessible:
+
+            **Valid image formats (publicly accessible):**
+            - Docker Hub: `organization/image:tag` (e.g., `lmsysorg/sglang:v0.5.7-rocm700-mi35x`)
+            - NGC: `nvcr.io/nvidia/...` (e.g., `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1`)
+            - Other public registries: `ghcr.io/...`, `quay.io/...`, `rocm/...`
+
+            **Invalid image formats (NOT publicly accessible):**
+            - Local file paths: `/scratch/...`, `/home/...`, `/data/...`, or any path starting with `/`
+            - `.sqsh` files (squashfs containers stored locally)
+            - Internal/private registry paths that are not publicly resolvable
+
+            If any `image:` field contains a local path or non-public image:
+            - This is a 🔴 **BLOCKING** issue
+            - Comment: "Image must be publicly accessible on NGC, Docker Hub, or another public registry. Local paths like `/scratch/...` or `.sqsh` files are not reproducible. Please push the container to a public registry (e.g., `nvcr.io/nvidia/...` for NGC) and update the config with the public image reference."
+            - Link to the specific line with the invalid image path
+
             ## vLLM and SGLang Source Code Access:
             You have access to vLLM and SGLang source code via the inferencemax-repos MCP server:
             - Use `mcp__inferencemax-repos__*` tools to access repository source code

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -130,7 +130,7 @@ jobs:
 
             **Valid image formats (publicly accessible):**
             - Docker Hub: `organization/image:tag` (e.g., `lmsysorg/sglang:v0.5.7-rocm700-mi35x`)
-            - NGC: `nvcr.io/nvidia/...` (e.g., `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1`)
+            - NGC: `nvcr.io/nvidia/...` or `nvcr.io#nvidia/...` (e.g., `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1` or `nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2`)
             - Other public registries: `ghcr.io/...`, `quay.io/...`, `rocm/...`
 
             **Invalid image formats (NOT publicly accessible):**

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -133,14 +133,15 @@ jobs:
             - NGC: `nvcr.io/nvidia/...` or `nvcr.io#nvidia/...` (e.g., `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1` or `nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2`)
             - Other public registries: `ghcr.io/...`, `quay.io/...`, `rocm/...`
 
-            **Invalid image formats (NOT publicly accessible):**
+            **Invalid image formats (NOT publicly accessible):** 
+            - generally these images are not best practices to have in:
             - Local file paths: `/scratch/...`, `/home/...`, `/data/...`, or any path starting with `/`
             - `.sqsh` files (squashfs containers stored locally)
             - Internal/private registry paths that are not publicly resolvable
 
             If any `image:` field contains a local path or non-public image:
             - This is a 🔴 **BLOCKING** issue
-            - Comment: "Image must be publicly accessible on NGC, Docker Hub, or another public registry. Local paths like `/scratch/...` or `.sqsh` files are not reproducible. Please push the container to a public registry (e.g., `nvcr.io/nvidia/...` for NGC) and update the config with the public image reference."
+            - Comment: "Image must be publicly accessible on NGC, Docker Hub, or another public registry. Local paths like `/scratch/...` or `.sqsh` files are generally not accepted. Please push the container to a public registry (e.g., `nvcr.io/nvidia/...` for NGC) and update the config with the public image reference."
             - Link to the specific line with the invalid image path
 
             ## vLLM and SGLang Source Code Access:


### PR DESCRIPTION
## Summary
- Adds a new validation rule to the `claude-pr-review.yml` workflow prompt
- Requires all `image:` values in `.github/configs/*-master.yaml` files to be publicly accessible
- Valid: NGC (`nvcr.io/nvidia/...`), Docker Hub (`org/image:tag`), other public registries
- Invalid: Local paths (`/scratch/...`), `.sqsh` files, non-public registries
- Non-public images are flagged as 🔴 **BLOCKING** issues

## Why
Local container paths are not reproducible and make it difficult for others to run benchmarks. This ensures all benchmark configurations use publicly accessible containers.

## Test plan
- [ ] Trigger PR review on a PR with local image paths to verify blocking issue is raised
- [ ] Verify valid NGC/Docker Hub images pass validation

---
Requested by @functionstackx in #588

🤖 Generated with [Claude Code](https://claude.ai/claude-code)