### PR TITLE
[NV] GLM5 fp8 b200 SGL

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1842,17 +1842,17 @@ glm5-fp8-b200-sglang:
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
   - isl: 1024
     osl: 8192
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
 
 kimik2.5-int4-b200-vllm:
   image: vllm/vllm-openai:v0.15.1

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1829,6 +1829,31 @@ qwen3.5-fp8-b200-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4}
     - { tp: 4, ep: 4, conc-start: 8, conc-end: 64 }
 
+glm5-fp8-b200-sglang:
+  image: lmsysorg/sglang:glm5-blackwell
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: b200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 64 }
+
 kimik2.5-int4-b200-vllm:
   image: vllm/vllm-openai:v0.15.1
   model: moonshotai/Kimi-K2.5

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1841,18 +1841,15 @@ glm5-fp8-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
   - isl: 1024
     osl: 8192
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
 
 kimik2.5-int4-b200-vllm:
   image: vllm/vllm-openai:v0.15.1

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1830,7 +1830,7 @@ qwen3.5-fp8-b200-sglang:
     - { tp: 4, ep: 4, conc-start: 8, conc-end: 64 }
 
 glm5-fp8-b200-sglang:
-  image: lmsysorg/sglang:glm5-blackwell
+  image: lmsysorg/sglang:nightly-dev-cu13-20260317-1eea7448
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: b200

--- a/benchmarks/single_node/glm5_fp8_b200.sh
+++ b/benchmarks/single_node/glm5_fp8_b200.sh
@@ -20,6 +20,8 @@ nvidia-smi
 
 hf download "$MODEL"
 
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+
 export SGL_ENABLE_JIT_DEEPGEMM=1
 
 SERVER_LOG=/workspace/server.log
@@ -45,8 +47,8 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --trust-remote-code \
 --tensor-parallel-size=$TP \
 $DP_FLAGS \
---kv-cache-dtype bf16 --quantization fp8 \
---attention-backend nsa --nsa-decode-backend trtllm \
+--kv-cache-dtype fp8_e4m3 --quantization fp8 \
+--nsa-decode-backend trtllm --nsa-prefill-backend trtllm \
 --moe-runner-backend flashinfer_trtllm \
 --cuda-graph-max-bs $CONC --max-running-requests $CONC \
 --mem-fraction-static 0.85 \

--- a/benchmarks/single_node/glm5_fp8_b200.sh
+++ b/benchmarks/single_node/glm5_fp8_b200.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+export SGL_ENABLE_JIT_DEEPGEMM=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# Mode-dependent config: TP8 vs DEP8
+if [[ "$DP_ATTENTION" == "true" ]]; then
+  # DEP8: high throughput
+  DP_SIZE=$EP_SIZE
+  DP_FLAGS="--data-parallel-size $DP_SIZE --expert-parallel-size $EP_SIZE --enable-dp-lm-head --enable-dp-attention"
+else
+  # TP8: low latency
+  DP_FLAGS="--data-parallel-size 1 --expert-parallel-size 1"
+fi
+
+echo "DP_ATTENTION: $DP_ATTENTION, EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+$DP_FLAGS \
+--kv-cache-dtype bf16 --quantization fp8 \
+--attention-backend nsa --nsa-decode-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--cuda-graph-max-bs $CONC --max-running-requests $CONC \
+--mem-fraction-static 0.85 \
+--chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --disable-radix-cache \
+--stream-interval 30 \
+--model-loader-extra-config '{"enable_multithread_load": true}' > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/glm5_fp8_b200.sh
+++ b/benchmarks/single_node/glm5_fp8_b200.sh
@@ -27,17 +27,8 @@ export SGL_ENABLE_JIT_DEEPGEMM=1
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-# Mode-dependent config: TP8 vs DEP8
-if [[ "$DP_ATTENTION" == "true" ]]; then
-  # DEP8: high throughput
-  DP_SIZE=$EP_SIZE
-  DP_FLAGS="--data-parallel-size $DP_SIZE --expert-parallel-size $EP_SIZE --enable-dp-lm-head --enable-dp-attention"
-else
-  # TP8: low latency
-  DP_FLAGS="--data-parallel-size 1 --expert-parallel-size 1"
-fi
 
-echo "DP_ATTENTION: $DP_ATTENTION, EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+echo "EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -46,8 +37,11 @@ set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
 --tensor-parallel-size=$TP \
-$DP_FLAGS \
+--data-parallel-size 1 --expert-parallel-size 1 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
 --kv-cache-dtype fp8_e4m3 --quantization fp8 \
+--attention-backend nsa \
 --nsa-decode-backend trtllm --nsa-prefill-backend trtllm \
 --moe-runner-backend flashinfer_trtllm \
 --cuda-graph-max-bs $CONC --max-running-requests $CONC \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -961,3 +961,10 @@
   description:
     - "Extend MiniMax M2.5 FP8 single-node config for H200 with vLLM v0.16.0 (TP8)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/869
+
+- config-keys:
+    - glm5-fp8-b200-sglang
+  description:
+    - "Add GLM-5 FP8 SGLang benchmark for B200"
+    - "Supports TP8 (low latency) and DEP8 (high throughput) modes with NSA attention backend"
+  pr-link: <PR_LINK>

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -967,4 +967,4 @@
   description:
     - "Add GLM-5 FP8 SGLang benchmark for B200"
     - "Supports TP8 (low latency) and DEP8 (high throughput) modes with NSA attention backend"
-  pr-link: <PR_LINK>
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/915


### PR DESCRIPTION
## Summary

Add GLM-5 (FP8) benchmark configuration and script for B200 GPUs using SGLang.

## Changes

- **`.github/configs/nvidia-master.yaml`**: Add `glm5-fp8-b200-sglang` config entry using the `lmsysorg/sglang:glm5-blackwell` image and `zai-org/GLM-5-FP8` model. Sweeps across three sequence length configs (1k/1k, 1k/8k, 8k/1k) with TP8 (conc 4–32) and DEP8 with dp-attention (conc 32–128).

- **`benchmarks/single_node/glm5_fp8_b200.sh`**: New benchmark script supporting two modes:
  - **TP8 (low latency)**: Standard tensor-parallel serving
  - **DEP8 (high throughput)**: Data-parallel attention with expert parallelism
  - Uses NSA attention backend with TRT-LLM decode, FlashInfer+TRT-LLM MoE runner, BF16 KV cache, FP8 quantization, and FlashInfer allreduce fusion.

- **`perf-changelog.yaml`**: Add changelog entry for the new config.

## Key Configuration Details

| Parameter | Value |
|---|---|
| Model | `zai-org/GLM-5-FP8` |
| Image | `lmsysorg/sglang:glm5-blackwell` |
| Framework | SGLang |
| GPU | B200 |
| Precision | FP8 |
| Attention Backend | NSA (TRT-LLM decode) |
| MoE Runner | FlashInfer + TRT-LLM |
| KV Cache | BF16 |
