### PR TITLE
[NV] Add B200 FP4 SGLANG dynamo MTP configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -522,37 +522,6 @@ dsr1-fp4-b200-dynamo-sglang:
         tp: 8
         ep: 1
         dp-attn: false
-    - spec-decoding: "mtp"
-      conc-list: [1024]
-      prefill:
-        num-worker: 4
-        tp: 4
-        ep: 4
-        dp-attn: true
-        additional-settings:
-        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-4p-dep8-1d.yaml
-        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-4p-dep8-1d.yaml"
-      decode:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
-    - spec-decoding: "mtp"
-      conc-list: [1024, 2048]
-      prefill:
-        num-worker: 7
-        tp: 4
-        ep: 4
-        dp-attn: true
-        additional-settings:
-        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-7p-dep8-2d.yaml
-        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-7p-dep8-2d.yaml"
-      decode:
-        num-worker: 2
-        tp: 8
-        ep: 8
-        dp-attn: true
-
 
 dsr1-fp4-b300-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -383,6 +383,177 @@ dsr1-fp4-b200-dynamo-trt:
         ep: 8
         dp-attn: true
 
+dsr1-fp4-b200-dynamo-sglang:
+  image: "lmsysorg/sglang:v0.5.8.post1-cu130"
+  model: deepseek-r1-fp4
+  model-prefix: dsr1
+  runner: b200-multinode-slurm
+  precision: fp4
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - spec-decoding: "mtp"
+      conc-list: [16, 512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [32, 64, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-6d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-6d.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [512, 1024]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-2d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+    
+
+
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - spec-decoding: "mtp"
+      conc-list: [64, 128]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [8]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [4, 128]
+      prefill:
+        num-worker: 2
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-2p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-2p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [4, 8, 16, 64]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-tp4-1p-tp8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-tp4-1p-tp8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [1024]
+      prefill:
+        num-worker: 4
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-4p-dep8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-4p-dep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [1024, 2048]
+      prefill:
+        num-worker: 7
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-7p-dep8-2d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/max-tpt-dep4-7p-dep8-2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+
+
 dsr1-fp4-b300-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
   model: deepseek-r1-fp4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -459,12 +459,14 @@
   description:
     - "New B300 FP8 Dynamo TRT configurations"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/638
+
 - config-keys:
     - dsr1-fp8-h100-dynamo-trt
   description:
     - "Add DeepSeek R1 FP8 H100 Dynamo TRT-LLM disaggregated multinode configurations"
     - "fix model_prefix bug from https://github.com/InferenceMAX/InferenceMAX/pull/651"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/663
+
 - config-keys:
     - dsr1-fp4-gb200-dynamo-sglang
   description:
@@ -491,3 +493,10 @@
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64"
     - "9 recipes: 4x 1k1k + 5x 8k1k, low-latency and max-throughput with EAGLE speculative decoding"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/667
+
+- config-keys:
+    - dsr1-fp4-b200-dynamo-sglang
+  description:
+    - "Update  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
+    - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/670


### PR DESCRIPTION
## Summary

Add B200 FP4 SGLANG disaggregated multinode MTP (Multi-Token Prediction) configurations to `nvidia-master.yaml`.

- **Config key:** `dsr1-fp4-b200-dynamo-sglang`
- **Image:** `lmsysorg/sglang:v0.5.8.post1-cu130`
- **Model:** `deepseek-r1-fp4`
- **Runner:** `b200-multinode-slurm` (multinode, disaggregated)
- **Framework:** `dynamo-sglang`
- **Spec decoding:** MTP across all entries

### Sequence length configs

**1k1k** (ISL=1024, OSL=1024):
- Low-latency: 1P/5D (TEP8), dp-attn=false, conc=[16, 512]
- Mid-curve: 1P/6D (TEP8), dp-attn=false, conc=[32, 64, 256, 512]
- dp-attn configs: 1P/1D and 1P/2D with dp-attn=true, conc=[512, 1024]

**8k1k** (ISL=8192, OSL=1024):
- Various prefill/decode topologies (1P/1D, 1P/5D, 2P/5D, 4P/1D, 7P/2D)
- Includes both TEP and TP-only (ep=1) configurations
- dp-attn configs for high-throughput targets, conc up to [1024, 2048]

### Files changed
- `.github/configs/nvidia-master.yaml` — New `dsr1-fp4-b200-dynamo-sglang` config block (171 lines)
- `perf-changelog.yaml` — Changelog entry for the new config