### PR TITLE
[NVIDIA] Add Kimi K2.5 NVFP4 single-node B200 vLLM benchmark (TP4, TP8)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1851,6 +1851,31 @@ kimik2.5-int4-b200-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+kimik2.5-fp4-b200-vllm:
+  image: vllm/vllm-openai:v0.15.1
+  model: nvidia/Kimi-K2.5-NVFP4
+  model-prefix: kimik2.5
+  runner: b200
+  precision: fp4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 kimik2.5-int4-h200-vllm:
   image: vllm/vllm-openai:v0.16.0
   model: moonshotai/Kimi-K2.5

--- a/benchmarks/single_node/kimik2.5_fp4_b200.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_b200.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export PYTHONNOUSERSITE=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT \
+--gpu-memory-utilization 0.95 \
+--tensor-parallel-size $TP \
+--max-model-len $MAX_MODEL_LEN \
+--max-num-seqs $CONC \
+--reasoning-parser kimi_k2 \
+--tool-call-parser kimi_k2 \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--trust-remote-code \
+--disable-log-requests > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4,7 +4,7 @@
     - "Add Kimi K2.5 NVFP4 single-node B200 vLLM benchmark (TP4, TP8)"
     - "Uses nvidia/Kimi-K2.5-NVFP4 checkpoint for native Blackwell tensor core execution"
     - "NVFP4 expected ~2.35x throughput improvement over INT4 on Blackwell"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/905
 
 - config-keys:
     - kimik2.5-int4-mi325x-vllm

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,12 @@
 - config-keys:
+    - kimik2.5-fp4-b200-vllm
+  description:
+    - "Add Kimi K2.5 NVFP4 single-node B200 vLLM benchmark (TP4, TP8)"
+    - "Uses nvidia/Kimi-K2.5-NVFP4 checkpoint for native Blackwell tensor core execution"
+    - "NVFP4 expected ~2.35x throughput improvement over INT4 on Blackwell"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+
+- config-keys:
     - kimik2.5-int4-mi325x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI325X vLLM benchmark (TP8)"


### PR DESCRIPTION
## Summary
- Add `kimik2.5-fp4-b200-vllm` config using `nvidia/Kimi-K2.5-NVFP4` checkpoint
- NVFP4 runs natively on Blackwell tensor cores (~2.35x throughput vs INT4 which requires software dequant to FP16)
- Sweeps TP4 and TP8 across concurrency 4-64 for all three ISL/OSL combos (1k1k, 1k8k, 8k1k)
- Benchmark script mirrors existing `kimik2.5_int4_b200.sh` pattern

## Test plan
- [x] `generate_sweep_configs.py test-config` validates successfully (30 matrix entries)
- [ ] Sweep run completes on B200 runners with `sweep-enabled` label
- [ ] Compare NVFP4 vs INT4 throughput on same hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)