### PR TITLE
[NVIDIA] Update GLM-5 NVFP4 B200 SGLang config

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1820,10 +1820,12 @@ glm5-fp4-b200-sglang:
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 128, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 128, conc-end: 256 }
 
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1819,13 +1819,13 @@ glm5-fp4-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
-    - { tp: 4, ep: 1, conc-start: 128, conc-end: 256 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
-    - { tp: 4, ep: 1, conc-start: 128, conc-end: 256 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130

--- a/benchmarks/single_node/glm5_fp4_b200.sh
+++ b/benchmarks/single_node/glm5_fp4_b200.sh
@@ -46,7 +46,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --nsa-prefill-backend trtllm \
 --moe-runner-backend flashinfer_trtllm \
 --enable-flashinfer-allreduce-fusion \
---cuda-graph-max-bs $CONC \
+--cuda-graph-max-bs 256 \
 --max-prefill-tokens 32768 \
 --chunked-prefill-size 32768 \
 --mem-fraction-static 0.9 \

--- a/benchmarks/single_node/glm5_fp4_b200.sh
+++ b/benchmarks/single_node/glm5_fp4_b200.sh
@@ -38,7 +38,6 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --trust-remote-code \
 --tensor-parallel-size=$TP \
 --data-parallel-size 1 --expert-parallel-size $EP_SIZE \
---enable-dp-lm-head \
 --disable-radix-cache \
 --quantization modelopt_fp4 \
 --kv-cache-dtype fp8_e4m3 \

--- a/benchmarks/single_node/glm5_fp4_b200.sh
+++ b/benchmarks/single_node/glm5_fp4_b200.sh
@@ -33,23 +33,27 @@ fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
-# following https://huggingface.co/nvidia/GLM-5-NVFP4#usage recipe
-# except using latest nightly at the time of writing
-# since the recommended nightly image in that recipe doesn't exist.
-
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
 --tensor-parallel-size=$TP \
---data-parallel-size 1 --expert-parallel-size 1 \
---tool-call-parser glm47 \
---reasoning-parser glm45 \
+--data-parallel-size 1 --expert-parallel-size $EP_SIZE \
+--enable-dp-lm-head \
+--disable-radix-cache \
 --quantization modelopt_fp4 \
---cuda-graph-max-bs $CONC --max-running-requests $CONC \
---mem-fraction-static 0.80 \
---chunked-prefill-size 131072 \
+--kv-cache-dtype fp8_e4m3 \
+--nsa-decode-backend trtllm \
+--nsa-prefill-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--enable-flashinfer-allreduce-fusion \
+--cuda-graph-max-bs $CONC \
+--max-prefill-tokens 32768 \
+--chunked-prefill-size 32768 \
+--mem-fraction-static 0.9 \
 --stream-interval 30 \
---model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+--scheduler-recv-interval 10 \
+--tokenizer-worker-num 6 \
+--tokenizer-path $MODEL $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1278,3 +1278,12 @@
     - "New framework: dynamo-vllm (Dynamo frontend + vLLM backend)"
     - "Runner script updated to clone NVIDIA/srt-slurm and map vLLM container image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1008
+
+- config-keys:
+    - glm5-fp4-b200-sglang
+  description:
+    - "Update GLM-5 NVFP4 B200 SGLang benchmark script with optimized launch parameters"
+    - "Add TP4 search space with higher concurrency (128-256) for 1k1k and 8k1k configs"
+    - "Enable FP8 E4M3 KV cache, NSA backends (trtllm), flashinfer allreduce fusion, MoE flashinfer_trtllm runner"
+    - "Tune mem-fraction-static to 0.9, chunked-prefill-size to 32768, add tokenizer-worker-num 6"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1011


### PR DESCRIPTION
## Summary

Update GLM-5 NVFP4 B200 SGLang benchmark configuration and script with optimized server launch parameters.

### Config changes (`nvidia-master.yaml`)
- Added TP4 search space with higher concurrency (128-256) for both 1k1k and 8k1k sequence length configs

### Benchmark script changes (`glm5_fp4_b200.sh`)
- Added `--enable-dp-lm-head` and `--disable-radix-cache` flags
- Enabled FP8 E4M3 KV cache (`--kv-cache-dtype fp8_e4m3`)
- Added NSA (Native Sparse Attention) backends: `--nsa-decode-backend trtllm` and `--nsa-prefill-backend trtllm`
- Added `--moe-runner-backend flashinfer_trtllm` and `--enable-flashinfer-allreduce-fusion`
- Tuned prefill tokens and chunked prefill size to 32768
- Increased `--mem-fraction-static` from 0.80 to 0.9
- Added `--scheduler-recv-interval 10` and `--tokenizer-worker-num 6`
- Added `--tokenizer-path` flag
- Removed `--tool-call-parser`, `--reasoning-parser`, `--max-running-requests`, and `--model-loader-extra-config` flags