### PR TITLE
[AMD] Add Kimi-K2.5 1T INT4 vLLM benchmark for MI355X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -158,6 +158,28 @@ qwen3.5-bf16-mi355x-sglang:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+kimik2.5-int4-mi355x-vllm:
+  image: vllm/vllm-openai-rocm:v0.15.1
+  model: moonshotai/Kimi-K2.5
+  model-prefix: kimik2.5
+  runner: mi355x
+  precision: int4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.14.0
   model: openai/gpt-oss-120b

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -92,7 +92,7 @@ wait_for_server_ready() {
 }
 
 # Run benchmark serving with standardized parameters
-# All parameters are required except --use-chat-template
+# All parameters are required except --use-chat-template and --trust-remote-code
 # Parameters:
 #   --model: Model name
 #   --port: Server port
@@ -105,6 +105,7 @@ wait_for_server_ready() {
 #   --result-filename: Result filename without extension
 #   --result-dir: Result directory
 #   --use-chat-template: Optional flag to enable chat template
+#   --trust-remote-code: Optional flag to trust remote code from HuggingFace
 #   --server-pid: Optional server process ID to monitor during benchmark
 run_benchmark_serving() {
     set +x
@@ -120,6 +121,7 @@ run_benchmark_serving() {
     local result_dir=""
     local workspace_dir=""
     local use_chat_template=false
+    local trust_remote_code=false
     local server_pid=""
 
     while [[ $# -gt 0 ]]; do
@@ -170,6 +172,10 @@ run_benchmark_serving() {
                 ;;
             --use-chat-template)
                 use_chat_template=true
+                shift
+                ;;
+            --trust-remote-code)
+                trust_remote_code=true
                 shift
                 ;;
             --server-pid)
@@ -253,6 +259,11 @@ run_benchmark_serving() {
     # Add --use-chat-template if requested
     if [[ "$use_chat_template" == true ]]; then
         benchmark_cmd+=(--use-chat-template)
+    fi
+
+    # Add --trust-remote-code if requested
+    if [[ "$trust_remote_code" == true ]]; then
+        benchmark_cmd+=(--trust-remote-code)
     fi
 
     # Run benchmark with optional server monitoring

--- a/benchmarks/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/kimik2.5_int4_mi355x.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --port $PORT \
+--tensor-parallel-size=$TP \
+--gpu-memory-utilization 0.95 \
+--max-model-len $MAX_MODEL_LEN \
+--max-seq-len-to-capture $MAX_MODEL_LEN \
+--block-size=64 \
+--disable-log-requests \
+--trust-remote-code \
+--mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/kimik2.5_int4_mi355x.sh
@@ -31,7 +31,6 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---max-seq-len-to-capture $MAX_MODEL_LEN \
 --block-size=64 \
 --disable-log-requests \
 --trust-remote-code \

--- a/benchmarks/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/kimik2.5_int4_mi355x.sh
@@ -51,7 +51,8 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir /workspace/ \
+    --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -660,4 +660,4 @@
     - "Model: moonshotai/Kimi-K2.5 with --mm-encoder-tp-mode data"
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/734

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -652,3 +652,12 @@
     - "Image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260215"
     - "Uses triton attention backend, TP=8, concurrency 4-64"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/705
+
+- config-keys:
+    - kimik2.5-int4-mi355x-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 vLLM benchmark for MI355X"
+    - "Model: moonshotai/Kimi-K2.5 with --mm-encoder-tp-mode data"
+    - "Image: vllm/vllm-openai-rocm:v0.15.1"
+    - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- Add benchmark configuration for moonshotai/Kimi-K2.5 with INT4 (W4A16) quantization on MI355X using vLLM
- Image: `vllm/vllm-openai-rocm:v0.15.1` (per Andy Luo's recipe)
- TP=8 with `--mm-encoder-tp-mode data` for multimodal encoder tensor parallelism
- Concurrency sweep from 4 to 64 across 1k1k, 1k8k, 8k1k sequence lengths
- No AITER env vars, no `--no-enable-prefix-caching` (following the recipe exactly)

## Files Changed
- `.github/configs/amd-master.yaml` - New `kimik2.5-int4-mi355x-vllm` config entry
- `benchmarks/kimik2.5_int4_mi355x.sh` - Benchmark script
- `perf-changelog.yaml` - Changelog entry

Closes #723

Generated with [Claude Code](https://claude.ai/code)