### PR TITLE
[NV] add DSR1 SGLang MTP configs on single node B200

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -950,15 +950,15 @@ dsr1-fp8-b200-sglang-mtp:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -939,7 +939,7 @@ dsr1-fp8-b200-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 32 }
 
 dsr1-fp8-b200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.6-cu129-amd64
+  image: lmsysorg/sglang:v0.5.8-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -950,15 +950,15 @@ dsr1-fp8-b200-sglang-mtp:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -938,6 +938,28 @@ dsr1-fp8-b200-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 32 }
 
+dsr1-fp8-b200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.6-cu129-amd64
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: b200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2
   model: deepseek-ai/DeepSeek-R1-0528

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# MTP only supports TP=8 for now
+if [[ $TP -ne 8 ]]; then
+  echo "MTP only supports TP=8, got TP=$TP!"
+  exit 1
+fi
+
+# Default: recv every ~10 requests; if CONC >= 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+
+# Setting these values (passed in to --cuda-graph-max-bs and --max-running-requests) as the maximum concurrency
+# this will help us save memory from being unnecessary used.
+MAX_RUNNING_REQUESTS=128
+CUDA_GRAPH_MAX_BATCH_SIZE=128
+
+MEM_FRAC_STATIC=0.82
+CHUNKED_PREFILL_SIZE=32768
+MAX_PREFILL_TOKENS=32768
+
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# MTP (Multi-Token Prediction) Config - EAGLE speculative decoding
+SPECULATIVE_NUM_STEPS=2
+SPECULATIVE_DRAFT_TOKENS=3
+SPECULATIVE_EAGLE_TOPK=1
+
+ps aux
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE --max-running-requests $MAX_RUNNING_REQUESTS \
+--mem-fraction-static $MEM_FRAC_STATIC --kv-cache-dtype fp8_e4m3 --chunked-prefill-size $CHUNKED_PREFILL_SIZE --max-prefill-tokens $MAX_PREFILL_TOKENS \
+--enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL --disable-radix-cache \
+--attention-backend trtllm_mla --stream-interval 30 --ep-size $EP_SIZE --moe-runner-backend flashinfer_trtllm --quantization fp8 \
+--speculative-algorithm EAGLE --speculative-num-steps $SPECULATIVE_NUM_STEPS --speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS --speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -54,8 +54,6 @@ SPECULATIVE_NUM_STEPS=2
 SPECULATIVE_DRAFT_TOKENS=3
 SPECULATIVE_EAGLE_TOPK=1
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
     --model-path=$MODEL \

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -57,13 +57,31 @@ SPECULATIVE_EAGLE_TOPK=1
 ps aux
 
 set -x
-PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
---tensor-parallel-size=$TP --data-parallel-size=1 \
---cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE --max-running-requests $MAX_RUNNING_REQUESTS \
---mem-fraction-static $MEM_FRAC_STATIC --kv-cache-dtype fp8_e4m3 --chunked-prefill-size $CHUNKED_PREFILL_SIZE --max-prefill-tokens $MAX_PREFILL_TOKENS \
---enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL --disable-radix-cache \
---attention-backend trtllm_mla --stream-interval 30 --ep-size $EP_SIZE --moe-runner-backend flashinfer_trtllm --quantization fp8 \
---speculative-algorithm EAGLE --speculative-num-steps $SPECULATIVE_NUM_STEPS --speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS --speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK > $SERVER_LOG 2>&1 &
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --tensor-parallel-size=$TP \
+    --data-parallel-size=1 \
+    --cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE \
+    --max-running-requests $MAX_RUNNING_REQUESTS \
+    --mem-fraction-static $MEM_FRAC_STATIC \
+    --kv-cache-dtype fp8_e4m3 \
+    --chunked-prefill-size $CHUNKED_PREFILL_SIZE \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --enable-flashinfer-allreduce-fusion \
+    --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+    --disable-radix-cache \
+    --attention-backend trtllm_mla \
+    --stream-interval 30 \
+    --ep-size $EP_SIZE \
+    --moe-runner-backend flashinfer_trtllm \
+    --quantization fp8 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps $SPECULATIVE_NUM_STEPS \
+    --speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS \
+    --speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK \
+    > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -40,8 +40,8 @@ fi
 
 # Setting these values (passed in to --cuda-graph-max-bs and --max-running-requests) as the maximum concurrency
 # this will help us save memory from being unnecessary used.
-MAX_RUNNING_REQUESTS=256
-CUDA_GRAPH_MAX_BATCH_SIZE=256
+MAX_RUNNING_REQUESTS=512
+CUDA_GRAPH_MAX_BATCH_SIZE=512
 
 MEM_FRAC_STATIC=0.82
 CHUNKED_PREFILL_SIZE=32768
@@ -98,7 +98,8 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir /workspace/ \
+    --use-chat-template
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -40,8 +40,8 @@ fi
 
 # Setting these values (passed in to --cuda-graph-max-bs and --max-running-requests) as the maximum concurrency
 # this will help us save memory from being unnecessary used.
-MAX_RUNNING_REQUESTS=64
-CUDA_GRAPH_MAX_BATCH_SIZE=64
+MAX_RUNNING_REQUESTS=256
+CUDA_GRAPH_MAX_BATCH_SIZE=256
 
 MEM_FRAC_STATIC=0.82
 CHUNKED_PREFILL_SIZE=32768

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -20,8 +20,8 @@ nvidia-smi
 
 hf download "$MODEL"
 
-export SGL_ENABLE_JIT_DEEPGEMM=false
-export SGLANG_ENABLE_FLASHINFER_GEMM=true
+export SGLANG_ENABLE_JIT_DEEPGEMM=false
+
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
@@ -44,8 +44,8 @@ MAX_RUNNING_REQUESTS=512
 CUDA_GRAPH_MAX_BATCH_SIZE=512
 
 MEM_FRAC_STATIC=0.82
-CHUNKED_PREFILL_SIZE=32768
-MAX_PREFILL_TOKENS=32768
+CHUNKED_PREFILL_SIZE=16384
+MAX_PREFILL_TOKENS=16384
 
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
@@ -53,6 +53,8 @@ echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL,
 SPECULATIVE_NUM_STEPS=2
 SPECULATIVE_DRAFT_TOKENS=3
 SPECULATIVE_EAGLE_TOPK=1
+
+SGLANG_ENABLE_SPEC_V2=1
 
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
@@ -70,6 +72,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
     --enable-flashinfer-allreduce-fusion \
     --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
     --disable-radix-cache \
+    --fp8-gemm-backend=flashinfer_trtllm \
     --attention-backend trtllm_mla \
     --stream-interval 30 \
     --ep-size $EP_SIZE \

--- a/benchmarks/dsr1_fp8_b200_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_mtp.sh
@@ -40,8 +40,8 @@ fi
 
 # Setting these values (passed in to --cuda-graph-max-bs and --max-running-requests) as the maximum concurrency
 # this will help us save memory from being unnecessary used.
-MAX_RUNNING_REQUESTS=128
-CUDA_GRAPH_MAX_BATCH_SIZE=128
+MAX_RUNNING_REQUESTS=64
+CUDA_GRAPH_MAX_BATCH_SIZE=64
 
 MEM_FRAC_STATIC=0.82
 CHUNKED_PREFILL_SIZE=32768

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -354,3 +354,13 @@
     - "8k1k: 14 scenarios (7 MTP, 7 STP) for long context workloads"
     - "Prefill workers: 1-5P, Decode workers: 1-4D, TP/EP: 8/16/32"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/617
+
+- config-keys:
+    - dsr1-fp8-b200-sglang-mtp
+  description:
+    - "Add MTP (Multi-Token Prediction) support for DeepSeek R1 FP8 B200 SGLang using EAGLE speculative decoding"
+    - "Image: lmsysorg/sglang:v0.5.8-cu130-amd64"
+    - "Add benchmark script dsr1_fp8_b200_mtp.sh with EAGLE speculative decoding (num-steps=2, draft-tokens=3, topk=1)"
+    - "Update launch_b200-dgxc.sh to support SPEC_SUFFIX for MTP script selection"
+    - "Configurations: TP=8, EP=1, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/626

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -418,4 +418,3 @@
     - "Configurations: TP=8, EP=1, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/626
   
-  

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -2,6 +2,7 @@
 
 HF_HUB_CACHE_MOUNT="/raid/hf_hub_cache/"
 FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
+SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
 PORT=8888
 
 # Create unique cache directory based on model parameters
@@ -34,7 +35,7 @@ docker run --rm --init --network host --name $server_name \
 -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e RESULT_FILENAME -e RANDOM_RANGE_RATIO -e RUN_EVAL -e RUNNER_TYPE \
 --entrypoint=/bin/bash \
 $(echo "$IMAGE" | sed 's/#/\//') \
-benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}.sh"
+benchmarks/"${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"
 
 # Try graceful first
 docker stop -t 90 "$server_name" || true


### PR DESCRIPTION
## Summary

This PR adds MTP (Multi-Token Prediction) support for DeepSeek R1 FP8 on B200 using SGLang with EAGLE speculative decoding.

### Changes
- Add new benchmark script `benchmarks/dsr1_fp8_b200_mtp.sh` with EAGLE speculative decoding configuration
- Add `dsr1-fp8-b200-sglang-mtp` config entry to `.github/configs/nvidia-master.yaml`
- Update `runners/launch_b200-dgxc.sh` to support `SPEC_SUFFIX` for MTP script selection
- Add perf-changelog entry documenting the changes

### Reference: perf-changelog.yaml entry
```yaml
- config-keys:
    - dsr1-fp8-b200-sglang-mtp
  description:
    - "Add MTP (Multi-Token Prediction) support for DeepSeek R1 FP8 B200 SGLang using EAGLE speculative decoding"
    - "Image: lmsysorg/sglang:v0.5.8-cu130-amd64"
    - "Add benchmark script dsr1_fp8_b200_mtp.sh with EAGLE speculative decoding (num-steps=2, draft-tokens=3, topk=1)"
    - "Update launch_b200-dgxc.sh to support SPEC_SUFFIX for MTP script selection"
    - "Configurations: TP=8, EP=1, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/626
```

---

## Configuration Details

### Config: `dsr1-fp8-b200-sglang-mtp`

| Parameter | Value |
|-----------|-------|
| **Image** | `lmsysorg/sglang:v0.5.8-cu130-amd64` |
| **Model** | `deepseek-ai/DeepSeek-R1-0528` |
| **Runner** | `b200` |
| **Precision** | `fp8` |
| **Framework** | `sglang` |
| **Multinode** | `false` |

### Sequence Length Configurations

| ISL | OSL | TP | EP | Concurrency Range | Spec Decoding |
|-----|-----|----|----|-------------------|---------------|
| 1024 | 1024 | 8 | 1 | 4-256 | MTP (EAGLE) |
| 1024 | 8192 | 8 | 1 | 4-256 | MTP (EAGLE) |
| 8192 | 1024 | 8 | 1 | 4-256 | MTP (EAGLE) |

### SGLang Server Configuration

| Parameter | Value | Description |
|-----------|-------|-------------|
| `--tensor-parallel-size` | 8 | Fixed at TP=8 (MTP requirement) |
| `--data-parallel-size` | 1 | Single data parallel instance |
| `--ep-size` | 1 | Expert parallelism size |
| `--cuda-graph-max-bs` | 256 | CUDA graph max batch size |
| `--max-running-requests` | 256 | Maximum concurrent requests |
| `--mem-fraction-static` | 0.82 | Static memory fraction |
| `--kv-cache-dtype` | fp8_e4m3 | FP8 KV cache |
| `--chunked-prefill-size` | 32768 | Chunked prefill size |
| `--max-prefill-tokens` | 32768 | Maximum prefill tokens |
| `--attention-backend` | trtllm_mla | TensorRT-LLM MLA attention |
| `--moe-runner-backend` | flashinfer_trtllm | FlashInfer TRT-LLM MoE backend |
| `--quantization` | fp8 | FP8 quantization |

### EAGLE Speculative Decoding Configuration

| Parameter | Value | Description |
|-----------|-------|-------------|
| `--speculative-algorithm` | EAGLE | Speculative decoding algorithm |
| `--speculative-num-steps` | 2 | Number of speculative steps |
| `--speculative-num-draft-tokens` | 3 | Draft tokens per step |
| `--speculative-eagle-topk` | 1 | Top-k for EAGLE |

### Environment Variables

| Variable | Value | Description |
|----------|-------|-------------|
| `SGL_ENABLE_JIT_DEEPGEMM` | false | Disable JIT DeepGEMM |
| `SGLANG_ENABLE_FLASHINFER_GEMM` | true | Enable FlashInfer GEMM |

### Additional Features
- `--enable-flashinfer-allreduce-fusion` - Enables FlashInfer all-reduce fusion
- `--disable-radix-cache` - Disables radix cache for MTP workloads
- `--stream-interval 30` - Stream interval for output
- `--scheduler-recv-interval` - Dynamic: 10 (CONC < 16), 30 (CONC >= 16)