### PR TITLE
fix duplicated outputs

### DIFF
--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -292,12 +292,11 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
 
                     # Apply max-tp filter if specified
-                    # If tp > max_tp, use max_tp instead of skipping (if valid)
                     if args.max_tp is not None:
                         if args.max_tp <= 0:
                             continue  # Skip if max_tp is not positive
                         if tp > args.max_tp:
-                            tp = args.max_tp
+                            continue
 
                     # Apply max-ep filter if specified
                     # If ep > max_ep, use max_ep instead of skipping (if valid)


### PR DESCRIPTION
For `python utils/matrix_logic/generate_sweep_configs.py full-sweep --framework vllm --seq-len 1k8k --model-prefix gptoss --single-node --evals-only --runner-type h200 --max-tp 1 --config-files .github/configs/nvidia-master.yaml`

Before:
```
[
{"image": "vllm/vllm-openai:v0.13.0", "model": "openai/gpt-oss-120b", "model-prefix": "gptoss", "precision": "fp4", "framework": "vllm", "runner": "h200", "isl": 1024, "osl": 8192, "tp": 1, "conc": 64, "max-model-len": 9416, "ep": 1, "dp-attn": false, "spec-decoding": "none", "exp-name": "gptoss_1k8k", "disagg": false, "run-eval": true}, 

{"image": "vllm/vllm-openai:v0.13.0", "model": "openai/gpt-oss-120b", "model-prefix": "gptoss", "precision": "fp4", "framework": "vllm", "runner": "h200", "isl": 1024, "osl": 8192, "tp": 1, "conc": 64, "max-model-len": 9416, "ep": 1, "dp-attn": false, "spec-decoding": "none", "exp-name": "gptoss_1k8k", "disagg": false, "run-eval": true},

{"image": "vllm/vllm-openai:v0.13.0", "model": "openai/gpt-oss-120b", "model-prefix": "gptoss", "precision": "fp4", "framework": "vllm", "runner": "h200", "isl": 1024, "osl": 8192, "tp": 1, "conc": 64, "max-model-len": 9416, "ep": 1, "dp-attn": false, "spec-decoding": "none", "exp-name": "gptoss_1k8k", "disagg": false, "run-eval": true}
]
```

After:
```
[{"image": "vllm/vllm-openai:v0.13.0", "model": "openai/gpt-oss-120b", "model-prefix": "gptoss", "precision": "fp4", "framework": "vllm", "runner": "h200", "isl": 1024, "osl": 8192, "tp": 1, "conc": 4, "max-model-len": 9416, "ep": 1, "dp-attn": false, "spec-decoding": "none", "exp-name": "gptoss_1k8k", "disagg": false, "run-eval": true}]
```
