### PR TITLE
Upgrade GLM-5 image to v0.5.10

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -240,7 +240,7 @@ qwen3.5-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 glm5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
+  image: rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260413
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -242,7 +242,7 @@ qwen3.5-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 glm5-fp8-mi355x-sglang:
-  image: rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260413
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260413
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -240,7 +240,7 @@ qwen3.5-fp8-mi300x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 glm5-fp8-mi355x-sglang:
-  image: rocm/sgl-dev:v0.5.8.post1-rocm720-mi35x-20260219
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: mi355x

--- a/benchmarks/single_node/glm5_fp8_mi355x.sh
+++ b/benchmarks/single_node/glm5_fp8_mi355x.sh
@@ -49,7 +49,9 @@ python3 -m sglang.launch_server \
     --mem-fraction-static 0.85 \
     --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
     --nsa-prefill-backend tilelang \
-    --nsa-decode-backend tilelang $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --nsa-decode-backend tilelang $EVAL_CONTEXT_ARGS  \
+    --kv-cache-dtype fp8_e4m3 \
+    --disable-radix-cache> $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1356,7 +1356,8 @@
 - config-keys:
     - glm5-fp8-mi355x-sglang
   description:
-    - "Upgrade GLM5 FP8 MI355X SGLang image to v0.5.10"
+    - "Upgrade GLM5 FP8 MI355X SGLang image to v0.5.10rc0-rocm720-mi35x-20260413"
+    - "Set --kv-cache-dtype fp8_e4m3 and --disable-radix-cache"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1023
 
 - config-keys:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1322,3 +1322,9 @@
   description:
     - "Qwen3.5 fp4 support on SGL"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1006
+
+- config-keys:
+    - glm5-fp8-mi355x-sglang
+  description:
+    - "Upgrade GLM5 FP8 MI355X SGLang image to v0.5.10"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1023


### PR DESCRIPTION
Upgrade GLM5-FP8-MI355X-SGLang Image to v0.5.10rc0-rocm720-mi35x-20260413 after fixing the Slurm shared cache issue. With this upstream daily image, we use a new aiter 0.1.12.post1 which can improve the performance.

```
    if [[ "$FRAMEWORK" == "atom" ]] || [[ "$FRAMEWORK" == "sglang" ]]; then
        SLRUM_HOME_MOUNT=""
    else
        SLRUM_HOME_MOUNT=" --container-mount-home "
    fi
```
e2e Test run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24441807614

Co-authored with: @1am9trash @zhentaocc 
Thanks to @cquil11 @billishyahao 
