### PR TITLE
[AMD][MI300X] Expand GPT-OSS FP4 TP=1 concurrency from 64 to 256

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -470,7 +470,7 @@ gptoss-fp4-mi300x-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 64, conc-end: 64 }
+    - { tp: 1, conc-start: 64, conc-end: 256 }
     - { tp: 2, conc-start: 4, conc-end: 64 }
     - { tp: 4, conc-start: 4, conc-end: 64 }
     - { tp: 8, conc-start: 4, conc-end: 16 }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1476,3 +1476,10 @@
     - "Image: vllm/vllm-openai:v0.19.0-cu130"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+  description:
+    - "Expand GPT-OSS 120B FP4 MI300X TP=1 concurrency from 64 to 256 for 1k1k"
+    - "Higher concurrency improves MoE weight amortization: 8552 total TPS at conc=256 vs 4016 at conc=64 (2.1x)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1053


### PR DESCRIPTION
> [!WARNING]
> This PR is a reopen of #1053, which was reverted in #1060 due to an error with the first PR. The contents and description are otherwise identical to the original.

## Summary

Expand the search space for GPT-OSS 120B FP4 on MI300X TP=1 from `conc=64` to `conc=256` for the 1k1k configuration.

## Motivation

With 128 experts and top-4 routing, larger batch sizes significantly improve MoE weight amortization across HBM. At batch=64, nearly all 111/128 unique experts are loaded per decode step — increasing concurrency amortizes this weight loading cost across more tokens.

## Results (single MI300X, vllm v0.17.0, ISL/OSL=1024)

| Concurrency | Output TPS | Total TPS | Median TPOT | vs Baseline |
|-------------|-----------|-----------|-------------|-------------|
| 64 (current) | 2,008 | 4,016 | 31.4 ms | — |
| 96 | 2,561 | 5,105 | 36.6 ms | +27% |
| 128 | 2,990 | 5,981 | 41.3 ms | +49% |
| 256 | 4,271 | 8,552 | 58.3 ms | +113% |

## Changes

- `.github/configs/amd-master.yaml`: TP=1 `conc-end` from 64 → 256
- `perf-changelog.yaml`: Added changelog entry

No benchmark script changes required.