### PR TITLE
[NV] Add B200 FP4 SGlang STP configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -5906,6 +5906,142 @@ dsr1-fp8-h200-dynamo-sglang:
         ep: 8
         dp-attn: true
 
+dsr1-fp4-b200-dynamo-sglang:
+  image: lmsysorg/sglang:v0.5.8.post1-cu130-runtime
+  model: deepseek-r1-fp4
+  model-prefix: dsr1
+  runner: b200-multinode-slurm
+  precision: fp4
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    # Non-MTP configurations
+    - conc-list: [16, 128]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/stp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - conc-list: [32, 64, 256]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/stp/low-latency-dep4-1p-tep8-6d.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - conc-list: [512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/stp/max-tpt-dep4-1p-dep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - conc-list: [512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/stp/max-tpt-dep4-1p-dep8-2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+  - isl: 8192
+    osl: 1024
+    search-space:
+    # Non-MTP configurations
+    - conc-list: [64, 128]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/stp/low-latency-dep4-1p-tep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - conc-list: [8]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/stp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - conc-list: [4, 128]
+      prefill:
+        num-worker: 2
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/stp/low-latency-dep4-2p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - conc-list: [4, 8, 16, 64]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/stp/low-latency-tp4-1p-tp8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+    - conc-list: [1024, 2048]
+      prefill:
+        num-worker: 7
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/stp/max-tpt-dep4-7p-dep8-2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+
 dsr1-fp8-b200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -500,3 +500,12 @@
     - "Image: rocm/atom:rocm7.2.0-ubuntu24.04-pytorch2.9-atom0.1.1"
     - "Deepseek R1 with speculative decoding: 1k1k, 1k8k, 8k1k"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/673
+
+- config-keys:
+    - dsr1-fp4-b200-dynamo-sglang
+  description:
+    - "Add DSR1 FP4 B200 Dynamo SGLang STP mode"
+    - "Image: lmsysorg/sglang:v0.5.8.post1-cu130-runtime"
+    - "1k1k configs: low-latency DEP (1P5D, 1P6D), max-throughput DEP (1P1D, 1P2D)"
+    - "8k1k configs: low-latency DEP/TEP (1P1D, 1P5D, 2P5D), TEP (1P1D), max-throughput DEP (7P2D)"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/672


### PR DESCRIPTION
## Summary

Add DeepSeek-R1 FP4 B200 Dynamo SGLang STP (disaggregated) benchmark configurations.

**Config key:** `dsr1-fp4-b200-dynamo-sglang`
**Image:** `lmsysorg/sglang:v0.5.8.post1-cu130-runtime`
**Model:** `deepseek-r1-fp4`
**Runner:** `b200-multinode-slurm`

### Configurations

**1k1k (ISL=1024, OSL=1024):**
| Mode | Topology | Concurrencies |
|------|----------|---------------|
| Low-latency DEP | 1P (EP4) + 5D (TP8) | 16, 128 |
| Low-latency DEP | 1P (EP4) + 6D (TP8) | 32, 64, 256 |
| Max-throughput DEP | 1P (EP4) + 1D (EP8, dp-attn) | 512 |
| Max-throughput DEP | 1P (EP4) + 2D (EP8, dp-attn) | 512 |

**8k1k (ISL=8192, OSL=1024):**
| Mode | Topology | Concurrencies |
|------|----------|---------------|
| Low-latency DEP/TEP | 1P (EP4) + 1D (TP8) | 64, 128 |
| Low-latency DEP/TEP | 1P (EP4) + 5D (TP8) | 8 |
| Low-latency DEP/TEP | 2P (EP4) + 5D (TP8) | 4, 128 |
| Low-latency TEP | 1P (TP4) + 1D (TP8) | 4, 8, 16, 64 |
| Max-throughput DEP | 7P (EP4) + 2D (EP8, dp-attn) | 1024, 2048 |
