### PR TITLE
[Do Not Merge] update glm5 fp8 b200 sglang container

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1808,7 +1808,7 @@ qwen3.5-fp4-b200-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 128 }
 
 glm5-fp8-b200-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260317-1eea7448
+  image: lmsysorg/sglang:v0.5.10.post1
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: b200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1808,7 +1808,7 @@ qwen3.5-fp4-b200-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 128 }
 
 glm5-fp8-b200-sglang:
-  image: lmsysorg/sglang:v0.5.10.post1
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1348,3 +1348,9 @@
   description:
     - "Enable SGLANG_ENABLE_SPEC_V2=1 for Qwen3.5 FP8 H200 SGLang MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1017
+
+- config-keys:
+    - glm5-fp8-b200-sglang
+  description:
+    - "Update SGLang image from nightly-dev-cu13-20260317-1eea7448 to v0.5.10.post1"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1353,4 +1353,4 @@
     - glm5-fp8-b200-sglang
   description:
     - "Update SGLang image from nightly-dev-cu13-20260317-1eea7448 to v0.5.10.post1"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1030


### PR DESCRIPTION
## Summary
- Update SGLang container image for `glm5-fp8-b200-sglang` from nightly build (`nightly-dev-cu13-20260317-1eea7448`) to stable release `v0.5.10.post1-cu130`
- Add corresponding entry to `perf-changelog.yaml`

## Details
**Config:** `glm5-fp8-b200-sglang`
**Model:** `zai-org/GLM-5-FP8` on B200 (TP=8, single-node)
**Image change:** `lmsysorg/sglang:nightly-dev-cu13-20260317-1eea7448` → `lmsysorg/sglang:v0.5.10.post1-cu130`

Moving from a nightly dev build to the stable v0.5.10.post1 release for improved reliability and reproducibility.

## Test plan
- [ ] Run e2e benchmark for `glm5-fp8-b200-sglang` to validate performance on the new image