### PR TITLE
[AMD] mi325x: port kimik2.5 int4 changes from mi355x PR #950

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -316,7 +316,7 @@ kimik2.5-int4-mi355x-vllm:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16.0
+  image: vllm/vllm-openai-rocm:v0.18.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi325x

--- a/benchmarks/single_node/kimik2.5_int4_mi325x.sh
+++ b/benchmarks/single_node/kimik2.5_int4_mi325x.sh
@@ -33,13 +33,14 @@ PORT=${PORT:-8888}
 start_gpu_monitor
 
 set -x
+export VLLM_ROCM_USE_AITER=1
 vllm serve $MODEL --port $PORT \
 --tensor-parallel-size=$TP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=64 \
---disable-log-requests \
 --trust-remote-code \
+--max-num-seqs 256 \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1090,6 +1090,7 @@
     - kimik2.5-int4-mi325x-vllm
   description:
     - "Upgrade vLLM ROCm image from v0.16.0 to v0.18.0"
-    - "Enable AITER MLA, export VLLM_ROCM_USE_AITER=1"
+    - "Enable AITER MLA, export VLLM_ROCM_USE_AITER=1, https://github.com/vllm-project/vllm/issues/35641"
+    - "Triton Fused Moe Tuning https://github.com/vllm-project/vllm/pull/35093"
     - "Add --max-num-seqs 256, remove --disable-log-requests"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/957

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1085,3 +1085,11 @@
     - "Triton Fused Moe Tuning https://github.com/vllm-project/vllm/pull/35093"
     - "Add --max-num-seqs 256, remove --disable-log-requests"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/950
+
+- config-keys:
+    - kimik2.5-int4-mi325x-vllm
+  description:
+    - "Upgrade vLLM ROCm image from v0.16.0 to v0.18.0"
+    - "Enable AITER MLA, export VLLM_ROCM_USE_AITER=1"
+    - "Add --max-num-seqs 256, remove --disable-log-requests"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
Closes #954

Ports the mi355x int4 changes from PR #950 to mi325x:
- Upgrade vLLM ROCm image from v0.16.0 to v0.18.0
- Enable AITER MLA (export VLLM_ROCM_USE_AITER=1)
- Add --max-num-seqs 256
- Remove --disable-log-requests

Generated with [Claude Code](https://claude.ai/code)