### PR TITLE
[NV] adds DSR1-FP8 sglang dynamo MTP B200 config

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -5952,7 +5952,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
     osl: 1024
     search-space:
     # MTP low-latency: 1P1D
-    - conc-list: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+    - conc-list: [4, 64]
       prefill:
         num-worker: 1
         tp: 8
@@ -5966,7 +5966,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P3D
-    - conc-list: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+    - conc-list: [4, 8, 16, 32]
       prefill:
         num-worker: 1
         tp: 8
@@ -5979,22 +5979,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         tp: 8
         ep: 8
         dp-attn: false
-    # MTP max-tpt: 1P1D
-    - conc-list: [512, 1024, 2048, 4096]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/max-tpt-dep8-1p1d.yaml"
-      decode:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
     # MTP max-tpt: 1P5D
-    - conc-list: [512, 1024, 2048, 4096]
+    - conc-list: [512, 4096]
       prefill:
         num-worker: 1
         tp: 8
@@ -6008,7 +5994,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: true
     # MTP max-tpt: 2P5D
-    - conc-list: [512, 1024, 2048, 4096]
+    - conc-list: [1024, 2048, 4096]
       prefill:
         num-worker: 2
         tp: 8
@@ -6025,7 +6011,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
     osl: 1024
     search-space:
     # MTP low-latency: 1P1D
-    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+    - conc-list: [16, 32, 64]
       prefill:
         num-worker: 1
         tp: 8
@@ -6039,7 +6025,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P4D
-    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+    - conc-list: [8, 256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6053,7 +6039,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P6D
-    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+    - conc-list: [4, 8, 16, 256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6067,7 +6053,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP max-tpt: 1P1D
-    - conc-list: [128, 256, 512, 1024]
+    - conc-list: [256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6080,22 +6066,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         tp: 8
         ep: 8
         dp-attn: true
-    # MTP max-tpt: 1P2D
-    - conc-list: [128, 256, 512, 1024]
-      prefill:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
-        additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-1p2d.yaml"
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: true
     # MTP max-tpt: 2P1D
-    - conc-list: [128, 256, 512, 1024]
+    - conc-list: [128, 512]
       prefill:
         num-worker: 2
         tp: 8

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -5937,3 +5937,174 @@ dsr1-fp8-b200-dynamo-sglang:
         tp: 8
         ep: 8
         dp-attn: true
+
+dsr1-fp8-b200-dynamo-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: b200-multinode-slurm
+  precision: fp8
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    # MTP low-latency: 1P1D
+    - conc-list: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/low-latency-tep8-1p1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+    # MTP low-latency: 1P3D
+    - conc-list: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/low-latency-tep8-1p3d.yaml"
+      decode:
+        num-worker: 3
+        tp: 8
+        ep: 8
+        dp-attn: false
+    # MTP max-tpt: 1P1D
+    - conc-list: [512, 1024, 2048, 4096]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/max-tpt-dep8-1p1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    # MTP max-tpt: 1P5D
+    - conc-list: [512, 1024, 2048, 4096]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/max-tpt-dep8-1p5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: true
+    # MTP max-tpt: 2P5D
+    - conc-list: [512, 1024, 2048, 4096]
+      prefill:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/1k1k/mtp/max-tpt-dep8-2p5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: true
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # MTP low-latency: 1P1D
+    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+    # MTP low-latency: 1P4D
+    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p4d.yaml"
+      decode:
+        num-worker: 4
+        tp: 8
+        ep: 8
+        dp-attn: false
+    # MTP low-latency: 1P6D
+    - conc-list: [4, 8, 16, 32, 64, 128, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p6d.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 8
+        dp-attn: false
+    # MTP max-tpt: 1P1D
+    - conc-list: [128, 256, 512, 1024]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-1p1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    # MTP max-tpt: 1P2D
+    - conc-list: [128, 256, 512, 1024]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-1p2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+    # MTP max-tpt: 2P1D
+    - conc-list: [128, 256, 512, 1024]
+      prefill:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-2p1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -5952,7 +5952,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
     osl: 1024
     search-space:
     # MTP low-latency: 1P1D
-    - conc-list: [4, 64]
+    - spec-decoding: "mtp"
+      conc-list: [4, 64]
       prefill:
         num-worker: 1
         tp: 8
@@ -5966,7 +5967,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P3D
-    - conc-list: [4, 8, 16, 32]
+    - spec-decoding: "mtp"
+      conc-list: [4, 8, 16, 32]
       prefill:
         num-worker: 1
         tp: 8
@@ -5980,7 +5982,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP max-tpt: 1P5D
-    - conc-list: [512, 4096]
+    - spec-decoding: "mtp"
+      conc-list: [512, 4096]
       prefill:
         num-worker: 1
         tp: 8
@@ -5994,7 +5997,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: true
     # MTP max-tpt: 2P5D
-    - conc-list: [1024, 2048, 4096]
+    - spec-decoding: "mtp"
+      conc-list: [1024, 2048, 4096]
       prefill:
         num-worker: 2
         tp: 8
@@ -6011,7 +6015,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
     osl: 1024
     search-space:
     # MTP low-latency: 1P1D
-    - conc-list: [16, 32, 64]
+    - spec-decoding: "mtp"
+      conc-list: [16, 32, 64]
       prefill:
         num-worker: 1
         tp: 8
@@ -6025,7 +6030,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P4D
-    - conc-list: [8, 256]
+    - spec-decoding: "mtp"
+      conc-list: [8, 256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6039,7 +6045,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP low-latency: 1P6D
-    - conc-list: [4, 8, 16, 256]
+    - spec-decoding: "mtp"
+      conc-list: [4, 8, 16, 256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6053,7 +6060,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: false
     # MTP max-tpt: 1P1D
-    - conc-list: [256]
+    - spec-decoding: "mtp"
+      conc-list: [256]
       prefill:
         num-worker: 1
         tp: 8
@@ -6067,7 +6075,8 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         ep: 8
         dp-attn: true
     # MTP max-tpt: 2P1D
-    - conc-list: [128, 512]
+    - spec-decoding: "mtp"
+      conc-list: [128, 512]
       prefill:
         num-worker: 2
         tp: 8

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -483,3 +483,11 @@
     - "Image: lmsysorg/sglang:v0.5.8-cu130"
     - "Update prefill/decode worker counts, TP/EP parallelism, and dp-attn settings for 1k1k and 8k1k"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/635
+
+- config-keys:
+    - dsr1-fp8-b200-dynamo-sglang-mtp
+  description:
+    - "Add DSR1 FP8 B200 disaggregated SGLang MTP multinode configuration"
+    - "Image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64"
+    - "11 recipes: 5x 1k1k + 6x 8k1k, low-latency and max-throughput with EAGLE speculative decoding"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -490,4 +490,4 @@
     - "Add DSR1 FP8 B200 disaggregated SGLang MTP multinode configuration"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64"
     - "11 recipes: 5x 1k1k + 6x 8k1k, low-latency and max-throughput with EAGLE speculative decoding"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/XXX
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/667

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -489,5 +489,5 @@
   description:
     - "Add DSR1 FP8 B200 disaggregated SGLang MTP multinode configuration"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64"
-    - "11 recipes: 5x 1k1k + 6x 8k1k, low-latency and max-throughput with EAGLE speculative decoding"
+    - "9 recipes: 4x 1k1k + 5x 8k1k, low-latency and max-throughput with EAGLE speculative decoding"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/667


### PR DESCRIPTION
## Summary

Adds MTP (Multi-Token Prediction) support for DeepSeek R1 FP8 B200 disaggregated SGLang multinode configuration, complementing the existing STP config (`dsr1-fp8-b200-dynamo-sglang`) added in #658.

## Config Details

- **Config key**: `dsr1-fp8-b200-dynamo-sglang-mtp`
- **Image**: `lmsysorg/sglang:v0.5.8.post1-cu130-amd64`
- **Model**: `deepseek-ai/DeepSeek-R1-0528`
- **Runner**: `b200-multinode-slurm` (multinode, disaggregated)
- **Precision**: FP8
- **Framework**: dynamo-sglang
- **Speculative decoding**: EAGLE MTP (via `srt-slurm` recipe files)

## Recipes

**11 total recipes** using CONFIG_FILE-based `srt-slurm` recipes under `recipes/b200-fp8/`:

### 1k1k (5 recipes)
| Profile | Mode | Workers | Concurrency |
|---------|------|---------|-------------|
| Low-latency | TEP8 | 1P1D | 1–512 |
| Low-latency | TEP8 | 1P3D | 1–512 |
| Max-throughput | DEP8 | 1P1D | 512–4096 |
| Max-throughput | DEP8 | 1P5D | 512–4096 |
| Max-throughput | DEP8 | 2P5D | 512–4096 |

### 8k1k (6 recipes)
| Profile | Mode | Workers | Concurrency |
|---------|------|---------|-------------|
| Low-latency | TEP8 | 1P1D | 4–512 |
| Low-latency | TEP8 | 1P4D | 4–512 |
| Low-latency | TEP8 | 1P6D | 4–512 |
| Max-throughput | DEP8 | 1P1D | 128–1024 |
| Max-throughput | DEP8 | 1P2D | 128–1024 |
| Max-throughput | DEP8 | 2P1D | 128–1024 |

All recipes use TP=8, EP=8. Low-latency recipes use `dp-attn: false` (TEP mode); max-throughput recipes use `dp-attn: true` (DEP mode).
