### PR TITLE
[AMD] Update MI300X DeepSeek R1 FP8 SGLang image from v0.5.7 to v0.5.8

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -71,7 +71,7 @@ dsr1-fp4-mi355x-atom-mtp:
     - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp  }
 
 dsr1-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.7-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.8-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -578,3 +578,8 @@
     - "Update MI325X DeepSeek R1 FP8 SGLang image from v0.5.7 to v0.5.8"
   pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/692
 
+- config-keys:
+    - dsr1-fp8-mi300x-sglang
+  description:
+    - "Update MI300X DeepSeek R1 FP8 SGLang image from v0.5.7 to v0.5.8"
+  pr-link: https://github.com/InferenceMAX/InferenceMAX/pull/696


### PR DESCRIPTION
Update MI300X DeepSeek R1 FP8 SGLang image to: lmsysorg/sglang:v0.5.8-rocm700-mi30x

e2e Test: https://github.com/InferenceMAX/InferenceMAX/actions/runs/21939340141

Authors: Xiao, Hai; Wang, Thomas