### PR TITLE
[NVIDIA] chore: update gptoss H100 & H200 vLLM image to v0.18.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3222,7 +3222,7 @@ minimaxm2.5-fp8-b200-vllm:
     - { tp: 4, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-h100-vllm:
-  image: vllm/vllm-openai:v0.15.1
+  image: vllm/vllm-openai:v0.18.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h100
@@ -3501,7 +3501,7 @@ gptoss-fp4-h200-trt:
     - { tp: 8, ep: 8, dp-attn: false, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-h200-vllm:
-  image: vllm/vllm-openai:v0.15.1
+  image: vllm/vllm-openai:v0.18.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h200

--- a/benchmarks/single_node/gptoss_fp4_h100.sh
+++ b/benchmarks/single_node/gptoss_fp4_h100.sh
@@ -37,8 +37,7 @@ vllm serve $MODEL --host=0.0.0.0 --port=$PORT \
 --config config.yaml \
 --gpu-memory-utilization=0.9 \
 --tensor-parallel-size=$TP \
---max-num-seqs=$CONC  \
---disable-log-requests > $SERVER_LOG 2>&1 &
+--max-num-seqs=$CONC > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_h200.sh
+++ b/benchmarks/single_node/gptoss_fp4_h200.sh
@@ -50,8 +50,7 @@ PYTHONNOUSERSITE=1 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
  --config config.yaml \
  --gpu-memory-utilization 0.9 \
  --tensor-parallel-size $TP \
- --max-num-seqs $CONC  \
- --disable-log-requests > $SERVER_LOG 2>&1 &
+ --max-num-seqs $CONC > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,11 @@
 - config-keys:
+    - gptoss-fp4-h100-vllm
+    - gptoss-fp4-h200-vllm
+  description:
+    - "Update vLLM image from v0.15.1 to v0.18.0 for gptoss H100 and H200 configs"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+
+- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,11 +1,4 @@
 - config-keys:
-    - gptoss-fp4-h100-vllm
-    - gptoss-fp4-h200-vllm
-  description:
-    - "Update vLLM image from v0.15.1 to v0.18.0 for gptoss H100 and H200 configs"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-
-- config-keys:
     - dsr1-fp8-b200-dynamo-trt
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp4-gb200-dynamo-trt
@@ -1092,3 +1085,10 @@
     - "Triton Fused Moe Tuning https://github.com/vllm-project/vllm/pull/35093"
     - "Add --max-num-seqs 256, remove --disable-log-requests"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/950
+
+- config-keys:
+    - gptoss-fp4-h100-vllm
+    - gptoss-fp4-h200-vllm
+  description:
+    - "Update vLLM image from v0.15.1 to v0.18.0 for gptoss H100 and H200 configs"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/960


### PR DESCRIPTION
Update vLLM image from `v0.15.1` to `v0.18.0` for `gptoss-fp4-h100-vllm` and `gptoss-fp4-h200-vllm` configs.

Closes #956

Generated with [Claude Code](https://claude.ai/code)