### PR TITLE
[AMD][MI300X] Expand GPT-OSS FP4 TP=1 concurrency from 64 to 256

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -470,7 +470,7 @@ gptoss-fp4-mi300x-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 64, conc-end: 64 }
+    - { tp: 1, conc-start: 64, conc-end: 256 }
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 16 }

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -459,7 +459,7 @@ minimaxm2.5-fp8-mi325x-vllm:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.19.0
+  image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -459,7 +459,7 @@ minimaxm2.5-fp8-mi325x-vllm:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.17.0
+  image: vllm/vllm-openai-rocm:v0.19.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1396,3 +1396,10 @@
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "TP=4, concurrency 4-256 for 1k1k and 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1048
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+  description:
+    - "Expand GPT-OSS 120B FP4 MI300X TP=1 concurrency from 64 to 256 for 1k1k"
+    - "Higher concurrency improves MoE weight amortization: 8552 total TPS at conc=256 vs 4016 at conc=64 (2.1x)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1053


### PR DESCRIPTION
## Summary

Expand the search space for GPT-OSS 120B FP4 on MI300X TP=1 from `conc=64` to `conc=256` for the 1k1k configuration.

## Motivation

With 128 experts and top-4 routing, larger batch sizes significantly improve MoE weight amortization across HBM. At batch=64, nearly all 111/128 unique experts are loaded per decode step — increasing concurrency amortizes this weight loading cost across more tokens.

## Results (single MI300X, vllm v0.17.0, ISL/OSL=1024)

| Concurrency | Output TPS | Total TPS | Median TPOT | vs Baseline |
|-------------|-----------|-----------|-------------|-------------|
| 64 (current) | 2,008 | 4,016 | 31.4 ms | — |
| 96 | 2,561 | 5,105 | 36.6 ms | +27% |
| 128 | 2,990 | 5,981 | 41.3 ms | +49% |
| 256 | 4,271 | 8,552 | 58.3 ms | +113% |

## Changes

- `.github/configs/amd-master.yaml`: TP=1 `conc-end` from 64 → 256
- `perf-changelog.yaml`: Added changelog entry

No benchmark script changes required.