### PR TITLE
Fix tokenizer mismatch between benchmark client and sglang server 

### DIFF
--- a/utils/bench_serving/backend_request_func.py
+++ b/utils/bench_serving/backend_request_func.py
@@ -449,6 +449,7 @@ def _fix_tokenizer_for_sglang(tokenizer, model_path):
     LlamaTokenizerFast but actually use a ByteLevel/Sequence tokenizer
     architecture, v5 incorrectly replaces the original Sequence pre_tokenizer
     with Metaspace, and the original ByteLevel decoder with Sequence.
+    See: https://github.com/sgl-project/sglang/blob/9238bd08a2895fa3b7ec79ea567e5c27ac951343/python/sglang/srt/utils/hf_transformers_utils.py#L836
 
     The sglang server applies fixes for this in hf_transformers_utils.py
     (_fix_v5_tokenizer_components and _fix_v5_add_bos_eos_token), but the

--- a/utils/bench_serving/backend_request_func.py
+++ b/utils/bench_serving/backend_request_func.py
@@ -439,6 +439,75 @@ def get_model(pretrained_model_name_or_path: str) -> str:
     return pretrained_model_name_or_path
 
 
+def _fix_tokenizer_for_sglang(tokenizer, model_path):
+    """Fix transformers v5 tokenizer to match sglang server-side behavior.
+
+    Root cause: transformers v5 (>= 5.0) changed how tokenizers are loaded.
+    Specifically, LlamaTokenizerFast.__init__ in v5 rebuilds the pre_tokenizer
+    and decoder from scratch using class-specific components, discarding the
+    originals from tokenizer.json. For models like DeepSeek-R1 that declare
+    LlamaTokenizerFast but actually use a ByteLevel/Sequence tokenizer
+    architecture, v5 incorrectly replaces the original Sequence pre_tokenizer
+    with Metaspace, and the original ByteLevel decoder with Sequence.
+
+    The sglang server applies fixes for this in hf_transformers_utils.py
+    (_fix_v5_tokenizer_components and _fix_v5_add_bos_eos_token), but the
+    benchmark client loads the tokenizer directly via AutoTokenizer without
+    these fixes. This mismatch causes the client to encode text differently
+    from the server -- e.g. a 7000-token prompt on the client becomes ~35000
+    tokens on the server, leading to ~5x TTFT inflation and false performance
+    regressions in benchmarks.
+
+    This function replicates the same fixes so the benchmark client tokenizes
+    identically to the sglang server. It is a no-op on transformers v4.
+    """
+    import json
+    from pathlib import Path
+
+    backend = getattr(tokenizer, "_tokenizer", None)
+    if backend is not None:
+        try:
+            from tokenizers import Tokenizer as RawTokenizer
+            tok_file = Path(model_path) / "tokenizer.json"
+            if tok_file.is_file():
+                raw = RawTokenizer.from_file(str(tok_file))
+                raw_pre = type(raw.pre_tokenizer).__name__ if raw.pre_tokenizer else None
+                loaded_pre = type(backend.pre_tokenizer).__name__ if backend.pre_tokenizer else None
+                if raw_pre and loaded_pre and raw_pre != loaded_pre:
+                    backend.pre_tokenizer = raw.pre_tokenizer
+                    backend.decoder = raw.decoder
+        except Exception:
+            pass
+
+    try:
+        config_file = Path(model_path) / "tokenizer_config.json"
+        if config_file.is_file():
+            with open(config_file) as f:
+                config = json.load(f)
+            tok_class = config.get("tokenizer_class", "")
+            bos_eos_classes = {
+                "LlamaTokenizer", "LlamaTokenizerFast",
+                "CodeLlamaTokenizer", "CodeLlamaTokenizerFast",
+                "GemmaTokenizer", "GemmaTokenizerFast", "CohereTokenizerFast",
+            }
+            if tok_class in bos_eos_classes:
+                defaults = {"add_bos_token": True, "add_eos_token": False}
+                changed = False
+                for attr in ("add_bos_token", "add_eos_token"):
+                    val = config.get(attr)
+                    if val is None:
+                        val = defaults.get(attr, False)
+                    if getattr(tokenizer, attr, None) != val:
+                        setattr(tokenizer, f"_{attr}", val)
+                        changed = True
+                if changed and hasattr(tokenizer, "update_post_processor"):
+                    tokenizer.update_post_processor()
+    except Exception:
+        pass
+
+    return tokenizer
+
+
 def get_tokenizer(
     pretrained_model_name_or_path: str,
     tokenizer_mode: str = "auto",
@@ -464,11 +533,12 @@ def get_tokenizer(
         return MistralTokenizer.from_pretrained(
             str(pretrained_model_name_or_path))
     else:
-        return AutoTokenizer.from_pretrained(
+        tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,
             trust_remote_code=trust_remote_code,
             **kwargs,
         )
+        return _fix_tokenizer_for_sglang(tokenizer, pretrained_model_name_or_path)
 
 
 ASYNC_REQUEST_FUNCS = {


### PR DESCRIPTION
## Summary

### Problem
When benchmarking sglang server performance with the latest sgalng (which uses transformers 5.3.0), we observed a significant performance regression compared to the older `0313-2` image (transformers 4.57.1):

- **TTFT**: 1394ms vs 482ms (~3x slower)
- **Output throughput**: 160 tok/s vs 212 tok/s (~24% drop)

### Root Cause
Transformers v5 changed how `LlamaTokenizerFast` is loaded. During `__init__`, v5 rebuilds the `pre_tokenizer` and `decoder` from scratch using Llama-specific components, discarding the originals defined in `tokenizer.json`. For models like DeepSeek-R1 that declare `LlamaTokenizerFast` but actually use a ByteLevel/Sequence tokenizer architecture, v5 incorrectly replaces:

- `pre_tokenizer`: `Sequence` → `Metaspace`
- `decoder`: `ByteLevel` → `Sequence`

The sglang server already fixes this at startup via `_fix_v5_tokenizer_components()` in `hf_transformers_utils.py`, but the benchmark client loads the tokenizer directly via `AutoTokenizer.from_pretrained()` without these fixes. This mismatch causes the client and server to tokenize text differently:

| | Client (unfixed) | Server (fixed) |
|---|---|---|
| pre_tokenizer | Metaspace | Sequence |
| 100 random tokens → text → re-encode | 102 tokens | **531 tokens** |
| 7140 token prompt | 7140 tokens | **35921 tokens** |

The ~5x token inflation on the server side results in 5x more prefill work, which directly causes the observed TTFT and throughput regression.

### Fix
Add `_fix_tokenizer_for_sglang()` to the benchmark client's `get_tokenizer()`, applying the same two fixes that sglang server applies:

1. **pre_tokenizer/decoder restoration**: Read the original components from `tokenizer.json` and overwrite the incorrect v5 replacements.
2. **add_bos_token recovery**: Restore `add_bos_token`/`add_eos_token` flags from `tokenizer_config.json` that v5 strips during loading.

This is a no-op on transformers v4.

### Results

**Token count (per request, ~7400 token input):**

| | Before fix | After fix |
|---|---|---|
| Client-side token count | 7140 | 7140 |
| Server-side prompt_tokens | 35921 (5x inflated) | 7141 (correct) |
| Prefill chunks | 3 (16384+16384+3153) | 1 (7141) |

**Benchmark (10 prompts, concurrency=1, input ~8K, output ~1K, `--disable-radix-cache`):**

| Metric | Before fix | After fix | Old image (baseline) |
|---|---|---|---|
| Output throughput (tok/s) | 160.49 | **211.71** | 212.00 |
| Mean TTFT (ms) | 1394.84 | **215.00** | 215.26 |
| Mean TPOT (ms) | 4.74 | **4.49** | 4.26 |
| Mean E2EL (ms) | 5796.15 | **4393.74** | 4387.54 |

After fix, new image performance matches old image — **no actual regression**.