### PR TITLE
Fix B200 enroot import race condition causing sweep failures

### DIFF
--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -217,16 +217,25 @@ else
     SQUASH_FILE="/home/sa-shared/containers/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+    LOCK_FILE="${SQUASH_FILE}.lock"
 
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
-    enroot import -o $SQUASH_FILE docker://$IMAGE
-    if ! unsquashfs -l $SQUASH_FILE > /dev/null; then
-        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
-        rm -f $SQUASH_FILE
-        enroot import -o $SQUASH_FILE docker://$IMAGE
-    fi
+    # Use flock to serialize concurrent imports to the same squash file
+    # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes
+    srun --jobid=$JOB_ID bash -c "
+        export ENROOT_CACHE_PATH=\$HOME/.cache/enroot
+        mkdir -p \$ENROOT_CACHE_PATH
+        exec 9>\"$LOCK_FILE\"
+        flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
+        if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
+            echo 'Squash file already exists and is valid, skipping import'
+        else
+            rm -f \"$SQUASH_FILE\"
+            enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
+        fi
+    "
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \


### PR DESCRIPTION
## Summary

- **Root cause**: All 9 B200 GH Actions runners (`b200-dgxc-slurm_0` through `_8`) share a single login node (`slurm-login-slinky`). When a matrix sweep launches, all runners call `enroot import` concurrently on the login node, each extracting the full vllm Docker image (~30-50GB) into `/raid/enroot/tmp` (305GB total). 9 concurrent extractions exhaust the temp space, the `.sqsh` file is never created, and every job fails with `pyxis: No such file or directory`.
- **Fix**: Adopt the same `flock` + `srun`-based import pattern already used by the H200 DGXC Slurm runner (`launch_h200-dgxc-slurm.sh`):
  1. **`flock`** serializes concurrent imports so only one runner builds the `.sqsh` at a time
  2. **`unsquashfs` validation** skips import if a valid `.sqsh` already exists
  3. **Import runs via `srun` on the GPU node** instead of the login node, using the GPU node's 12TB `/raid` for temp space instead of the login node's 305GB

## Context

Failed run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24151864340

All 40 sweep jobs failed at "Launch job script" — the underlying error chain was:
```
enroot import → mkdir: No space left on device → .sqsh not created → pyxis: No such file or directory
```

## Test plan

- [ ] Re-run the multi-turn benchmark sweep on B200 and verify jobs complete successfully
- [ ] Verify the `.sqsh` file is created once and reused by subsequent runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)