### PR TITLE
[NVIDIA] Bump dsr1-fp8-h200-sglang image from v0.5.7 to v0.5.9

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1953,7 +1953,7 @@ dsr1-fp8-b200-trt-mtp:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-h200-sglang:
-  image: lmsysorg/sglang:v0.5.7-cu129-amd64
+  image: lmsysorg/sglang:v0.5.9-cu129-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -267,6 +267,12 @@
     - Add official GSM8k eval results to GPT-OSS and DeepSeek R1 scenarios
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/558
   evals-only: true
+
+- config-keys:
+    - dsr1-fp8-h200-sglang
+  description:
+    - "Update H200 DeepSeek R1 FP8 SGLang image from v0.5.7 to v0.5.9"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
   
 - config-keys:
   - dsr1-fp4-b300-dynamo-trt


### PR DESCRIPTION
Update the SGLang image tag for `dsr1-fp8-h200-sglang` config from `lmsysorg/sglang:v0.5.7-cu129-amd64` to `lmsysorg/sglang:v0.5.9-cu129-amd64`.

Closes #886

Generated with [Claude Code](https://claude.ai/code)