### PR TITLE
[NV] dsr1 fp8 b200 trt agg mtp update

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -966,7 +966,7 @@ dsr1-fp8-b200-trt:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 8 }
 
 dsr1-fp8-b200-trt-mtp:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b200-trt
@@ -974,25 +974,26 @@ dsr1-fp8-b200-trt-mtp:
   framework: trt
   multinode: false
   seq-len-configs:
-  # For all sequence lengths, EP=TP, MOE_BACKEND=DEEPGEMM, MTP=3 (or MTP=1 when DP_ATTN=true)
+  # For all sequence lengths, MTP=3 (or MTP=1 when DP_ATTN=true)
   - isl: 1024
     osl: 1024
     search-space:
-    # If CONC >= 64, then DP_ATTN=true, MTP=1
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 32, spec-decoding: mtp }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+    # mostly TP8
+    # If CONC == 256, then TP8, EP8, DP_ATTN=true
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256, spec-decoding: mtp }
   - isl: 1024
     osl: 8192
     search-space:
-    # If CONC >= 128, then DP_ATTN=true, MTP=1
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    # mostly TP8
+    # If CONC >= 128, then TP8, EP8, DP_ATTN=true
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
   - isl: 8192
     osl: 1024
     search-space:
-    # If CONC >= 64, then DP_ATTN=true, MTP=1
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 32, spec-decoding: mtp }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+    # TP8 for all points
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-h200-sglang:
   image: lmsysorg/sglang:v0.5.7-cu129-amd64

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -969,7 +969,7 @@ dsr1-fp8-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-nb_0
+  runner: b200-nv_0
   precision: fp8
   framework: trt
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -969,7 +969,7 @@ dsr1-fp8-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-trt
+  runner: b200-nv_0
   precision: fp8
   framework: trt
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -969,7 +969,7 @@ dsr1-fp8-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-nv_0
+  runner: b200-trt
   precision: fp8
   framework: trt
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -969,7 +969,7 @@ dsr1-fp8-b200-trt-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-nv_0
+  runner: b200-nb_0
   precision: fp8
   framework: trt
   multinode: false

--- a/benchmarks/dsr1_fp8_b200_trt_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_trt_mtp.sh
@@ -22,14 +22,41 @@ echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTIO
 
 hf download "$MODEL"
 
-# ========= Determine MOE_BACKEND and MTP based on DP_ATTENTION =========
-MOE_BACKEND="DEEPGEMM"
+# ========= Determine other parameters based on ISL, OSL, CONC =========
+MOE_BACKEND="TRTLLM"
+PIECEWISE_CUDA_GRAPHS="true"
+MAX_BATCH_SIZE=$CONC
+KV_CACHE_FREE_MEM_FRACTION=0.8
+MTP=3
 
+# DP ATTENTION requires different optimizations
 if [[ "$DP_ATTENTION" == "true" ]]; then
+    MOE_BACKEND="DEEPGEMM"
+    PIECEWISE_CUDA_GRAPHS="false"
+    MAX_BATCH_SIZE=$(( CONC < 8 ? CONC : CONC / 8 ))
+    KV_CACHE_FREE_MEM_FRACTION=0.7
+    if [[ $CONC -eq 128 ]]; then
+        # use the new MOE backend from latest trtllm to get All2All comms
+        export ENABLE_CONFIGURABLE_MOE=1
+    fi
     MTP=1
-else
-    MTP=3
 fi
+
+# currently narrow CONC cases don't benefit from PW CUDA
+if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
+    if [[ $CONC -le 4 ]]; then
+        PIECEWISE_CUDA_GRAPHS="false"
+    fi
+elif [[ "$ISL" == "1024" && "$OSL" == "8192" ]]; then
+    if [[ $CONC -le 8 ]]; then
+        PIECEWISE_CUDA_GRAPHS="false"
+    fi
+elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
+    if [[ $CONC -le 16 ]]; then
+        PIECEWISE_CUDA_GRAPHS="false"
+    fi
+fi
+
 
 echo "MOE_BACKEND='$MOE_BACKEND', MTP='$MTP'"
 
@@ -40,12 +67,12 @@ EXTRA_CONFIG_FILE="dsr1-fp8-mtp.yml"
 cat > $EXTRA_CONFIG_FILE << EOF
 cuda_graph_config:
     enable_padding: true
-    max_batch_size: 256
+    max_batch_size: $MAX_BATCH_SIZE
 enable_attention_dp: $DP_ATTENTION
 print_iter_log: true
 kv_cache_config:
     dtype: fp8
-    free_gpu_memory_fraction: 0.8
+    free_gpu_memory_fraction: $KV_CACHE_FREE_MEM_FRACTION
     enable_block_reuse: false 
 stream_interval: 10
 moe_config:
@@ -64,13 +91,24 @@ attention_dp_config:
 EOF
 fi
 
-if [[ "$DP_ATTENTION" == "true" ]]; then
-    MAX_BATCH_SIZE=$((CONC/TP))
-else
-    MAX_BATCH_SIZE=$CONC
-fi
-
 MAX_NUM_TOKENS=$(( ((MTP+1)*MAX_BATCH_SIZE+ISL+64+63)/64*64 ))
+
+# prep PW CUDA config per the documentation
+if [[ "$PIECEWISE_CUDA_GRAPHS" == "true" ]]; then
+    # [2^i for i in range(8)] + [i for i in range(256, max_num_tokens, 256)] + [max_num_tokens]
+    capture_tokens=(1 2 4 8 16 32 64 128)
+    capture_tokens+=( $(seq 256 256 $MAX_NUM_TOKENS))
+    if [ $((MAX_NUM_TOKENS%256)) -ne 0 ]; then
+        capture_tokens+=($MAX_NUM_TOKENS)
+    fi
+    CAPTURE_TOKENS_LIST=$(printf "%s, " "${capture_tokens[@]}")
+
+    cat << EOF >> $EXTRA_CONFIG_FILE
+torch_compile_config:
+    capture_num_tokens: [${CAPTURE_TOKENS_LIST%, }]
+    enable_piecewise_cuda_graph: true 
+EOF
+fi
 
 set -x
 # Launch TRT-LLM server

--- a/benchmarks/dsr1_fp8_b200_trt_mtp.sh
+++ b/benchmarks/dsr1_fp8_b200_trt_mtp.sh
@@ -35,10 +35,8 @@ if [[ "$DP_ATTENTION" == "true" ]]; then
     PIECEWISE_CUDA_GRAPHS="false"
     MAX_BATCH_SIZE=$(( CONC < 8 ? CONC : CONC / 8 ))
     KV_CACHE_FREE_MEM_FRACTION=0.7
-    if [[ $CONC -eq 128 ]]; then
-        # use the new MOE backend from latest trtllm to get All2All comms
-        export ENABLE_CONFIGURABLE_MOE=1
-    fi
+    # use the new MOE backend from latest trtllm to get better comms
+    export ENABLE_CONFIGURABLE_MOE=1
     MTP=1
 fi
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -370,6 +370,8 @@
     - Enable piecewise CUDA graphs under most conditions
     - fine-tune max batch sizes and other optimizations
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/632
+
+- config-keys:  
     - dsr1-fp8-gb200-dynamo-trt
   description:
     - "Fix model_prefix argument in yaml configs"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -361,3 +361,12 @@
     - "8k1k: 14 scenarios (7 MTP, 7 STP) for long context workloads"
     - "Prefill workers: 1-5P, Decode workers: 1-4D, TP/EP: 8/16/32"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/617
+
+- config-keys:
+    - dsr1-fp8-b200-trt-mtp
+  description:
+    - Update to the latest TRTLLM 1.2 release container version
+    - Fine-tune the choice of parallelism in nvidia-master file, mainly going to TP for most points
+    - Enable piecewise CUDA graphs under most conditions
+    - fine-tune max batch sizes and other optimizations
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/632

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -362,6 +362,12 @@
     - "Prefill workers: 1-5P, Decode workers: 1-4D, TP/EP: 8/16/32"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/617
 
+- config-keys:  
+    - dsr1-fp8-gb200-dynamo-trt
+  description:
+    - "Fix model_prefix argument in yaml configs"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/646
+
 - config-keys:
     - dsr1-fp8-b200-trt-mtp
   description:
@@ -371,8 +377,3 @@
     - fine-tune max batch sizes and other optimizations
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/632
 
-- config-keys:  
-    - dsr1-fp8-gb200-dynamo-trt
-  description:
-    - "Fix model_prefix argument in yaml configs"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/646

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -362,7 +362,7 @@
     - "Prefill workers: 1-5P, Decode workers: 1-4D, TP/EP: 8/16/32"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/617
 
-- config-keys:  
+- config-keys:
     - dsr1-fp8-gb200-dynamo-trt
   description:
     - "Fix model_prefix argument in yaml configs"


### PR DESCRIPTION
- update to the latest TRTLLM 1.2 release container
- fine-tune choice of parallelism in nvidia master (go to TP only for most points)
- Enable latest optimizations offered by trtllm

For most of the tests we switch to the TRTLLM backend for best performance.

As in the non-mtp fp8 agg code, we use Piecewise Cuda Graphs (https://nvidia.github.io/TensorRT-LLM/features/torch_compile_and_piecewise_cuda_graph.html) which enables some components to execute thorugh cuda graphs while other components are run eagerly, to gain benefit with lower overhead. We prepare the yaml configuration as per the documentation including a "capture_num_tokens" list based partly on `MAX_NUM_TOKENS`.  Though we still exclude a few narrow-concurrency scenarios for performance reasons, we are working to improve this and will update this config once that is done.

For some of the higher-concurrency points we use data-parallel attention, through the DEEPGEMM MOE backend. This backend requires a few different optimizations vs TRTLLM as can be seen in lines 33-43.  Particularly the flag `ENABLE_CONFIGURABLE_MOE` enables DEEPGEMM to use the MOE backend from the latest 1.3 code tree for its improved communication performance.