### PR TITLE
[AMD] Add Qwen3.5-397B-A17B-FP8 MI355X SGLang benchmark configuration (STP only) 

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -158,6 +158,28 @@ qwen3.5-bf16-mi355x-sglang:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+qwen3.5-fp8-mi355x-sglang:
+  image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260218
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 kimik2.5-int4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.15.1
   model: moonshotai/Kimi-K2.5

--- a/benchmarks/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/qwen3.5_fp8_mi355x.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+python3 -m sglang.launch_server \
+    --attention-backend triton \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")/benchmark_lib.sh"
+source "$(dirname "$0")/../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -671,3 +671,11 @@
     - "Environment: VLLM_ROCM_USE_AITER=1"
     - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/755
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang
+  description:
+    - "Add Qwen3.5-397B-A17B-FP8 SGLang benchmark configuration for MI355X"
+    - "Image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260218"
+    - "Uses triton attention backend, TP=8, concurrency 4-64"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/768


### PR DESCRIPTION
Add Qwen3.5-397B-A17B-FP8 SGLang benchmark configuration for MI355X

Create "benchmarks/qwen3.5_fp8_mi355x.sh" with Triton attention backend. 
Add `qwen3.5-fp8-mi355x-sglang` config to "amd-master.yaml". 
Image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260218.
Updated perf-changelog

e2e Test: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/22200271889

Author: Hai