### PR TITLE
[NVIDIA] feat: update NVIDIA GPT-OSS vLLM image from v0.13.0 to v0.15.1

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3007,7 +3007,7 @@ gptoss-fp4-b200-trt:
     - { tp: 8, conc-start:   4, conc-end:   4}
 
 gptoss-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.13.0
+  image: vllm/vllm-openai:v0.15.1
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: b200
@@ -3038,7 +3038,7 @@ gptoss-fp4-b200-vllm:
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
 gptoss-fp4-h100-vllm:
-  image: vllm/vllm-openai:v0.13.0
+  image: vllm/vllm-openai:v0.15.1
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h100
@@ -3292,7 +3292,7 @@ gptoss-fp4-h200-trt:
     - { tp: 8, ep: 8, dp-attn: false, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-h200-vllm:
-  image: vllm/vllm-openai:v0.13.0
+  image: vllm/vllm-openai:v0.15.1
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h200

--- a/benchmarks/single_node/gptoss_fp4_b200.sh
+++ b/benchmarks/single_node/gptoss_fp4_b200.sh
@@ -32,7 +32,6 @@ fi
 cat > config.yaml << EOF
 kv-cache-dtype: fp8
 compilation-config: '{"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}'
-async-scheduling: true
 no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192

--- a/benchmarks/single_node/gptoss_fp4_h100.sh
+++ b/benchmarks/single_node/gptoss_fp4_h100.sh
@@ -18,7 +18,6 @@ fi
 hf download "$MODEL"
 
 cat > config.yaml << EOF
-async-scheduling: true
 no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192

--- a/benchmarks/single_node/gptoss_fp4_h200.sh
+++ b/benchmarks/single_node/gptoss_fp4_h200.sh
@@ -31,7 +31,6 @@ fi
 
 # Create config.yaml
 cat > config.yaml << EOF
-async-scheduling: true
 no-enable-prefix-caching: true
 max-cudagraph-capture-size: 2048
 max-num-batched-tokens: 8192

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -722,4 +722,4 @@
     - "Remove deprecated async-scheduling flag (now enabled by default since v0.14.0)"
     - "Gains: CUTLASS MoE optimizations (~8% throughput), FP4 kernel improvements (~4% E2E on B200), torch.compile cold-start fix"
     - "v0.15.1 includes fix for prefix cache hit rate of 0% on GPT-OSS hybrid attention models"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/789

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -712,3 +712,14 @@
     - "Image: vllm/vllm-openai:v0.15.1"
     - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/735
+
+- config-keys:
+    - gptoss-fp4-b200-vllm
+    - gptoss-fp4-h100-vllm
+    - gptoss-fp4-h200-vllm
+  description:
+    - "Update vLLM image from v0.13.0 to v0.15.1 for NVIDIA GPT-OSS configs"
+    - "Remove deprecated async-scheduling flag (now enabled by default since v0.14.0)"
+    - "Gains: CUTLASS MoE optimizations (~8% throughput), FP4 kernel improvements (~4% E2E on B200), torch.compile cold-start fix"
+    - "v0.15.1 includes fix for prefix cache hit rate of 0% on GPT-OSS hybrid attention models"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
Update H100, H200, and B200 GPT-OSS FP4 vLLM configs to v0.15.1:
- Update image tags in nvidia-master.yaml
- Remove deprecated async-scheduling flag (default since v0.14.0)
- Keep VLLM_MXFP4_USE_MARLIN=1 for Hopper (H100/H200)
- Keep VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8=1 for Blackwell (B200)

Key vLLM improvements from v0.13.0 to v0.15.1:
- CUTLASS MoE optimizations (~8% throughput, ~13% TTFT)
- 65% faster FP4 quantization kernels on Blackwell (~4% E2E)
- torch.compile cold-start regression fix (~88s to ~22s)
- Fix for prefix cache hit rate of 0% on GPT-OSS hybrid attention

Closes #788