### PR TITLE
feat: add sinlge+multinode e2e tests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,12 +3,12 @@
 In order to test configurations described in `.github/configs`, the primary workflow file used is `.github/workflows/e2e-tests.yml`. As input, this workflow takes in the CLI arguments for the `utils/matrix_logic/generate_sweep_configs.py` script. The usage for this script is shown below:
 
 ```
-usage: generate_sweep_configs.py [-h] {full-sweep,runner-model-sweep} ...
+usage: generate_sweep_configs.py [-h] {full-sweep,runner-model-sweep,test-config} ...
 
 Generate benchmark configurations from YAML config files
 
 positional arguments:
-  {full-sweep,runner-model-sweep}
+  {full-sweep,runner-model-sweep,test-config}
                         Available commands
     full-sweep          Generate full sweep configurations with optional
                         filtering by model, precision, framework, runner type,
@@ -20,6 +20,9 @@ positional arguments:
                         configurations for a runner type. For instance, to
                         validate that all configs that specify an h200 runner
                         successfully run across all h200 runner nodes.
+    test-config         Generate full sweep for specific config keys.
+                        Supports wildcard patterns (* and ?) for matching
+                        multiple keys at once.
 
 options:
   -h, --help            show this help message and exit
@@ -123,6 +126,57 @@ runner-model-sweep --single-node --runner-type mi300x --runner-node-filter mi300
 ```
 
 This will only include runner nodes whose names contain "mi300x-amd"
+
+## `test-config` Command
+
+The `test-config` command generates the full sweep for one or more specific config keys. This is useful for testing individual configurations without filtering by model prefix, framework, etc.
+
+```
+usage: generate_sweep_configs.py test-config
+    --config-files CONFIG_FILES [CONFIG_FILES ...]
+    [--runner-config RUNNER_CONFIG]
+    --config-keys CONFIG_KEYS [CONFIG_KEYS ...]
+    [--conc CONC [CONC ...]]
+```
+
+Config keys support **wildcard patterns** using `*` (matches any characters) and `?` (matches a single character). Patterns that match no keys will raise an error.
+
+### Examples
+
+**Test a single config by exact name:**
+```
+test-config --config-keys dsr1-fp4-b200-sglang --config-files .github/configs/nvidia-master.yaml
+```
+
+**Test multiple exact configs:**
+```
+test-config --config-keys dsr1-fp4-b200-sglang dsr1-fp8-h200-trt --config-files .github/configs/nvidia-master.yaml
+```
+
+**Use wildcard to test all B200 configs:**
+```
+test-config --config-keys *-b200-* --config-files .github/configs/nvidia-master.yaml
+```
+
+**Use wildcard to test all sglang configs:**
+```
+test-config --config-keys *-sglang --config-files .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml
+```
+
+**Use wildcard to test all dsr1 model configs:**
+```
+test-config --config-keys dsr1* --config-files .github/configs/nvidia-master.yaml
+```
+
+**Mix exact keys and patterns:**
+```
+test-config --config-keys dsr1-fp4-b200-sglang gptoss* --config-files .github/configs/nvidia-master.yaml
+```
+
+**Override concurrency for targeted testing:**
+```
+test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvidia-master.yaml
+```
 
 ## Validation Architecture
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,7 +27,7 @@ options:
 
 ## `full-sweep` Command
 
-The `full-sweep` command generates benchmark configurations with optional filtering. It requires specifying either `--single-node` or `--multi-node`.
+The `full-sweep` command generates benchmark configurations with optional filtering. You can specify `--single-node`, `--multi-node`, or both. If neither is specified, both types are generated.
 
 ```
 usage: generate_sweep_configs.py full-sweep
@@ -42,10 +42,17 @@ usage: generate_sweep_configs.py full-sweep
     [--max-conc MAX_CONC]
     [--max-tp MAX_TP]
     [--max-ep MAX_EP]
-    (--single-node | --multi-node)
+    [--single-node] [--multi-node]
 ```
 
+If neither `--single-node` nor `--multi-node` is specified, both types are generated.
+
 ### Examples
+
+**Generate all single-node and multi-node configurations (default):**
+```
+full-sweep --config-files .github/configs/nvidia-master.yaml
+```
 
 **Test all single-node gptoss configurations on B200 with 1k1k sequence lengths:**
 ```
@@ -79,7 +86,7 @@ full-sweep --multi-node --config-files .github/configs/nvidia-master.yaml
 
 ## `runner-model-sweep` Command
 
-The `runner-model-sweep` command validates that all runner nodes of a specific type work with all model configurations. It requires specifying either `--single-node` or `--multi-node`.
+The `runner-model-sweep` command validates that all runner nodes of a specific type work with all model configurations. You can specify `--single-node`, `--multi-node`, or both. If neither is specified, both types are generated.
 
 ```
 usage: generate_sweep_configs.py runner-model-sweep
@@ -87,7 +94,7 @@ usage: generate_sweep_configs.py runner-model-sweep
     [--runner-config RUNNER_CONFIG]
     --runner-type RUNNER_TYPE
     [--runner-node-filter RUNNER_NODE_FILTER]
-    (--single-node | --multi-node)
+    [--single-node] [--multi-node]
 ```
 
 ### Scenario: Validating Runner Infrastructure

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.multi-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: multi-node
+        name: multi-node \
         strategy:
             fail-fast: false
             matrix:
@@ -100,7 +100,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.single-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: single-node
+        name: single-node \
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.multi-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: multi-node \
+        name: multi-node /
         strategy:
             fail-fast: false
             matrix:
@@ -100,7 +100,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.single-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: single-node \
+        name: single-node /
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,7 +35,8 @@ jobs:
     get-jobs:
         runs-on: ubuntu-latest
         outputs:
-            search-space-config: ${{ steps.get-jobs.outputs.search-space-config }}
+            single-node-config: ${{ steps.get-jobs.outputs.single-node-config }}
+            multi-node-config: ${{ steps.get-jobs.outputs.multi-node-config }}
         steps:
             - name: Checkout code (ref)
               if: ${{ inputs.ref && inputs.ref != '' }}
@@ -52,20 +53,20 @@ jobs:
                   pip install pydantic
                   CONFIG_JSON=$(python3 ${GITHUB_WORKSPACE}/utils/matrix_logic/generate_sweep_configs.py \
                     ${{ inputs.generate-cli-command || github.event.inputs.generate-cli-command }})
-                  echo "search-space-config=$CONFIG_JSON" >> $GITHUB_OUTPUT
+                  SINGLE=$(echo "$CONFIG_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps([x for x in d if 'prefill' not in x]))")
+                  MULTI=$(echo "$CONFIG_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps([x for x in d if 'prefill' in x]))")
+                  echo "single-node-config=$SINGLE" >> $GITHUB_OUTPUT
+                  echo "multi-node-config=$MULTI" >> $GITHUB_OUTPUT
 
     test-sweep-multi-node:
         needs: get-jobs
-        # Use existence (or non-existence) of 'prefill' field as a proxy to determined multi-node tests.
-        # We only need to check the first entry because by design, all entries in the matrix will be of the same type (there will
-        # never be a mix of multi-node and single-node entries as output from generate_sweep_configs.py).
-        if: ${{ needs.get-jobs.outputs.search-space-config != '[]' && fromJson(needs.get-jobs.outputs.search-space-config)[0].prefill != null }}
+        if: ${{ needs.get-jobs.outputs.multi-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
         name: ${{ inputs.generate-cli-command }} multi-node
         strategy:
             fail-fast: false
             matrix:
-                config: ${{ fromJson(needs.get-jobs.outputs.search-space-config) }}
+                config: ${{ fromJson(needs.get-jobs.outputs.multi-node-config) }}
         secrets: inherit
         with:
             isl: ${{ matrix.config.isl }}
@@ -97,13 +98,13 @@ jobs:
 
     test-sweep-single-node:
         needs: get-jobs
-        if: ${{ needs.get-jobs.outputs.search-space-config != '[]' && fromJson(needs.get-jobs.outputs.search-space-config)[0].prefill == null }}
+        if: ${{ needs.get-jobs.outputs.single-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
         name: ${{ inputs.generate-cli-command }} single-node
         strategy:
             fail-fast: false
             matrix:
-                config: ${{ fromJson(needs.get-jobs.outputs.search-space-config) }}
+                config: ${{ fromJson(needs.get-jobs.outputs.single-node-config) }}
         secrets: inherit
         with:
             exp-name: ${{ matrix.config.exp-name }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.multi-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
-        name: ${{ inputs.generate-cli-command }} multi-node
+        name: multi-node
         strategy:
             fail-fast: false
             matrix:
@@ -100,7 +100,7 @@ jobs:
         needs: get-jobs
         if: ${{ needs.get-jobs.outputs.single-node-config != '[]' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
-        name: ${{ inputs.generate-cli-command }} single-node
+        name: single-node
         strategy:
             fail-fast: false
             matrix:

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -1,4 +1,5 @@
 from ast import For
+import fnmatch
 import json
 import argparse
 import sys
@@ -560,18 +561,11 @@ def generate_test_config_sweep(args, all_config_data):
     Validates that all specified config keys exist before generating.
     Expands all configs fully without any filtering.
     """
-    # Validate all config keys exist
-    missing_keys = [key for key in args.config_keys if key not in all_config_data]
-    if missing_keys:
-        available_keys = sorted(all_config_data.keys())
-        raise ValueError(
-            f"Config key(s) not found: {', '.join(missing_keys)}.\n"
-            f"Available keys: {', '.join(available_keys)}"
-        )
+    resolved_keys = expand_config_keys(args.config_keys, all_config_data.keys())
 
     matrix_values = []
 
-    for key in args.config_keys:
+    for key in resolved_keys:
         val = all_config_data[key]
         is_multinode = val.get(Fields.MULTINODE.value, False)
 
@@ -690,6 +684,37 @@ def generate_test_config_sweep(args, all_config_data):
                         matrix_values.append(validate_matrix_entry(entry, is_multinode=False))
 
     return matrix_values
+
+
+def expand_config_keys(config_keys, available_keys):
+    """Expand config key patterns (glob wildcards) against available keys.
+
+    Keys containing '*' or '?' are treated as glob patterns and expanded via
+    fnmatch.filter(). Plain keys are validated for existence. Results are
+    deduplicated while preserving order.
+
+    Raises ValueError if a pattern matches nothing or an exact key is missing.
+    """
+    available = list(available_keys)
+    seen = {}  # use dict to preserve insertion order
+    for key in config_keys:
+        if '*' in key or '?' in key:
+            matches = fnmatch.filter(available, key)
+            if not matches:
+                raise ValueError(
+                    f"Pattern '{key}' matched no config keys.\n"
+                    f"Available keys: {', '.join(sorted(available))}"
+                )
+            for m in matches:
+                seen.setdefault(m, None)
+        else:
+            if key not in available:
+                raise ValueError(
+                    f"Config key(s) not found: {key}.\n"
+                    f"Available keys: {', '.join(sorted(available))}"
+                )
+            seen.setdefault(key, None)
+    return list(seen)
 
 
 def apply_node_type_defaults(args):

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -185,11 +185,13 @@ def generate_full_sweep(args, all_config_data, runner_data):
             bmk_space = seq_config[Fields.SEARCH_SPACE.value]
 
             for bmk in bmk_space:
-                if is_multinode:
-                    # Skip multinode configs when --single-node is specified
-                    if not args.multi_node:
-                        continue
+                # Skip configs that don't match the requested node type
+                if is_multinode and not args.multi_node:
+                    continue
+                if not is_multinode and not args.single_node:
+                    continue
 
+                if is_multinode:
                     # Multinode configuration
                     # spec_decoding defaults to "none" if not specified
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
@@ -283,7 +285,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
                         validate_matrix_entry(entry, is_multinode)
                         matrix_values.append(entry)
-                elif args.single_node:
+                else:
                     # Single-node configuration
                     tp = bmk[Fields.TP.value]
                     conc_start = bmk[Fields.CONC_START.value]
@@ -433,9 +435,9 @@ def generate_runner_model_sweep_config(args, all_config_data, runner_data):
         is_multinode = val.get(Fields.MULTINODE.value, False)
 
         # Skip configs that don't match the requested node type
-        if args.single_node and is_multinode:
+        if is_multinode and not args.multi_node:
             continue
-        if args.multi_node and not is_multinode:
+        if not is_multinode and not args.single_node:
             continue
 
         # Get model code for exp_name
@@ -690,6 +692,15 @@ def generate_test_config_sweep(args, all_config_data):
     return matrix_values
 
 
+def apply_node_type_defaults(args):
+    """Default both single_node and multi_node to True when neither is specified."""
+    if hasattr(args, 'single_node') and hasattr(args, 'multi_node'):
+        if not args.single_node and not args.multi_node:
+            args.single_node = True
+            args.multi_node = True
+    return args
+
+
 def main():
     # Create parent parser with common arguments
     parent_parser = argparse.ArgumentParser(add_help=False)
@@ -801,16 +812,15 @@ def main():
         required=False,
         help='Maximum expert parallelism value to include (single-node only)'
     )
-    node_type_group = full_sweep_parser.add_mutually_exclusive_group(required=True)
-    node_type_group.add_argument(
+    full_sweep_parser.add_argument(
         '--single-node',
         action='store_true',
-        help='Only generate single-node configurations'
+        help='Only generate single-node configurations. If neither --single-node nor --multi-node is specified, both types are generated.'
     )
-    node_type_group.add_argument(
+    full_sweep_parser.add_argument(
         '--multi-node',
         action='store_true',
-        help='Only generate multi-node configurations'
+        help='Only generate multi-node configurations. If neither --single-node nor --multi-node is specified, both types are generated.'
     )
     full_sweep_parser.add_argument(
         '-h', '--help',
@@ -854,17 +864,15 @@ def main():
         required=False,
         help='Override concurrency value for all runs (default: uses lowest concurrency from config)'
     )
-    test_node_group = test_config_parser.add_mutually_exclusive_group(
-        required=True)
-    test_node_group.add_argument(
+    test_config_parser.add_argument(
         '--single-node',
         action='store_true',
-        help='Generate single-node configurations only'
+        help='Generate single-node configurations only. If neither --single-node nor --multi-node is specified, both types are generated.'
     )
-    test_node_group.add_argument(
+    test_config_parser.add_argument(
         '--multi-node',
         action='store_true',
-        help='Generate multi-node configurations only'
+        help='Generate multi-node configurations only. If neither --single-node nor --multi-node is specified, both types are generated.'
     )
     test_config_parser.add_argument(
         '-h', '--help',
@@ -899,6 +907,7 @@ def main():
     )
 
     args = parser.parse_args()
+    apply_node_type_defaults(args)
 
     # Load and validate configuration files (validation happens by default in load functions)
     all_config_data = load_config_files(args.config_files)

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -8,6 +8,7 @@ from generate_sweep_configs import (
     generate_full_sweep,
     generate_runner_model_sweep_config,
     apply_node_type_defaults,
+    expand_config_keys,
 )
 
 
@@ -1507,3 +1508,80 @@ class TestRunnerModelSweepMixed:
         )
         # mi300x only has single-node configs, so multi-node filter should produce empty
         assert len(result) == 0
+
+
+# =============================================================================
+# Test expand_config_keys
+# =============================================================================
+
+class TestExpandConfigKeys:
+    """Tests for expand_config_keys glob/wildcard matching."""
+
+    AVAILABLE = [
+        "dsr1-fp4-b200-sglang",
+        "dsr1-fp8-mi300x-sglang",
+        "dsr1-fp8-h200-trt",
+        "gptoss-fp4-b200-vllm",
+        "gptoss-fp8-b200-sglang",
+    ]
+
+    def test_exact_keys_pass_through(self):
+        """Exact keys should be returned unchanged."""
+        result = expand_config_keys(
+            ["dsr1-fp4-b200-sglang", "dsr1-fp8-h200-trt"], self.AVAILABLE
+        )
+        assert result == ["dsr1-fp4-b200-sglang", "dsr1-fp8-h200-trt"]
+
+    def test_star_sglang_matches(self):
+        """*-sglang should match all keys ending with -sglang."""
+        result = expand_config_keys(["*-sglang"], self.AVAILABLE)
+        assert result == [
+            "dsr1-fp4-b200-sglang",
+            "dsr1-fp8-mi300x-sglang",
+            "gptoss-fp8-b200-sglang",
+        ]
+
+    def test_prefix_glob(self):
+        """dsr1* should match all keys starting with dsr1."""
+        result = expand_config_keys(["dsr1*"], self.AVAILABLE)
+        assert result == [
+            "dsr1-fp4-b200-sglang",
+            "dsr1-fp8-mi300x-sglang",
+            "dsr1-fp8-h200-trt",
+        ]
+
+    def test_question_mark_wildcard(self):
+        """? wildcard should match a single character."""
+        result = expand_config_keys(["?sr1-fp8-mi300x-sglang"], self.AVAILABLE)
+        assert result == ["dsr1-fp8-mi300x-sglang"]
+
+    def test_no_match_pattern_raises(self):
+        """Pattern matching nothing should raise ValueError."""
+        with pytest.raises(ValueError, match="matched no config keys"):
+            expand_config_keys(["*-b300"], self.AVAILABLE)
+
+    def test_missing_exact_key_raises(self):
+        """Missing exact key should raise ValueError."""
+        with pytest.raises(ValueError, match="Config key\\(s\\) not found"):
+            expand_config_keys(["nonexistent-key"], self.AVAILABLE)
+
+    def test_mixed_exact_and_glob(self):
+        """Mix of exact keys and glob patterns should work."""
+        result = expand_config_keys(
+            ["dsr1-fp8-h200-trt", "gptoss*"], self.AVAILABLE
+        )
+        assert result == [
+            "dsr1-fp8-h200-trt",
+            "gptoss-fp4-b200-vllm",
+            "gptoss-fp8-b200-sglang",
+        ]
+
+    def test_overlapping_patterns_deduplicate(self):
+        """Overlapping patterns should deduplicate while preserving order."""
+        result = expand_config_keys(["dsr1*", "*-sglang"], self.AVAILABLE)
+        assert result == [
+            "dsr1-fp4-b200-sglang",
+            "dsr1-fp8-mi300x-sglang",
+            "dsr1-fp8-h200-trt",
+            "gptoss-fp8-b200-sglang",
+        ]

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -7,6 +7,7 @@ from generate_sweep_configs import (
     seq_len_to_str,
     generate_full_sweep,
     generate_runner_model_sweep_config,
+    apply_node_type_defaults,
 )
 
 
@@ -1295,3 +1296,214 @@ class TestArgumentDefaults:
 
         # Verify the explicit value
         assert args.runner_config == 'custom/path/runners.yaml'
+
+
+# =============================================================================
+# Mixed-mode fixtures
+# =============================================================================
+
+@pytest.fixture
+def sample_mixed_config(sample_single_node_config, sample_multinode_config):
+    """Config dict containing both single-node and multinode entries."""
+    merged = {}
+    merged.update(sample_single_node_config)
+    merged.update(sample_multinode_config)
+    return merged
+
+
+@pytest.fixture
+def full_sweep_args_both():
+    """Args for full-sweep with both single_node and multi_node True."""
+    args = argparse.Namespace()
+    args.model_prefix = None
+    args.precision = None
+    args.framework = None
+    args.runner_type = None
+    args.seq_lens = None
+    args.step_size = 2
+    args.min_conc = None
+    args.max_conc = None
+    args.max_tp = None
+    args.max_ep = None
+    args.runner_node_filter = None
+    args.single_node = True
+    args.multi_node = True
+    return args
+
+
+# =============================================================================
+# Test apply_node_type_defaults
+# =============================================================================
+
+class TestApplyNodeTypeDefaults:
+    """Tests for apply_node_type_defaults function."""
+
+    def test_neither_flag_sets_both_true(self):
+        """When neither flag is set, both should become True."""
+        args = argparse.Namespace(single_node=False, multi_node=False)
+        apply_node_type_defaults(args)
+        assert args.single_node is True
+        assert args.multi_node is True
+
+    def test_single_only_stays_single(self):
+        """When only single_node is set, it stays that way."""
+        args = argparse.Namespace(single_node=True, multi_node=False)
+        apply_node_type_defaults(args)
+        assert args.single_node is True
+        assert args.multi_node is False
+
+    def test_multi_only_stays_multi(self):
+        """When only multi_node is set, it stays that way."""
+        args = argparse.Namespace(single_node=False, multi_node=True)
+        apply_node_type_defaults(args)
+        assert args.single_node is False
+        assert args.multi_node is True
+
+    def test_both_flags_stays_both(self):
+        """When both flags are set, they stay that way."""
+        args = argparse.Namespace(single_node=True, multi_node=True)
+        apply_node_type_defaults(args)
+        assert args.single_node is True
+        assert args.multi_node is True
+
+    def test_no_node_attrs_is_noop(self):
+        """When args lacks node type attrs, nothing happens."""
+        args = argparse.Namespace(command="test-config")
+        apply_node_type_defaults(args)
+        assert not hasattr(args, 'single_node')
+        assert not hasattr(args, 'multi_node')
+
+
+# =============================================================================
+# Test generate_full_sweep mixed mode
+# =============================================================================
+
+class TestGenerateFullSweepMixed:
+    """Tests for generate_full_sweep with both single-node and multi-node configs."""
+
+    def test_both_flags_generates_mixed(self, sample_mixed_config, sample_runner_config, full_sweep_args_both):
+        """Both flags True should produce both single-node and multinode entries."""
+        result = generate_full_sweep(
+            full_sweep_args_both,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        has_single = any("tp" in entry and "prefill" not in entry for entry in result)
+        has_multi = any("prefill" in entry for entry in result)
+        assert has_single, "Expected single-node entries in mixed output"
+        assert has_multi, "Expected multinode entries in mixed output"
+
+    def test_single_node_only_from_mixed(self, sample_mixed_config, sample_runner_config, full_sweep_args_single_node):
+        """--single-node should skip multinode entries from mixed config."""
+        result = generate_full_sweep(
+            full_sweep_args_single_node,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        assert len(result) > 0
+        assert all("prefill" not in entry for entry in result), "No multinode entries expected"
+        assert all("tp" in entry for entry in result), "All entries should have tp field"
+
+    def test_multi_node_only_from_mixed(self, sample_mixed_config, sample_runner_config, full_sweep_args_multi_node):
+        """--multi-node should skip single-node entries from mixed config."""
+        result = generate_full_sweep(
+            full_sweep_args_multi_node,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        assert len(result) > 0
+        assert all("prefill" in entry for entry in result), "All entries should be multinode"
+
+
+# =============================================================================
+# Test runner-model-sweep with both flags (regression for filtering bug)
+# =============================================================================
+
+class TestRunnerModelSweepMixed:
+    """Tests for runner-model-sweep with both node types enabled."""
+
+    @pytest.fixture
+    def runner_sweep_args_both(self):
+        """Args for runner-model-sweep with both single_node and multi_node True."""
+        args = argparse.Namespace()
+        args.runner_type = "gb200"
+        args.runner_config = "runners.yaml"
+        args.runner_node_filter = None
+        args.model_prefix = None
+        args.precision = None
+        args.framework = None
+        args.conc = None
+        args.single_node = True
+        args.multi_node = True
+        return args
+
+    def test_both_flags_with_mixed_config(self, sample_mixed_config, sample_runner_config, runner_sweep_args_both):
+        """Both flags should produce multinode entries for gb200 runner."""
+        # gb200 runner has multinode config (dsr1-fp4-gb200-dynamo-trt)
+        result = generate_runner_model_sweep_config(
+            runner_sweep_args_both,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        assert len(result) > 0
+        assert all("prefill" in entry for entry in result), "gb200 configs are multinode"
+
+    def test_both_flags_single_node_runner(self, sample_mixed_config, sample_runner_config):
+        """Both flags with mi300x runner should produce single-node entries."""
+        args = argparse.Namespace()
+        args.runner_type = "mi300x"
+        args.runner_config = "runners.yaml"
+        args.runner_node_filter = None
+        args.model_prefix = None
+        args.precision = None
+        args.framework = None
+        args.conc = None
+        args.single_node = True
+        args.multi_node = True
+        result = generate_runner_model_sweep_config(
+            args,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        assert len(result) > 0
+        assert all("tp" in entry and "prefill" not in entry for entry in result), "mi300x configs are single-node"
+
+    def test_single_only_skips_multinode(self, sample_mixed_config, sample_runner_config):
+        """--single-node only should skip multinode configs in runner-model-sweep."""
+        args = argparse.Namespace()
+        args.runner_type = "gb200"
+        args.runner_config = "runners.yaml"
+        args.runner_node_filter = None
+        args.model_prefix = None
+        args.precision = None
+        args.framework = None
+        args.conc = None
+        args.single_node = True
+        args.multi_node = False
+        result = generate_runner_model_sweep_config(
+            args,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        # gb200 only has multinode configs, so single-node filter should produce empty
+        assert len(result) == 0
+
+    def test_multi_only_skips_singlenode(self, sample_mixed_config, sample_runner_config):
+        """--multi-node only should skip single-node configs in runner-model-sweep."""
+        args = argparse.Namespace()
+        args.runner_type = "mi300x"
+        args.runner_config = "runners.yaml"
+        args.runner_node_filter = None
+        args.model_prefix = None
+        args.precision = None
+        args.framework = None
+        args.conc = None
+        args.single_node = False
+        args.multi_node = True
+        result = generate_runner_model_sweep_config(
+            args,
+            sample_mixed_config,
+            sample_runner_config
+        )
+        # mi300x only has single-node configs, so multi-node filter should produce empty
+        assert len(result) == 0


### PR DESCRIPTION
Previously, the E2E testing workflow didn't allow developers to run both single and multi-node sweeps in the same run.

This enables that, as well as enabling wildcard matching for `test-config`.