### PR TITLE
[AMD] Fix slurm command for AMD devices

### DIFF
--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -129,6 +129,7 @@ fi
 sbatch_cmd=(
     sbatch
     --parsable
+    --exclusive
     -N "$NUM_NODES"
     -n "$NUM_NODES"
     "${NODELIST_OPT[@]}"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1024,4 +1024,21 @@
     - "Only non-TP8 configs are affected; TP8 already uses all GPUs on the node"
     - "May yield performance improvements"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/931
-  
+
+- config-keys:
+    - dsr1-fp4-mi355x-atom
+    - dsr1-fp4-mi355x-atom-mtp
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp4-mi355x-sglang-disagg
+    - dsr1-fp4-mi355x-sglang-disagg-mtp
+    - dsr1-fp8-mi355x-sglang
+    - dsr1-fp8-mi355x-sglang-disagg
+    - dsr1-fp8-mi355x-sglang-disagg-mtp
+    - gptoss-fp4-mi355x-atom
+    - gptoss-fp4-mi355x-vllm
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Add --exclusive flag to MI355X single-node salloc and multi-node sbatch to prevent node sharing during benchmarks"
+    - "Only non-TP8 configs listed; TP8 already uses all GPUs on the node"
+  pr-link: TBD
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1040,5 +1040,5 @@
   description:
     - "Add --exclusive flag to MI355X single-node salloc and multi-node sbatch to prevent node sharing during benchmarks"
     - "Only non-TP8 configs listed; TP8 already uses all GPUs on the node"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/934
 

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -159,7 +159,7 @@ else
     LOCK_FILE="${SQUASH_FILE}.lock"
 
     set -x
-    salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
+    salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -h -o %A | head -n1)
 
     srun --jobid=$JOB_ID bash -c "docker stop \$(docker ps -a -q)"


### PR DESCRIPTION
> **Note:** Re-opening of #929 which was reverted.

Hi @cquil11 @functionstackx 

Motivation is AMD slurm clusters are missing **--exclusive** option and they showed regressed performance. NV slurm clusters are already using **--exclusive** option. 

without --exclusive
https://github.com/SemiAnalysisAI/InferenceX/actions/runs/23433485252
<img width="1760" height="112" alt="image" src="https://github.com/user-attachments/assets/bbbf1331-72ce-4568-8de1-72d448ff8a59" />


with --exclusive 
https://github.com/SemiAnalysisAI/InferenceX/actions/runs/23439928217
<img width="1756" height="108" alt="image" src="https://github.com/user-attachments/assets/1bca1b88-deef-40b0-949d-3f83b596a705" />


Regards, 
Seungrok 