### PR TITLE
Add B300 config: minimaxm2.5-fp8-vllm

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3308,6 +3308,31 @@ minimaxm2.5-fp8-b200-vllm:
     - { tp: 2, conc-start: 4, conc-end: 512 }
     - { tp: 4, conc-start: 4, conc-end: 512 }
 
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html
+# does not have a B300-specific recipe, so this config reuses the existing
+# MiniMax-M2.5 FP8 B200 vLLM recipe as-is until B300-specific tuning is available.
+minimaxm2.5-fp8-b300-vllm:
+  image: vllm/vllm-openai:v0.19.0-cu130
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: b300
+  precision: fp8
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 512 }
+    - { tp: 2, ep: 2, conc-start: 512, conc-end: 512 }
+    - { tp: 4, ep: 4, conc-start: 256, conc-end: 512 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 512 }
+
 minimaxm2.5-fp4-b200-vllm:
   image: vllm/vllm-openai:v0.19.0-cu130
   model: nvidia/MiniMax-M2.5-NVFP4

--- a/benchmarks/single_node/minimaxm2.5_fp8_b300.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b300.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html
+# does not have a B300-specific recipe, so this script reuses the existing
+# MiniMax-M2.5 FP8 B200 vLLM recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+export VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl
+
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve $MODEL --port $PORT \
+--tensor-parallel-size=$TP \
+$EP \
+--gpu-memory-utilization 0.90 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size=32 \
+--kv-cache-dtype fp8 \
+--max-cudagraph-capture-size 2048 \
+--max-num-batched-tokens "$((ISL * 2 ))" \
+--stream-interval 20 --no-enable-prefix-caching \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1452,4 +1452,4 @@
     - "Add MiniMax-M2.5 FP8 B300 vLLM benchmark"
     - "Image: vllm/vllm-openai:v0.19.0-cu130"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html does not have a B300-specific recipe, so this reuses the existing MiniMax-M2.5 FP8 B200 vLLM recipe as-is"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1054

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1445,3 +1445,11 @@
     - "Image: vllm/vllm-openai:v0.19.0-cu130"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html does not have a B300-specific recipe, so this reuses the existing MiniMax-M2.5 FP4 B200 vLLM recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1055
+
+- config-keys:
+    - minimaxm2.5-fp8-b300-vllm
+  description:
+    - "Add MiniMax-M2.5 FP8 B300 vLLM benchmark"
+    - "Image: vllm/vllm-openai:v0.19.0-cu130"
+    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html does not have a B300-specific recipe, so this reuses the existing MiniMax-M2.5 FP8 B200 vLLM recipe as-is"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Add `minimaxm2.5-fp8-b300-vllm` benchmark config and the corresponding `benchmarks/single_node/minimaxm2.5_fp8_b300.sh` launch script
- At the time of submission, [the vLLM MiniMax-M2 recipes page](https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html) does not have a B300-specific recipe, so this reuses the existing MiniMax-M2.5 FP8 B200 vLLM recipe as-is until B300-specific tuning is available
- Image: `vllm/vllm-openai:v0.19.0-cu130` (same as B200), runner: `b300`, same TP/EP/concurrency search-space as B200

## Test plan
- [ ] CI config validation passes
- [ ] Run `minimaxm2.5-fp8-b300-vllm` single-node benchmark on a B300 node and confirm server starts, benchmark completes, and result file is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)