### PR TITLE
[AMD/ROCM] ATOM support for new models: Kimi-K2.5 FP4 and MiniMax-M2.5

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -12,6 +12,10 @@ dsr1-fp4-mi355x-sglang:
     search-space:
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -31,6 +35,11 @@ dsr1-fp4-mi355x-atom:
     search-space:
     - { tp: 4, ep: 1, conc-start: 32, conc-end: 256 }
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 4, ep: 1, conc-start: 128, conc-end: 256 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -52,6 +61,11 @@ dsr1-fp4-mi355x-atom-mtp:
     search-space:
     - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
     - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    # - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+    - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
   - isl: 8192
     osl: 1024
     search-space:
@@ -69,6 +83,10 @@ dsr1-fp8-mi300x-sglang:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -89,6 +107,10 @@ dsr1-fp8-mi325x-sglang:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -105,6 +127,10 @@ dsr1-fp8-mi355x-sglang:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -126,6 +152,10 @@ qwen3.5-bf16-mi355x-sglang:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -142,6 +172,10 @@ qwen3.5-bf16-mi300x-sglang:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -162,6 +196,10 @@ qwen3.5-bf16-mi325x-sglang:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -178,6 +216,10 @@ qwen3.5-fp8-mi325x-sglang:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -198,6 +240,10 @@ qwen3.5-fp8-mi355x-sglang:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -214,6 +260,10 @@ qwen3.5-fp8-mi300x-sglang:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -234,10 +284,36 @@ glm5-fp8-mi355x-sglang:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
+
+glm5-fp8-mi355x-atom:
+  image: TBD
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: mi355x
+  precision: fp8
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
 
 kimik2.5-int4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.18.0
@@ -250,6 +326,10 @@ kimik2.5-int4-mi355x-vllm:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -270,22 +350,8 @@ kimik2.5-int4-mi325x-vllm:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
-  - isl: 8192
-    osl: 1024
-    search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
-
-kimik2.5-int4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.18.0
-  model: moonshotai/Kimi-K2.5
-  model-prefix: kimik2.5
-  runner: mi300x
-  precision: int4
-  framework: vllm
-  multinode: false
-  seq-len-configs:
   - isl: 1024
-    osl: 1024
+    osl: 8192
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
@@ -307,11 +373,42 @@ kimik2.5-fp4-mi355x-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
+
+kimik2.5-fp4-mi355x-atom:
+  image: TBD
+  model: amd/Kimi-K2.5-MXFP4
+  model-prefix: kimik2.5
+  runner: mi355x
+  precision: fp4
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
 
 minimaxm2.5-fp8-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.18.0
@@ -328,11 +425,45 @@ minimaxm2.5-fp8-mi355x-vllm:
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
+
+minimaxm2.5-fp8-mi355x-atom:
+  image: TBD
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp8
+  framework: atom
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
     - { tp: 8, ep: 8, conc-start: 32, conc-end: 256 }
 
 minimaxm2.5-fp8-mi300x-vllm:
@@ -349,6 +480,11 @@ minimaxm2.5-fp8-mi300x-vllm:
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -356,7 +492,7 @@ minimaxm2.5-fp8-mi300x-vllm:
     - { tp: 4, conc-start: 4, conc-end: 64 }
 
 minimaxm2.5-fp8-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.18.0
+  image: vllm/vllm-openai-rocm:v0.16.0
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: mi325x
@@ -368,12 +504,17 @@ minimaxm2.5-fp8-mi325x-vllm:
     osl: 1024
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 64 }
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 64 }
-    - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
 
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.17.0
@@ -386,6 +527,13 @@ gptoss-fp4-mi300x-vllm:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 1, conc-start: 64, conc-end: 64 }
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 16 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 1, conc-start: 64, conc-end: 64 }
     - { tp: 2, conc-start: 4, conc-end: 64 }
@@ -415,6 +563,13 @@ gptoss-fp4-mi325x-vllm:
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 1, conc-start: 64, conc-end: 64 }
+    - { tp: 2, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 64, conc-end: 64 }
+    - { tp: 8, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -434,6 +589,12 @@ gptoss-fp4-mi355x-vllm:
   seq-len-configs:
   - isl: 1024
     osl: 1024
+    search-space:
+    - { tp: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 4, conc-start: 4, conc-end: 8 }
+    - { tp: 8, conc-start: 4, conc-end: 16 }
+  - isl: 1024
+    osl: 8192
     search-space:
     - { tp: 1, conc-start: 4, conc-end: 128 }
     - { tp: 4, conc-start: 4, conc-end: 8 }
@@ -459,6 +620,11 @@ gptoss-fp4-mi355x-atom:
     search-space:
     - { tp: 1, conc-start: 16, conc-end: 128 }
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 1, conc-start: 16, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
@@ -479,17 +645,22 @@ dsr1-fp8-mi355x-atom:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 128 }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 128 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 128 }
 
 dsr1-fp8-mi355x-atom-mtp:
-  image: rocm/atom:rocm7.2.1-ubuntu24.04-pytorch2.9.1-atom0.1.2
+  image: rocm/atom:rocm7.2.0-ubuntu24.04-pytorch2.9-atom0.1.1
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x
   precision: fp8
+  # WIP framwork (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:
@@ -497,6 +668,10 @@ dsr1-fp8-mi355x-atom-mtp:
     osl: 1024
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+  - isl: 1024
+    osl: 8192
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp  }
   - isl: 8192
     osl: 1024
     search-space:
@@ -810,6 +985,129 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
         additional-settings:
         - "DECODE_NODES=1"
         - "DECODE_MTP_SIZE=2"
+
+  # FIXME(billishyahao): disable 1k8k for now
+  # - isl: 1024
+  #   osl: 8192
+  #   search-space:
+  #   # MTP configurations
+  #   # "Top of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=1"
+
+
+  #   # "Middle of curve" (1 prefill worker at DEP8 and 2 decode workers each at DEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=1"
+
+
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=1"
+
+  #   # non-MTP configurations
+  #   # "Top of curve" (1 prefill workers each at DEP8 and 1 decode workers at DEP16)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 2048 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 16
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Middle of curve" (1 prefill workers each at DEP8 and 2 decode workers at DEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 256, 512, 1024 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 1
+  #       ep: 8
+  #       dp-attn: true
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
+
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
 
 
 dsr1-fp4-mi355x-sglang-disagg:
@@ -1229,4 +1527,50 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
         additional-settings:
         - "DECODE_NODES=1"
         - "DECODE_MTP_SIZE=1"
+
+
+  # FIXME(billishyahao): disable FP4 1k8k for now
+  # - isl: 1024
+  #   osl: 8192
+  #   search-space:
+  #   # MTP configurations
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "mtp"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=1"
+
+  #   # non-MTP configurations
+  #   # "Bottom of curve" (1 prefill worker at TEP8 and 2 decode workers at TEP8)
+  #   - spec-decoding: "none"
+  #     conc-list: [ 32, 64, 128 ]
+  #     prefill:
+  #       num-worker: 1
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "PREFILL_NODES=1"
+  #     decode:
+  #       num-worker: 2
+  #       tp: 8
+  #       ep: 8
+  #       dp-attn: false
+  #       additional-settings:
+  #       - "DECODE_NODES=2"
+  #       - "DECODE_MTP_SIZE=0"
 

--- a/benchmarks/single_node/glm5_fp8_mi355x_atom.sh
+++ b/benchmarks/single_node/glm5_fp8_mi355x_atom.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE \
+    DP_ATTENTION
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+export OMP_NUM_THREADS=1
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN $EP \
+    --trust-remote-code \
+    > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+export PYTHONDONTWRITEBYTECODE=1
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/kimik2.5_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/kimik2.5_fp4_mi355x_atom.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE \
+    DP_ATTENTION
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+export OMP_NUM_THREADS=1
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN $EP \
+    --trust-remote-code \
+    > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+export PYTHONDONTWRITEBYTECODE=1
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x_atom.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x_atom.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE \
+    DP_ATTENTION
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+export OMP_NUM_THREADS=1
+
+# Calculate max-model-len based on ISL and OSL
+if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
+    CALCULATED_MAX_MODEL_LEN=""
+else
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
+fi
+
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN $EP \
+    --trust-remote-code \
+    > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+export PYTHONDONTWRITEBYTECODE=1
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT" --concurrent-requests $CONC
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - kimik2.5-fp4-mi355x-atom
-    - minimaxm2.5-fp8-mi355x-atom
-  description:
-    - "ATOM support for Kimi-K2.5 FP4 and MiniMax-M2.5 FP8 on MI355X"
-    - "Uses ATOM framework with rocm7.2.0-ubuntu24.04-pytorch2.9-atom0.1.1 image"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/989
-
-- config-keys:
     - kimik2.5-int4-mi300x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"
@@ -1235,3 +1227,12 @@
     - "DeepSeek R1 MI355X FP8 ATOM-MTP config to support MTP 3 tokens"
     - "Image: rocm/atom:rocm7.2.1-ubuntu24.04-pytorch2.9.1-atom0.1.2"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/984
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-atom
+    - minimaxm2.5-fp8-mi355x-atom
+  description:
+    - "ATOM support for Kimi-K2.5 FP4 and MiniMax-M2.5 FP8 on MI355X"
+    - "Uses ATOM framework with rocm7.2.0-ubuntu24.04-pytorch2.9-atom0.1.1 image"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/989
+  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,19 @@
 - config-keys:
+    - kimik2.5-fp4-mi355x-atom
+    - minimaxm2.5-fp8-mi355x-atom
+  description:
+    - "ATOM support for Kimi-K2.5 FP4 and MiniMax-M2.5 FP8 on MI355X"
+    - "Uses ATOM framework with rocm7.2.0-ubuntu24.04-pytorch2.9-atom0.1.1 image"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/989
+
+- config-keys:
+    - kimik2.5-int4-mi300x-vllm
+  description:
+    - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"
+    - "Uses vLLM ROCm v0.18.0 image following AMD Andy Luo's recipe"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+
+- config-keys:
     - minimaxm2.5-fp8-h100-vllm
     - minimaxm2.5-fp8-h200-vllm
   description:
@@ -999,7 +1014,7 @@
     - "Benchmark script: benchmarks/single_node/glm5_fp8_h200.sh"
     - "Tool-call-parser glm47, reasoning-parser glm45, mem-fraction-static 0.85"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/914
-  
+
 - config-keys:
     - glm5-fp8-b200-sglang
   description:
@@ -1074,6 +1089,13 @@
     - "dsr1-fp8-b200-sglang-mtp: v0.5.8-cu130-amd64 → v0.5.9-cu130"
     - "dsr1-fp8-h200-sglang: v0.5.9-cu129-amd64 → v0.5.9-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/943
+  
+- config-keys:
+    - minimaxm2.5-fp8-mi325x-vllm
+  description:
+    - "Upgrade vLLM ROCm image from v0.16.0 to v0.18.0"
+    - "Replace TP4 with TP8/EP8, add conc range 4-256"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/953
 
 - config-keys:
     - kimik2.5-fp4-mi355x-vllm
@@ -1110,10 +1132,106 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/960
 
 - config-keys:
-    - kimik2.5-fp4-mi355x-atom
-    - glm5-fp8-mi355x-atom
-    - minimaxm2.5-fp8-mi355x-atom
+    - kimik2.5-int4-mi325x-vllm
+    - kimik2.5-int4-mi355x-vllm
+    - kimik2.5-int4-h200-vllm
+    - kimik2.5-fp4-mi355x-vllm
+    - kimik2.5-fp4-b200-vllm
   description:
-    - "New model support on ATOM framework"
-    - "Kimi-K2.5 FP4, GLM-5 FP8, and MiniMax-M2.5 FP8 configs added for MI355X ATOM"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/963
+    - "Disable prefix caching (--no-enable-prefix-caching) for all Kimi K2.5 benchmarks using random datasets"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/926
+
+- config-keys:
+    - minimaxm2.5-fp8-b200-vllm
+    - minimaxm2.5-fp8-h100-vllm
+    - minimaxm2.5-fp8-h200-vllm
+    - minimaxm2.5-fp8-mi300x-vllm
+    - minimaxm2.5-fp8-mi325x-vllm
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Disable prefix caching (--no-enable-prefix-caching) for all MiniMax benchmarks using random datasets"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/966
+  
+- config-keys:
+    # NVIDIA single-node
+    - dsr1-fp4-b200-sglang
+    - dsr1-fp4-b200-trt
+    - dsr1-fp4-b200-trt-mtp
+    - dsr1-fp8-b200-sglang
+    - dsr1-fp8-b200-sglang-mtp
+    - dsr1-fp8-b200-trt
+    - dsr1-fp8-b200-trt-mtp
+    - dsr1-fp8-h200-sglang
+    - dsr1-fp8-h200-trt
+    - dsr1-fp8-h200-trt-mtp
+    - glm5-fp8-b200-sglang
+    - glm5-fp8-h200-sglang
+    - gptoss-fp4-b200-trt
+    - gptoss-fp4-b200-vllm
+    - gptoss-fp4-h100-vllm
+    - gptoss-fp4-h200-trt
+    - gptoss-fp4-h200-vllm
+    - kimik2.5-fp4-b200-vllm
+    - kimik2.5-int4-b200-vllm
+    - kimik2.5-int4-h200-vllm
+    - minimaxm2.5-fp8-b200-vllm
+    - minimaxm2.5-fp8-h100-vllm
+    - minimaxm2.5-fp8-h200-vllm
+    - qwen3.5-bf16-b200-sglang
+    - qwen3.5-fp8-b200-sglang
+    - qwen3.5-fp8-b200-sglang-mtp
+    - qwen3.5-fp8-h200-sglang
+    # AMD single-node
+    - dsr1-fp4-mi355x-atom
+    - dsr1-fp4-mi355x-atom-mtp
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp8-mi325x-sglang
+    - dsr1-fp8-mi300x-sglang
+    - dsr1-fp8-mi355x-atom
+    - dsr1-fp8-mi355x-atom-mtp
+    - dsr1-fp8-mi355x-sglang
+    - glm5-fp8-mi355x-sglang
+    - gptoss-fp4-mi300x-vllm
+    - gptoss-fp4-mi325x-vllm
+    - gptoss-fp4-mi355x-atom
+    - gptoss-fp4-mi355x-vllm
+    - kimik2.5-fp4-mi355x-vllm
+    - kimik2.5-int4-mi325x-vllm
+    - kimik2.5-int4-mi355x-vllm
+    - minimaxm2.5-fp8-mi300x-vllm
+    - minimaxm2.5-fp8-mi325x-vllm
+    - minimaxm2.5-fp8-mi355x-vllm
+    - qwen3.5-bf16-mi300x-sglang
+    - qwen3.5-bf16-mi325x-sglang
+    - qwen3.5-bf16-mi355x-sglang
+    - qwen3.5-fp8-mi300x-sglang
+    - qwen3.5-fp8-mi325x-sglang
+    - qwen3.5-fp8-mi355x-sglang
+  description:
+    - "Separate evals, change to 8k1k, fail loudly, 5-shot, top of curve & middle of curve"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/911
+  evals-only: true
+
+- config-keys:
+    - qwen3.5-bf16-mi300x-sglang
+    - qwen3.5-bf16-mi325x-sglang
+    - qwen3.5-fp8-mi300x-sglang
+    - qwen3.5-fp8-mi325x-sglang
+  description:
+    - "Add --disable-radix-cache to SGLang server launch command for qwen3.5 MI300X and MI325X benchmark scripts"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/970
+
+- config-keys:
+    - glm5-nvfp4-b200-sglang
+  description:
+    - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
+    - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
+    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/973
+
+- config-keys:
+    - dsr1-fp8-mi355x-atom-mtp
+  description:
+    - "DeepSeek R1 MI355X FP8 ATOM-MTP config to support MTP 3 tokens"
+    - "Image: rocm/atom:rocm7.2.1-ubuntu24.04-pytorch2.9.1-atom0.1.2"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/984

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,11 +1,4 @@
 - config-keys:
-    - kimik2.5-int4-mi300x-vllm
-  description:
-    - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"
-    - "Uses vLLM ROCm v0.18.0 image following AMD Andy Luo's recipe"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-
-- config-keys:
     - minimaxm2.5-fp8-h100-vllm
     - minimaxm2.5-fp8-h200-vllm
   description:
@@ -1006,7 +999,7 @@
     - "Benchmark script: benchmarks/single_node/glm5_fp8_h200.sh"
     - "Tool-call-parser glm47, reasoning-parser glm45, mem-fraction-static 0.85"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/914
-
+  
 - config-keys:
     - glm5-fp8-b200-sglang
   description:
@@ -1081,13 +1074,6 @@
     - "dsr1-fp8-b200-sglang-mtp: v0.5.8-cu130-amd64 → v0.5.9-cu130"
     - "dsr1-fp8-h200-sglang: v0.5.9-cu129-amd64 → v0.5.9-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/943
-  
-- config-keys:
-    - minimaxm2.5-fp8-mi325x-vllm
-  description:
-    - "Upgrade vLLM ROCm image from v0.16.0 to v0.18.0"
-    - "Replace TP4 with TP8/EP8, add conc range 4-256"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/953
 
 - config-keys:
     - kimik2.5-fp4-mi355x-vllm
@@ -1124,106 +1110,10 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/960
 
 - config-keys:
-    - kimik2.5-int4-mi325x-vllm
-    - kimik2.5-int4-mi355x-vllm
-    - kimik2.5-int4-h200-vllm
-    - kimik2.5-fp4-mi355x-vllm
-    - kimik2.5-fp4-b200-vllm
+    - kimik2.5-fp4-mi355x-atom
+    - glm5-fp8-mi355x-atom
+    - minimaxm2.5-fp8-mi355x-atom
   description:
-    - "Disable prefix caching (--no-enable-prefix-caching) for all Kimi K2.5 benchmarks using random datasets"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/926
-
-- config-keys:
-    - minimaxm2.5-fp8-b200-vllm
-    - minimaxm2.5-fp8-h100-vllm
-    - minimaxm2.5-fp8-h200-vllm
-    - minimaxm2.5-fp8-mi300x-vllm
-    - minimaxm2.5-fp8-mi325x-vllm
-    - minimaxm2.5-fp8-mi355x-vllm
-  description:
-    - "Disable prefix caching (--no-enable-prefix-caching) for all MiniMax benchmarks using random datasets"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/966
-  
-- config-keys:
-    # NVIDIA single-node
-    - dsr1-fp4-b200-sglang
-    - dsr1-fp4-b200-trt
-    - dsr1-fp4-b200-trt-mtp
-    - dsr1-fp8-b200-sglang
-    - dsr1-fp8-b200-sglang-mtp
-    - dsr1-fp8-b200-trt
-    - dsr1-fp8-b200-trt-mtp
-    - dsr1-fp8-h200-sglang
-    - dsr1-fp8-h200-trt
-    - dsr1-fp8-h200-trt-mtp
-    - glm5-fp8-b200-sglang
-    - glm5-fp8-h200-sglang
-    - gptoss-fp4-b200-trt
-    - gptoss-fp4-b200-vllm
-    - gptoss-fp4-h100-vllm
-    - gptoss-fp4-h200-trt
-    - gptoss-fp4-h200-vllm
-    - kimik2.5-fp4-b200-vllm
-    - kimik2.5-int4-b200-vllm
-    - kimik2.5-int4-h200-vllm
-    - minimaxm2.5-fp8-b200-vllm
-    - minimaxm2.5-fp8-h100-vllm
-    - minimaxm2.5-fp8-h200-vllm
-    - qwen3.5-bf16-b200-sglang
-    - qwen3.5-fp8-b200-sglang
-    - qwen3.5-fp8-b200-sglang-mtp
-    - qwen3.5-fp8-h200-sglang
-    # AMD single-node
-    - dsr1-fp4-mi355x-atom
-    - dsr1-fp4-mi355x-atom-mtp
-    - dsr1-fp4-mi355x-sglang
-    - dsr1-fp8-mi325x-sglang
-    - dsr1-fp8-mi300x-sglang
-    - dsr1-fp8-mi355x-atom
-    - dsr1-fp8-mi355x-atom-mtp
-    - dsr1-fp8-mi355x-sglang
-    - glm5-fp8-mi355x-sglang
-    - gptoss-fp4-mi300x-vllm
-    - gptoss-fp4-mi325x-vllm
-    - gptoss-fp4-mi355x-atom
-    - gptoss-fp4-mi355x-vllm
-    - kimik2.5-fp4-mi355x-vllm
-    - kimik2.5-int4-mi325x-vllm
-    - kimik2.5-int4-mi355x-vllm
-    - minimaxm2.5-fp8-mi300x-vllm
-    - minimaxm2.5-fp8-mi325x-vllm
-    - minimaxm2.5-fp8-mi355x-vllm
-    - qwen3.5-bf16-mi300x-sglang
-    - qwen3.5-bf16-mi325x-sglang
-    - qwen3.5-bf16-mi355x-sglang
-    - qwen3.5-fp8-mi300x-sglang
-    - qwen3.5-fp8-mi325x-sglang
-    - qwen3.5-fp8-mi355x-sglang
-  description:
-    - "Separate evals, change to 8k1k, fail loudly, 5-shot, top of curve & middle of curve"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/911
-  evals-only: true
-
-- config-keys:
-    - qwen3.5-bf16-mi300x-sglang
-    - qwen3.5-bf16-mi325x-sglang
-    - qwen3.5-fp8-mi300x-sglang
-    - qwen3.5-fp8-mi325x-sglang
-  description:
-    - "Add --disable-radix-cache to SGLang server launch command for qwen3.5 MI300X and MI325X benchmark scripts"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/970
-
-- config-keys:
-    - glm5-nvfp4-b200-sglang
-  description:
-    - "Add GLM-5 NVFP4 single-node B200 SGLang benchmark (TP8, conc 4-64)"
-    - "Uses nvidia/GLM-5-NVFP4 model with modelopt_fp4 quantization"
-    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/973
-
-- config-keys:
-    - dsr1-fp8-mi355x-atom-mtp
-  description:
-    - "DeepSeek R1 MI355X FP8 ATOM-MTP config to support MTP 3 tokens"
-    - "Image: rocm/atom:rocm7.2.1-ubuntu24.04-pytorch2.9.1-atom0.1.2"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/984
+    - "New model support on ATOM framework"
+    - "Kimi-K2.5 FP4, GLM-5 FP8, and MiniMax-M2.5 FP8 configs added for MI355X ATOM"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/963


### PR DESCRIPTION
> **Note:** This is a re-merge of #963, which had to be reverted (#988) and re-submitted.

---

Hi @functionstackx @cquil11 

This is a PR to include ATOM framework of the following models. 

    - kimik2.5-fp4-mi355x-atom
    - minimaxm2.5-fp8-mi355x-atom

Will submit glm5 in a different PR. 
    - glm5-fp8-mi355x-atom
    
cc. @ChuanLi1101 @andyluo7 @chunfangamd 



Regards,
Seungrok 