### PR TITLE
Add official InferenceMAX disclaimer to benchmark summaries

### DIFF
--- a/utils/summarize.py
+++ b/utils/summarize.py
@@ -102,6 +102,7 @@ def main():
         ]
 
         print("## Single-Node Results\n")
+        print("Only [InferenceMAX/InferenceMAX](https://github.com/InferenceMAX/InferenceMAX) repo contains the Official InferenceMAX™ result, all other forks & repos are Unofficial. The benchmark setup & quality of machines/clouds in unofficial repos may be differ leading to subpar benchmarking. Unofficial must be explicitly labelled as Unofficial. Forks may not remove this disclaimer.\n")
         print(tabulate(single_node_rows, headers=single_node_headers, tablefmt="github"))
         print("\n")
 
@@ -148,6 +149,7 @@ def main():
         ]
 
         print("## Multi-Node Results\n")
+        print("Only [InferenceMAX/InferenceMAX](https://github.com/InferenceMAX/InferenceMAX) repo contains the Official InferenceMAX™ result, all other forks & repos are Unofficial. The benchmark setup & quality of machines/clouds in unofficial repos may be differ leading to subpar benchmarking. Unofficial must be explicitly labelled as Unofficial. Forks may not remove this disclaimer.\n")
         print(tabulate(multinode_rows, headers=multinode_headers, tablefmt="github"))
 
 


### PR DESCRIPTION
## Summary

Adds a disclaimer after the Single-Node and Multi-Node results headers to clarify that only the official InferenceMAX/InferenceMAX repo contains official benchmark results.

Closes #608

Generated with [Claude Code](https://claude.ai/claude-code)