### PR TITLE
[AMD][1/N] feat: add distributed inference FP4 workflow for MI355X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -627,3 +627,150 @@ dsr1-fp8-mi355x-sglang-disagg:
         additional-settings:
         - "DECODE_NODES=2"
         - "DECODE_MTP_SIZE=0"
+
+
+dsr1-fp4-mi355x-sglang-disagg:
+  image: rocm/pytorch-private:sglang-0.5.7-rocm700-mi35x-mori-fp4-0122
+  model: amd/DeepSeek-R1-0528-MXFP4
+  model-prefix: dsr1
+  runner: mi355x-disagg
+  precision: fp4
+  framework: sglang-disagg
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    # MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+
+
+  - isl: 1024
+    osl: 8192
+    search-space:
+    # MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "mtp"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=2"
+
+    # non-MTP configurations
+    # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+    - spec-decoding: "none"
+      conc-list: [ 32, 64, 128 ]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "PREFILL_NODES=1"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "DECODE_NODES=2"
+        - "DECODE_MTP_SIZE=0"
+

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -630,7 +630,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
 
 dsr1-fp4-mi355x-sglang-disagg:
-  image: rocm/pytorch-private:sglang-0.5.7-rocm700-mi35x-mori-fp4-0122
+  image: rocm/sgl-dev:sglang-0.5.7-rocm700-mi35x-mori-fp4-0122
   model: amd/DeepSeek-R1-0528-MXFP4
   model-prefix: dsr1
   runner: mi355x-disagg

--- a/benchmarks/dsr1_fp4_mi355x_sglang-disagg.sh
+++ b/benchmarks/dsr1_fp4_mi355x_sglang-disagg.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    CONC_LIST \
+    ISL \
+    OSL \
+    IMAGE \
+    SPEC_DECODING \
+    MODEL_PATH \
+    PREFILL_NUM_WORKERS \
+    PREFILL_TP \
+    PREFILL_EP \
+    PREFILL_DP_ATTN \
+    DECODE_NUM_WORKERS \
+    DECODE_TP \
+    DECODE_EP \
+    DECODE_DP_ATTN \
+    PREFILL_NODES \
+    DECODE_NODES \
+    SGL_SLURM_JOBS_PATH \
+    RANDOM_RANGE_RATIO
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+set -x
+
+# Always clone and setup sglang_disagg
+git clone --branch sa-260114-fp4 https://github.com/billishyahao/sglang_disagg.git
+
+cd "$SGL_SLURM_JOBS_PATH" || exit 1
+
+# Set up SGL launch script-specific environment variables
+export TIME_LIMIT="08:00:00"
+export MODEL_PATH=$MODEL_PATH
+export MODEL_NAME="DeepSeek-R1-0528-MXFP4-Preview"
+export CONTAINER_IMAGE=$IMAGE
+
+export PREFILL_ENABLE_EP=true
+if [[ "$PREFILL_DP_ATTN" == "true" ]]; then
+export PREFILL_ENABLE_DP=true
+else
+export PREFILL_ENABLE_DP=false
+fi
+
+export DECODE_ENABLE_EP=true
+if [[ "$DECODE_DP_ATTN" == "true" ]]; then
+export DECODE_ENABLE_DP=true
+else
+export DECODE_ENABLE_DP=false
+fi
+
+# Launch jobs based on ISL/OSL
+# Replace ' ' in CONC_LIST with 'x' such that the concurrency list is represented
+# by a list of numbers delimited by 'x'. This is because of how the underlying launch script
+# expects the concurrencies.
+JOB_ID=$(bash ./submit_disagg.sh $PREFILL_NODES \
+    $PREFILL_NUM_WORKERS \
+    $DECODE_NODES \
+    $DECODE_NUM_WORKERS \
+    $ISL $OSL "${CONC_LIST// /x}" inf \
+    ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
+    ${RANDOM_RANGE_RATIO})
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to submit job" >&2
+    exit 1
+fi
+
+echo "$JOB_ID"

--- a/benchmarks/dsr1_fp4_mi355x_sglang-disagg.sh
+++ b/benchmarks/dsr1_fp4_mi355x_sglang-disagg.sh
@@ -29,7 +29,7 @@ fi
 set -x
 
 # Always clone and setup sglang_disagg
-git clone --branch sa-260114-fp4 https://github.com/billishyahao/sglang_disagg.git
+git clone --branch sa-260203 https://github.com/billishyahao/sglang_disagg.git
 
 cd "$SGL_SLURM_JOBS_PATH" || exit 1
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -325,3 +325,9 @@
     - "Disable torch.compile for MI355X DeepSeek-R1 FP8 SGLang"
     - "set cuda-graph-max-bs to CONC"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/613
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang-disagg
+  description:
+    - "enable PD/D for both MTP and non-MTP MI355X DeepSeek-R1 FP4 SGLang"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/622

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -349,3 +349,4 @@
   description:
     - "enable PD/D for both MTP and non-MTP MI355X DeepSeek-R1 FP4 SGLang"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/622
+  


### PR DESCRIPTION
This patch is to enable FP4 support for distributed inference workflow of MI355X. This workflow can co-work with the recipe sa-260203 https://github.com/billishyahao/sglang_disagg/tree/sa-260203 . 
Key updates since Jan 24:
1. Add dsr1 FP4 support
2. Support mori shmem mode isolation
3. Fix chunked prefill size
4. Support dry run