### PR TITLE
[NV] dsr1 fp8 b200 agg update 

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -149,7 +149,7 @@ dsr1-fp8-b200-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 32 }
 
 dsr1-fp8-b200-trt:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b200-trt
@@ -157,23 +157,24 @@ dsr1-fp8-b200-trt:
   framework: trt
   multinode: false
   seq-len-configs:
-  # For all sequence lengths, EP=TP
   - isl: 1024
     osl: 1024
     search-space:
-    # If CONC > 32, then DP_ATTN=true
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256}
+    - { tp: 8, ep: 1, conc-start: 64, conc-end: 128 }
+    - { tp: 4, ep: 1, conc-start: 8, conc-end: 16 } 
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 8 }
   - isl: 1024
     osl: 8192
     search-space:
-    # If CONC > 64, then DP_ATTN=true
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256}
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }    
   - isl: 8192
     osl: 1024
     search-space:
-    # If CONC > 64, then DP_ATTN=true
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 1, conc-start: 64, conc-end: 256 }
+    - { tp: 4, ep: 1, conc-start: 8, conc-end: 32 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 8 }
 
 dsr1-fp8-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -160,7 +160,6 @@ dsr1-fp8-b200-trt:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256}
     - { tp: 8, ep: 1, conc-start: 64, conc-end: 128 }
     - { tp: 4, ep: 1, conc-start: 8, conc-end: 16 } 
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 8 }

--- a/benchmarks/dsr1_fp8_b200_trt.sh
+++ b/benchmarks/dsr1_fp8_b200_trt.sh
@@ -33,11 +33,7 @@ DELAY_BATCHING="false"
 KV_CACHE_FREE_MEM_FRACTION=0.8
 
 if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
-    if [[ $CONC -ge 256 ]]; then
-        CUDA_GRAPH_MAX_BATCH_SIZE=$(( $CONC / 8 ))
-        MOE_BACKEND="DEEPGEMM"
-        KV_CACHE_FREE_MEM_FRACTION=0.7
-    elif [[ $CONC -ge 64 ]]; then
+    if [[ $CONC -ge 64 ]]; then
         PIECEWISE_CUDA_GRAPHS="true"
         DELAY_BATCHING="true"
     fi

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -279,3 +279,5 @@
   description:
     - "Update tensorrt-llm container to release:1.2.0rc6.post2"
     - "update configurations for improved performance"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/594
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -277,7 +277,12 @@
 - config-keys:
     - dsr1-fp8-b200-trt
   description:
-    - "Update tensorrt-llm container to release:1.2.0rc6.post2"
-    - "update configurations for improved performance"
+    - "Update TensorRT-LLM container from release:1.1.0rc2.post2 to release:1.2.0rc6.post2"
+    - "Change default MOE backend from DEEPGEMM to TRTLLM"
+    - "Add dynamic piecewise CUDA graphs for 1k1k (CONC≥64) and 8k1k (CONC≥64) workloads"
+    - "Add delay batching (batch_wait_timeout_iters/batch_wait_max_tokens_ratio) for 1k1k high-concurrency"
+    - "Add dynamic KV cache memory fraction tuning (0.7-0.8) based on ISL/OSL/TP configuration"
+    - "Update search space: remove EP=TP constraint, add TP=4 configurations, extend concurrency ranges"
+    - "Add TLLM_OVERRIDE_LAYER_NUM=61 to avoid OOM errors"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/594
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -235,3 +235,9 @@
     - "Update MI355X DeepSeek R1 FP8 SGLang image from v0.5.5.post3 to v0.5.8"
     - "Key fix: Disables mla persistent kernel when not using fp8 kv_cache (https://github.com/sgl-project/sglang/pull/17327)"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/572
+
+- config-keys:
+    - dsr1-fp8-b200-trt
+  description:
+    - "Update tensorrt-llm container to release:1.2.0rc6.post2"
+    - "update configurations for improved performance"


### PR DESCRIPTION
- update to the latest TRTLLM release container
- fine-tune choice of parallelism in nvidia-master for various cases
- Enable a few optimizations offered by TensorRT LLM on specific cases

Near the top of the benchmark script (L28-55), we use flags to enable specific optimizations for specific ISL/OSL/CONC combinations according to the chosen TP/EP/DP-ATTENTION in nvidia-master and to what is best for balancing ctx vs gen workload and achieving good utilization.  

Further down the script, from L63 onwards, we key off these flags to generate the necessary yaml for enabling these features in the runtime config file. 

Delay batching (https://nvidia.github.io/TensorRT-LLM/1.2.0rc6/llm-api/reference.html#tensorrt_llm.llmapi.TorchLlmArgs.batch_wait_timeout_iters) improves GPU utilization by waiting to accumulate more requests before processing a batch. The wait is bound here by the number of iterations as well as by the fraction of "max tokens" achieved. 

Piecewise Cuda Graphs (https://nvidia.github.io/TensorRT-LLM/features/torch_compile_and_piecewise_cuda_graph.html) enables some components to execute thorugh cuda graphs while other components are run eagerly, to gain benefit with lower overhead. We use the formula from the documentation to generate a `capture_num_tokens` list dynamically as it depends on `MAX_NUM_TOKENS` which is not constant across cases.

"cuda graph max batch size" is mostly equal to CONC as the natural limit on the expected size of a batch, but is different when DP_ATTENTION is enabled. 