### PR TITLE
Add B300 config: qwen3.5-fp4-sglang-mtp

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2027,6 +2027,26 @@ qwen3.5-fp4-b300-sglang:
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 128 }
     - { tp: 2, ep: 2, conc-start: 4, conc-end: 128 }
 
+qwen3.5-fp4-b300-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: nvidia/Qwen3.5-397B-A17B-NVFP4
+  model-prefix: qwen3.5
+  runner: b300
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+    - { tp: 2, ep: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+    - { tp: 2, ep: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+
 qwen3.5-bf16-b300-sglang:
   image: lmsysorg/sglang:v0.5.10.post1-cu130
   model: Qwen/Qwen3.5-397B-A17B

--- a/benchmarks/single_node/qwen3.5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp4_b300_mtp.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Follows the SGLang cookbook recipe at
+# https://cookbook.sglang.io/autoregressive/Qwen/Qwen3.5 as of 2026-04-17.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+export NCCL_NVLS_ENABLE=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+export PYTHONUNBUFFERED=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# Default: recv every ~10 requests; if CONC >= 16, relax to ~30 requests between scheduler recv polls.
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+
+MEM_FRAC_STATIC=0.8
+CHUNKED_PREFILL_SIZE=32768
+MAX_PREFILL_TOKENS=32768
+CUDA_GRAPH_MAX_BATCH_SIZE=$CONC
+MAX_RUNNING_REQUESTS=128
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    CONTEXT_LENGTH="$EVAL_MAX_MODEL_LEN"
+fi
+
+if [[ $TP -eq 8 ]]; then
+  EXTRA_ARGS="--enable-flashinfer-allreduce-fusion"
+else
+  EXTRA_ARGS=""
+fi
+
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 --ep-size $EP_SIZE \
+--reasoning-parser qwen3 \
+--tool-call-parser qwen3_coder \
+--mamba-scheduler-strategy no_buffer \
+--quantization modelopt_fp4 --fp4-gemm-backend flashinfer_cutlass \
+--kv-cache-dtype fp8_e4m3 \
+--mamba-ssm-dtype bfloat16 \
+--cuda-graph-max-bs $CUDA_GRAPH_MAX_BATCH_SIZE --max-running-requests $MAX_RUNNING_REQUESTS \
+--mem-fraction-static $MEM_FRAC_STATIC --chunked-prefill-size $CHUNKED_PREFILL_SIZE --max-prefill-tokens $MAX_PREFILL_TOKENS \
+--context-length $CONTEXT_LENGTH --disable-radix-cache \
+--attention-backend trtllm_mha --moe-runner-backend flashinfer_trtllm \
+$EXTRA_ARGS --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--tokenizer-worker-num 6 --stream-interval 30 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+> $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1516,3 +1516,13 @@
     - "Mirrors the qwen3.5-bf16-b300-sglang non-MTP recipe and adds EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4)"
     - "Configs: 1k1k and 8k1k, TP8/EP1 conc 4-64 + TP4/EP1 conc 4-64, spec-decoding=mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+
+- config-keys:
+    - qwen3.5-fp4-b300-sglang-mtp
+  description:
+    - "Add Qwen3.5-397B-A17B NVFP4 B300 SGLang MTP benchmark"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "Model: nvidia/Qwen3.5-397B-A17B-NVFP4"
+    - "Mirrors the qwen3.5-fp4-b300-sglang non-MTP recipe and adds EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4)"
+    - "Configs: 1k1k and 8k1k, TP4/EP1 conc 4-128 + TP2/EP2 conc 4-128, spec-decoding=mtp"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Adds `qwen3.5-fp4-b300-sglang-mtp` config mirroring the existing `qwen3.5-fp4-b300-sglang` non-MTP recipe, plus a new `benchmarks/single_node/qwen3.5_fp4_b300_mtp.sh` launch script.
- Adds EAGLE speculative decoding flags on top of the non-MTP script: `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.
- Passes `--use-chat-template` to `run_benchmark_serving` per the AGENTS.md requirement for all MTP scripts.
- Search space rows carry `spec-decoding: mtp` so the runner picks up the `_mtp.sh` variant.
- `perf-changelog.yaml` diff is append-only (no modifications to any existing line).

## Test plan
- [x] YAML parses for both master config and perf-changelog.
- [x] `bash -n benchmarks/single_node/qwen3.5_fp4_b300_mtp.sh` — bash syntax OK.
- [x] `git diff perf-changelog.yaml` shows only additions.
- [x] `python3 utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/nvidia-master.yaml` — emits 24 entries (2 ISL/OSL × 2 search-space rows × 6 concurrencies) with spec-decoding=mtp.
- [ ] CI sweep passes on B300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)