### PR TITLE
Add B300 config: kimi-k2.5-int4-vllm

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2007,6 +2007,27 @@ kimik2.5-int4-b200-vllm:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64 }
 
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
+# does not have a B300-specific recipe, so this config reuses the existing
+# Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
+kimik2.5-int4-b300-vllm:
+  image: vllm/vllm-openai:v0.15.1
+  model: moonshotai/Kimi-K2.5
+  model-prefix: kimik2.5
+  runner: b300
+  precision: int4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64 }
+
 kimik2.5-int4-h200-vllm:
   image: vllm/vllm-openai:v0.16.0
   model: moonshotai/Kimi-K2.5

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2011,7 +2011,7 @@ kimik2.5-int4-b200-vllm:
 # does not have a B300-specific recipe, so this config reuses the existing
 # Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
 kimik2.5-int4-b300-vllm:
-  image: vllm/vllm-openai:v0.15.1
+  image: vllm/vllm-openai:v0.19.0-cu130
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: b300

--- a/benchmarks/single_node/kimik2.5_int4_b300.sh
+++ b/benchmarks/single_node/kimik2.5_int4_b300.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
+# does not have a B300-specific recipe, so this script reuses the existing
+# Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export PYTHONNOUSERSITE=1
+export VLLM_USE_FLASHINFER_MOE_INT4=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT \
+--gpu-memory-utilization 0.95 \
+--tensor-parallel-size $TP \
+--max-model-len $MAX_MODEL_LEN \
+--max-num-seqs $CONC \
+--reasoning-parser kimi_k2 \
+--tool-call-parser kimi_k2 \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--trust-remote-code \
+--disable-log-requests \
+--no-enable-prefix-caching > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1473,6 +1473,6 @@
     - kimik2.5-int4-b300-vllm
   description:
     - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
-    - "Image: vllm/vllm-openai:v0.15.1"
+    - "Image: vllm/vllm-openai:v0.19.0-cu130"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1468,3 +1468,11 @@
     - "Image: vllm/vllm-openai:v0.19.0-cu130"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 FP4 B200 vLLM recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1056
+
+- config-keys:
+    - kimik2.5-int4-b300-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
+    - "Image: vllm/vllm-openai:v0.15.1"
+    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1475,4 +1475,4 @@
     - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
     - "Image: vllm/vllm-openai:v0.15.1"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057


### PR DESCRIPTION
## Summary
- Add `kimik2.5-int4-b300-vllm` benchmark config and the corresponding `benchmarks/single_node/kimik2.5_int4_b300.sh` launch script
- At the time of submission, [the vLLM Kimi-K2.5 recipes page](https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html) does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available
- Image: `vllm/vllm-openai:v0.15.1` (same as B200), runner: `b300`, same TP=8 and concurrency 4-64 search-space as B200

## Test plan
- [ ] CI config validation passes
- [ ] Run `kimik2.5-int4-b300-vllm` single-node benchmark on a B300 node and confirm server starts, benchmark completes, and result file is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)