### PR TITLE
[NVIDIA] Add Kimi K2.5 INT4 single-node H200 vLLM benchmark (TP8)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1826,6 +1826,28 @@ kimik2.5-int4-b200-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+kimik2.5-int4-h200-vllm:
+  image: vllm/vllm-openai:v0.16.0
+  model: moonshotai/Kimi-K2.5
+  model-prefix: kimik2.5
+  runner: h200
+  precision: int4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.8-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528

--- a/benchmarks/single_node/kimik2.5_int4_h200.sh
+++ b/benchmarks/single_node/kimik2.5_int4_h200.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export PYTHONNOUSERSITE=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT \
+--gpu-memory-utilization 0.95 \
+--tensor-parallel-size $TP \
+--max-model-len $MAX_MODEL_LEN \
+--max-num-seqs $CONC \
+--reasoning-parser kimi_k2 \
+--tool-call-parser kimi_k2 \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--trust-remote-code \
+--disable-log-requests > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/benchmarks/single_node/kimik2.5_int4_h200.sh
+++ b/benchmarks/single_node/kimik2.5_int4_h200.sh
@@ -25,6 +25,8 @@ export PYTHONNOUSERSITE=1
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+# following https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html recipe
+
 set -x
 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --gpu-memory-utilization 0.95 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -782,3 +782,12 @@
     - "TP=2 and TP=4, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/837
 
+- config-keys:
+    - kimik2.5-int4-h200-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 vLLM benchmark for H200"
+    - "Model: moonshotai/Kimi-K2.5 with --reasoning-parser kimi_k2 and --trust-remote-code"
+    - "Image: vllm/vllm-openai:v0.16.0"
+    - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -798,4 +798,5 @@
     - "Model: moonshotai/Kimi-K2.5 with --reasoning-parser kimi_k2 and --trust-remote-code"
     - "Image: vllm/vllm-openai:v0.16.0"
     - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+    - "following https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/839


### PR DESCRIPTION
- following https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html recipe after nvidia recently updated it


Add Kimi-K2.5 INT4 vLLM benchmark for H200 single-node with TP=8.

- New benchmark script: `benchmarks/single_node/kimik2.5_int4_h200.sh`
- New config key: `kimik2.5-int4-h200-vllm` in `nvidia-master.yaml`
- Image: `vllm/vllm-openai:v0.16.0`
- Model: `moonshotai/Kimi-K2.5`
- TP=8, concurrency 4-64 for 1k1k, 1k8k, 8k1k

Closes #838

Generated with [Claude Code](https://claude.ai/code)