### PR TITLE
[AMD] Add MiniMax-M2.5 FP8 vLLM benchmark for MI355X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -180,6 +180,31 @@ kimik2.5-int4-mi355x-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+minimaxm2.5-fp8-mi355x-vllm:
+  image: vllm/vllm-openai-rocm:v0.15.1
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.14.0
   model: openai/gpt-oss-120b

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -192,18 +192,21 @@ minimaxm2.5-fp8-mi355x-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 64 }
-    - { tp: 4, conc-start: 4, conc-end: 64 }
+    # - { tp: 2, conc-start: 4, conc-end: 64 }
+    # - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 64 }
-    - { tp: 4, conc-start: 4, conc-end: 64 }
+    # - { tp: 2, conc-start: 4, conc-end: 64 }
+    # - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 64 }
-    - { tp: 4, conc-start: 4, conc-end: 64 }
+    # - { tp: 2, conc-start: 4, conc-end: 64 }
+    # - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.14.0

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -192,18 +192,18 @@ minimaxm2.5-fp8-mi355x-vllm:
   - isl: 1024
     osl: 1024
     search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 1024
     osl: 8192
     search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.14.0

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -192,21 +192,18 @@ minimaxm2.5-fp8-mi355x-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    # - { tp: 2, conc-start: 4, conc-end: 64 }
-    # - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
   - isl: 1024
     osl: 8192
     search-space:
-    # - { tp: 2, conc-start: 4, conc-end: 64 }
-    # - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
-    # - { tp: 2, conc-start: 4, conc-end: 64 }
-    # - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.14.0

--- a/benchmarks/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/minimaxm2.5_fp8_mi355x.sh
@@ -33,7 +33,7 @@ vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
---block-size=64 \
+--block-size=32 \
 --disable-log-requests \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/minimaxm2.5_fp8_mi355x.sh
@@ -5,7 +5,6 @@ source "$(dirname "$0")/benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
-    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -26,12 +25,6 @@ fi
 
 export VLLM_ROCM_USE_AITER=1
 
-# Enable expert parallel if EP_SIZE > 1
-EP_FLAG=""
-if [ "$EP_SIZE" -gt 1 ]; then
-  EP_FLAG="--enable-expert-parallel"
-fi
-
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
@@ -42,7 +35,7 @@ vllm serve $MODEL --port $PORT \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
 --disable-log-requests \
---trust-remote-code $EP_FLAG > $SERVER_LOG 2>&1 &
+--trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/minimaxm2.5_fp8_mi355x.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+export VLLM_ROCM_USE_AITER=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --port $PORT \
+--tensor-parallel-size=$TP \
+--gpu-memory-utilization 0.95 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size=64 \
+--disable-log-requests \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/minimaxm2.5_fp8_mi355x.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -25,6 +26,12 @@ fi
 
 export VLLM_ROCM_USE_AITER=1
 
+# Enable expert parallel if EP_SIZE > 1
+EP_FLAG=""
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP_FLAG="--enable-expert-parallel"
+fi
+
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
@@ -35,7 +42,7 @@ vllm serve $MODEL --port $PORT \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
 --disable-log-requests \
---trust-remote-code > $SERVER_LOG 2>&1 &
+--trust-remote-code $EP_FLAG > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -669,5 +669,5 @@
     - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "Environment: VLLM_ROCM_USE_AITER=1"
-    - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+    - "TP=8 EP=8 with --enable-expert-parallel, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/755

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -669,5 +669,5 @@
     - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "Environment: VLLM_ROCM_USE_AITER=1"
-    - "TP=8 EP=8 with --enable-expert-parallel, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+    - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/755

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -670,4 +670,4 @@
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "Environment: VLLM_ROCM_USE_AITER=1"
     - "TP=4 and TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/755

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -669,5 +669,5 @@
     - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "Environment: VLLM_ROCM_USE_AITER=1"
-    - "TP=4 and TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+    - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/755

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -661,3 +661,13 @@
     - "Image: vllm/vllm-openai-rocm:v0.15.1"
     - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/734
+
+- config-keys:
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Add MiniMax-M2.5 FP8 vLLM benchmark for MI355X"
+    - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
+    - "Image: vllm/vllm-openai-rocm:v0.15.1"
+    - "Environment: VLLM_ROCM_USE_AITER=1"
+    - "TP=4 and TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- Add benchmark script `benchmarks/minimaxm2.5_fp8_mi355x.sh` for MiniMax-M2.5 FP8 on MI355X using vLLM
  - Image: `vllm/vllm-openai-rocm:v0.15.1`
  - Sets `VLLM_ROCM_USE_AITER=1` environment variable
  - Uses `--trust-remote-code` flag
- Add `minimaxm2.5-fp8-mi355x-vllm` config to `amd-master.yaml`
  - Model: `MiniMaxAI/MiniMax-M2.5`
  - TP=4 and TP=8, concurrency 4-64
  - All three sequence length configs: 1k1k, 1k8k, 8k1k
- Update `perf-changelog.yaml` with new entry

Closes #754

## Test plan
- [ ] Verify benchmark script runs correctly on MI355X hardware
- [ ] Validate TP=4 and TP=8 configurations
- [ ] Confirm concurrency sweep from 4 to 64

Generated with [Claude Code](https://claude.ai/code)