### PR TITLE
Add B300 config: dsr1-fp8-sglang-mtp

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2063,6 +2063,28 @@ dsr1-fp8-b200-sglang-mtp:
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
 
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
+# does not have a B300-specific recipe, so this config reuses the existing DSR1 FP8
+# B200 SGLang MTP recipe as-is until B300-specific tuning is available. Image bumped
+# to v0.5.10.post1-cu130 to match the standard B300 SGLang image used by other B300 configs.
+dsr1-fp8-b300-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: b300
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
+
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2
   model: deepseek-ai/DeepSeek-R1-0528

--- a/benchmarks/single_node/dsr1_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp8_b300_mtp.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
+# does not have a B300-specific recipe, so this script reuses the existing
+# DSR1 FP8 B200 SGLang MTP recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+export SGLANG_ENABLE_JIT_DEEPGEMM=false
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# MTP only supports TP=8 for now
+if [[ $TP -ne 8 ]]; then
+  echo "MTP only supports TP=8, got TP=$TP!"
+  exit 1
+fi
+
+# Default: recv every ~10 requests; if CONC >= 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+
+# Setting these values (passed in to --cuda-graph-max-bs and --max-running-requests) as the maximum concurrency
+# this will help us save memory from being unnecessary used.
+MAX_RUNNING_REQUESTS=512
+CUDA_GRAPH_MAX_BATCH_SIZE=512
+
+MEM_FRAC_STATIC=0.82
+CHUNKED_PREFILL_SIZE=16384
+MAX_PREFILL_TOKENS=16384
+
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# MTP (Multi-Token Prediction) Config - EAGLE speculative decoding
+SPECULATIVE_NUM_STEPS=2
+SPECULATIVE_DRAFT_TOKENS=3
+SPECULATIVE_EAGLE_TOPK=1
+
+SGLANG_ENABLE_SPEC_V2=1
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
+    --model-path=$MODEL \
+    --host=0.0.0.0 \
+    --port=$PORT \
+    --tensor-parallel-size=$TP \
+    --data-parallel-size=1 \
+    --cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE \
+    --max-running-requests $MAX_RUNNING_REQUESTS \
+    --mem-fraction-static $MEM_FRAC_STATIC \
+    --kv-cache-dtype fp8_e4m3 \
+    --chunked-prefill-size $CHUNKED_PREFILL_SIZE \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --enable-flashinfer-allreduce-fusion \
+    --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+    --disable-radix-cache \
+    --fp8-gemm-backend=flashinfer_trtllm \
+    --attention-backend trtllm_mla \
+    --stream-interval 30 \
+    --ep-size $EP_SIZE \
+    --moe-runner-backend flashinfer_trtllm \
+    --quantization fp8 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps $SPECULATIVE_NUM_STEPS \
+    --speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS \
+    --speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK \
+    $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1436,4 +1436,4 @@
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "EAGLE speculative decoding with MTP, TP=8, concurrency 4-512 for 1k1k and 8k1k"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1 does not have a B300-specific recipe, so this reuses the existing DSR1 FP8 B200 SGLang MTP recipe as-is"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1059

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1428,3 +1428,12 @@
     - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
     - "At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5 does not have a B300-specific recipe, so this reuses the existing GLM-5 FP4 B200 SGLang recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1058
+
+- config-keys:
+    - dsr1-fp8-b300-sglang-mtp
+  description:
+    - "Add DeepSeek-R1-0528 FP8 B300 SGLang MTP benchmark"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "EAGLE speculative decoding with MTP, TP=8, concurrency 4-512 for 1k1k and 8k1k"
+    - "At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1 does not have a B300-specific recipe, so this reuses the existing DSR1 FP8 B200 SGLang MTP recipe as-is"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Add `dsr1-fp8-b300-sglang-mtp` benchmark config and the corresponding `benchmarks/single_node/dsr1_fp8_b300_mtp.sh` launch script
- At the time of submission, [the SGLang DSR1 cookbook](https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1) does not have a B300-specific recipe, so this reuses the existing DSR1 FP8 B200 SGLang MTP (EAGLE speculative decoding) recipe as-is until B300-specific tuning is available
- Image bumped from B200's `v0.5.9-cu130` to `lmsysorg/sglang:v0.5.10.post1-cu130` to match the standard B300 SGLang image used by other B300 configs
- Runner: `b300`, same TP=8 / concurrency 4-512 search-space and same MTP knobs (`SPECULATIVE_NUM_STEPS=2`, `SPECULATIVE_DRAFT_TOKENS=3`, `SPECULATIVE_EAGLE_TOPK=1`) as B200

> Note: the URL cited in the request was the Kimi-K2.5 cookbook page; substituted the DSR1 cookbook URL which is the correct reference for this config.

## Test plan
- [ ] CI config validation passes
- [ ] Run `dsr1-fp8-b300-sglang-mtp` single-node benchmark on a B300 node and confirm the SGLang server starts with EAGLE MTP, benchmark completes, and result file is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)