### PR TITLE
[AMD] GPT-OSS vLLM 0.17.0 AMD update

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -390,7 +390,7 @@ minimaxm2.5-fp8-mi325x-vllm:
     - { tp: 4, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16.0
+  image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x
@@ -421,7 +421,7 @@ gptoss-fp4-mi300x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16.0
+  image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi325x
@@ -452,8 +452,8 @@ gptoss-fp4-mi325x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16.0
-  model: openai/gpt-oss-120b
+  image: vllm/vllm-openai-rocm:v0.17.0
+  model: amd/gpt-oss-120b-w-mxfp4-a-fp8
   model-prefix: gptoss
   runner: mi355x
   precision: fp4

--- a/benchmarks/single_node/gptoss_fp4_mi300x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi300x.sh
@@ -49,8 +49,7 @@ vllm serve $MODEL --port $PORT \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
-  --no-enable-prefix-caching \
-  --disable-log-requests > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi300x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi300x.sh
@@ -33,23 +33,24 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
+export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
-export VLLM_ROCM_USE_AITER_MHA=0
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
+FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 set -x
 vllm serve $MODEL --port $PORT \
---tensor-parallel-size=$TP \
---gpu-memory-utilization 0.95 \
---max-model-len $MAX_MODEL_LEN \
---compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
---block-size=64 \
---no-enable-prefix-caching \
---disable-log-requests > $SERVER_LOG 2>&1 &
+  $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
+  --tensor-parallel-size=$TP \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len $MAX_MODEL_LEN \
+  --block-size=64 \
+  --no-enable-prefix-caching \
+  --disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi325x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi325x.sh
@@ -49,8 +49,7 @@ vllm serve $MODEL --port $PORT \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
-  --no-enable-prefix-caching \
-  --disable-log-requests > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi325x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi325x.sh
@@ -33,22 +33,24 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
+export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
-export VLLM_ROCM_USE_AITER_MHA=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
+FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 set -x
 vllm serve $MODEL --port $PORT \
---tensor-parallel-size=$TP \
---gpu-memory-utilization 0.95 \
---max-model-len $MAX_MODEL_LEN \
---compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
---block-size=64 \
---no-enable-prefix-caching \
---disable-log-requests > $SERVER_LOG 2>&1 &
+  $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
+  --tensor-parallel-size=$TP \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len $MAX_MODEL_LEN \
+  --block-size=64 \
+  --no-enable-prefix-caching \
+  --disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -50,8 +50,7 @@ vllm serve $MODEL --port $PORT \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
-  --no-enable-prefix-caching \
-  --disable-log-requests > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -35,6 +35,7 @@ fi
 
 export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
 FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -33,22 +33,24 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
+export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
-export VLLM_ROCM_USE_AITER_MHA=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
+FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 set -x
 vllm serve $MODEL --port $PORT \
---tensor-parallel-size=$TP \
---gpu-memory-utilization 0.95 \
---max-model-len $MAX_MODEL_LEN \
---compilation-config  '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
---block-size=64 \
---no-enable-prefix-caching \
---disable-log-requests > $SERVER_LOG 2>&1 &
+  $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
+  --tensor-parallel-size=$TP \
+  --gpu-memory-utilization 0.95 \
+  --max-model-len $MAX_MODEL_LEN \
+  --block-size=64 \
+  --no-enable-prefix-caching \
+  --disable-log-requests > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -875,3 +875,15 @@
     - "Server: reasoning-parser qwen3, tool-call-parser qwen3_coder, enable-flashinfer-allreduce-fusion, mem-fraction-static 0.8"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/855
 
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+    - gptoss-fp4-mi325x-vllm
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Update AMD GPT-OSS vLLM image from v0.16.0 to v0.17.0 for MI300X, MI325X, and MI355X"
+    - "MI355X: Switch model to amd/gpt-oss-120b-w-mxfp4-a-fp8 (MXFP4 weights + FP8 activations)"
+    - "MI355X: Add VLLM_ROCM_USE_AITER_TRITON_ROPE=1 for AITER triton RoPE kernel"
+    - "Add AMDGCN_USE_BUFFER_OPS=0 and VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 env vars"
+    - "Switch to --attention-backend ROCM_AITER_UNIFIED_ATTN and add fuse_rope_kvcache compilation pass"
+    - "Remove deprecated VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION/VLLM_ROCM_USE_AITER_MHA env vars and compilation-config cudagraph_mode"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/867

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -179,6 +179,8 @@ else
         fi
     "
 
+    export VLLM_CACHE_ROOT="/it-share/gharunners/.cache/vllm"
+
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
         --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -156,6 +156,7 @@ else
 
     PARTITION="compute"
     SQUASH_FILE="/var/lib/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    LOCK_FILE="${SQUASH_FILE}.lock"
 
     set -x
     salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
@@ -163,16 +164,20 @@ else
 
     srun --jobid=$JOB_ID bash -c "docker stop \$(docker ps -a -q)"
 
-    if [[ "$FRAMEWORK" == "atom" ]]; then
-        srun --jobid=$JOB_ID bash -c "rm $SQUASH_FILE"
-    fi
-
-    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
-    if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
-        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
-        srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
-        srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
-    fi
+    # Use flock to serialize concurrent imports to the same squash file
+    srun --jobid=$JOB_ID bash -c "
+        exec 9>\"$LOCK_FILE\"
+        flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
+        if [[ \"$FRAMEWORK\" == \"atom\" ]]; then
+            rm -f \"$SQUASH_FILE\"
+        fi
+        if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
+            echo 'Squash file already exists and is valid, skipping import'
+        else
+            rm -f \"$SQUASH_FILE\"
+            enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
+        fi
+    "
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \


### PR DESCRIPTION
Opening as draft until vllm v0.17.0 is released. This release will include multiple optimizations for gpt-oss:

- Enable https://huggingface.co/amd/gpt-oss-120b-w-mxfp4-a-fp8 moe quant: https://github.com/vllm-project/vllm/pull/30357 (10-15%)
- RoPE+KVCache fusion: https://github.com/vllm-project/vllm/pull/33443 (3-4%)
- Enable AITER RoPE: https://github.com/vllm-project/vllm/pull/35180 (1%)

Some other updates:
- gpt-oss CK moe backend: https://github.com/vllm-project/vllm/pull/34301 (Not used in this PR since Triton W4A8 is better, but was previously the default MOE on MI355 before #806)
- Attention backends can no longer be passed in as env vars in vLLM, update to `--attention-backend`: https://github.com/vllm-project/vllm/pull/32812
- FULL_AND_PIECEWISE is already the default, no need to specify it

Author: https://github.com/Rohan138