### PR TITLE
fix: multi-turn benchmark hangs after all clients finish

### DIFF
--- a/experimental/multiturn/vllm_benchmark/benchmark/benchmark_serving_multi_turn.py
+++ b/experimental/multiturn/vllm_benchmark/benchmark/benchmark_serving_multi_turn.py
@@ -1098,6 +1098,16 @@ async def main_mp(
             while not result_queue.empty():
                 client_metrics.append(result_queue.get())
                 pbar.update(1)
+            # Fallback: detect dead children whose TERM_SIGNAL was lost
+            dead = sum(1 for c in clients if not c.is_alive())
+            if dead >= bench_args.num_clients:
+                lost = bench_args.num_clients - num_clients_finished
+                logger.warning(
+                    f"{Color.YELLOW}All client processes are dead but "
+                    f"{lost} TERM_SIGNALs were lost — breaking out of "
+                    f"main loop{Color.RESET}"
+                )
+                break
             continue
 
         # Collect results (measurements)
@@ -2011,3 +2021,7 @@ async def main() -> None:
 
 if __name__ == "__main__":
     asyncio.run(main())
+    # Force exit to avoid hanging on multiprocessing Queue feeder threads
+    # during interpreter shutdown (the queues may still have thousands of
+    # undelivered items whose feeder threads deadlock on GC).
+    os._exit(0)


### PR DESCRIPTION
## Summary

Two deadlock bugs in `benchmark_serving_multi_turn.py`, both present since the initial commit (`ebd571e`, Feb 25 2026):

**Bug 1 — Main loop deadlock on lost TERM_SIGNALs**

The main loop waits for exactly `num_clients` TERM_SIGNAL messages from `conv_queue`. Some worker processes exit without putting their TERM_SIGNAL on the queue — they become zombies but the main loop has no way to detect this. It hangs forever waiting for signals that will never arrive. Observed: 32 clients launched, all reported "is done" in logs, but only 24 out of 32 TERM_SIGNALs received. Reproducible with both `--early-stop` and `--no-early-stop`.

**Fix**: On each timeout in the main loop, check if all child processes are dead. If so, log a warning and break out.

**Bug 2 — Process exit hang on Queue feeder threads**

After all user code completes (statistics printed, metadata written), the process hangs at interpreter shutdown. The `task_queue` has ~19,700 large conversation objects that were enqueued but never consumed (only ~32 picked up before global request limit hit). Despite `cancel_join_thread()` + `close()`, the Queue's internal feeder thread deadlocks during garbage collection. Observed: main thread stuck in `futex_wait_queue` with 93 threads, no children alive.

**Fix**: Call `os._exit(0)` after `main()` returns to bypass interpreter shutdown deadlock.

## Test plan
- [x] Run benchmark with 32 clients / 320 requests against trtllm server
- [x] Verify "TERM_SIGNALs were lost — breaking out" warning appears (8 lost signals detected)
- [x] Verify process exits cleanly after printing statistics (no hang)
- [ ] Run with `--early-stop` (default) to confirm fix works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)