### PR TITLE
Fix config/script consistency: remove bogus ep, add missing env var checks

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1912,12 +1912,12 @@ kimik2.5-fp4-b200-vllm:
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130

--- a/benchmarks/single_node/glm5_fp8_b200.sh
+++ b/benchmarks/single_node/glm5_fp8_b200.sh
@@ -9,8 +9,7 @@ check_env_vars \
     ISL \
     OSL \
     RANDOM_RANGE_RATIO \
-    RESULT_FILENAME \
-    EP_SIZE
+    RESULT_FILENAME
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -28,7 +27,7 @@ SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 
-echo "EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Remove `ep: 4` from `kimik2.5-fp4-b200-vllm` search-space entries — the benchmark script (`kimik2.5_fp4_b200.sh`) has no EP support, so the ep value was silently ignored
- Remove unused `EP_SIZE` from `glm5_fp8_b200.sh` check_env_vars and echo — config never uses ep > 1 and script hardcodes `--expert-parallel-size 1`