### PR TITLE
Add B200 config: glm5-fp8-sglang-mtp

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1888,6 +1888,24 @@ glm5-fp8-b200-sglang:
     search-space:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
+glm5-fp8-b200-sglang-mtp:
+  image: lmsysorg/sglang:nightly-dev-cu13-20260317-1eea7448
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: b200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
 # does not have a B300-specific recipe, so this config reuses the existing GLM5 FP8
 # B200 SGLang recipe as-is until B300-specific tuning is available.

--- a/benchmarks/single_node/glm5_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_b200_mtp.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+
+export SGL_ENABLE_JIT_DEEPGEMM=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+--data-parallel-size 1 --expert-parallel-size 1 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
+--kv-cache-dtype fp8_e4m3 --quantization fp8 \
+--attention-backend nsa \
+--nsa-decode-backend trtllm --nsa-prefill-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--cuda-graph-max-bs $CONC --max-running-requests $CONC \
+--mem-fraction-static 0.85 \
+--chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --disable-radix-cache \
+--stream-interval 30 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+--model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1546,3 +1546,13 @@
     - "Mirrors the qwen3.5-bf16-mi355x-sglang non-MTP recipe and adds EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4)"
     - "Configs: 1k1k and 8k1k, TP=8/EP=1 conc 4-256 with spec-decoding=mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+
+- config-keys:
+    - glm5-fp8-b200-sglang-mtp
+  description:
+    - "Add GLM-5 FP8 B200 SGLang MTP benchmark"
+    - "Image: lmsysorg/sglang:nightly-dev-cu13-20260317-1eea7448"
+    - "Model: zai-org/GLM-5-FP8"
+    - "Mirrors the glm5-fp8-b200-sglang non-MTP recipe and adds EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4) behind SGLANG_ENABLE_SPEC_V2=1"
+    - "Configs: 1k1k and 8k1k, TP=8/EP=1 conc 4-256 with spec-decoding=mtp"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Adds `glm5-fp8-b200-sglang-mtp` config mirroring the existing `glm5-fp8-b200-sglang` non-MTP recipe, plus a new `benchmarks/single_node/glm5_fp8_b200_mtp.sh` launch script.
- Adds EAGLE speculative decoding flags on top of the non-MTP script: `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.
- Sets `SGLANG_ENABLE_SPEC_V2=1` in the env before `sglang.launch_server` (required for GLM-5 MTP).
- Passes `--use-chat-template` to `run_benchmark_serving` per the AGENTS.md requirement for all MTP scripts.
- Search space rows carry `spec-decoding: mtp` so the runner picks up the `_mtp.sh` variant.
- `perf-changelog.yaml` diff is append-only (no modifications to any existing line).

## Test plan
- [x] YAML parses for both master config and perf-changelog.
- [x] `bash -n benchmarks/single_node/glm5_fp8_b200_mtp.sh` — bash syntax OK.
- [x] `git diff perf-changelog.yaml` shows only additions.
- [x] `python3 utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/nvidia-master.yaml` — emits 14 entries (2 ISL/OSL × 7 concurrencies) with spec-decoding=mtp.
- [ ] CI sweep passes on B200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)