### PR TITLE
[AMD] Add more MI355X disagg DSR1 FP8 configs

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -373,7 +373,7 @@ dsr1-fp8-mi355x-sglang-disagg:
     # non-MTP configurations
     # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
     - spec-decoding: "none"
-      conc-list: [ 2048 ]
+      conc-list: [ 1024, 2048 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -392,7 +392,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
     - spec-decoding: "none"
-      conc-list: [ 1024, 512, 256 ]
+      conc-list: [ 1536, 1024, 512, 256 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -412,7 +412,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
     - spec-decoding: "none"
-      conc-list: [ 128, 64, 32, 16, 8, 4 ]
+      conc-list: [ 256, 128, 64, 32, 16, 8, 4 ]
       prefill:
         num-worker: 1
         tp: 8
@@ -496,7 +496,7 @@ dsr1-fp8-mi355x-sglang-disagg:
     # non-MTP configurations
     # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
     - spec-decoding: "none"
-      conc-list: [ 2048 ]
+      conc-list: [ 1024, 2048 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -515,7 +515,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
     - spec-decoding: "none"
-      conc-list: [ 1024, 512, 256 ]
+      conc-list: [ 1536, 1024, 512, 256 ]
       prefill:
         num-worker: 1
         tp: 1

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -313,7 +313,7 @@ dsr1-fp8-mi355x-sglang-disagg:
     # MTP configurations
     # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
     - spec-decoding: "mtp"
-      conc-list: [ 2048 ]
+      conc-list: [ 1024, 2048 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -332,7 +332,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
     - spec-decoding: "mtp"
-      conc-list: [ 1024, 512, 256 ]
+      conc-list: [ 1536, 1024, 512, 256 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -352,7 +352,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
     - spec-decoding: "mtp"
-      conc-list: [ 128, 64, 32, 16, 8, 4 ]
+      conc-list: [ 256, 128, 64, 32, 16, 8, 4 ]
       prefill:
         num-worker: 1
         tp: 8
@@ -436,7 +436,7 @@ dsr1-fp8-mi355x-sglang-disagg:
     # MTP configurations
     # "Top of curve" (1 prefill worker at DEP8 and 1 decode worker at DEP16)
     - spec-decoding: "mtp"
-      conc-list: [ 2048 ]
+      conc-list: [ 1024, 2048 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -455,7 +455,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
     - spec-decoding: "mtp"
-      conc-list: [ 1024, 512, 256 ]
+      conc-list: [ 1536, 1024, 512, 256 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -475,11 +475,11 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
     - spec-decoding: "mtp"
-      conc-list: [ 128, 64, 32, 16, 8, 4 ]
+      conc-list: [ 256, 128, 64, 32, 16, 8, 4 ]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
         additional-settings:
         - "PREFILL_NODES=1"
@@ -487,11 +487,11 @@ dsr1-fp8-mi355x-sglang-disagg:
       decode:
         num-worker: 2
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
         additional-settings:
         - "DECODE_NODES=2"
-        - "DECODE_MTP_SIZE=1"
+        - "DECODE_MTP_SIZE=2"
 
     # non-MTP configurations
     # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
@@ -515,7 +515,7 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
     - spec-decoding: "none"
-      conc-list: [ 256, 512, 1024 ]
+      conc-list: [ 1024, 512, 256 ]
       prefill:
         num-worker: 1
         tp: 1
@@ -534,11 +534,11 @@ dsr1-fp8-mi355x-sglang-disagg:
 
     # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
     - spec-decoding: "none"
-      conc-list: [ 32, 64, 128 ]
+      conc-list: [ 256, 128, 64, 32, 16, 8, 4 ]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
         additional-settings:
         - "PREFILL_NODES=1"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -558,3 +558,10 @@
   description:
     - "Update max_num_tokens and max_batch_size for min-latency decode workers"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/690
+
+- config-keys:
+    - dsr1-fp8-mi355x-sglang-disagg
+  description:
+    - "Add more sweep points for DSR1 FP8 both MTP and non-MTP 1k1k, 8k1k"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/689
+  


### PR DESCRIPTION
This patch is to add more sweep points for DSR1 FP8 both MTP and non-MTP 1k1k, 8k1k. No recipe changed. @functionstackx 