### PR TITLE
[NVIDIA] H200 MINIMAX vLLM extend configs 

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3428,15 +3428,15 @@ minimaxm2.5-fp8-h200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 128 }
 
 dsr1-fp4-gb200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3428,17 +3428,14 @@ minimaxm2.5-fp8-h200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 16 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 16 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 dsr1-fp4-gb200-dynamo-trt:

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3429,14 +3429,17 @@ minimaxm2.5-fp8-h200-vllm:
     osl: 1024
     search-space:
     - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 16 }
   - isl: 1024
     osl: 8192
     search-space:
     - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 16 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 16 }
 
 dsr1-fp4-gb200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3428,15 +3428,15 @@ minimaxm2.5-fp8-h200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 16 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 16 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 16 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp4-gb200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2

--- a/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
@@ -22,7 +22,7 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-if [ "$EP_SIZE" -gt 1 ]; then
+if [ "$EP_SIZE" -ge 1 ]; then
   EP=" --enable-expert-parallel"
 else
   EP=" "

--- a/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
@@ -28,6 +28,9 @@ else
   EP=" "
 fi
 
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
 set -x
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
@@ -60,4 +63,7 @@ if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
     append_lm_eval_summary
 fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
 set +x

--- a/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
@@ -22,7 +22,7 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-if [ "$EP_SIZE" -ge 1 ]; then
+if [ "$EP_SIZE" -gt 1 ]; then
   EP=" --enable-expert-parallel"
 else
   EP=" "

--- a/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -21,9 +22,16 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+if [ "$EP_SIZE" -ge 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
 set -x
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
+$EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --disable-log-requests \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -881,3 +881,9 @@
     - "Expanding TP search space"
     - "Adding kv-cache-fp8"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/865
+
+- config-keys:
+    - minimaxm2.5-fp8-h200-vllm
+  description:
+    - "Extend MiniMax M2.5 FP8 single-node config for H200 with vLLM v0.16.0 (TP8)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/869


### PR DESCRIPTION
## Summary

Extends the MiniMax M2.5 FP8 H200 vLLM benchmark configuration with updated parallelism and concurrency settings:

- **Config (`nvidia-master.yaml`):** Changed TP from 4 → 8 and extended max concurrency from 64 → 128 across all sequence length configs (1k1k, 1k8k, 8k1k)
- **Benchmark script (`minimaxm2.5_fp8_h200.sh`):** Added `EP_SIZE` env var check and conditional `--enable-expert-parallel` flag for vLLM, required for MoE models like MiniMax M2.5
- **Perf changelog:** Added entry documenting the config update

## Changes

| File | Change |
|------|--------|
| `.github/configs/nvidia-master.yaml` | TP 4→8, concurrency 64→128 for `minimaxm2.5-fp8-h200-vllm` |
| `benchmarks/single_node/minimaxm2.5_fp8_h200.sh` | Add expert parallelism support via `EP_SIZE` env var |
| `perf-changelog.yaml` | Add changelog entry for this PR |

## Context

MiniMax M2.5 is a Mixture-of-Experts (MoE) model that requires expert parallelism (EP) to run efficiently. Pure TP=8 alone is insufficient — EP must be enabled alongside it. This PR adds the conditional `--enable-expert-parallel` flag following the [vLLM MiniMax recipe](https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html).

## Test Plan

- [ ] Run `minimaxm2.5-fp8-h200-vllm` benchmarks on H200 to validate TP=8 + EP configuration
- [ ] Verify server starts successfully with `--enable-expert-parallel`
