### PR TITLE
[NV] dsr1 fp4 b200 trt agg update

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -833,6 +833,9 @@ dsr1-fp4-b200-trt:
   - isl: 1024
     osl: 1024
     search-space:
+    # low concurrency cases use TP only
+    # concurrency 64 uses TP & EP
+    # high concurrency cases use TP & EP & DP-ATTN
     - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }
     - { tp: 8, conc-start: 4, conc-end: 4 }
@@ -841,6 +844,9 @@ dsr1-fp4-b200-trt:
   - isl: 1024
     osl: 8192
     search-space:
+    # low concurrency cases use TP only
+    # concurrency 64 uses TP & EP
+    # high concurrency cases use TP & EP & DP-ATTN
     - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }
     - { tp: 8, conc-start: 4, conc-end: 4 }
@@ -849,6 +855,9 @@ dsr1-fp4-b200-trt:
   - isl: 8192
     osl: 1024
     search-space:
+    # low concurrency cases use TP only
+    # concurrency 32 uses TP & EP
+    # high concurrency cases use TP & EP & DP-ATTN
     - { tp: 4, conc-start: 4, conc-end: 32 }
     - { tp: 4, ep: 4, conc-start: 32, conc-end: 32 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -822,7 +822,7 @@ dsr1-fp4-b200-sglang:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 16 }
 
 dsr1-fp4-b200-trt:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
   runner: b200-trt
@@ -833,44 +833,27 @@ dsr1-fp4-b200-trt:
   - isl: 1024
     osl: 1024
     search-space:
-    # If TP=4, 
-    #   If CONC > 32, then EP=4
-    #   If CONC >= 256, DP_ATTN=true
-    - { tp: 4, conc-start: 4, conc-end: 32 }
-    - { tp: 4, ep: 4, conc-start: 64, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }
-    # If TP=8, 
-    #   If CONC > 8, then EP=8
-    #   If CONC >= 256, DP_ATTN=true
-    - { tp: 8, conc-start: 4, conc-end: 8 }
-    - { tp: 8, ep: 8, conc-start: 16, conc-end: 128 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256 }
+    - { tp: 8, conc-start: 4, conc-end: 4 }
+    - { tp: 8, ep: 8, conc-start: 64, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
   - isl: 1024
     osl: 8192
     search-space:
-    # If TP=4, 
-    #   If CONC > 32, then EP=4
-    #   If CONC >= 256, DP_ATTN=true
-    - { tp: 4, conc-start: 4, conc-end: 32 }
-    - { tp: 4, ep: 4, conc-start: 64, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
     - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }
-    # If TP=8, 
-    #   If CONC > 16, then EP=8
-    #   If CONC >= 256, DP_ATTN=true
-    - { tp: 8, conc-start: 4, conc-end: 16 }
-    - { tp: 8, ep: 8, conc-start: 32, conc-end: 128 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256 }
+    - { tp: 8, conc-start: 4, conc-end: 4 }
+    - { tp: 8, ep: 8, conc-start: 64, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
-    # If TP=4, 
-    #   If CONC > 32, then EP=4 and DP_ATTN=true
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 32 }
-    - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 256 }
-    # If TP=8, 
-    #   If CONC > 32, then EP=8 and DP_ATTN=true
-    - { tp: 8, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 256 }
+    - { tp: 4, conc-start: 4, conc-end: 32 }
+    - { tp: 4, ep: 4, conc-start: 32, conc-end: 32 }
+    - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 256 }
+    - { tp: 8, conc-start: 4, conc-end: 4 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
 
 dsr1-fp4-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2

--- a/benchmarks/dsr1_fp4_b200_trt.sh
+++ b/benchmarks/dsr1_fp4_b200_trt.sh
@@ -22,37 +22,20 @@ echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTIO
 
 hf download "$MODEL"
 
-# ========= Determine DP_ATTENTION, EP_SIZE and MOE_BACKEND based on ISL, OSL, CONC =========
+# ========= Determine other parameters based on ISL, OSL, CONC =========
+CUDA_GRAPH_MAX_BATCH_SIZE=$CONC
 MOE_BACKEND="TRTLLM"
+PIECEWISE_CUDA_GRAPHS="false"
 
-if [[ "$TP" == "4" ]]; then
-    if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
-        if [[ $CONC -ge 256 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
-    elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
-        if [[ $CONC -ge 256 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
-    elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-        if [[ $CONC -gt 32 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
+if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
+    if [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
+        PIECEWISE_CUDA_GRAPHS="true"
     fi
-elif [[ "$TP" == "8" ]]; then
-    if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
-        if [[ $CONC -ge 256 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
-    elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
-        if [[ $CONC -ge 256 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
-    elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-        if [[ $CONC -gt 32 ]]; then
-            MOE_BACKEND="CUTLASS"
-        fi
-    fi
+fi
+
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    MOE_BACKEND="CUTLASS"
+    CUDA_GRAPH_MAX_BATCH_SIZE=$(( $CONC / 4 ))
 fi
 
 echo "MOE_BACKEND set to '$MOE_BACKEND'"
@@ -64,7 +47,7 @@ EXTRA_CONFIG_FILE="dsr1-fp4.yml"
 cat > $EXTRA_CONFIG_FILE << EOF
 cuda_graph_config:
     enable_padding: true
-    max_batch_size: 512
+    max_batch_size: $CUDA_GRAPH_MAX_BATCH_SIZE
 enable_attention_dp: $DP_ATTENTION
 print_iter_log: true
 kv_cache_config:
@@ -90,6 +73,19 @@ set -x
 MAX_NUM_TOKENS=$(( ($CONC+$ISL+64+63)/64*64 ))
 MAX_MODEL_LEN=$(( MAX_MODEL_LEN > 8192 ? MAX_MODEL_LEN : 8192 ))
 MAX_NUM_TOKENS=$(( MAX_NUM_TOKENS > 8192 ? MAX_NUM_TOKENS : 8192 ))
+
+if [[ "$PIECEWISE_CUDA_GRAPHS" == "true" ]]; then
+    # [2^i for i in range(8)] + [i for i in range(256, max_num_tokens, 256)] + [max_num_tokens]
+    capture_tokens=(1 2 4 8 16 32 64 128)
+    capture_tokens+=( $(seq 256 256 $MAX_NUM_TOKENS))
+    CAPTURE_TOKENS_LIST=$(printf "%s, " "${capture_tokens[@]}")
+
+    cat << EOF >> $EXTRA_CONFIG_FILE
+torch_compile_config:
+    capture_num_tokens: [${CAPTURE_TOKENS_LIST%, }]
+    enable_piecewise_cuda_graph: true 
+EOF
+fi
 
 # Launch TRT-LLM server
 mpirun -n 1 --oversubscribe --allow-run-as-root \

--- a/benchmarks/dsr1_fp4_b200_trt.sh
+++ b/benchmarks/dsr1_fp4_b200_trt.sh
@@ -35,7 +35,7 @@ fi
 
 if [[ "$DP_ATTENTION" == "true" ]]; then
     MOE_BACKEND="CUTLASS"
-    CUDA_GRAPH_MAX_BATCH_SIZE=$(( $CONC / 4 ))
+    CUDA_GRAPH_MAX_BATCH_SIZE=$(( CONC < 4 ? CONC : CONC / 4 ))
 fi
 
 echo "MOE_BACKEND set to '$MOE_BACKEND'"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -334,4 +334,3 @@
     - "Add dynamic piecewise CUDA graphs for 1k1k (TEP8 and CONC64)"
     - "Update search space: remove EP=TP constraint, add TP=4 configurations, extend concurrency ranges"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/620
-  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -333,3 +333,4 @@
     - "Change default MOE backend from DEEPGEMM to TRTLLM"
     - "Add dynamic piecewise CUDA graphs for 1k1k (TEP8 and CONC64)"
     - "Update search space: remove EP=TP constraint, add TP=4 configurations, extend concurrency ranges"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/620

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -334,3 +334,4 @@
     - "Add dynamic piecewise CUDA graphs for 1k1k (TEP8 and CONC64)"
     - "Update search space: remove EP=TP constraint, add TP=4 configurations, extend concurrency ranges"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/620
+  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -325,3 +325,11 @@
     - "Disable torch.compile for MI355X DeepSeek-R1 FP8 SGLang"
     - "set cuda-graph-max-bs to CONC"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/613
+
+- config-keys:
+    - dsr1-fp4-b200-trt
+  description:
+    - "Update TensorRT-LLM container from release:1.1.0rc2.post2 to release:1.2.0rc6.post2"
+    - "Change default MOE backend from DEEPGEMM to TRTLLM"
+    - "Add dynamic piecewise CUDA graphs for 1k1k (TEP8 and CONC64)"
+    - "Update search space: remove EP=TP constraint, add TP=4 configurations, extend concurrency ranges"


### PR DESCRIPTION
This PR contains below updates:
- Update to the scripts to use latest TRTLLM release container
- Fine-tune choice of parallelism in nvidia-master for various cases
- Enable a few optimizations offered by TensorRT LLM on specific cases (MOE_BACKEND and Piecewise cuda graphs)

Near the top of the benchmark script (L26-28), we use flags to enable specific optimizations for specific ISL/OSL/CONC combinations according to the chosen TP/EP/DP-ATTENTION in nvidia-master and to what is best for balancing ctx vs gen workload and achieving good utilization.

Further down the script, from L47 onwards, we key off these flags to generate the necessary yaml for enabling these features in the runtime config file.

Piecewise Cuda Graphs (https://nvidia.github.io/TensorRT-LLM/features/torch_compile_and_piecewise_cuda_graph.html) enables some components to execute thorugh cuda graphs while other components are run eagerly, to gain benefit with lower overhead. We use the formula from the documentation to generate a capture_num_tokens list dynamically as it depends on MAX_NUM_TOKENS which is not constant across cases.

"cuda graph max batch size" is mostly equal to CONC as the natural limit on the expected size of a batch, but is configured as batch_size/4 when DP_ATTENTION is enabled.