### PR TITLE
[NV] update minimaxm2.5 fp4 b200 vllm flag

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3389,21 +3389,20 @@ minimaxm2.5-fp4-b200-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 4, conc-end: 4 }
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 2, ep: 2, conc-start: 128, conc-end: 256 }
-    - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
-    - { tp: 4, ep: 4, conc-start: 32, conc-end: 128 }
-    - { tp: 8, conc-start: 4, conc-end: 4 }
+    - { tp: 1, conc-start: 4, conc-end: 16 }
+    - { tp: 2, conc-start: 16, conc-end: 16 }
+    - { tp: 2, ep: 2, conc-start: 128, conc-end: 128 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 256, conc-end: 1024 }
+    - { tp: 4, conc-start: 4, conc-end: 16 }
+    - { tp: 4, ep: 4, conc-start: 64, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 8 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 1, conc-start: 256, conc-end: 512 }
-    - { tp: 2, conc-start: 4, conc-end: 512 }
+    - { tp: 1, conc-start: 256, conc-end: 256 }
+    - { tp: 1, conc-start: 1024, conc-end: 1024 }
     - { tp: 2, ep: 2, conc-start: 128, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 8 }
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/MiniMax/MiniMax-M2.html

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3399,8 +3399,8 @@ minimaxm2.5-fp4-b200-vllm:
   - isl: 8192
     osl: 1024
     search-space:
+    - { tp: 1, conc-start: 4, conc-end: 32 }
     - { tp: 1, conc-start: 256, conc-end: 256 }
-    - { tp: 1, conc-start: 1024, conc-end: 1024 }
     - { tp: 2, ep: 2, conc-start: 128, conc-end: 512 }
     - { tp: 4, conc-start: 4, conc-end: 8 }
     - { tp: 8, conc-start: 4, conc-end: 4 }

--- a/benchmarks/single_node/minimaxm2.5_fp4_b200.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp4_b200.sh
@@ -25,6 +25,8 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+export VLLM_FLOAT32_MATMUL_PRECISION=high
+
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
 elif [ "$EP_SIZE" -gt 1 ]; then

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1672,16 +1672,15 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1047
 
 - config-keys:
-<<<<<<< minimaxm2.5_fp4_b200-v2
-    - minimaxm2.5-fp4-b200-vllm
-  description:
-    - "Add VLLM_FLOAT32_MATMUL_PRECISION=high"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1069
-=======
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp8-h200-dynamo-sglang
   description:
     - "Add H200 multinode evals-only runs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1094
   evals-only: true
->>>>>>> main
+
+- config-keys:
+    - minimaxm2.5-fp4-b200-vllm
+  description:
+    - "Add VLLM_FLOAT32_MATMUL_PRECISION=high"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1069

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1478,4 +1478,4 @@
     - minimaxm2.5-fp4-b200-vllm
   description:
     - "Add VLLM_FLOAT32_MATMUL_PRECISION=high"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1069

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1473,3 +1473,9 @@
     - "Expand GPT-OSS 120B FP4 MI300X TP=1 concurrency from 64 to 256 for 1k1k"
     - "Higher concurrency improves MoE weight amortization: 8552 total TPS at conc=256 vs 4016 at conc=64 (2.1x)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1053
+
+- config-keys:
+    - minimaxm2.5-fp4-b200-vllm
+  description:
+    - "Add VLLM_FLOAT32_MATMUL_PRECISION=high"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Add `export VLLM_FLOAT32_MATMUL_PRECISION=high` environment variable to the MiniMax-M2.5 FP4 B200 vLLM benchmark script to improve NVFP4 matmul precision and performance
- Refine concurrency search space in `nvidia-master.yaml` for `minimaxm2.5-fp4-b200-vllm` to focus on more targeted concurrency ranges across TP/EP/DP-attention configurations
- Add perf-changelog entry documenting the `VLLM_FLOAT32_MATMUL_PRECISION=high` addition

## Changes

### Benchmark Script (`benchmarks/single_node/minimaxm2.5_fp4_b200.sh`)
- Set `VLLM_FLOAT32_MATMUL_PRECISION=high` before vLLM server launch to use higher precision float32 matmul operations

### Config (`nvidia-master.yaml`)
- Narrowed concurrency ranges for `minimaxm2.5-fp4-b200-vllm` across multiple TP/EP configurations (1k1k and 8k1k sequence lengths) to focus benchmark sweeps on the most relevant operating points

### Changelog (`perf-changelog.yaml`)
- Added entry for `minimaxm2.5-fp4-b200-vllm` documenting the new env var
