### PR TITLE
Remove unnecessary ps aux calls from benchmark scripts

### DIFF
--- a/benchmarks/single_node/dsr1_fp4_b200.sh
+++ b/benchmarks/single_node/dsr1_fp4_b200.sh
@@ -31,8 +31,6 @@ else
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 \

--- a/benchmarks/single_node/dsr1_fp8_b200.sh
+++ b/benchmarks/single_node/dsr1_fp8_b200.sh
@@ -63,8 +63,6 @@ else
 fi
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --tensor-parallel-size=$TP --data-parallel-size=1 \

--- a/benchmarks/single_node/qwen3.5_bf16_b200.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_b200.sh
@@ -44,8 +44,6 @@ CONTEXT_LENGTH=$((ISL + OSL + 20))
 
 echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
-ps aux
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --served-model-name "Qwen/Qwen3.5-397B-A17B" --trust-remote-code \


### PR DESCRIPTION
Removes standalone `ps aux` calls from three benchmark scripts where they served no functional purpose.

Closes #776

Generated with [Claude Code](https://claude.ai/code)