### PR TITLE
Remind PR authors of post-merge CI responsibility

### DIFF
--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -42,6 +42,8 @@ jobs:
             - https://github.com/vllm-project/recipes
             - https://github.com/sgl-project/sgl-cookbook
 
-            **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.**`.replace(/^            /gm, '');
+            **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.** A lot of the time, failures are just flakes and simply re-running the failed jobs will fix it. If re-running failed jobs is attempted, PR authors are responsible for ensuring it passes. See GitHub's docs on re-running failed jobs: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow
+
+            If additional help is needed, PR authors can reach out to core maintainers over Slack.`.replace(/^            /gm, '');
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -40,6 +40,8 @@ jobs:
 
             If it is not, please create a PR first before we can merge your PR into the master branch. Let's ensure that the documentation is first class such that the entire ML community can benefit from your hard work! Thank you
             - https://github.com/vllm-project/recipes
-            - https://github.com/sgl-project/sgl-cookbook`.replace(/^            /gm, '');
+            - https://github.com/sgl-project/sgl-cookbook
+
+            **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.**`.replace(/^            /gm, '');
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });


### PR DESCRIPTION
## Summary
- Adds a bolded reminder to the PR recipe reminder workflow stating that PR authors are responsible for ensuring all GitHub Action jobs fully pass after merging.

## Test plan
- [ ] Open a PR touching one of the trigger paths and confirm the bot comment renders the new bolded line correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)