### PR TITLE
Trigger H200 multinode evals & revert MI355X image to mori-0227-3

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -953,7 +953,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
 
 
 dsr1-fp4-mi355x-sglang-disagg:
-  image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0313-2
+  image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-3
   model: amd/DeepSeek-R1-0528-MXFP4
   model-prefix: dsr1
   runner: mi355x-disagg
@@ -1161,7 +1161,7 @@ dsr1-fp4-mi355x-sglang-disagg:
         - "DECODE_MTP_SIZE=0"
 
 dsr1-fp4-mi355x-sglang-disagg-mtp:
-  image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0313-2
+  image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-3
   model: amd/DeepSeek-R1-0528-MXFP4
   model-prefix: dsr1
   runner: mi355x-disagg

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,16 @@
 - config-keys:
+    - dsr1-fp4-gb300-dynamo-trt
+    - dsr1-fp8-gb300-dynamo-trt
+    - dsr1-fp4-gb300-dynamo-sglang
+    - dsr1-fp8-gb300-dynamo-sglang
+    - dsr1-fp8-h200-dynamo-trt
+    - dsr1-fp8-h200-dynamo-sglang
+  description:
+    - "Add GB300 and H200 multinode evals-only runs"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1094
+  evals-only: true
+
+- config-keys:
     - kimik2.5-fp4-gb200-dynamo-trt
   description:
     - "Add Kimi K2.5 NVFP4 GB200 disaggregated TRT-LLM benchmarks via Dynamo (14 STP configs)"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,4 @@
 - config-keys:
-    - dsr1-fp8-h200-dynamo-trt
-    - dsr1-fp8-h200-dynamo-sglang
-  description:
-    - "Add H200 multinode evals-only runs"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1094
-  evals-only: true
-
-- config-keys:
     - kimik2.5-fp4-gb200-dynamo-trt
   description:
     - "Add Kimi K2.5 NVFP4 GB200 disaggregated TRT-LLM benchmarks via Dynamo (14 STP configs)"
@@ -1648,3 +1640,11 @@
     - "Follows the glm5-fp8-b200-sglang launch recipe as requested, plus EAGLE speculative decoding (num-steps=3, eagle-topk=1, num-draft-tokens=4) behind SGLANG_ENABLE_SPEC_V2=1"
     - "Configs: 1k1k and 8k1k, TP8/EP1 conc 4-4 + TP4/EP1 conc 4-256 with spec-decoding=mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+
+- config-keys:
+    - dsr1-fp8-h200-dynamo-trt
+    - dsr1-fp8-h200-dynamo-sglang
+  description:
+    - "Add H200 multinode evals-only runs"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1094
+  evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,12 +1,8 @@
 - config-keys:
-    - dsr1-fp4-gb300-dynamo-trt
-    - dsr1-fp8-gb300-dynamo-trt
-    - dsr1-fp4-gb300-dynamo-sglang
-    - dsr1-fp8-gb300-dynamo-sglang
     - dsr1-fp8-h200-dynamo-trt
     - dsr1-fp8-h200-dynamo-sglang
   description:
-    - "Add GB300 and H200 multinode evals-only runs"
+    - "Add H200 multinode evals-only runs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1094
   evals-only: true
 

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -126,13 +126,8 @@ EOF
 
     # Override the job name in the config file with the runner name
     sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_FILE"
-    # Bump health check timeout: replace if exists, append if not
-    CONFIG_YAML="${CONFIG_FILE%%:*}"
-    if grep -q 'max_attempts' "$CONFIG_YAML"; then
-        sed -i 's/^  max_attempts: [0-9]*/  max_attempts: 720/' "$CONFIG_YAML"
-    else
-        printf '\nhealth_check:\n  max_attempts: 720\n  interval_seconds: 10\n' >> "$CONFIG_YAML"
-    fi
+    sed -i '/^health_check:/,/^[^ ]/{ /^health_check:/d; /^  /d; }' "${CONFIG_FILE%%:*}"
+    printf '\nhealth_check:\n  max_attempts: 720\n  interval_seconds: 10\n' >> "${CONFIG_FILE%%:*}"
     SRTCTL_OUTPUT=$(srtctl apply -f "$CONFIG_FILE" --tags "h200,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)" 2>&1)
     echo "$SRTCTL_OUTPUT"
 

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -126,7 +126,13 @@ EOF
 
     # Override the job name in the config file with the runner name
     sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_FILE"
-    sed -i 's/^  max_attempts: [0-9]*/  max_attempts: 720/' "${CONFIG_FILE%%:*}"
+    # Bump health check timeout: replace if exists, append if not
+    CONFIG_YAML="${CONFIG_FILE%%:*}"
+    if grep -q 'max_attempts' "$CONFIG_YAML"; then
+        sed -i 's/^  max_attempts: [0-9]*/  max_attempts: 720/' "$CONFIG_YAML"
+    else
+        printf '\nhealth_check:\n  max_attempts: 720\n  interval_seconds: 10\n' >> "$CONFIG_YAML"
+    fi
     SRTCTL_OUTPUT=$(srtctl apply -f "$CONFIG_FILE" --tags "h200,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)" 2>&1)
     echo "$SRTCTL_OUTPUT"
 

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -126,6 +126,7 @@ EOF
 
     # Override the job name in the config file with the runner name
     sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_FILE"
+    sed -i 's/^  max_attempts: [0-9]*/  max_attempts: 720/' "${CONFIG_FILE%%:*}"
     SRTCTL_OUTPUT=$(srtctl apply -f "$CONFIG_FILE" --tags "h200,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)" 2>&1)
     echo "$SRTCTL_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Trigger missing H200 multinode evals from #1000 
- Revert `dsr1-fp4-mi355x-sglang-disagg` and `dsr1-fp4-mi355x-sglang-disagg-mtp` image from `mori-0313-2` back to `mori-0227-3`
- H100 multinode still missing due to cluster NVSHEMM issues