### PR TITLE
[AMD] Disable torch compile and set cuda-graph-max-bs to CONC for MI355X DSR1 FP8 SGLang

### DIFF
--- a/benchmarks/dsr1_fp8_mi355x.sh
+++ b/benchmarks/dsr1_fp8_mi355x.sh
@@ -38,8 +38,7 @@ python3 -m sglang.launch_server \
     --mem-fraction-static 0.8 --disable-radix-cache \
     --num-continuous-decode-steps 4 \
     --max-prefill-tokens 196608 \
-    --enable-torch-compile \
-    --cuda-graph-max-bs 128 > $SERVER_LOG 2>&1 &
+    --cuda-graph-max-bs $CONC > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -318,3 +318,10 @@
     - "Refactor configurations to use CONFIG_FILE-based recipes instead of inline parameter settings"
     - "Introduce srt-slurm workflow for launching Dynamo jobs"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/510
+
+- config-keys:
+    - dsr1-fp8-mi355x-sglang
+  description:
+    - "Disable torch.compile for MI355X DeepSeek-R1 FP8 SGLang"
+    - "set cuda-graph-max-bs to CONC"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/613


### PR DESCRIPTION
Disable torch compile and set `--cuda-graph-max-bs $CONC` for MI355X DSR1 FP8 SGLang 

| ISL/OSL+K49:S60 | CONC | TPUT per GPU | TPUT per GPU | Performance | Launch job script time | Launch job script time | Time saving |
| --- | --- | --- | --- | --- | --- | --- | --- |
|  |  | disable torch comple | enable_torch_compile | Enable/Disable | Disable torch compile | Enable_torch_compile | Disable - Enable |
| 1k1k | 4 | 94.9097 | 92.9432 | 1.02 | 37m | 1h7m | 30m |
| 1k1k | 8 | 167.042 | 164.066 | 1.02 | 37m | 1h9m | 32m |
| 1k1k | 16 | 270.173 | 267.209 | 1.01 | 53m | 1h9m | 16m |
| 1k1k | 32 | 395.575 | 391.661 | 1.01 | 54m | 1h10m | 16m |
| 1k1k | 64 | 622.1 | 621.585 | 1 | 54m | 1h11m | 17m |
| 1k8k | 4 | 55.0335 | 54.0147 | 1.02 | 49m | 1h27m | 38m |
| 1k8k | 8 | 98.0511 | 96.8306 | 1.01 | 51m | 1h23m | 32m |
| 1k8k | 16 | 161.092 | 159.811 | 1.01 | 1h1m | 1h32m | 31m |
| 1k8k | 32 | 242.925 | 241.512 | 1.01 | 1h2m | 1h33m | 31m |
| 1k8k | 64 | 377.21 | 376.431 | 1 | 1h10m | 1h55m | 45m |
| 8k1k | 4 | 324.555 | 319.784 | 1.01 | 37m | 1h9m | 32m |
| 8k1k | 8 | 569.572 | 554.629 | 1.03 | 38m | 1h9m | 31m |
| 8k1k | 16 | 877.311 | 874.081 | 1 | 54m | 1h16m | 22m |
| 8k1k | 32 | 1176.06 | 1165.06 | 1.01 | 41m | 1h12m | 31m |
| 8k1k | 64 | 1553.58 | 1572.91 | 0.99 | 42m | 1h15m |  |

- Enable torch compile: https://github.com/InferenceMAX/InferenceMAX/actions/runs/21407590933
- Disable torch compile: https://github.com/InferenceMAX/InferenceMAX/actions/runs/21515925993

Co-work with 1am9trash