### PR TITLE
adding jgangani to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 .github/configs/amd-master.yaml @billishyahao @chunfangamd
 
 # NVIDIA master config
-.github/configs/nvidia-master.yaml @ankursingh-nv @kedarpotdar-nv
+.github/configs/nvidia-master.yaml @ankursingh-nv @kedarpotdar-nv @jgangani


### PR DESCRIPTION
Adding @jgangani back. although @kedarpotdar-nv and @ankursingh-nv can approve most of the PRs, I would like to keep track of GPTOSS related PRs for v2 and v3.