### PR TITLE
Add B300 config: qwen3.5-bf16-sglang (re-submit of #1073)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2009,6 +2009,26 @@ qwen3.5-fp4-b300-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 128 }
     - { tp: 2, ep: 2, conc-start: 4, conc-end: 128 }
 
+qwen3.5-bf16-b300-sglang:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: Qwen/Qwen3.5-397B-A17B
+  model-prefix: qwen3.5
+  runner: b300
+  precision: bf16
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+
 kimik2.5-int4-b200-vllm:
   image: vllm/vllm-openai:v0.15.1
   model: moonshotai/Kimi-K2.5

--- a/benchmarks/single_node/qwen3.5_bf16_b300.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_b300.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+export NCCL_NVLS_ENABLE=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+export PYTHONUNBUFFERED=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# Default: recv every ~10 requests; if CONC ≥ 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+
+MEM_FRAC_STATIC=0.82
+CHUNKED_PREFILL_SIZE=32768
+MAX_PREFILL_TOKENS=32768
+CUDA_GRAPH_MAX_BATCH_SIZE=$CONC
+MAX_RUNNING_REQUESTS=128
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    CONTEXT_LENGTH="$EVAL_MAX_MODEL_LEN"
+fi
+
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--served-model-name "Qwen/Qwen3.5-397B-A17B" --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 --ep-size $EP_SIZE \
+--cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE --max-running-requests $MAX_RUNNING_REQUESTS \
+--mem-fraction-static $MEM_FRAC_STATIC --chunked-prefill-size $CHUNKED_PREFILL_SIZE --max-prefill-tokens $MAX_PREFILL_TOKENS \
+--context-length $CONTEXT_LENGTH --disable-radix-cache \
+--attention-backend trtllm_mha --moe-runner-backend flashinfer_trtllm \
+--enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--tokenizer-worker-num 6 --stream-interval 30 > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1486,3 +1486,13 @@
     - "Mirrors the B200 FP4 recipe with mem-fraction-static lowered to 0.8 and an extra TP2/EP2 search-space entry"
     - "Configs: 1k1k and 8k1k, TP4/EP1 conc 4-128 + TP2/EP2 conc 4-128"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+
+- config-keys:
+    - qwen3.5-bf16-b300-sglang
+  description:
+    - "Add Qwen3.5-397B-A17B BF16 B300 SGLang benchmark"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "Model: Qwen/Qwen3.5-397B-A17B"
+    - "Mirrors the B200 BF16 recipe with an extra TP4/EP1 search-space entry alongside the existing TP8/EP1 sweep"
+    - "Configs: 1k1k and 8k1k, TP8/EP1 conc 4-64 + TP4/EP1 conc 4-64"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
Re-submits the `qwen3.5-bf16-b300-sglang` config after #1080 reverted the original merge #1073. Contents are identical to #1073:
- New `benchmarks/single_node/qwen3.5_bf16_b300.sh` launch script.
- New config block in `.github/configs/nvidia-master.yaml` with TP8/EP1 + TP4/EP1 rows (conc 4-64) for 1k1k and 8k1k.
- New `perf-changelog.yaml` entry.

## Why this re-submit is needed
The rebase conflict resolution in #1073 changed the existing `qwen3.5-fp4-b300-sglang` perf-changelog entry's `pr-link` from `XXXX` to `1072`. `utils/process_changelog.py` treats any removed line as a forbidden deletion and fails the post-merge workflow:

```
ValueError: Deletions are not allowed in perf-changelog.yaml.
Only additions to the changelog are permitted.
Found deleted line:
  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
```

This PR is pure-append on `perf-changelog.yaml` — `git diff` shows additions only, no modifications to any existing line — so the process_changelog check passes.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/configs/nvidia-master.yaml'))"` — YAML parses.
- [x] `python3 -c "import yaml; yaml.safe_load(open('perf-changelog.yaml'))"` — YAML parses.
- [x] `bash -n benchmarks/single_node/qwen3.5_bf16_b300.sh` — bash syntax OK.
- [x] `git diff perf-changelog.yaml` shows only additions (no `-` lines).
- [ ] CI sweep passes on B300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)