### PR TITLE
[AMD] Upgrade GLM-5 SGLang mi35x image to 0.5.10

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -222,7 +222,7 @@ qwen3.5-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 glm5-fp8-mi355x-sglang:
-  image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260219
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1278,3 +1278,10 @@
     - "New framework: dynamo-vllm (Dynamo frontend + vLLM backend)"
     - "Runner script updated to clone NVIDIA/srt-slurm and map vLLM container image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1008
+
+- config-keys:
+    - glm5-fp8-mi355x-sglang
+  description:
+    - "Upgrade SGLang image to v0.5.10"
+    - "Resolve the issue: https://github.com/sgl-project/sglang/issues/19028"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1014


### PR DESCRIPTION
This pull request updates the container image used for the `glm5-fp8-mi355x-sglang` configuration in the `.github/configs/amd-master.yaml` file. The new image version is likely to include important updates or fixes.

Configuration update:

* Updated the `image` field for `glm5-fp8-mi355x-sglang` from `rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260219` to `lmsysorg/sglang:v0.5.10-rocm720-mi35x` in `.github/configs/amd-master.yaml`