### PR TITLE
[NV] Add system configs for DSR1 B200 fp4 sglang MTP (New)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -6779,3 +6779,143 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
         tp: 8
         ep: 8
         dp-attn: true
+
+dsr1-fp4-b200-dynamo-sglang-mtp:
+  image: "lmsysorg/sglang:v0.5.8.post1-cu130"
+  model: deepseek-r1-fp4
+  model-prefix: dsr1
+  runner: b200-multinode-slurm
+  precision: fp4
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - spec-decoding: "mtp"
+      conc-list: [16, 512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [32, 64, 256, 512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-6d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/low-latency-dep4-1p-tep8-6d.yaml"
+      decode:
+        num-worker: 6
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [512, 1024]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [512]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-2d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/1k1k/mtp/max-tpt-dep4-1p-dep8-2d.yaml"
+      decode:
+        num-worker: 2
+        tp: 8
+        ep: 8
+        dp-attn: true
+    
+
+
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - spec-decoding: "mtp"
+      conc-list: [64, 128]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [8]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-1p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [4, 128]
+      prefill:
+        num-worker: 2
+        tp: 4
+        ep: 4
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-dep4-2p-tep8-5d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-dep4-2p-tep8-5d.yaml"
+      decode:
+        num-worker: 5
+        tp: 8
+        ep: 8
+        dp-attn: false
+    - spec-decoding: "mtp"
+      conc-list: [4, 8, 16, 64]
+      prefill:
+        num-worker: 1
+        tp: 4
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp4/8k1k/mtp/low-latency-tp4-1p-tp8-1d.yaml
+        - "CONFIG_FILE=recipes/b200-fp4/8k1k/mtp/low-latency-tp4-1p-tp8-1d.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -6853,7 +6853,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
         tp: 8
         ep: 8
         dp-attn: true
-    
+
 
 
   - isl: 8192

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -459,12 +459,14 @@
   description:
     - "New B300 FP8 Dynamo TRT configurations"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/638
+
 - config-keys:
     - dsr1-fp8-h100-dynamo-trt
   description:
     - "Add DeepSeek R1 FP8 H100 Dynamo TRT-LLM disaggregated multinode configurations"
     - "fix model_prefix bug from https://github.com/InferenceMAX/InferenceMAX/pull/651"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/663
+
 - config-keys:
     - dsr1-fp4-gb200-dynamo-sglang
   description:
@@ -515,3 +517,10 @@
   description:
     - "Introduce new DSR1 FP8 B200 Dynamo TRT configurations for 8k1k and 1k1k"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/616
+
+- config-keys:
+    - dsr1-fp4-b200-dynamo-sglang
+  description:
+    - "Update  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
+    - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/670

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -534,3 +534,4 @@
     - "Add B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/683
+  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -521,6 +521,6 @@
 - config-keys:
     - dsr1-fp4-b200-dynamo-sglang-mtp
   description:
-    - "Add  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
+    - "Add B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/683

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -519,8 +519,8 @@
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/616
 
 - config-keys:
-    - dsr1-fp4-b200-dynamo-sglang
+    - dsr1-fp4-b200-dynamo-sglang-mtp
   description:
-    - "Update  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
+    - "Add  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/670

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -523,4 +523,4 @@
   description:
     - "Add  B200 configs for DSR1 FP4 SGLANG MTP mode for 1k1k and 8k1k"
     - "Image: lmsysorg/sglang:v0.5.8.post1-cu130"
-  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/670
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/683


### PR DESCRIPTION
## Summary

Add B200 disaggregated multinode configs for **DeepSeek R1 FP4 SGLang with MTP** (Multi-Token Prediction) speculative decoding.

- **Config key:** `dsr1-fp4-b200-dynamo-sglang-mtp`
- **Image:** `lmsysorg/sglang:v0.5.8.post1-cu130`
- **Model:** `deepseek-r1-fp4`
- **Runner:** `b200-multinode-slurm` (multinode, disaggregated)
- **Precision:** FP4
- **Framework:** dynamo-sglang

### Configurations

**1k1k (ISL=1024, OSL=1024) — 4 search-space entries:**
| Profile | Recipe | Prefill | Decode | Concurrencies |
|---|---|---|---|---|
| Low-latency | `dep4-1p-tep8-5d` | 1P, TP4/EP4, dp-attn | 5D, TP8/EP8 | 16, 512 |
| Low-latency | `dep4-1p-tep8-6d` | 1P, TP4/EP4, dp-attn | 6D, TP8/EP8 | 32, 64, 256, 512 |
| Max-throughput | `dep4-1p-dep8-1d` | 1P, TP4/EP4, dp-attn | 1D, TP8/EP8, dp-attn | 512, 1024 |
| Max-throughput | `dep4-1p-dep8-2d` | 1P, TP4/EP4, dp-attn | 2D, TP8/EP8, dp-attn | 512 |

**8k1k (ISL=8192, OSL=1024) — 4 search-space entries:**
| Profile | Recipe | Prefill | Decode | Concurrencies |
|---|---|---|---|---|
| Low-latency | `dep4-1p-tep8-1d` | 1P, TP4/EP4, dp-attn | 1D, TP8/EP8 | 64, 128 |
| Low-latency | `dep4-1p-tep8-5d` | 1P, TP4/EP4, dp-attn | 5D, TP8/EP8 | 8 |
| Low-latency | `dep4-2p-tep8-5d` | 2P, TP4/EP4, dp-attn | 5D, TP8/EP8 | 4, 128 |
| Low-latency | `tp4-1p-tp8-1d` | 1P, TP4/EP1, no dp-attn | 1D, TP8/EP1 | 4, 8, 16, 64 |

### Notes
- MTP counterpart to existing STP config `dsr1-fp4-b200-dynamo-sglang` (PR #672)
- Recipe files sourced from [srt-slurm](https://github.com/ishandhanani/srt-slurm/tree/sa-submission-q1-2026/recipes/b200-fp4) (`mtp/` subdirectory)
- New branch created from main to avoid complex merge conflict resolution
