### PR TITLE
[NVIDIA] Update DSR1 FP4 SGLang Image from 0.5.7 to 0.5.8

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.7-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.8-rocm700-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -273,3 +273,9 @@
   description:
     - "Add DSR1 FP4 B300 Dynamo TRT configurations"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/585
+
+- config-keys:
+  - dsr1-fp4-mi355x-sglang
+  description:
+    - "Update SGL image to 0.5.8"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/595

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -277,5 +277,5 @@
 - config-keys:
   - dsr1-fp4-mi355x-sglang
   description:
-    - "Update SGL image to 0.5.8"
+    - "Update SGLang image from v0.5.7 to v0.5.8 for DeepSeek-R1 FP4 on MI355x"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/595


### PR DESCRIPTION
Updating the SGLang docker image to the SGLang community docker image
Image=lmsysorg/sglang:v0.5.8-rocm700-mi35x

Impacted configurations: MI355x Deepseek-R1 FP4

Link to the runs: TBD