### PR TITLE
[AMD][MI30X]Update Qwen3.5 perf

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -132,7 +132,7 @@ qwen3.5-bf16-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-bf16-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi300x
@@ -150,7 +150,7 @@ qwen3.5-bf16-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-bf16-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi325x
@@ -168,7 +168,7 @@ qwen3.5-bf16-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi325x
@@ -204,7 +204,7 @@ qwen3.5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi300x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -132,7 +132,7 @@ qwen3.5-bf16-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-bf16-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi300x
@@ -150,7 +150,7 @@ qwen3.5-bf16-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-bf16-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi325x
@@ -168,7 +168,7 @@ qwen3.5-bf16-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi325x
@@ -204,7 +204,7 @@ qwen3.5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi300x

--- a/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
@@ -33,7 +33,7 @@ start_gpu_monitor
 
 # following Andy Luo linkedin's recipe https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \

--- a/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
@@ -19,11 +19,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -35,9 +38,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 \
-    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi300x.sh
@@ -38,7 +38,6 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
-    --ep-size $EP_SIZE \
     --data-parallel-size 1 \
     --trust-remote-code \
     --tokenizer-worker-num 6 \

--- a/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
@@ -33,7 +33,7 @@ start_gpu_monitor
 
 # following Andy Luo linkedin's recipe https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \

--- a/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
@@ -19,11 +19,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -35,9 +38,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 \
-    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi325x.sh
@@ -38,7 +38,6 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
-    --ep-size $EP_SIZE \
     --data-parallel-size 1 \
     --trust-remote-code \
     --tokenizer-worker-num 6 \

--- a/benchmarks/single_node/qwen3.5_bf16_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi355x.sh
@@ -9,7 +9,8 @@ check_env_vars \
     ISL \
     OSL \
     RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+    RESULT_FILENAME \
+    EP_SIZE
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -19,11 +20,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -34,8 +38,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
@@ -34,7 +34,7 @@ start_gpu_monitor
 # following AMD Andy linkedin's recipe
 # https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \

--- a/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
@@ -19,11 +19,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -36,9 +39,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 \
-    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi300x.sh
@@ -39,7 +39,6 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
-    --ep-size $EP_SIZE \
     --data-parallel-size 1 \
     --trust-remote-code \
     --tokenizer-worker-num 6 \

--- a/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
@@ -34,7 +34,7 @@ start_gpu_monitor
 # following AMD Andy linkedin's recipe
 # https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \

--- a/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
@@ -19,11 +19,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -36,9 +39,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 \
-    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi325x.sh
@@ -39,7 +39,6 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
-    --ep-size $EP_SIZE \
     --data-parallel-size 1 \
     --trust-remote-code \
     --tokenizer-worker-num 6 \

--- a/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi355x.sh
@@ -9,7 +9,8 @@ check_env_vars \
     ISL \
     OSL \
     RANDOM_RANGE_RATIO \
-    RESULT_FILENAME
+    RESULT_FILENAME \
+    EP_SIZE
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -19,11 +20,14 @@ hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -34,8 +38,16 @@ python3 -m sglang.launch_server \
     --host=0.0.0.0 \
     --port $PORT \
     --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --data-parallel-size 1 \
     --trust-remote-code \
-    --mem-fraction-static 0.8 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1307,3 +1307,13 @@
     - "Model: nvidia/Qwen3.5-397B-A17B-NVFP4"
     - "Configs: 1k1k (TP4 conc 4-128), 8k1k (TP4 conc 4-128)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/820
+
+- config-keys:
+    - qwen3.5-bf16-mi300x-sglang
+    - qwen3.5-bf16-mi325x-sglang
+    - qwen3.5-fp8-mi300x-sglang
+    - qwen3.5-fp8-mi325x-sglang
+  description:
+    - "Update cli args of Qwen3.5 FP8 and BF16 SGLang benchmarks for MI300X and  MI325X to achieve better performance"
+    - "Use lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xx

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1315,5 +1315,5 @@
     - qwen3.5-fp8-mi325x-sglang
   description:
     - "Update cli args of Qwen3.5 FP8 and BF16 SGLang benchmarks for MI300X and  MI325X to achieve better performance"
-    - "Use lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x"
+    - "Use lmsysorg/sglang:v0.5.10-rocm720-mi30x"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/986

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1316,4 +1316,4 @@
   description:
     - "Update cli args of Qwen3.5 FP8 and BF16 SGLang benchmarks for MI300X and  MI325X to achieve better performance"
     - "Use lmsysorg/sglang:v0.5.10rc0-rocm720-mi30x"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xx
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/986


### PR DESCRIPTION
- Added new config keys for Qwen3.5 BF16 and FP8 benchmarks on MI300X and MI325X.
- Updated Docker image to lmsysorg/sglang:v0.5.10-rocm720-mi30x for better compatibility.
- Enhanced benchmark scripts with additional parameters for context length and prefill tokens.
- Adjusted memory fraction settings and added new flags for server launch to optimize performance.

e2e Test: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24170176668

Co-Authored-by: @chunfangamd  @1am9trash