### PR TITLE
Revert "[AMD] Upgrade GLM-5 SGLang mi35x image to 0.5.10 (#1014)"

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -222,7 +222,7 @@ qwen3.5-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 glm5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
+  image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260219
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1286,18 +1286,11 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1008
 
 - config-keys:
-    - glm5-fp8-mi355x-sglang
-  description:
-    - "Upgrade SGLang image to v0.5.10"
-    - "Resolve the issue: https://github.com/sgl-project/sglang/issues/19028"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1014
-  
-- config-keys:
     - minimaxm2.5-fp8-b200-vllm
   description:
     - "Update MiniMax-M2.5 FP8 B200 config with new search spaces"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1010
-  
+
 - config-keys:
     - minimaxm2.5-fp4-b200-vllm
   description:


### PR DESCRIPTION
## Summary
- Reverts #1014
- Restores `glm5-fp8-mi355x-sglang` image to `rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260219`
- Removes the corresponding changelog entry