### PR TITLE
[AMD] Add GPU power monitoring for MI325X using amd-smi

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -94,6 +94,20 @@ dsr1-fp8-mi300x-sglang:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+dsr1-power-fp8-mi325x-sglang:
+  image: lmsysorg/sglang:v0.5.9-rocm700-mi30x
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1-power
+  runner: mi325x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 4 }
+
 dsr1-fp8-mi325x-sglang:
   image: lmsysorg/sglang:v0.5.9-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -180,6 +180,14 @@ jobs:
           path: server.log
           if-no-files-found: ignore
 
+      - name: Upload GPU power CSV (if any)
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: gpu_power_${{ env.RESULT_FILENAME }}
+          path: gpu_power_${{ env.RESULT_FILENAME }}.csv
+          if-no-files-found: ignore
+
       - name: Upload eval results (if any)
         if: ${{ env.RUN_EVAL == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
+++ b/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/bash
+
+# Source benchmark utilities early
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=8888
+hf download $MODEL
+
+# Reference
+# https://rocm.docs.amd.com/en/docs-7.0-rc1/preview/benchmark-docker/inference-sglang-deepseek-r1-fp8.html#run-the-inference-benchmark
+
+export SGLANG_USE_AITER=1
+export SGLANG_AITER_MLA_PERSIST=1
+
+# --- GPU Power Monitoring via amd-smi ---
+GPU_POWER_CSV="/workspace/gpu_power_${RESULT_FILENAME}.csv"
+
+# Write CSV header
+echo "timestamp,gpu,power_w,power_limit_w,temp_junction_c,temp_edge_c,temp_mem_c,gfx_clock_mhz,mem_clock_mhz,gpu_util_pct,vram_used_mib,vram_total_mib" > "$GPU_POWER_CSV"
+
+# Start background amd-smi polling loop (1-second intervals)
+(
+  while true; do
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    # Use amd-smi metric --csv to get power, temperature, clock, usage, and VRAM
+    csv_output=$(amd-smi metric --power --clock --temperature --usage --vram --csv 2>/dev/null)
+    if [ -n "$csv_output" ]; then
+      # Parse the CSV output (skip header line)
+      echo "$csv_output" | tail -n +2 | while IFS=',' read -r gpu power_socket power_gfx power_limit temp_edge temp_junction temp_mem temp_vram gfx_clk mem_clk gpu_busy mem_busy enc_busy dec_busy vram_used vram_total rest; do
+        gpu=$(echo "$gpu" | xargs)
+        power_socket=$(echo "$power_socket" | xargs)
+        power_limit=$(echo "$power_limit" | xargs)
+        temp_junction=$(echo "$temp_junction" | xargs)
+        temp_edge=$(echo "$temp_edge" | xargs)
+        temp_mem=$(echo "$temp_mem" | xargs)
+        gfx_clk=$(echo "$gfx_clk" | xargs)
+        mem_clk=$(echo "$mem_clk" | xargs)
+        gpu_busy=$(echo "$gpu_busy" | xargs)
+        vram_used=$(echo "$vram_used" | xargs)
+        vram_total=$(echo "$vram_total" | xargs)
+        echo "${ts},${gpu},${power_socket},${power_limit},${temp_junction},${temp_edge},${temp_mem},${gfx_clk},${mem_clk},${gpu_busy},${vram_used},${vram_total}"
+      done >> "$GPU_POWER_CSV"
+    fi
+    sleep 1
+  done
+) &
+POWER_MONITOR_PID=$!
+echo "GPU power monitor started (PID=$POWER_MONITOR_PID) using amd-smi, logging to $GPU_POWER_CSV"
+
+set -x
+python3 -m sglang.launch_server \
+--model-path=$MODEL --host=0.0.0.0 --port=$PORT --trust-remote-code \
+--tensor-parallel-size=$TP \
+--mem-fraction-static=0.8 \
+--cuda-graph-max-bs=128 \
+--chunked-prefill-size=131072 \
+--num-continuous-decode-steps=4 \
+--max-prefill-tokens=131072 \
+--kv-cache-dtype fp8_e4m3 \
+--attention-backend aiter \
+--disable-radix-cache \
+> $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( $CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# Stop GPU power monitor
+kill $POWER_MONITOR_PID 2>/dev/null || true
+wait $POWER_MONITOR_PID 2>/dev/null || true
+echo "GPU power monitor stopped"
+
+POWER_LINE_COUNT=$(wc -l < "$GPU_POWER_CSV")
+echo "GPU power CSV: $POWER_LINE_COUNT lines written to $GPU_POWER_CSV"
+
+# Copy power CSV to workspace root for artifact upload
+cp "$GPU_POWER_CSV" /workspace/ 2>/dev/null || true
+
+set +x

--- a/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
+++ b/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
@@ -28,70 +28,59 @@ export SGLANG_AITER_MLA_PERSIST=1
 
 # --- GPU Power Monitoring via amd-smi ---
 GPU_POWER_CSV="/workspace/gpu_power_${RESULT_FILENAME}.csv"
-GPU_POWER_LOG="/workspace/gpu_power_debug.log"
-
-# Diagnostic: check amd-smi availability and output format
-echo "=== amd-smi diagnostics ===" | tee "$GPU_POWER_LOG"
-echo "which amd-smi: $(which amd-smi 2>&1)" | tee -a "$GPU_POWER_LOG"
-echo "amd-smi version: $(amd-smi version 2>&1)" | tee -a "$GPU_POWER_LOG"
-echo "--- amd-smi metric --csv sample ---" | tee -a "$GPU_POWER_LOG"
-amd-smi metric --csv 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
-echo "--- amd-smi metric --power --csv sample ---" | tee -a "$GPU_POWER_LOG"
-amd-smi metric --power --csv 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
-echo "--- amd-smi monitor sample ---" | tee -a "$GPU_POWER_LOG"
-amd-smi monitor -ptcug 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
-echo "--- amd-smi static --csv sample ---" | tee -a "$GPU_POWER_LOG"
-amd-smi static --csv 2>&1 | head -3 | tee -a "$GPU_POWER_LOG"
-echo "=== end diagnostics ===" | tee -a "$GPU_POWER_LOG"
 
 # Write CSV header
-echo "timestamp,gpu,power_w,power_limit_w,temp_junction_c,temp_edge_c,temp_mem_c,gfx_clock_mhz,mem_clock_mhz,gpu_util_pct,vram_used_mib,vram_total_mib" > "$GPU_POWER_CSV"
+echo "timestamp,gpu,socket_power_w,gfx_clock_mhz,mem_clock_mhz,temp_edge_c,temp_hotspot_c,temp_mem_c,gfx_activity_pct,umc_activity_pct,vram_used_mib,vram_total_mib" > "$GPU_POWER_CSV"
 
 # Start background amd-smi polling loop (1-second intervals)
-# We use a Python script for robust CSV parsing since amd-smi output format varies
+# Uses separate amd-smi metric calls to avoid embedded-list CSV parsing issues
 (
-  first_iter=true
   while true; do
     ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    # Use Python to query amd-smi for each metric category separately and merge
+    python3 -c "
+import subprocess, csv, io, sys
 
-    # Try amd-smi metric with --csv
-    csv_output=$(amd-smi metric --power --clock --temperature --usage --vram --csv 2>/tmp/amdsmi_err.log)
-    rc=$?
+def parse_csv(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    if result.returncode != 0 or not result.stdout.strip():
+        return {}
+    reader = csv.DictReader(io.StringIO(result.stdout))
+    rows = {}
+    for row in reader:
+        gpu = row.get('gpu', '')
+        rows[gpu] = row
+    return rows
 
-    if [ "$first_iter" = true ]; then
-      echo "[power-monitor] amd-smi metric --csv rc=$rc" >> "$GPU_POWER_LOG"
-      echo "[power-monitor] stderr: $(cat /tmp/amdsmi_err.log 2>/dev/null)" >> "$GPU_POWER_LOG"
-      echo "[power-monitor] stdout lines: $(echo "$csv_output" | wc -l)" >> "$GPU_POWER_LOG"
-      echo "[power-monitor] stdout head:" >> "$GPU_POWER_LOG"
-      echo "$csv_output" | head -3 >> "$GPU_POWER_LOG"
-      first_iter=false
-    fi
+try:
+    power = parse_csv(['amd-smi', 'metric', '--power', '--csv'])
+    clock = parse_csv(['amd-smi', 'metric', '--clock', '--csv'])
+    temp = parse_csv(['amd-smi', 'metric', '--temperature', '--csv'])
+    usage = parse_csv(['amd-smi', 'metric', '--usage', '--csv'])
+    vram = parse_csv(['amd-smi', 'metric', '--vram', '--csv'])
 
-    if [ $rc -eq 0 ] && [ -n "$csv_output" ] && [ "$(echo "$csv_output" | wc -l)" -gt 1 ]; then
-      # Parse using Python for robustness — handles varying column counts
-      python3 -c "
-import sys, csv, io
-reader = csv.DictReader(io.StringIO(sys.argv[1]))
-for row in reader:
-    gpu = row.get('gpu', row.get('GPU', ''))
-    # Power fields
-    power = row.get('power_socket_power', row.get('SOCKET_POWER', row.get('power', '')))
-    power_limit = row.get('power_socket_power_cap', row.get('POWER_CAP', row.get('power_cap', '')))
-    # Temperature fields
-    temp_junction = row.get('temperature_hotspot', row.get('TEMPERATURE_HOTSPOT', row.get('temperature_junction', '')))
-    temp_edge = row.get('temperature_edge', row.get('TEMPERATURE_EDGE', ''))
-    temp_mem = row.get('temperature_mem', row.get('TEMPERATURE_MEM', row.get('temperature_vram', '')))
-    # Clock fields
-    gfx_clk = row.get('clock_gfx', row.get('GFX_SCLK', row.get('sclk', '')))
-    mem_clk = row.get('clock_mem', row.get('MEM_MCLK', row.get('mclk', '')))
-    # Usage fields
-    gpu_busy = row.get('usage_gfx_activity', row.get('GFX_ACTIVITY', row.get('gpu_busy_percent', '')))
-    # VRAM fields
-    vram_used = row.get('vram_used', row.get('VRAM_USED', ''))
-    vram_total = row.get('vram_total', row.get('VRAM_TOTAL', ''))
-    print(f'${ts},{gpu},{power},{power_limit},{temp_junction},{temp_edge},{temp_mem},{gfx_clk},{mem_clk},{gpu_busy},{vram_used},{vram_total}')
-" "$csv_output" >> "$GPU_POWER_CSV" 2>/dev/null
-    fi
+    for gpu_id in sorted(power.keys()):
+        p = power.get(gpu_id, {})
+        c = clock.get(gpu_id, {})
+        t = temp.get(gpu_id, {})
+        u = usage.get(gpu_id, {})
+        v = vram.get(gpu_id, {})
+
+        socket_power = p.get('socket_power', '')
+        gfx_clk = c.get('gfx_0_clk', '')
+        mem_clk = c.get('mem_0_clk', '')
+        temp_edge = t.get('edge', '')
+        temp_hotspot = t.get('hotspot', '')
+        temp_mem = t.get('mem', '')
+        gfx_activity = u.get('gfx_activity', '')
+        umc_activity = u.get('umc_activity', '')
+        vram_used = v.get('used_vram', '')
+        vram_total = v.get('total_vram', '')
+
+        print(f'$ts,{gpu_id},{socket_power},{gfx_clk},{mem_clk},{temp_edge},{temp_hotspot},{temp_mem},{gfx_activity},{umc_activity},{vram_used},{vram_total}')
+except Exception as e:
+    pass
+" >> "$GPU_POWER_CSV" 2>/dev/null
     sleep 1
   done
 ) &
@@ -136,11 +125,6 @@ echo "GPU power monitor stopped"
 
 POWER_LINE_COUNT=$(wc -l < "$GPU_POWER_CSV")
 echo "GPU power CSV: $POWER_LINE_COUNT lines written to $GPU_POWER_CSV"
-
-# Print debug log
-echo "=== Power monitor debug log ==="
-cat "$GPU_POWER_LOG" 2>/dev/null || true
-echo "=== End debug log ==="
 
 # Copy power CSV to workspace root for artifact upload
 cp "$GPU_POWER_CSV" /workspace/ 2>/dev/null || true

--- a/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
+++ b/benchmarks/single_node/dsr1-power_fp8_mi325x.sh
@@ -28,32 +28,69 @@ export SGLANG_AITER_MLA_PERSIST=1
 
 # --- GPU Power Monitoring via amd-smi ---
 GPU_POWER_CSV="/workspace/gpu_power_${RESULT_FILENAME}.csv"
+GPU_POWER_LOG="/workspace/gpu_power_debug.log"
+
+# Diagnostic: check amd-smi availability and output format
+echo "=== amd-smi diagnostics ===" | tee "$GPU_POWER_LOG"
+echo "which amd-smi: $(which amd-smi 2>&1)" | tee -a "$GPU_POWER_LOG"
+echo "amd-smi version: $(amd-smi version 2>&1)" | tee -a "$GPU_POWER_LOG"
+echo "--- amd-smi metric --csv sample ---" | tee -a "$GPU_POWER_LOG"
+amd-smi metric --csv 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
+echo "--- amd-smi metric --power --csv sample ---" | tee -a "$GPU_POWER_LOG"
+amd-smi metric --power --csv 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
+echo "--- amd-smi monitor sample ---" | tee -a "$GPU_POWER_LOG"
+amd-smi monitor -ptcug 2>&1 | head -5 | tee -a "$GPU_POWER_LOG"
+echo "--- amd-smi static --csv sample ---" | tee -a "$GPU_POWER_LOG"
+amd-smi static --csv 2>&1 | head -3 | tee -a "$GPU_POWER_LOG"
+echo "=== end diagnostics ===" | tee -a "$GPU_POWER_LOG"
 
 # Write CSV header
 echo "timestamp,gpu,power_w,power_limit_w,temp_junction_c,temp_edge_c,temp_mem_c,gfx_clock_mhz,mem_clock_mhz,gpu_util_pct,vram_used_mib,vram_total_mib" > "$GPU_POWER_CSV"
 
 # Start background amd-smi polling loop (1-second intervals)
+# We use a Python script for robust CSV parsing since amd-smi output format varies
 (
+  first_iter=true
   while true; do
     ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    # Use amd-smi metric --csv to get power, temperature, clock, usage, and VRAM
-    csv_output=$(amd-smi metric --power --clock --temperature --usage --vram --csv 2>/dev/null)
-    if [ -n "$csv_output" ]; then
-      # Parse the CSV output (skip header line)
-      echo "$csv_output" | tail -n +2 | while IFS=',' read -r gpu power_socket power_gfx power_limit temp_edge temp_junction temp_mem temp_vram gfx_clk mem_clk gpu_busy mem_busy enc_busy dec_busy vram_used vram_total rest; do
-        gpu=$(echo "$gpu" | xargs)
-        power_socket=$(echo "$power_socket" | xargs)
-        power_limit=$(echo "$power_limit" | xargs)
-        temp_junction=$(echo "$temp_junction" | xargs)
-        temp_edge=$(echo "$temp_edge" | xargs)
-        temp_mem=$(echo "$temp_mem" | xargs)
-        gfx_clk=$(echo "$gfx_clk" | xargs)
-        mem_clk=$(echo "$mem_clk" | xargs)
-        gpu_busy=$(echo "$gpu_busy" | xargs)
-        vram_used=$(echo "$vram_used" | xargs)
-        vram_total=$(echo "$vram_total" | xargs)
-        echo "${ts},${gpu},${power_socket},${power_limit},${temp_junction},${temp_edge},${temp_mem},${gfx_clk},${mem_clk},${gpu_busy},${vram_used},${vram_total}"
-      done >> "$GPU_POWER_CSV"
+
+    # Try amd-smi metric with --csv
+    csv_output=$(amd-smi metric --power --clock --temperature --usage --vram --csv 2>/tmp/amdsmi_err.log)
+    rc=$?
+
+    if [ "$first_iter" = true ]; then
+      echo "[power-monitor] amd-smi metric --csv rc=$rc" >> "$GPU_POWER_LOG"
+      echo "[power-monitor] stderr: $(cat /tmp/amdsmi_err.log 2>/dev/null)" >> "$GPU_POWER_LOG"
+      echo "[power-monitor] stdout lines: $(echo "$csv_output" | wc -l)" >> "$GPU_POWER_LOG"
+      echo "[power-monitor] stdout head:" >> "$GPU_POWER_LOG"
+      echo "$csv_output" | head -3 >> "$GPU_POWER_LOG"
+      first_iter=false
+    fi
+
+    if [ $rc -eq 0 ] && [ -n "$csv_output" ] && [ "$(echo "$csv_output" | wc -l)" -gt 1 ]; then
+      # Parse using Python for robustness — handles varying column counts
+      python3 -c "
+import sys, csv, io
+reader = csv.DictReader(io.StringIO(sys.argv[1]))
+for row in reader:
+    gpu = row.get('gpu', row.get('GPU', ''))
+    # Power fields
+    power = row.get('power_socket_power', row.get('SOCKET_POWER', row.get('power', '')))
+    power_limit = row.get('power_socket_power_cap', row.get('POWER_CAP', row.get('power_cap', '')))
+    # Temperature fields
+    temp_junction = row.get('temperature_hotspot', row.get('TEMPERATURE_HOTSPOT', row.get('temperature_junction', '')))
+    temp_edge = row.get('temperature_edge', row.get('TEMPERATURE_EDGE', ''))
+    temp_mem = row.get('temperature_mem', row.get('TEMPERATURE_MEM', row.get('temperature_vram', '')))
+    # Clock fields
+    gfx_clk = row.get('clock_gfx', row.get('GFX_SCLK', row.get('sclk', '')))
+    mem_clk = row.get('clock_mem', row.get('MEM_MCLK', row.get('mclk', '')))
+    # Usage fields
+    gpu_busy = row.get('usage_gfx_activity', row.get('GFX_ACTIVITY', row.get('gpu_busy_percent', '')))
+    # VRAM fields
+    vram_used = row.get('vram_used', row.get('VRAM_USED', ''))
+    vram_total = row.get('vram_total', row.get('VRAM_TOTAL', ''))
+    print(f'${ts},{gpu},{power},{power_limit},{temp_junction},{temp_edge},{temp_mem},{gfx_clk},{mem_clk},{gpu_busy},{vram_used},{vram_total}')
+" "$csv_output" >> "$GPU_POWER_CSV" 2>/dev/null
     fi
     sleep 1
   done
@@ -99,6 +136,11 @@ echo "GPU power monitor stopped"
 
 POWER_LINE_COUNT=$(wc -l < "$GPU_POWER_CSV")
 echo "GPU power CSV: $POWER_LINE_COUNT lines written to $GPU_POWER_CSV"
+
+# Print debug log
+echo "=== Power monitor debug log ==="
+cat "$GPU_POWER_LOG" 2>/dev/null || true
+echo "=== End debug log ==="
 
 # Copy power CSV to workspace root for artifact upload
 cp "$GPU_POWER_CSV" /workspace/ 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Add `dsr1-power_fp8_mi325x.sh` benchmark script that monitors GPU power, clocks, temperature, and VRAM usage via `amd-smi` during DeepSeek R1 SGLang inference
- Add `dsr1-power-fp8-mi325x-sglang` config entry to `amd-master.yaml`
- Add GPU power CSV artifact upload step to `benchmark-tmpl.yml`

## Context
`rocm-smi --showpower --csv` reports 0-2W on MI325X (broken). `amd-smi` correctly reports power (~140W idle, 450-670W per GPU under load). Combined `amd-smi metric --csv` output contains embedded Python lists that break CSV parsing, so each metric category is queried separately and merged via Python.

## Results (run [#22742040394](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/22742040394))
- **Throughput:** 40 tok/s/GPU (19.9 output tok/s/GPU)
- **Mean system power under load:** 4,041W (8x MI325X)
- **Peak system power:** 5,367W
- **GPU temps:** 55-65°C mean hotspot

## Test plan
- [x] E2E test run completed successfully with power data captured (1,664 rows across 8 GPUs)
- [x] GPU power CSV artifact uploaded and verified

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)