### PR TITLE
[NVIDIA] [WIP] Bump GLM-5 FP8 B200 SGLang concurrency to 256

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1801,11 +1801,11 @@ glm5-fp8-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
 glm5-fp4-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1278,3 +1278,10 @@
     - "New framework: dynamo-vllm (Dynamo frontend + vLLM backend)"
     - "Runner script updated to clone NVIDIA/srt-slurm and map vLLM container image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1008
+
+- config-keys:
+    - glm5-fp8-b200-sglang
+  description:
+    - "Bump GLM-5 FP8 B200 SGLang concurrency from 128 to 256"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1012
+


### PR DESCRIPTION
## Summary
- Increase `conc-end` from 128 to 256 for `glm5-fp8-b200-sglang` config (both 1k1k and 8k1k seq-len configs)
- Add perf-changelog entry