### PR TITLE
Add B300 config: glm5-fp4-sglang

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1911,6 +1911,29 @@ glm5-fp4-b200-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5
+# does not have a B300-specific recipe, so this config reuses the existing
+# GLM-5 FP4 B200 SGLang recipe as-is until B300-specific tuning is available.
+glm5-fp4-b300-sglang:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: nvidia/GLM-5-NVFP4
+  model-prefix: glm5
+  runner: b300
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
+
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/glm5_fp4_b300.sh
+++ b/benchmarks/single_node/glm5_fp4_b300.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5
+# does not have a B300-specific recipe, so this script reuses the existing
+# GLM-5 FP4 B200 SGLang recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+echo "EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+--data-parallel-size 1 --expert-parallel-size $EP_SIZE \
+--disable-radix-cache \
+--quantization modelopt_fp4 \
+--kv-cache-dtype fp8_e4m3 \
+--nsa-decode-backend trtllm \
+--nsa-prefill-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--enable-flashinfer-allreduce-fusion \
+--cuda-graph-max-bs 256 \
+--max-prefill-tokens 32768 \
+--chunked-prefill-size 32768 \
+--mem-fraction-static 0.9 \
+--stream-interval 30 \
+--scheduler-recv-interval 10 \
+--tokenizer-worker-num 6 \
+--tokenizer-path $MODEL $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1427,4 +1427,4 @@
     - "Add GLM-5 FP4 (NVFP4) B300 SGLang benchmark"
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5 does not have a B300-specific recipe, so this reuses the existing GLM-5 FP4 B200 SGLang recipe as-is"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1058

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1420,3 +1420,11 @@
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1 does not have a B300-specific recipe, so this reuses the existing GLM5 FP8 B200 SGLang recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1051
+
+- config-keys:
+    - glm5-fp4-b300-sglang
+  description:
+    - "Add GLM-5 FP4 (NVFP4) B300 SGLang benchmark"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5 does not have a B300-specific recipe, so this reuses the existing GLM-5 FP4 B200 SGLang recipe as-is"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Add `glm5-fp4-b300-sglang` benchmark config and the corresponding `benchmarks/single_node/glm5_fp4_b300.sh` launch script
- At the time of submission, [the SGLang GLM-5 cookbook](https://cookbook.sglang.io/autoregressive/GLM/GLM-5) does not have a B300-specific recipe, so this reuses the existing GLM-5 FP4 (NVFP4) B200 SGLang recipe as-is until B300-specific tuning is available
- Image: `lmsysorg/sglang:v0.5.10.post1-cu130` (same as B200), runner: `b300`, same TP=4/8 and concurrency search-space as B200

## Test plan
- [ ] CI config validation passes
- [ ] Run `glm5-fp4-b300-sglang` single-node benchmark on a B300 node and confirm server starts, benchmark completes, and result file is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)