### PR TITLE
[AMD] Disable prefix caching for qwen3.5 & glm5 AMD benchmarks

### DIFF
--- a/benchmarks/single_node/glm5_fp8_mi355x.sh
+++ b/benchmarks/single_node/glm5_fp8_mi355x.sh
@@ -44,7 +44,8 @@ python3 -m sglang.launch_server \
     --mem-fraction-static 0.85 \
     --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
     --nsa-prefill-backend tilelang \
-    --nsa-decode-backend tilelang > $SERVER_LOG 2>&1 &
+    --nsa-decode-backend tilelang \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
@@ -31,7 +31,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
@@ -31,7 +31,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_bf16_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi355x.sh
@@ -30,7 +30,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
@@ -32,7 +32,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
@@ -32,7 +32,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
@@ -30,7 +30,8 @@ python3 -m sglang.launch_server \
     --port $PORT \
     --tensor-parallel-size $TP \
     --trust-remote-code \
-    --mem-fraction-static 0.8 > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 


### PR DESCRIPTION
Disable prefix caching (radix cache) for qwen3.5 and glm5 AMD benchmark scripts by adding `--disable-radix-cache` to SGLang server launch commands.

Files changed:
- qwen3.5_bf16_mi300x.sh
- qwen3.5_bf16_mi325x.sh
- qwen3.5_bf16_mi355x.sh
- qwen3.5_fp8_mi300x.sh
- qwen3.5_fp8_mi325x.sh
- qwen3.5_fp8_mi355x.sh
- glm5_fp8_mi355x.sh

Closes #968

Generated with [Claude Code](https://claude.ai/code)