### PR TITLE
[AMD] Add Kimi K2.5 MXFP4 vLLM benchmark for MI355X (TP8)

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -204,6 +204,28 @@ kimik2.5-int4-mi355x-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+kimik2.5-fp4-mi355x-vllm:
+  image: vllm/vllm-openai-rocm:v0.15.1
+  model: amd/Kimi-K2.5-MXFP4
+  model-prefix: kimik2.5
+  runner: mi355x
+  precision: fp4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 minimaxm2.5-fp8-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.15.1
   model: MiniMaxAI/MiniMax-M2.5

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -205,7 +205,7 @@ kimik2.5-int4-mi355x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.15.1
+  image: vllm/vllm-openai-rocm:v0.16
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -205,7 +205,7 @@ kimik2.5-int4-mi355x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16
+  image: vllm/vllm-openai-rocm:v0.16.0
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
   runner: mi355x

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -90,7 +90,7 @@ permissions:
 jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 240
+    timeout-minutes: 300
     name: "${{ inputs.exp-name }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }} | tp=${{ inputs.tp }} ep=${{ inputs.ep }} dpa=${{ inputs.dp-attn }} | disagg-${{ inputs.disagg }} spec-${{ inputs.spec-decoding }} conc-${{ inputs.conc }}${{ inputs.run-eval && ' | eval' || '' }}"
     steps:
       - name: Resource cleanup (pre-run)

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+# Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --port $PORT \
+--tensor-parallel-size=$TP \
+--gpu-memory-utilization 0.95 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size=64 \
+--disable-log-requests \
+--trust-remote-code \
+--mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
@@ -18,6 +18,9 @@ fi
 
 hf download "$MODEL"
 
+# Install amd-quark for MXFP4 quantization support
+pip install amd-quark
+
 # Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
 if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
@@ -26,6 +26,9 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
+# Enable AMD AIter kernels for ROCm
+export VLLM_ROCM_USE_AITER=1
+
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
@@ -19,6 +19,8 @@ fi
 hf download "$MODEL"
 
 # Install amd-quark for MXFP4 quantization support
+# need to manually install due to ROCm vLLM bug
+# https://github.com/vllm-project/vllm/issues/35633
 pip install amd-quark
 
 # Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
@@ -29,6 +31,12 @@ fi
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+# do not enable aiter due to Aiter MLA not currently supporting num_heads=8
+# https://github.com/vllm-project/vllm/issues/35641
+# export VLLM_ROCM_USE_AITER=1
+
+# following AMD andy luo's recipe
+# https://x.com/linluo77/status/2017024513595301985
 set -x
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x.sh
@@ -26,9 +26,6 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
-# Enable AMD AIter kernels for ROCm
-export VLLM_ROCM_USE_AITER=1
-
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -754,3 +754,12 @@
     - "Update SGLang image from v0.5.8 to v0.5.9 for AMD single-node DeepSeek R1 configs"
     - "Key changes: AITER v0.1.10.post3 with FP8 Prefill/Decode/KV Cache, FP8 prefill attention kernel, MORI EP two-batch overlapping, OOM fix for DeepSeek weight loading"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/816
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-vllm
+  description:
+    - "Add Kimi-K2.5 MXFP4 vLLM benchmark for MI355X"
+    - "Model: amd/Kimi-K2.5-MXFP4 with --mm-encoder-tp-mode data and --trust-remote-code"
+    - "Image: vllm/vllm-openai-rocm:v0.15.1"
+    - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
Add Kimi K2.5 MXFP4 (FP4) vLLM benchmark configuration for MI355X with TP8.

- Add `kimik2.5-fp4-mi355x-vllm` config to `amd-master.yaml`
- Model: `amd/Kimi-K2.5-MXFP4`
- Image: `vllm/vllm-openai-rocm:v0.16.0`
- Add benchmark script `benchmarks/single_node/kimik2.5_fp4_mi355x.sh`
- Update `perf-changelog.yaml`

Closes #824

Generated with [Claude Code](https://claude.ai/code)