### PR TITLE
[AMD] Update single-node DeepSeek R1 SGLang image from v0.5.8 to v0.5.9

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.8-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.9-rocm700-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x
@@ -73,7 +73,7 @@ dsr1-fp4-mi355x-atom-mtp:
     - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.8-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.9-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x
@@ -95,7 +95,7 @@ dsr1-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.8-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.9-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi325x
@@ -117,7 +117,7 @@ dsr1-fp8-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.8-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.9-rocm700-mi35x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -742,4 +742,4 @@
   description:
     - "Update SGLang image from v0.5.8 to v0.5.9 for AMD single-node DeepSeek R1 configs"
     - "Key changes: AITER v0.1.10.post3 with FP8 Prefill/Decode/KV Cache, FP8 prefill attention kernel, MORI EP two-batch overlapping, OOM fix for DeepSeek weight loading"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/816

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -733,4 +733,13 @@
     - "Extend concurrency range to conc-end: 256 across all sequence lengths (1k1k, 1k8k, 8k1k)"
     - "Fix MTP 1k8k conc-start from 256 to 4 to enable full concurrency sweep"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/699
-  
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp8-mi300x-sglang
+    - dsr1-fp8-mi325x-sglang
+    - dsr1-fp8-mi355x-sglang
+  description:
+    - "Update SGLang image from v0.5.8 to v0.5.9 for AMD single-node DeepSeek R1 configs"
+    - "Key changes: AITER v0.1.10.post3 with FP8 Prefill/Decode/KV Cache, FP8 prefill attention kernel, MORI EP two-batch overlapping, OOM fix for DeepSeek weight loading"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
Update SGLang image from v0.5.8 to v0.5.9 for AMD single-node DeepSeek R1 configs (MI300X, MI325X, MI355X).

Key SGLang v0.5.9 changes for AMD:
- AITER v0.1.10.post3 with FP8 Prefill/Decode/KV Cache
- FP8 prefill attention kernel integration
- MORI EP two-batch overlapping optimization
- OOM fix for DeepSeek weight loading

Configs updated:
- dsr1-fp4-mi355x-sglang
- dsr1-fp8-mi300x-sglang
- dsr1-fp8-mi325x-sglang
- dsr1-fp8-mi355x-sglang

E2E test run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/22450172501

Closes #812

Generated with [Claude Code](https://claude.ai/code)