### PR TITLE
Add benchmarks and perf-changelog to PR recipe reminder paths

### DIFF
--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '.github/configs/amd-master.yaml'
       - '.github/configs/nvidia-master.yaml'
+      - 'benchmarks/**'
+      - 'perf-changelog.yaml'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Extends the PR recipe reminder workflow to also trigger on changes to `benchmarks/**` and `perf-changelog.yaml`.

Closes #872

Generated with [Claude Code](https://claude.ai/code)