### PR TITLE
[AMD] fix: add --exclusive to MI355X multi-node sbatch for accurate benchmarks

### DIFF
--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -129,6 +129,7 @@ fi
 sbatch_cmd=(
     sbatch
     --parsable
+    --exclusive
     -N "$NUM_NODES"
     -n "$NUM_NODES"
     "${NODELIST_OPT[@]}"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,21 @@
 - config-keys:
+    - dsr1-fp4-mi355x-atom
+    - dsr1-fp4-mi355x-atom-mtp
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp4-mi355x-sglang-disagg
+    - dsr1-fp4-mi355x-sglang-disagg-mtp
+    - dsr1-fp8-mi355x-sglang
+    - dsr1-fp8-mi355x-sglang-disagg
+    - dsr1-fp8-mi355x-sglang-disagg-mtp
+    - gptoss-fp4-mi355x-atom
+    - gptoss-fp4-mi355x-vllm
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Add --exclusive flag to MI355X multi-node sbatch to prevent node sharing during benchmarks"
+    - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
+  pr-link: TBD
+
+- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1007,3 +1007,10 @@
     - "EAGLE speculative decoding: num-steps 3, draft-tokens 4, topk 1"
     - "New script: benchmarks/single_node/qwen3.5_fp8_b200_mtp.sh"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/898
+
+- config-keys:
+    - "*mi355x*"
+    - "*mi325x*"
+  description:
+    - "Add --exclusive option to salloc commands on MI325X and MI355X nodes which may yield performance improvements"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/929

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -9,7 +9,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -9,7 +9,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"

--- a/runners/launch_mi325x-amd.sh
+++ b/runners/launch_mi325x-amd.sh
@@ -9,7 +9,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -159,7 +159,7 @@ else
     LOCK_FILE="${SQUASH_FILE}.lock"
 
     set -x
-    salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
+    salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -h -o %A | head -n1)
 
     srun --jobid=$JOB_ID bash -c "docker stop \$(docker ps -a -q)"


### PR DESCRIPTION
## Summary
- Add `--exclusive` flag to `sbatch` in `benchmarks/multi_node/amd_utils/submit.sh` to prevent node sharing during multi-node MI355X benchmarks
- Only non-TP8 configs are affected (TP8 already uses all GPUs); perf-changelog updated for all 11 non-TP8 MI355X configs
- Single-node MI355X `salloc` already has `--exclusive`; this brings the multi-node path to parity

## Test plan
- [ ] Run a non-TP8 MI355X multi-node disagg benchmark (e.g. dsr1-fp8-mi355x-sglang-disagg TP4) and verify results are consistent with exclusive node access

🤖 Generated with [Claude Code](https://claude.com/claude-code)