### PR TITLE
[NV] Kimi fp4 b200 vllm configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1885,17 +1885,16 @@ kimik2.5-fp4-b200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
     - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-b200-sglang-mtp:

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1873,6 +1873,31 @@ kimik2.5-int4-h200-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+kimik2.5-fp4-b200-vllm:
+  image: vllm/vllm-openai:v0.17.0
+  model: nvidia/Kimi-K2.5-NVFP4
+  model-prefix: kimik2.5
+  runner: b200
+  precision: fp4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
+
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.8-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528

--- a/benchmarks/single_node/kimik2.5_fp4_b200.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_b200.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export PYTHONNOUSERSITE=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT \
+--tensor-parallel-size=$TP \
+--gpu-memory-utilization 0.90 \
+--max-model-len $MAX_MODEL_LEN \
+--max-num-seqs $CONC \
+--reasoning-parser kimi_k2 \
+--tool-call-parser kimi_k2 \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -932,3 +932,9 @@
     - "Remove deprecated VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION/VLLM_ROCM_USE_AITER_MHA env vars and compilation-config cudagraph_mode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/867
   
+ - config-keys:
+    - kimik2.5-fp4-b200-vllm
+  description:
+    - "Add Kimi K2.5 FP4 B200 vLLM benchmark configuration"
+    - "Image: vllm/vllm-openai:v0.17.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/862

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -938,3 +938,4 @@
     - "Add Kimi K2.5 FP4 B200 vLLM benchmark configuration"
     - "Image: vllm/vllm-openai:v0.17.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/862
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -932,7 +932,7 @@
     - "Remove deprecated VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION/VLLM_ROCM_USE_AITER_MHA env vars and compilation-config cudagraph_mode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/867
   
- - config-keys:
+- config-keys:
     - kimik2.5-fp4-b200-vllm
   description:
     - "Add Kimi K2.5 FP4 B200 vLLM benchmark configuration"


### PR DESCRIPTION
## Summary
Add Kimi K2.5 FP4 benchmark configuration for B200 using vLLM.

## Changes
- **New config** `kimik2.5-fp4-b200-vllm` in `nvidia-master.yaml`
  - Model: `nvidia/Kimi-K2.5-NVFP4`
  - Image: `vllm/vllm-openai:v0.16.0`
  - Parallelism: TP=8/EP=1 (conc 4-128) and TP=4/EP=4 (conc 4-64)
  - Sequence lengths: 1k1k, 1k8k, 8k1k
- **New benchmark script** `benchmarks/single_node/kimik2.5_fp4_b200.sh`
  - Uses `--reasoning-parser kimi_k2` and `--tool-call-parser kimi_k2`
  - Enables `--compilation_config.pass_config.fuse_allreduce_rms true`
  - Sets `TORCH_CUDA_ARCH_LIST="10.0"` for B200
  - GPU memory utilization: 0.90