### PR TITLE
[AMD] Update MI325X DeepSeek R1 FP8 SGLang Image from v0.5.7 to v0.5.8

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -93,7 +93,7 @@ dsr1-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.7-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.8-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -564,4 +564,9 @@
   description:
     - "Add more sweep points for DSR1 FP8 both MTP and non-MTP 1k1k, 8k1k"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/689
-  
+
+- config-keys:
+    - dsr1-fp8-mi325x-sglang
+  description:
+    - "Update MI325X DeepSeek R1 FP8 SGLang image from v0.5.7 to v0.5.8"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/692


### PR DESCRIPTION
Update MI325X DSR1 FP8 Image to lmsysorg/sglang:v0.5.8-rocm700-mi30x

E2E test run: https://github.com/InferenceMAX/InferenceMAX/actions/runs/21939573806

author: Xiao, Hai; Wang, Thomas