### PR TITLE
[NVIDIA] Update Minimax fp8 B200 Configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3130,15 +3130,15 @@ minimaxm2.5-fp8-b200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 512 }
     - { tp: 2, ep: 2, conc-start: 512, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 128 }
     - { tp: 4, ep: 4, conc-start: 256, conc-end: 512 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 64, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 64 }
-    - { tp: 4, conc-start: 512, conc-end: 512 }
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 512 }
 
 gptoss-fp4-h100-vllm:
   image: vllm/vllm-openai:v0.18.0

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3130,15 +3130,15 @@ minimaxm2.5-fp8-b200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 2, ep: 2, conc-start: 4, conc-end: 256 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
-    - { tp: 4, ep: 4, conc-start: 16, conc-end: 64 }
+    - { tp: 2, ep: 2, conc-start: 512, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 4, ep: 4, conc-start: 256, conc-end: 512 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 256 }
-    - { tp: 4, conc-start: 4, conc-end: 256 }
+    - { tp: 2, conc-start: 64, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 4, conc-start: 512, conc-end: 512 }
 
 gptoss-fp4-h100-vllm:
   image: vllm/vllm-openai:v0.18.0

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1265,3 +1265,10 @@
   description:
     - "Add Qwen3.5-397B-A17B-FP8 H200 SGLang MTP (EAGLE speculative decoding)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1001
+
+- config-keys:
+    - minimaxm2.5-fp8-b200-vllm
+  description:
+    - "Update MiniMax-M2.5 FP8 B200 config with new search spaces and vllm args"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1270,5 +1270,5 @@
     - minimaxm2.5-fp8-b200-vllm
   description:
     - "Update MiniMax-M2.5 FP8 B200 config with new search spaces and vllm args"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1010
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1282,6 +1282,5 @@
 - config-keys:
     - minimaxm2.5-fp8-b200-vllm
   description:
-    - "Update MiniMax-M2.5 FP8 B200 config with new search spaces and vllm args"
+    - "Update MiniMax-M2.5 FP8 B200 config with new search spaces"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1010
- 


### PR DESCRIPTION
## Summary

Update benchmark search-space configurations for `minimaxm2.5-fp8-b200-vllm` to refine concurrency ranges and parallelism strategies.

### Changes

**`.github/configs/nvidia-master.yaml`** — Updated search-space for MiniMax-M2.5 FP8 B200 vLLM:

- **ISL 1024 / OSL 1024:**
  - Removed `tp:2` (no EP) sweep; replaced with `tp:2, ep:2` at `conc: 512`
  - Narrowed `tp:4` (no EP) range from `conc 4–512` → `conc 4–128`
  - Widened `tp:4, ep:4` range from `conc 16–64` → `conc 256–512`

- **ISL 8192 / OSL 1024:**
  - Shifted `tp:2` range from `conc 4–256` → `conc 64–512`
  - Narrowed `tp:4` range from `conc 4–256` → `conc 4–64`
  - Added new `tp:4` sweep point at `conc 512`

**`perf-changelog.yaml`** — Added changelog entry for this config update.
