### PR TITLE
AMD: Update MI300X and MI325X GPT-OSS vLLM from v0.14.0 to v0.15.1

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -228,7 +228,7 @@ minimaxm2.5-fp8-mi355x-vllm:
     - { tp: 4, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.14.0
+  image: vllm/vllm-openai-rocm:v0.15.1
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x
@@ -259,7 +259,7 @@ gptoss-fp4-mi300x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.14.0
+  image: vllm/vllm-openai-rocm:v0.15.1
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -689,3 +689,12 @@
     - "Add context-length, tokenizer-worker-num, env tuning (NCCL_NVLS_ENABLE, SGLANG_ENABLE_FLASHINFER_GEMM)"
     - "Set cuda-graph-max-bs to match concurrency, scheduler-recv-interval based on concurrency"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/758
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+    - gptoss-fp4-mi325x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.14.0 to v0.15.1 for MI300X and MI325X GPT-OSS"
+    - "Gains: ROCm skinny GEMM dispatch fix, MoRI EP all2all backend, KV cache shuffle + paged attention for AITER"
+    - "Note: v0.16.0 ROCm image not yet published; upgrade to v0.16.0 pending image availability"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
Update `gptoss-fp4-mi300x-vllm` and `gptoss-fp4-mi325x-vllm` image tags from `vllm/vllm-openai-rocm:v0.14.0` to `vllm/vllm-openai-rocm:v0.15.1` (latest available ROCm image).

v0.16.0 ROCm Docker image has not been published yet. This upgrade captures v0.15.x improvements: ROCm skinny GEMM fix, MoRI EP all2all backend, KV cache shuffle + paged attention for AITER.

All e2e tests passed on both MI300X and MI325X.

Closes #607

Generated with [Claude Code](https://claude.ai/code)