### PR TITLE
[SGLang broken] Add MI355X config: glm5-fp4-sglang-mtp

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -319,6 +319,24 @@ glm5-fp8-mi355x-sglang-mtp:
     search-space:
     - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
+glm5-fp4-mi355x-sglang-mtp:
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm700-mi35x-20260422
+  model: amd/GLM-5-MXFP4
+  model-prefix: glm5
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 glm5-fp8-mi355x-atom:
   image: rocm/atom:rocm7.2.1-ubuntu24.04-pytorch2.9.1-atom0.1.2.post
   model: zai-org/GLM-5-FP8

--- a/benchmarks/single_node/glm5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/glm5_fp4_mi355x_mtp.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --trust-remote-code \
+    --tp $TP \
+    --chunked-prefill-size 131072 \
+    --disable-radix-cache \
+    --mem-fraction-static 0.85 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    --watchdog-timeout 1200 \
+    --reasoning-parser glm45 \
+    --tool-call-parser glm47 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1702,3 +1702,14 @@
   description:
     - "Add VLLM_FLOAT32_MATMUL_PRECISION=high"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1069
+
+- config-keys:
+    - glm5-fp4-mi355x-sglang-mtp
+  description:
+    - "Add GLM-5 MXFP4 MI355X SGLang MTP benchmark"
+    - "Image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm700-mi35x-20260422"
+    - "Model: amd/GLM-5-MXFP4"
+    - "EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4) behind SGLANG_ENABLE_SPEC_V2=1"
+    - "Image ships transformers with glm_moe_dsa support, so no extra pip install is needed (unlike glm5-fp8-mi355x-sglang)"
+    - "Configs: 1k1k and 8k1k, TP=8 conc 4-64 with spec-decoding=mtp"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX


### PR DESCRIPTION
## Summary
- Adds `glm5-fp4-mi355x-sglang-mtp` config + new `benchmarks/single_node/glm5_fp4_mi355x_mtp.sh` launch script.
- **Image**: `lmsysorg/sglang-rocm:v0.5.10rc0-rocm700-mi35x-20260417` — already ships transformers with `glm_moe_dsa` support, so no `pip install -U transformers` is needed (unlike `glm5-fp8-mi355x-sglang`).
- **Model**: `amd/GLM-5-MXFP4`.
- Launch flags per the request: `--trust-remote-code`, `--tp $TP`, `--chunked-prefill-size 131072`, `--disable-radix-cache`, `--mem-fraction-static 0.85`, `--model-loader-extra-config '{"enable_multithread_load": true}'`, `--watchdog-timeout 1200`, `--reasoning-parser glm45`, `--tool-call-parser glm47`, plus EAGLE spec-decoding (`--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`) behind `SGLANG_ENABLE_SPEC_V2=1`.
- Client passes `--use-chat-template` per AGENTS.md for MTP.
- Search-space: `{ tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }` for 1k1k and 8k1k.
- `perf-changelog.yaml` diff is append-only.

## Test plan
- [x] YAML parses for both master config and perf-changelog.
- [x] `bash -n benchmarks/single_node/glm5_fp4_mi355x_mtp.sh` — bash syntax OK.
- [x] `git diff perf-changelog.yaml` shows only additions.
- [x] `python3 utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/amd-master.yaml` — emits 10 entries (2 ISL/OSL × 5 concurrencies) with spec-decoding=mtp.
- [ ] CI sweep passes on MI355X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)