### PR TITLE
[NV] update glm5-fp4-b200 sglang image

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1826,7 +1826,7 @@ glm5-fp8-b200-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
 glm5-fp4-b200-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1353,4 +1353,4 @@
     - glm5-fp4-b200-sglang
   description:
     - "Update SGLang image from nightly-dev-cu13-20260328-a27651d5 to v0.5.10.post1-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1031

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1348,3 +1348,9 @@
   description:
     - "Enable SGLANG_ENABLE_SPEC_V2=1 for Qwen3.5 FP8 H200 SGLang MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1017
+
+- config-keys:
+    - glm5-fp4-b200-sglang
+  description:
+    - "Update SGLang image from nightly-dev-cu13-20260328-a27651d5 to v0.5.10.post1-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

Update the SGLang image for `glm5-fp4-b200-sglang` (B200) from the nightly dev build to the stable release.

**Image change:**
- **Before:** `lmsysorg/sglang:nightly-dev-cu13-20260328-a27651d5`
- **After:** `lmsysorg/sglang:v0.5.10.post1-cu130`

## Changes

- `.github/configs/nvidia-master.yaml` — Update `glm5-fp4-b200-sglang` image tag to `v0.5.10.post1-cu130`
- `perf-changelog.yaml` — Add changelog entry for the image update