### PR TITLE
feat(benchmarks): Add torch profiler support via `ENABLE_PROFILE` environment variable

### DIFF
--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -32,6 +32,7 @@ docker run --rm --init --network host --name $server_name \
 -e NCCL_GRAPH_REGISTER=0 \
 -e TORCH_CUDA_ARCH_LIST="10.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
 -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e RESULT_FILENAME -e RANDOM_RANGE_RATIO -e RUN_EVAL -e RUNNER_TYPE \
+-e ENABLE_PROFILE -e VLLM_TORCH_PROFILER_DIR \
 --entrypoint=/bin/bash \
 $(echo "$IMAGE" | sed 's/#/\//') \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}.sh"

--- a/runners/launch_h100-cr.sh
+++ b/runners/launch_h100-cr.sh
@@ -12,6 +12,7 @@ docker run --rm --network=host --name=$server_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e ISL -e OSL -e RUN_EVAL -e RUNNER_TYPE -e RESULT_FILENAME -e RANDOM_RANGE_RATIO -e PORT=$PORT \
 -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e TORCH_CUDA_ARCH_LIST="9.0" -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
+-e ENABLE_PROFILE -e VLLM_TORCH_PROFILER_DIR \
 --entrypoint=/bin/bash \
 $IMAGE \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_h100.sh"

--- a/runners/launch_mi300x-amd.sh
+++ b/runners/launch_mi300x-amd.sh
@@ -15,6 +15,7 @@ docker run --rm --ipc=host --shm-size=16g --network=host --name=$server_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e ISL -e OSL -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e RANDOM_RANGE_RATIO -e RESULT_FILENAME -e RUN_EVAL -e RUNNER_TYPE \
+-e ENABLE_PROFILE -e VLLM_TORCH_PROFILER_DIR \
 --entrypoint=/bin/bash \
 $IMAGE \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi300x.sh"

--- a/runners/launch_mi300x-cr.sh
+++ b/runners/launch_mi300x-cr.sh
@@ -15,6 +15,7 @@ docker run --rm --ipc=host --shm-size=16g --network=host --name=$server_name \
 -v $GITHUB_WORKSPACE:/workspace/ -w /workspace/ \
 -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e PORT=$PORT \
 -e ISL -e OSL -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e RANDOM_RANGE_RATIO -e RESULT_FILENAME -e RUN_EVAL -e RUNNER_TYPE \
+-e ENABLE_PROFILE -e VLLM_TORCH_PROFILER_DIR \
 --entrypoint=/bin/bash \
 $IMAGE \
 benchmarks/"${EXP_NAME%%_*}_${PRECISION}_mi300x.sh"


### PR DESCRIPTION
## Summary

Add torch profiler support to benchmark scripts, enabling collection of detailed GPU performance data during benchmark runs.

Resolves #610 

## Changes

### `benchmarks/benchmark_lib.sh`
- Added automatic profiler setup when `ENABLE_PROFILE=true`
- Auto-configure `VLLM_TORCH_PROFILER_DIR` to `/workspace/profiling` if not explicitly set
- Auto-create profiling output directory
- Added `--profile` flag to `benchmark_serving.py` invocation in `run_benchmark_serving()`

### Runner Scripts
Added `ENABLE_PROFILE` and `VLLM_TORCH_PROFILER_DIR` environment variable passthrough to docker containers:
- `runners/launch_b200-dgxc.sh`
- `runners/launch_h100-cr.sh`
- `runners/launch_mi300x-amd.sh`
- `runners/launch_mi300x-cr.sh`

> Note: SLURM-based runners using `--export=ALL` already pass through all environment variables.

## Usage


### Enable profiling with default output directory (/workspace/profiling)
`ENABLE_PROFILE=true ./benchmarks/dsr1_fp8_b200.sh`

### Enable profiling with custom output directory

`ENABLE_PROFILE=true VLLM_TORCH_PROFILER_DIR=/custom/path ./benchmarks/dsr1_fp8_b200.sh`

## How It Works
1. When `benchmark_lib.sh` is sourced, it checks `ENABLE_PROFILE`
2. If enabled, sets `VLLM_TORCH_PROFILER_DIR` (server uses this to enable `/start_profile` and `/stop_profile` endpoints)
3. During benchmark, `benchmark_serving.py` calls these endpoints to collect torch profiling data
4. Profiling results are saved to `VLLM_TORCH_PROFILER_DIR`

## Testing


- [x] Tested with `ENABLE_PROFILE=true` on AMD GPU node
- [x] Verified profiling data is generated in the output directory