### PR TITLE
[NVIDIA] Disable prefix caching for MiniMax M2.5 vLLM benchmarks

### DIFF
--- a/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b200.sh
@@ -43,6 +43,7 @@ $EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
+--no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_h100.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h100.sh
@@ -42,6 +42,7 @@ $EP \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs 256 \
+--no-enable-prefix-caching \
 --trust-remote-code \
 --compilation-config '{"cudagraph_mode":"PIECEWISE"}' > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_h200.sh
@@ -37,6 +37,7 @@ vllm serve $MODEL --port $PORT \
 $EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
+--no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi300x.sh
@@ -38,6 +38,7 @@ vllm serve $MODEL --port $PORT \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
 --disable-log-requests \
+--no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi325x.sh
@@ -40,6 +40,7 @@ vllm serve $MODEL --port $PORT \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
 --disable-log-requests \
+--no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -45,6 +45,7 @@ $EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
+--no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!


### PR DESCRIPTION
## Summary
- Add `--no-enable-prefix-caching` to all 6 MiniMax M2.5 vLLM benchmark scripts
- Prefix caching is unnecessary for benchmarks using random datasets (zero cache hits, pure overhead)
- Follows the same pattern applied to Kimi K2.5 and GPT-OSS scripts in #937

## Test plan
- [ ] Verify MiniMax M2.5 benchmarks run correctly with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)