### PR TITLE
[NVIDIA] Add MiniMax-M2.5 FP8 vLLM benchmark for B200

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3110,7 +3110,7 @@ minimaxm2.5-fp8-b200-vllm:
   image: vllm/vllm-openai:v0.15.1-cu130
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
-  runner: b200-nvs
+  runner: b200
   precision: fp8
   framework: vllm
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3107,7 +3107,7 @@ gptoss-fp4-b200-vllm:
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
 minimaxm2.5-fp8-b200-vllm:
-  image: vllm/vllm-openai:v0.15.1-cu130
+  image: vllm/vllm-openai:v0.16.0-cu130
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: b200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3106,6 +3106,31 @@ gptoss-fp4-b200-vllm:
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
+minimaxm2.5-fp8-b200-vllm:
+  image: vllm/vllm-openai:v0.15.1-cu130
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: b200
+  precision: fp8
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+
 gptoss-fp4-h100-vllm:
   image: vllm/vllm-openai:v0.15.1
   model: openai/gpt-oss-120b

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3110,7 +3110,7 @@ minimaxm2.5-fp8-b200-vllm:
   image: vllm/vllm-openai:v0.15.1-cu130
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
-  runner: b200
+  runner: b200-nvs
   precision: fp8
   framework: vllm
   multinode: false

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3107,7 +3107,7 @@ gptoss-fp4-b200-vllm:
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
 minimaxm2.5-fp8-b200-vllm:
-  image: vllm/vllm-openai:v0.16.0-cu130
+  image: vllm/vllm-openai:v0.17.0-cu130
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: b200

--- a/benchmarks/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/minimaxm2.5_fp8_b200.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --port $PORT \
+--tensor-parallel-size=$TP \
+--gpu-memory-utilization 0.95 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size=32 \
+--disable-log-requests \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")/benchmark_lib.sh"
+source "$(dirname "$0")/../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -29,6 +29,7 @@ vllm serve $MODEL --port $PORT \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
+--enable-expert-parallel \
 --disable-log-requests \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -40,7 +40,6 @@ $EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
---disable-log-requests \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -24,6 +24,7 @@ SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 export VLLM_USE_FLASHINFER_MOE_FP8=0
+export VLLM_MOE_USE_DEEP_GEMM=0
 
 set -x
 vllm serve $MODEL --port $PORT \

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -26,13 +27,19 @@ PORT=${PORT:-8888}
 export VLLM_USE_FLASHINFER_MOE_FP8=0
 export VLLM_MOE_USE_DEEP_GEMM=0
 
+if [ "$EP_SIZE" -ge 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
 set -x
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
+$EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
---enable-expert-parallel \
 --disable-log-requests \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -23,6 +23,8 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+export VLLM_USE_FLASHINFER_MOE_FP8=0
+
 set -x
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -931,4 +931,13 @@
     - "Switch to --attention-backend ROCM_AITER_UNIFIED_ATTN and add fuse_rope_kvcache compilation pass"
     - "Remove deprecated VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION/VLLM_ROCM_USE_AITER_MHA env vars and compilation-config cudagraph_mode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/867
-  
+
+- config-keys:
+    - minimaxm2.5-fp8-b200-vllm
+  description:
+    - "Add MiniMax-M2.5 FP8 vLLM benchmark for B200"
+    - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
+    - "Image: vllm/vllm-openai:v0.15.1-cu130"
+    - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -937,7 +937,6 @@
   description:
     - "Add MiniMax-M2.5 FP8 vLLM benchmark for B200"
     - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
-    - "Image: vllm/vllm-openai:v0.15.1-cu130"
+    - "Image: vllm/vllm-openai:v0.17.0"
     - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/757 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -939,4 +939,5 @@
     - "Model: MiniMaxAI/MiniMax-M2.5 with --trust-remote-code"
     - "Image: vllm/vllm-openai:v0.17.0"
     - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/757 
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/757
+


### PR DESCRIPTION
Add MiniMax-M2.5 FP8 vLLM benchmark configuration for B200 GPUs.

- New benchmark script `benchmarks/single_node/minimaxm2.5_fp8_b200.sh`
- Config entry `minimaxm2.5-fp8-b200-vllm` in nvidia-master.yaml
- Image: `vllm/vllm-openai:v0.16.0-cu130`
- TP=2 and TP=4, concurrency 4-64
- Sequence lengths: 1k1k, 1k8k, 8k1k

Closes #756

Generated with [Claude Code](https://claude.ai/code)