### PR TITLE
[AMD] Add Qwen3.5 FP8 single-node MI325X SGLang following AMD Andy recipe (TP8)

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -204,6 +204,28 @@ qwen3.5-bf16-mi325x-sglang:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+qwen3.5-fp8-mi325x-sglang:
+  image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: mi325x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 qwen3.5-fp8-mi355x-sglang:
   image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260218
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# following AMD Andy linkedin's recipe
+# https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
+python3 -m sglang.launch_server \
+    --attention-backend triton \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -806,3 +806,12 @@
     - "Image: lmsysorg/sglang:v0.5.9-rocm720-mi30x"
     - "Uses triton attention backend, TP=8, concurrency 4-64"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/843
+
+- config-keys:
+    - qwen3.5-fp8-mi325x-sglang
+  description:
+    - "Add Qwen3.5-397B-A17B-FP8 SGLang benchmark for MI325X"
+    - "Image: lmsysorg/sglang:v0.5.9-rocm720-mi30x"
+    - "Following AMD Andy Luo's recipe with triton attention backend"
+    - "TP=8, concurrency 4-64 for 1k1k, 1k8k, and 8k1k sequence lengths"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
# following AMD Andy linkedin's recipe
# https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/

Closes #848

- New benchmark script: `benchmarks/single_node/qwen3.5_fp8_mi325x.sh`
- Model: Qwen/Qwen3.5-397B-A17B-FP8
- Image: `lmsysorg/sglang:v0.5.9-rocm720-mi30x`
- Following AMD Andy Luo's recipe with triton attention backend
- TP=8, concurrency 4-64 for 1k1k, 1k8k, 8k1k
- Add `qwen3.5-fp8-mi325x-sglang` config to amd-master.yaml
- Update `perf-changelog.yaml`

Generated with [Claude Code](https://claude.ai/code)