### PR TITLE
[AMD] Upgrade DeepSeek-R1 MI35x docker to the latest SGLang version 0.5.10

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x
@@ -95,7 +95,7 @@ dsr1-fp8-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x
@@ -95,7 +95,7 @@ dsr1-fp8-mi325x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.9-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1358,3 +1358,11 @@
   description:
     - "Enable SGLANG_ENABLE_SPEC_V2=1 for Qwen3.5 FP8 H200 SGLang MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1017
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp8-mi355x-sglang
+  description:
+    - "Update DeepSeek R1 MI355X single-node SGLang container to lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415"
+    - "Replaces lmsysorg/sglang:v0.5.10-rocm720-mi35x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
This pull request updates the container images used for DeepSeek R1 MI355X single-node SGLang configurations to a newer version, and documents the change in the performance changelog. These updates ensure that the latest features and fixes from the new image are used in relevant workflows.

**Configuration updates:**

* Updated the `image` field for both `dsr1-fp4-mi355x-sglang` and `dsr1-fp8-mi355x-sglang` in `.github/configs/amd-master.yaml` to use `lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415` instead of the previous version.


