### PR TITLE
[NV] Update: sglang v2 Qwen3.5 h200 MTP

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2019,7 +2019,7 @@ qwen3.5-fp8-h200-sglang:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-h200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.9-cu129-amd64
+  image: lmsysorg/sglang:v0.5.10.post1
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: h200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1998,6 +1998,24 @@ qwen3.5-fp8-h200-sglang:
     search-space:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
 
+qwen3.5-fp8-h200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.9-cu129-amd64
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: h200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+
 glm5-fp8-h200-sglang:
   image: lmsysorg/sglang:glm5-hopper
   model: zai-org/GLM-5-FP8

--- a/benchmarks/single_node/qwen3.5_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_h200_mtp.sh
@@ -35,7 +35,7 @@ echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_MODEL_LEN: $MAX_MODEL_LEN"
 start_gpu_monitor
 
 set -x
-python3 -m sglang.launch_server \
+SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server \
   --model "$MODEL" \
   --host 0.0.0.0 \
   --port "$PORT" \

--- a/benchmarks/single_node/qwen3.5_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_h200_mtp.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE \
+    MAX_MODEL_LEN
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# MTP (Multi-Token Prediction) Config - EAGLE speculative decoding
+SPECULATIVE_NUM_STEPS=3
+SPECULATIVE_DRAFT_TOKENS=4
+SPECULATIVE_EAGLE_TOPK=1
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_MODEL_LEN: $MAX_MODEL_LEN"
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp "$TP" \
+  --expert-parallel-size "$EP_SIZE" \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --enable-flashinfer-allreduce-fusion \
+  --max-running-requests 128 \
+  --chunked-prefill-size 16384 \
+  --mem-fraction-static 0.8 \
+  --cuda-graph-max-bs "$CONC" \
+  --context-length "$MAX_MODEL_LEN" \
+  --kv-cache-dtype fp8_e4m3 \
+  --quantization fp8 \
+  --attention-backend flashinfer \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --mamba-ssm-dtype bfloat16 \
+  --disable-radix-cache \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps "$SPECULATIVE_NUM_STEPS" \
+  --speculative-num-draft-tokens "$SPECULATIVE_DRAFT_TOKENS" \
+  --speculative-eagle-topk "$SPECULATIVE_EAGLE_TOPK" \
+  > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --use-chat-template \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    export EVAL_CONCURRENT_REQUESTS="${EVAL_CONCURRENT_REQUESTS:-$CONC}"
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1243,11 +1243,10 @@
     - "Add tp4 ep4 search-space entries (conc 32-256) for all seq-len configs"
     - "Remove ISL 1024 / OSL 8192 seq-len config"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/947
-  
-  
-  - config-keys:
+
+
+- config-keys:
     - qwen3.5-fp8-h200-sglang-mtp
   description:
     - "Add Qwen3.5-397B-A17B-FP8 H200 SGLang MTP (EAGLE speculative decoding)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1001
-  

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1240,4 +1240,4 @@
     - qwen3.5-fp8-h200-sglang-mtp
   description:
     - "Add Qwen3.5-397B-A17B-FP8 H200 SGLang MTP (EAGLE speculative decoding)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/921
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1235,3 +1235,9 @@
     - "New model support on ATOM framework"
     - "Kimi-K2.5 FP4, and MiniMax-M2.5 FP8 configs added for MI355X ATOM"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/963
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-mtp
+  description:
+    - "Add Qwen3.5-397B-A17B-FP8 H200 SGLang MTP (EAGLE speculative decoding)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/921

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1307,3 +1307,10 @@
     - "Model: nvidia/Qwen3.5-397B-A17B-NVFP4"
     - "Configs: 1k1k (TP4 conc 4-128), 8k1k (TP4 conc 4-128)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/820
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-mtp
+  description:
+    - "Enable SGLANG_ENABLE_SPEC_V2=1 for Qwen3.5 FP8 H200 SGLang MTP"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1312,5 +1312,5 @@
     - qwen3.5-fp8-h200-sglang-mtp
   description:
     - "Enable SGLANG_ENABLE_SPEC_V2=1 for Qwen3.5 FP8 H200 SGLang MTP"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1017
 


### PR DESCRIPTION
## Summary

Enable SGLang speculative decoding v2 (`SGLANG_ENABLE_SPEC_V2=1`) for the Qwen3.5 FP8 H200 MTP benchmark configuration.

## Changes

- **`benchmarks/single_node/qwen3.5_fp8_h200_mtp.sh`**: Set `SGLANG_ENABLE_SPEC_V2=1` environment variable on the `sglang.launch_server` command to enable the v2 speculative decoding engine for EAGLE-based multi-token prediction
- **`perf-changelog.yaml`**: Added changelog entry for `qwen3.5-fp8-h200-sglang-mtp` documenting the spec v2 enablement

## Context

The Qwen3.5 FP8 H200 MTP benchmark uses EAGLE speculative decoding (3 speculative steps, 4 draft tokens, topk=1). This PR enables SGLang's v2 speculative decoding implementation via the `SGLANG_ENABLE_SPEC_V2=1` flag, which is expected to improve MTP performance.
