### PR TITLE
Add enroot import validation for launch scripts in PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -162,7 +162,7 @@ jobs:
             - Makes benchmarks reproducible by anyone with access to the public image
             - Prevents reliance on pre-existing local container images that others cannot access
 
-            **Validation rules:**
+            **Validation Steps:**
             1. Look for `enroot import` commands that convert `docker://` images to local `.sqsh` files
             2. The image source should be a public registry (NGC, Docker Hub, etc.), not a local path
             3. If the script uses containers but does NOT have an `enroot import docker://` pattern:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -144,6 +144,34 @@ jobs:
             - Comment: "Image must be publicly accessible on NGC, Docker Hub, or another public registry. Local paths like `/scratch/...` or `.sqsh` files are generally not accepted. Please push the container to a public registry (e.g., `nvcr.io/nvidia/...` for NGC) and update the config with the public image reference."
             - Link to the specific line with the invalid image path
 
+            ## Enroot Import Validation for Launch Scripts:
+            When reviewing changes to `runners/launch_*.sh` files, verify that the script properly transforms public Docker images to enroot local images for reproducibility.
+
+            **Expected pattern:**
+            The script should include an enroot import command like:
+            ```bash
+            srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+            ```
+            or similar variations such as:
+            ```bash
+            srun -N 1 -A $SLURM_ACCOUNT -p $SLURM_PARTITION bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+            ```
+
+            **Why this matters:**
+            - Ensures the exact same public NGC/Docker Hub image is used
+            - Makes benchmarks reproducible by anyone with access to the public image
+            - Prevents reliance on pre-existing local container images that others cannot access
+
+            **Validation rules:**
+            1. Look for `enroot import` commands that convert `docker://` images to local `.sqsh` files
+            2. The image source should be a public registry (NGC, Docker Hub, etc.), not a local path
+            3. If the script uses containers but does NOT have an `enroot import docker://` pattern:
+               - This is a 🟡 **WARNING** issue
+               - Comment: "This launch script uses container images but does not appear to transform a public Docker image to an enroot local image using `enroot import -o $SQUASH_FILE docker://$IMAGE`. For reproducibility, please either:
+                 1. Add the enroot import pattern to pull from a public registry, OR
+                 2. Explain why this script has a different workflow (e.g., uses a different container runtime, pre-built images are acceptable for this use case, etc.)"
+               - Ask the developer to provide a reasonable explanation if the pattern is intentionally omitted
+
             ## vLLM and SGLang Source Code Access:
             You have access to vLLM and SGLang source code via the inferencemax-repos MCP server:
             - Use `mcp__inferencemax-repos__*` tools to access repository source code


### PR DESCRIPTION
## Summary
- Add PR review validation to warn when `runners/launch_*.sh` scripts don't transform public Docker images to enroot local images
- The validation checks for the `enroot import -o $SQUASH_FILE docker://$IMAGE` pattern
- Issues a 🟡 **WARNING** (not blocking) when the pattern is missing, prompting the developer to either add the pattern or explain why it's intentionally omitted

## Why this matters
- Ensures the exact same public NGC/Docker Hub image is used
- Makes benchmarks reproducible by anyone with access to the public image
- Prevents reliance on pre-existing local container images that others cannot access

## Test plan
- [ ] Verify PR review workflow triggers on launch script changes
- [ ] Check that the validation correctly identifies scripts with enroot import patterns
- [ ] Confirm the warning message is helpful and actionable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Triggered from: https://github.com/InferenceMAX/InferenceMAX/pull/588#discussion_r2739397836