### PR TITLE
Add B300 config: glm5-fp8-sglang

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1870,6 +1870,27 @@ glm5-fp8-b200-sglang:
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
+# does not have a B300-specific recipe, so this config reuses the existing GLM5 FP8
+# B200 SGLang recipe as-is until B300-specific tuning is available.
+glm5-fp8-b300-sglang:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: b300
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
+
 glm5-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.10.post1-cu130
   model: nvidia/GLM-5-NVFP4

--- a/benchmarks/single_node/glm5_fp8_b300.sh
+++ b/benchmarks/single_node/glm5_fp8_b300.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
+# does not have a B300-specific recipe, so this script reuses the existing
+# GLM5 FP8 B200 SGLang recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+
+export SGL_ENABLE_JIT_DEEPGEMM=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+--data-parallel-size 1 --expert-parallel-size 1 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
+--kv-cache-dtype fp8_e4m3 --quantization fp8 \
+--attention-backend nsa \
+--nsa-decode-backend trtllm --nsa-prefill-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--cuda-graph-max-bs $CONC --max-running-requests $CONC \
+--mem-fraction-static 0.85 \
+--chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --disable-radix-cache \
+--stream-interval 30 \
+--model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1419,4 +1419,4 @@
     - "Add GLM-5 FP8 B300 SGLang benchmark"
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1 does not have a B300-specific recipe, so this reuses the existing GLM5 FP8 B200 SGLang recipe as-is"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1051

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1412,3 +1412,11 @@
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1 does not have a B300-specific recipe, so this reuses the existing DSR1 FP8 B200 SGLang recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1050
+
+- config-keys:
+    - glm5-fp8-b300-sglang
+  description:
+    - "Add GLM-5 FP8 B300 SGLang benchmark"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1 does not have a B300-specific recipe, so this reuses the existing GLM5 FP8 B200 SGLang recipe as-is"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Adds `glm5-fp8-b300-sglang` config (GLM-5 FP8 on B300 via SGLang).
- New benchmark script `benchmarks/single_node/glm5_fp8_b300.sh` reuses the existing B200 GLM5 FP8 SGLang recipe as-is — at the time of submission, the [SGLang GLM-5.1 cookbook](https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1) does not yet have a B300-specific recipe. The note is mirrored in `glm5_fp8_b300.sh`, `nvidia-master.yaml`, and `perf-changelog.yaml`.
- Image: `lmsysorg/sglang:v0.5.10.post1-cu130` — the standard B300 SGLang image already used by other B300 configs.
- No changes to `runners/launch_b300-nv.sh` or `.github/workflows/benchmark-tmpl.yml` — already wired up by #1035.

## Test plan
- [ ] Sweep picks up `glm5-fp8-b300-sglang` and runs 1k1k / 8k1k at TP=8, concurrency 4-256
- [ ] Results publish to inferencex.com and look sane relative to B200 GLM5 FP8 SGLang

🤖 Generated with [Claude Code](https://claude.com/claude-code)