### PR TITLE
[AMD] fix: add --exclusive to MI300X SLURM salloc for accurate benchmarks

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,12 @@
 - config-keys:
+    - gptoss-fp4-mi300x-vllm
+    - minimaxm2.5-fp8-mi300x-vllm
+  description:
+    - "Add --exclusive flag to MI300X salloc to prevent node sharing during benchmarks"
+    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+  pr-link: TBD
+
+- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - gptoss-fp4-mi300x-vllm
-    - minimaxm2.5-fp8-mi300x-vllm
-  description:
-    - "Add --exclusive flag to MI300X salloc to prevent node sharing during benchmarks"
-    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
-  pr-link: TBD
-
-- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt
@@ -1023,3 +1015,12 @@
     - "Config concurrency: 32-256"
     - "update image to vllm/vllm-openai-rocm:v0.18.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/927
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+    - minimaxm2.5-fp8-mi300x-vllm
+  description:
+    - "Add --exclusive flag to MI300X salloc to prevent node sharing during benchmarks"
+    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/930
+  

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -9,7 +9,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Summary
- Add `--exclusive` flag to `salloc` in `runners/launch_mi300x-amds.sh` to prevent node sharing during benchmarks
- Only non-TP8 configs are affected (TP8 already uses all GPUs); perf-changelog updated for `gptoss-fp4-mi300x-vllm` and `minimaxm2.5-fp8-mi300x-vllm`
- NVIDIA runners already use `--exclusive`; this brings MI300X to parity

## Test plan
- [ ] Run a non-TP8 MI300X benchmark (e.g. gptoss-fp4-mi300x-vllm TP4) and verify results are consistent with exclusive node access

🤖 Generated with [Claude Code](https://claude.com/claude-code)