### PR TITLE
[AMD/ROCm] kimik2.5 int4 mi355x: upgrade to vllm-openai-rocm:v0.18.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -294,7 +294,7 @@ glm5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.15.1
+  image: vllm/vllm-openai-rocm:v0.18.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi355x

--- a/benchmarks/single_node/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/kimik2.5_int4_mi355x.sh
@@ -30,13 +30,14 @@ PORT=${PORT:-8888}
 start_gpu_monitor
 
 set -x
+export VLLM_ROCM_USE_AITER=1
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=64 \
---disable-log-requests \
 --trust-remote-code \
+--max-num-seqs 256 \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1084,4 +1084,4 @@
     - "Enable AITER MLA, export VLLM_ROCM_USE_AITER=1, https://github.com/vllm-project/vllm/issues/35641"
     - "Triton Fused Moe Tuning https://github.com/vllm-project/vllm/pull/35093"
     - "Add --max-num-seqs 256, remove --disable-log-requests"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/950

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1076,4 +1076,12 @@
     - "Add expert parallel, TP4, and TP4/EP4 search spaces"
     - "Switch block-size 64 to 1 gpu-memory-utilization 0.95 to 0.90"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/936
-  
+
+- config-keys:
+    - kimik2.5-int4-mi355x-vllm
+  description:
+    - "Upgrade vLLM ROCm image from v0.15.1 to v0.18.0"
+    - "Enable AITER MLA, export VLLM_ROCM_USE_AITER=1, https://github.com/vllm-project/vllm/issues/35641"
+    - "Triton Fused Moe Tuning https://github.com/vllm-project/vllm/pull/35093"
+    - "Add --max-num-seqs 256, remove --disable-log-requests"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

Ports PR #909 with the resolved upstream docker image (`vllm/vllm-openai-rocm:v0.18.0`).

### Changes
- **Image upgrade**: `vllm/vllm-openai-rocm:v0.15.1` → `vllm/vllm-openai-rocm:v0.18.0` in `amd-master.yaml`
- **Enable AITER MLA**: `export VLLM_ROCM_USE_AITER=1` (ref: https://github.com/vllm-project/vllm/issues/35641)
- **Benchmark script updates**: Add `--max-num-seqs 256`, remove `--disable-log-requests`
- **perf-changelog.yaml**: Added entry documenting all changes

Supersedes #909.

CC: @seungrokj @functionstackx