### PR TITLE
Revert "Fix the RP#673 by removing incorrect comments"

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -52,6 +52,7 @@ dsr1-fp4-mi355x-atom-mtp:
   model-prefix: dsr1
   runner: mi355x
   precision: fp4
+  # WIP framwork (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:
@@ -256,6 +257,7 @@ dsr1-fp8-mi355x-atom:
   model-prefix: dsr1
   runner: mi355x
   precision: fp8
+  # WIP framwork (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:
@@ -278,6 +280,7 @@ dsr1-fp8-mi355x-atom-mtp:
   model-prefix: dsr1
   runner: mi355x
   precision: fp8
+  # WIP framwork (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:


### PR DESCRIPTION
Reverts InferenceMAX/InferenceMAX#678

not incorrect comment, this is accurate comment about ATOM that nobody uses it https://github.com/InferenceMAX/InferenceMAX/pull/673/changes
