### PR TITLE
[AMD] Add Qwen3.5 MXFP4 single-node MI355X SGLang benchmark (TP4)

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -215,11 +215,11 @@ qwen3.5-fp4-mi355x-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.9-rocm720-mi30x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -204,7 +204,7 @@ qwen3.5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260330
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260401
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -203,6 +203,24 @@ qwen3.5-fp8-mi355x-sglang:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+qwen3.5-fp4-mi355x-sglang:
+  image: rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260330
+  model: amd/Qwen3.5-397B-A17B-MXFP4
+  model-prefix: qwen3.5
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 qwen3.5-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.9-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/qwen3.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_fp4_mi355x.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+export SGLANG_USE_AITER=1
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
+--host=0.0.0.0 --port=$PORT \
+--tensor-parallel-size=$TP \
+--attention-backend aiter \
+--mem-fraction-static=0.9 \
+--model-loader-extra-config '{"enable_multithread_load": true}' \
+--watchdog-timeout 1200 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/qwen3.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/qwen3.5_fp4_mi355x.sh
@@ -18,7 +18,6 @@ fi
 hf download "$MODEL"
 
 export SGLANG_USE_AITER=1
-export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1239,7 +1239,7 @@
 - config-keys:
     - qwen3.5-fp4-mi355x-sglang
   description:
-    - "Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP8)"
+    - "Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP4)"
     - "Uses nightly SGLang ROCm image with AMD MXFP4 support (sgl-project/sglang#21234)"
     - "Model: amd/Qwen3.5-397B-A17B-MXFP4"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/994

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - qwen3.5-fp4-mi355x-sglang
-  description:
-    - "Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP8)"
-    - "Uses nightly SGLang ROCm image with AMD MXFP4 support (sgl-project/sglang#21234)"
-    - "Model: amd/Qwen3.5-397B-A17B-MXFP4"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-
-- config-keys:
     - kimik2.5-int4-mi300x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"
@@ -1243,3 +1235,11 @@
     - "New model support on ATOM framework"
     - "Kimi-K2.5 FP4, and MiniMax-M2.5 FP8 configs added for MI355X ATOM"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/963
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+  description:
+    - "Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP8)"
+    - "Uses nightly SGLang ROCm image with AMD MXFP4 support (sgl-project/sglang#21234)"
+    - "Model: amd/Qwen3.5-397B-A17B-MXFP4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,12 @@
 - config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+  description:
+    - "Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP8)"
+    - "Uses nightly SGLang ROCm image with AMD MXFP4 support (sgl-project/sglang#21234)"
+    - "Model: amd/Qwen3.5-397B-A17B-MXFP4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+
+- config-keys:
     - kimik2.5-int4-mi300x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"


### PR DESCRIPTION
- Add Qwen3.5 397B MXFP4 single-node MI355X SGLang benchmark (TP4, conc 4-64)
- Uses amd/Qwen3.5-397B-A17B-MXFP4 model with nightly ROCm image (rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260330)
- Server flags follow upstream recipe from sgl-project/sglang#21234