### PR TITLE
Add B300 config: glm5-fp4-sglang-mtp

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1988,6 +1988,26 @@ glm5-fp4-b300-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
+glm5-fp4-b300-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  model: nvidia/GLM-5-NVFP4
+  model-prefix: glm5
+  runner: b300
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4, spec-decoding: mtp }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 4, spec-decoding: mtp }
+    - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.9-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/glm5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/glm5_fp4_b300_mtp.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
+# does not have a B300-specific recipe, so this script reuses the existing
+# GLM5 FP8 B200 SGLang recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+
+export SGL_ENABLE_JIT_DEEPGEMM=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP \
+--data-parallel-size 1 --expert-parallel-size 1 \
+--tool-call-parser glm47 \
+--reasoning-parser glm45 \
+--kv-cache-dtype fp8_e4m3 --quantization fp8 \
+--attention-backend nsa \
+--nsa-decode-backend trtllm --nsa-prefill-backend trtllm \
+--moe-runner-backend flashinfer_trtllm \
+--cuda-graph-max-bs $CONC --max-running-requests $CONC \
+--mem-fraction-static 0.85 \
+--chunked-prefill-size 32768 --max-prefill-tokens 32768 \
+--enable-flashinfer-allreduce-fusion --disable-radix-cache \
+--stream-interval 30 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+--model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1556,3 +1556,13 @@
     - "Mirrors the glm5-fp8-b200-sglang non-MTP recipe and adds EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4) behind SGLANG_ENABLE_SPEC_V2=1"
     - "Configs: 1k1k and 8k1k, TP=8/EP=1 conc 4-256 with spec-decoding=mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+
+- config-keys:
+    - glm5-fp4-b300-sglang-mtp
+  description:
+    - "Add GLM-5 NVFP4 B300 SGLang MTP benchmark (draft)"
+    - "Image: lmsysorg/sglang:v0.5.10.post1-cu130"
+    - "Model: nvidia/GLM-5-NVFP4"
+    - "Follows the glm5-fp8-b300-sglang launch recipe as requested, plus EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4) behind SGLANG_ENABLE_SPEC_V2=1"
+    - "Configs: 1k1k and 8k1k, TP8/EP1 conc 4-4 + TP4/EP1 conc 4-256 with spec-decoding=mtp"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Status
**Draft** — opening for review before labeling for sweep.

## Summary
- Adds `glm5-fp4-b300-sglang-mtp` config + new `benchmarks/single_node/glm5_fp4_b300_mtp.sh` launch script.
- **Launch recipe**: follows `glm5-fp8-b300-sglang` non-MTP script verbatim (as requested), not the existing `glm5_fp4_b200.sh` fp4 recipe. Please sanity-check whether this is intended — the fp8 script has `--quantization fp8` and `--kv-cache-dtype fp8_e4m3` hardcoded, which may or may not interact correctly with the NVFP4 weights in `nvidia/GLM-5-NVFP4`.
- Adds EAGLE speculative decoding flags on top of the fp8 script: `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.
- Sets `SGLANG_ENABLE_SPEC_V2=1` in the env before `sglang.launch_server` (required for GLM-5 MTP).
- Passes `--use-chat-template` to `run_benchmark_serving` per the AGENTS.md requirement for all MTP scripts.
- Config block: NVFP4 model, fp4 precision, search-space mirrors `glm5-fp4-b300-sglang` (TP8/EP1 conc 4-4 + TP4/EP1 conc 4-256, for 1k1k and 8k1k), with `spec-decoding: mtp` on every row.
- `perf-changelog.yaml` diff is append-only.

## Test plan
- [x] YAML parses for both master config and perf-changelog.
- [x] `bash -n benchmarks/single_node/glm5_fp4_b300_mtp.sh` — bash syntax OK.
- [x] `git diff perf-changelog.yaml` shows only additions.
- [x] `python3 utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/nvidia-master.yaml` — emits 16 entries with spec-decoding=mtp.
- [ ] Decide whether fp8 launch flags are correct for NVFP4 weights, or if script should switch to fp4-specific quantization.
- [ ] CI sweep passes on B300 once labeled `sweep-enabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)