### PR TITLE
[NVIDIA] Update B200 FP8 DSR1 8k1k dynamo-sglang recipes to new pareto configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -7032,67 +7032,101 @@ dsr1-fp8-b200-dynamo-sglang:
   - isl: 8192
     osl: 1024
     search-space:
-    # Non-MTP configurations
-    - conc-list: [4, 32, 64, 512]
+    # STP low-latency: resolved from 8k1k.yaml zip_override_stp_lowlat
+    - conc-list: [128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/stp/low-latency-tep8-1p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_lowlat_0.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_0.yaml"
       decode:
-        num-worker: 1
+        num-worker: 3
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    - conc-list: [64, 512]
+    - conc-list: [128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/stp/low-latency-tep8-1p4d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_lowlat_1.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_1.yaml"
       decode:
         num-worker: 4
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    - conc-list: [32]
+    - conc-list: [8, 16, 32, 64, 128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/stp/low-latency-tep8-1p6d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_lowlat_2.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_2.yaml"
       decode:
         num-worker: 6
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    - conc-list: [128, 512, 1024]
+    # STP max-throughput: resolved from 8k1k.yaml zip_override_stp_maxtpt
+    - conc-list: [288]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/stp/max-tpt-dep8-1p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_maxtpt_0.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_0.yaml"
       decode:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
-    - conc-list: [256, 512, 1024]
-      prefill:
         num-worker: 2
         tp: 8
         ep: 8
         dp-attn: true
+    - conc-list: [160, 288]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/stp/max-tpt-dep8-2p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_maxtpt_1.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_1.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - conc-list: [512]
+      prefill:
+        num-worker: 2
+        tp: 8
+        ep: 1
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_maxtpt_2.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_2.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - conc-list: [1024]
+      prefill:
+        num-worker: 3
+        tp: 8
+        ep: 1
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_stp_maxtpt_3.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_3.yaml"
       decode:
         num-worker: 1
         tp: 8
@@ -7190,76 +7224,108 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
   - isl: 8192
     osl: 1024
     search-space:
-    # MTP low-latency: 1P1D
+    # MTP low-latency: resolved from 8k1k.yaml zip_override_mtp_lowlat
     - spec-decoding: "mtp"
-      conc-list: [16, 32, 64]
+      conc-list: [128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_lowlat_0.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_0.yaml"
       decode:
-        num-worker: 1
+        num-worker: 3
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    # MTP low-latency: 1P4D
     - spec-decoding: "mtp"
-      conc-list: [8, 256]
+      conc-list: [128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p4d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_lowlat_1.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_1.yaml"
       decode:
         num-worker: 4
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    # MTP low-latency: 1P6D
     - spec-decoding: "mtp"
-      conc-list: [4, 8, 16, 256]
+      conc-list: [8, 16, 32, 64, 128]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: false
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/low-latency-tep8-1p6d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_lowlat_2.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_2.yaml"
       decode:
         num-worker: 6
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: false
-    # MTP max-tpt: 1P1D
+    # MTP max-throughput: resolved from 8k1k.yaml zip_override_mtp_maxtpt
     - spec-decoding: "mtp"
-      conc-list: [256]
+      conc-list: [288]
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-1p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_0.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_0.yaml"
       decode:
-        num-worker: 1
-        tp: 8
-        ep: 8
-        dp-attn: true
-    # MTP max-tpt: 2P1D
-    - spec-decoding: "mtp"
-      conc-list: [128, 512]
-      prefill:
         num-worker: 2
         tp: 8
         ep: 8
         dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [160, 288]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: true
         additional-settings:
-        - "CONFIG_FILE=recipes/b200-fp8/8k1k/mtp/max-tpt-dep8-2p1d.yaml"
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_1.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_1.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [512]
+      prefill:
+        num-worker: 2
+        tp: 8
+        ep: 1
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_2.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_2.yaml"
+      decode:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+    - spec-decoding: "mtp"
+      conc-list: [1024]
+      prefill:
+        num-worker: 3
+        tp: 8
+        ep: 1
+        dp-attn: true
+        additional-settings:
+        # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_3.yaml
+        - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_3.yaml"
       decode:
         num-worker: 1
         tp: 8

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -961,3 +961,12 @@
   description:
     - "Extend MiniMax M2.5 FP8 single-node config for H200 with vLLM v0.16.0 (TP8)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/869
+
+- config-keys:
+    - dsr1-fp8-b200-dynamo-sglang
+    - dsr1-fp8-b200-dynamo-sglang-mtp
+  description:
+    - "Update B200 FP8 DSR1 8k1k dynamo-sglang recipes to new pareto configs"
+    - "Replace old per-file recipes with resolved variants from consolidated 8k1k.yaml"
+    - "14 variants: STP/MTP x low-latency/max-throughput with updated concurrencies and scale points"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/907

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -21,7 +21,7 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
         export MODEL_PATH="/lustre/fsw/models/dsr1-0528-nvfp4-v2"
         export SRT_SLURM_MODEL_PREFIX="dsr1"
     elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp8" ]]; then
-        export MODEL_PATH="/raid/models/dsr1-0528-fp8"
+        export MODEL_PATH="/raid/tmp/dsr1-0528-fp8"
         export SRT_SLURM_MODEL_PREFIX="dsr1-fp8"
     else
         echo "Unsupported model prefix/precision: $MODEL_PREFIX/$PRECISION"


### PR DESCRIPTION
Replace old per-file 8k1k recipe paths with resolved variants from the consolidated 8k1k.yaml. 14 variants total covering STP/MTP x low-latency/max-throughput with updated concurrencies and scale points.
