### PR TITLE
fix: remove dead import and redundant entry dicts in generate_sweep_configs

### DIFF
--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -1,4 +1,3 @@
-from ast import For
 import fnmatch
 import json
 import argparse
@@ -265,26 +264,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                         else:
                             conc_values = filtered_conc
 
-                    # For multinode, create a single entry with conc as a list
                     seq_len_str = seq_len_to_str(isl, osl)
-                    entry = {
-                        Fields.IMAGE.value: image,
-                        Fields.MODEL.value: model,
-                        Fields.MODEL_PREFIX.value: model_code,
-                        Fields.PRECISION.value: precision,
-                        Fields.FRAMEWORK.value: framework,
-                        Fields.RUNNER.value: runner,
-                        Fields.ISL.value: isl,
-                        Fields.OSL.value: osl,
-                        Fields.SPEC_DECODING.value: spec_decoding,
-                        Fields.PREFILL.value: prefill,
-                        Fields.DECODE.value: decode,
-                        Fields.CONC.value: conc_values,  # Pass the entire list for multinode
-                        Fields.MAX_MODEL_LEN.value: isl + osl + 200,
-                        Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                        Fields.DISAGG.value: disagg,
-                        Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
-                    }
 
                     # Determine which runner(s) to use
                     runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
@@ -355,32 +335,11 @@ def generate_full_sweep(args, all_config_data, runner_data):
                         else:
                             conc_end = min(conc_end, args.max_conc)
 
+                    seq_len_str = seq_len_to_str(isl, osl)
+                    runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
+
                     conc = conc_start
                     while conc <= conc_end:
-                        seq_len_str = seq_len_to_str(isl, osl)
-                        entry = {
-                            Fields.IMAGE.value: image,
-                            Fields.MODEL.value: model,
-                            Fields.MODEL_PREFIX.value: model_code,
-                            Fields.PRECISION.value: precision,
-                            Fields.FRAMEWORK.value: framework,
-                            Fields.RUNNER.value: runner,
-                            Fields.ISL.value: isl,
-                            Fields.OSL.value: osl,
-                            Fields.TP.value: tp,
-                            Fields.CONC.value: conc,
-                            Fields.MAX_MODEL_LEN.value: isl + osl + 200,
-                            Fields.EP.value: 1,  # Default
-                            Fields.DP_ATTN.value: False,  # Default
-                            Fields.SPEC_DECODING.value: spec_decoding,
-                            Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                            Fields.DISAGG.value: disagg,
-                            Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
-                        }
-
-                        # Determine which runner(s) to use
-                        runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
-
                         for runner_value in runners_for_entry:
                             entry = {
                                 Fields.IMAGE.value: image,


### PR DESCRIPTION
## Summary

Two dead code issues in `utils/matrix_logic/generate_sweep_configs.py`:

- **Unused import**: `from ast import For` — `For` is an AST node class that's never referenced in this file. Left over from an earlier draft, importing it silently pulls in `ast` for no reason.
- **Redundant dict construction**: In both the multinode and single-node branches of `generate_full_sweep()`, an `entry` dict was built and immediately thrown away because the very next line starts a `for runner_value in runners_for_entry:` loop that rebuilds an identical dict. The outer construction was dead code — it was never validated or appended. Removed it and hoisted `seq_len_str` / `runners_for_entry` above the loop where they belong.

## Test plan

- [ ] `python3 -c "from utils.matrix_logic.generate_sweep_configs import generate_full_sweep"` — no ImportError
- [ ] Existing unit tests pass: `python3 -m pytest utils/matrix_logic/`
- [ ] Output of `generate_full_sweep` is identical before and after (behavior unchanged, only dead code removed)