### PR TITLE
[NVIDIA] Add GLM-5 NVFP4 B200 TP8 SGLang benchmark (conc 4-64)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1808,7 +1808,7 @@ glm5-fp8-b200-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
 
 glm5-nvfp4-b200-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260305-33c92732
+  image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1807,6 +1807,24 @@ glm5-fp8-b200-sglang:
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
 
+glm5-nvfp4-b200-sglang:
+  image: lmsysorg/sglang:nightly-dev-cu13-20260305-33c92732
+  model: nvidia/GLM-5-NVFP4
+  model-prefix: glm5
+  runner: b200
+  precision: nvfp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/glm5_nvfp4_b200.sh
+++ b/benchmarks/single_node/glm5_nvfp4_b200.sh
@@ -33,6 +33,10 @@ fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
+# following https://huggingface.co/nvidia/GLM-5-NVFP4#usage recipe
+# except using latest nightly at the time of writing
+# since the recommended nightly image in that recipe doesn't exist.
+
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \

--- a/benchmarks/single_node/glm5_nvfp4_b200.sh
+++ b/benchmarks/single_node/glm5_nvfp4_b200.sh
@@ -20,8 +20,6 @@ nvidia-smi
 
 hf download "$MODEL"
 
-pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
-
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 

--- a/benchmarks/single_node/glm5_nvfp4_b200.sh
+++ b/benchmarks/single_node/glm5_nvfp4_b200.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+echo "EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+--data-parallel-size 1 --expert-parallel-size 1 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
+--quantization modelopt_fp4 \
+--cuda-graph-max-bs $CONC --max-running-requests $CONC \
+--mem-fraction-static 0.80 \
+--chunked-prefill-size 131072 \
+--stream-interval 30 \
+--model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,12 @@
 - config-keys:
+    - glm5-nvfp4-b200-sglang
+  description:
+    - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
+    - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
+    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260305-33c92732"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+
+- config-keys:
     - minimaxm2.5-fp8-h100-vllm
     - minimaxm2.5-fp8-h200-vllm
   description:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3,7 +3,7 @@
   description:
     - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
     - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
-    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260305-33c92732"
+    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
 
 - config-keys:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - glm5-nvfp4-b200-sglang
-  description:
-    - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
-    - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
-    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-
-- config-keys:
     - minimaxm2.5-fp8-h100-vllm
     - minimaxm2.5-fp8-h200-vllm
   description:
@@ -1213,3 +1205,11 @@
   description:
     - "Add --disable-radix-cache to SGLang server launch command for qwen3.5 MI300X and MI325X benchmark scripts"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/970
+
+- config-keys:
+    - glm5-nvfp4-b200-sglang
+  description:
+    - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
+    - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
+    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/973


### PR DESCRIPTION
Add GLM-5 NVFP4 single-node B200 SGLang benchmark with modelopt_fp4 quantization.

following https://huggingface.co/nvidia/GLM-5-NVFP4 recipe

Closes #972

Generated with [Claude Code](https://claude.ai/claude-code)