### PR TITLE
Fix nvidia-master.yaml metadata to align with recipe files

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -615,7 +615,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx1_gen6_tp8_batch8_eplb0_mtp3_8.yaml
@@ -630,7 +630,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx1_gen2_tp8_batch32_eplb0_mtp3_8.yaml
@@ -645,7 +645,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx1_gen6_tp8_batch8_eplb0_mtp3_48.yaml
@@ -660,7 +660,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx1_gen4_tp8_batch16_eplb0_mtp3_64.yaml
@@ -676,7 +676,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 2
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx2_gen3_dep8_batch8_eplb0_mtp3_224.yaml
@@ -691,7 +691,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 2
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx2_gen1_dep8_batch32_eplb0_mtp3_288.yaml
@@ -706,7 +706,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 4
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/mtp/ctx4_gen1_dep8_batch128_eplb0_mtp2_1088.yaml
@@ -722,8 +722,8 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
-        dp-attn: true
+        ep: 1
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen1_tp8_batch1_eplb0_mtp0_1.yaml
         - "CONFIG_FILE=recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen1_tp8_batch1_eplb0_mtp0_1.yaml"
@@ -736,7 +736,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen4_tp8_batch32_eplb0_mtp0_32.yaml
@@ -750,7 +750,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen4_tp8_batch32_eplb0_mtp0_128.yaml
@@ -764,7 +764,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen6_tp8_batch16_eplb0_mtp0_96.yaml
@@ -779,7 +779,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen1_dep8_batch128_eplb0_mtp0_128.yaml
@@ -793,7 +793,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen2_dep8_batch64_eplb0_mtp0_128.yaml
@@ -807,7 +807,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 1
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx1_gen1_dep8_batch256_eplb0_mtp0_256.yaml
@@ -821,7 +821,7 @@ dsr1-fp8-b200-dynamo-trt:
       prefill:
         num-worker: 2
         tp: 8
-        ep: 8
+        ep: 1
         dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/b200-fp8/8k1k/stp/ctx2_gen1_dep8_batch640_eplb0_mtp0_640.yaml
@@ -2111,7 +2111,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/mtp/c4_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/mtp/c4_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml"
@@ -2126,7 +2126,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/mtp/c8_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/mtp/c8_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml"
@@ -2141,7 +2141,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/mtp/c16_ctx1_gen9_tep8_batch128_eplb0_mtp3.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/mtp/c16_ctx1_gen9_tep8_batch128_eplb0_mtp3.yaml"
@@ -2156,7 +2156,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/mtp/c32_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/mtp/c32_ctx1_gen11_tep8_batch128_eplb0_mtp3.yaml"
@@ -2245,7 +2245,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/stp/c4_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/stp/c4_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml"
@@ -2259,7 +2259,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/stp/c8_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/stp/c8_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml"
@@ -2273,7 +2273,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/stp/c16_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/stp/c16_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml"
@@ -2287,7 +2287,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/stp/c32_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/stp/c32_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml"
@@ -2301,7 +2301,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: false
+        dp-attn: true
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/1k1k/stp/c64_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/1k1k/stp/c64_ctx1_gen9_tep8_batch256_eplb0_mtp0.yaml"
@@ -2437,7 +2437,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/mtp/c64_ctx1_gen1_dep8_batch32_eplb0_mtp2.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/mtp/c64_ctx1_gen1_dep8_batch32_eplb0_mtp2.yaml"
@@ -2452,7 +2452,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 2
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/mtp/c128_ctx2_gen1_dep8_batch32_eplb0_mtp2.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/mtp/c128_ctx2_gen1_dep8_batch32_eplb0_mtp2.yaml"
@@ -2467,7 +2467,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 3
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/mtp/c256_ctx3_gen1_dep8_batch32_eplb0_mtp2.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/mtp/c256_ctx3_gen1_dep8_batch32_eplb0_mtp2.yaml"
@@ -2482,7 +2482,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 3
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/mtp/c512_ctx3_gen1_dep8_batch64_eplb0_mtp1.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/mtp/c512_ctx3_gen1_dep8_batch64_eplb0_mtp1.yaml"
@@ -2567,7 +2567,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 2
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/stp/c64_ctx2_gen3_dep8_batch128_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/stp/c64_ctx2_gen3_dep8_batch128_eplb0_mtp0.yaml"
@@ -2581,7 +2581,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 1
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/stp/c128_ctx1_gen1_dep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/stp/c128_ctx1_gen1_dep8_batch256_eplb0_mtp0.yaml"
@@ -2595,7 +2595,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 5
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/stp/c256_ctx5_gen3_dep8_batch256_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/stp/c256_ctx5_gen3_dep8_batch256_eplb0_mtp0.yaml"
@@ -2609,7 +2609,7 @@ dsr1-fp8-h200-dynamo-trt:
         num-worker: 3
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
         additional-settings:
         # https://github.com/ishandhanani/srt-slurm/blob/sa-submission-q1-2026/recipes/trtllm/h200/8k1k/stp/c512_ctx3_gen1_dep8_batch512_eplb0_mtp0.yaml
         - "CONFIG_FILE=recipes/trtllm/h200/8k1k/stp/c512_ctx3_gen1_dep8_batch512_eplb0_mtp0.yaml"
@@ -3982,7 +3982,7 @@ dsr1-fp4-gb200-dynamo-trt:
         num-worker: 4
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
     - conc-list: [ 5 ]
       prefill:
         num-worker: 1
@@ -3996,7 +3996,7 @@ dsr1-fp4-gb200-dynamo-trt:
         num-worker: 4
         tp: 8
         ep: 8
-        dp-attn: true
+        dp-attn: false
     - conc-list: [ 333 ]
       prefill:
         num-worker: 2

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,17 @@
 - config-keys:
+    - dsr1-fp8-b200-dynamo-trt
+    - dsr1-fp8-h200-dynamo-trt
+    - dsr1-fp4-gb200-dynamo-trt
+  description:
+    - "Fix metadata inconsistencies in nvidia-master.yaml - TP/EP/DP-attn values now match actual recipe files"
+    - "B200 FP8 TRT 8K/1K: prefill_ep 8→1 (15 entries), prefill_dp_attn true→false (1 entry)"
+    - "H200 FP8 TRT 1K/1K: prefill_dp_attn false→true (9 entries)"
+    - "H200 FP8 TRT 8K/1K: prefill_dp_attn true→false (8 entries)"
+    - "GB200 FP4 TRT 8K/1K: decode_dp_attn true→false (2 entries)"
+    - "All fixes are metadata-only; no recipe files were modified"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/919
+
+- config-keys:
     - kimik2.5-int4-mi325x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI325X vLLM benchmark (TP8)"


### PR DESCRIPTION
Audit found 34 metadata mismatches across 412 entries in nvidia-master.yaml where declared TP/EP/DP-attn values didn't match the actual recipe files.

Fixes applied:
- B200 FP8 TRT 8K/1K: 15 prefill_ep (8->1), 1 prefill_dp_attn (true->false)
- H200 FP8 TRT: 17 prefill_dp_attn mismatches
  - 1K/1K: false->true (9 entries)
  - 8K/1K: true->false (8 entries)
- GB200 FP4 TRT 8K/1K: 2 decode_dp_attn (true->false)

All changes are metadata-only in nvidia-master.yaml to reflect actual recipe values. No recipe files were modified.
