### PR TITLE
Docs: require --use-chat-template in MTP scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ When working with benchmark configurations, use these valid values:
 - Source shared utilities: `source benchmark_lib.sh`
 - Functions: `check_env_vars()`, `wait_for_server_ready()`, `run_benchmark_serving()`, `run_eval()`, `append_lm_eval_summary()`
 - Parameters passed via environment variables
+- **MTP scripts MUST pass `--use-chat-template` to `run_benchmark_serving` — no exceptions.** EAGLE-style speculative decoding is trained against chat-formatted inputs, so benchmarking against raw prompts silently regresses acceptance rate and produces misleading numbers. This applies to every `*_mtp.sh` script regardless of model, precision, or runner.
 
 ### Git
 


### PR DESCRIPTION
## Summary
Adds a one-liner to AGENTS.md under **Code Conventions → Bash** stating that every MTP (`*_mtp.sh`) script MUST pass `--use-chat-template` to `run_benchmark_serving`, no exceptions.

## Why
EAGLE-style speculative decoding is trained against chat-formatted inputs. When the benchmark client sends raw prompts, the draft model's acceptance rate silently collapses and the numbers no longer reflect realistic serving. Several recent MTP PRs shipped without the flag (#1074, #1075, #1076, #1077), so codifying this in AGENTS.md keeps future MTP additions from hitting the same foot-gun.

## Test plan
- [x] Markdown-only change, no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)