### PR TITLE
[AMD/ROCM] Qwen3.5 FP4 MI355x Perf - New SGLang Image 

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -215,12 +215,12 @@ qwen3.5-fp4-mi355x-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 2, conc-start: 4, conc-end: 256 }
     - { tp: 4, conc-start: 4, conc-end: 16 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 2, conc-start: 4, conc-end: 256 }
     - { tp: 4, conc-start: 4, conc-end: 16 }
 
 qwen3.5-fp8-mi300x-sglang:

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -204,7 +204,7 @@ qwen3.5-fp8-mi355x-sglang:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi35x
+  image: rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260413
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x
@@ -215,13 +215,13 @@ qwen3.5-fp4-mi355x-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 256 }
-    - { tp: 4, conc-start: 4, conc-end: 4 }
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 256 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 256 }
-    - { tp: 4, conc-start: 4, conc-end: 32 }
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.10-rocm720-mi30x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -216,12 +216,12 @@ qwen3.5-fp4-mi355x-sglang:
     osl: 1024
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 256 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
   - isl: 8192
     osl: 1024
     search-space:
     - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 256 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
 
 qwen3.5-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.10-rocm720-mi30x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,10 @@
 - config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+  description:
+    - "Update SGLang image from 'lmsysorg/sglang:v0.5.10-rocm720-mi35x' to 'rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260413'"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1041
+
+- config-keys:
     - kimik2.5-int4-mi300x-vllm
   description:
     - "Add Kimi K2.5 INT4 single-node MI300X vLLM benchmark (TP8)"


### PR DESCRIPTION
## Overview
Add benchmark configuration and testing support for AMD MI355X hardware.

## Changes
- Added benchmark script for Qwen3.5 FP4 model on MI355X to run with Updated SGLang Image. 
- Updated GitHub Actions configuration for AMD master branch

## Testing
- Verify benchmark execution on MI355X hardware
- Validate configuration settings

e2e Test run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24503738833
