### PR TITLE
[AMD/ROCm] kimik2.5 + mi355x update

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -183,7 +183,7 @@ qwen3.5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.15.1
+  image: aigmkt/vllm-dev:tuned-moe
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi355x

--- a/benchmarks/single_node/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_int4_mi355x.sh
@@ -8,7 +8,6 @@ check_env_vars \
     CONC \
     ISL \
     OSL \
-    MAX_MODEL_LEN \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 

--- a/benchmarks/single_node/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_int4_mi355x.sh
@@ -30,7 +30,6 @@ set -x
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MLA=0
 vllm serve $MODEL --port $PORT \
---config config.yaml \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-num-seqs 256 \

--- a/benchmarks/single_node/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_int4_mi355x.sh
@@ -27,14 +27,18 @@ SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 set -x
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MLA=0
 vllm serve $MODEL --port $PORT \
+--config config.yaml \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
---max-model-len $MAX_MODEL_LEN \
---block-size=64 \
+--max-num-seqs 256 \
 --disable-log-requests \
 --trust-remote-code \
---mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
+--block-size=64 \
+--mm-encoder-tp-mode data \
+> $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -734,3 +734,10 @@
     - "Fix MTP 1k8k conc-start from 256 to 4 to enable full concurrency sweep"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/699
   
+- config-keys:
+    - kimik2.5-int4-mi355x-vllm
+  description:
+    - "Update moe optimized custom docker img."
+    - "Will change to the upstream vLLM image"
+    - "When this PR is merged (https://github.com/vllm-project/vllm/pull/35093)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/807

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -740,4 +740,4 @@
     - "Update moe optimized custom docker img."
     - "Will change to the upstream vLLM image"
     - "When this PR is merged (https://github.com/vllm-project/vllm/pull/35093)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/807
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/808


### PR DESCRIPTION
Hi, 

@cquil11  @functionstackx 

Updated the kimik2.5 docker img. Temporarily used dev img. but will switch back to the upstream img once the vllm PR (https://github.com/vllm-project/vllm/pull/35093) is merged. 

One question, are you going to enable prefix caching ? I see the existing benchmark codes allow prefix caching. Is this intentional ?

Regards, 
Seungrok 