### PR TITLE
[AMD] chore: add perf-changelog for MI325X --exclusive flag impact

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - gptoss-fp4-mi325x-vllm
-    - minimaxm2.5-fp8-mi325x-vllm
-  description:
-    - "Document --exclusive flag on MI325X salloc prevents node sharing during benchmarks"
-    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
-  pr-link: TBD
-
-- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt
@@ -1023,3 +1015,12 @@
     - "Config concurrency: 32-256"
     - "update image to vllm/vllm-openai-rocm:v0.18.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/927
+
+- config-keys:
+    - gptoss-fp4-mi325x-vllm
+    - minimaxm2.5-fp8-mi325x-vllm
+  description:
+    - "Document --exclusive flag on MI325X salloc prevents node sharing during benchmarks"
+    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/931
+  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1022,5 +1022,6 @@
   description:
     - "Document --exclusive flag on MI325X salloc prevents node sharing during benchmarks"
     - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+    - "May yield performance improvements"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/931
   

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,12 @@
 - config-keys:
+    - gptoss-fp4-mi325x-vllm
+    - minimaxm2.5-fp8-mi325x-vllm
+  description:
+    - "Document --exclusive flag on MI325X salloc prevents node sharing during benchmarks"
+    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+  pr-link: TBD
+
+- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt


### PR DESCRIPTION
## Summary
- MI325X runner already has `--exclusive` in its `salloc` command
- Add perf-changelog entry to document impact on non-TP8 configs (`gptoss-fp4-mi325x-vllm`, `minimaxm2.5-fp8-mi325x-vllm`)
- TP8 configs are unaffected since they already use all GPUs on the node

## Test plan
- [ ] No code changes to runners — perf-changelog documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)