### PR TITLE
Fix #1110 docker-tag-monitor workflow

### DIFF
--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -38,6 +38,15 @@ jobs:
           # Only monitor these Docker Hub repos for updates
           MONITORED_REPOS="lmsysorg/sglang lmsysorg/sglang-rocm vllm/vllm-openai vllm/vllm-openai-rocm"
 
+          # Normalize suffix: strip rc prefixes and date stamps so suffixes
+          # like "rc0-rocm720-mi35x-20260413" become "-rocm720-mi35x"
+          normalize_suffix() {
+            local s="$1"
+            s=$(echo "$s" | sed -E 's/^rc[0-9]+//; s/-[0-9]{8}(-[0-9]+)?$//')
+            [[ -z "$s" ]] && s="BARE"
+            echo "$s"
+          }
+
           while IFS= read -r img; do
             repo="${img%%:*}"
             tag="${img#*:}"
@@ -49,15 +58,13 @@ jobs:
             base_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
             [[ -z "$base_ver" ]] && continue
 
-            # Extract suffix after the version (e.g., "-cu130" from "v0.19.0-cu130")
             suffix="${tag#"$base_ver"}"
-            [[ -z "$suffix" ]] && suffix="BARE"
+            suffix=$(normalize_suffix "$suffix")
 
             prev="${CURRENT_VERSIONS[$repo]:-}"
             if [[ -z "$prev" ]] || [[ "$(printf '%s\n%s\n' "$prev" "$base_ver" | sort -V | tail -1)" == "$base_ver" ]]; then
               CURRENT_VERSIONS[$repo]="$base_ver"
             fi
-            # Collect unique suffixes per repo (space-separated)
             if [[ ! " ${REPO_SUFFIXES[$repo]:-} " == *" ${suffix} "* ]]; then
               REPO_SUFFIXES[$repo]="${REPO_SUFFIXES[$repo]:-} ${suffix}"
             fi
@@ -92,9 +99,9 @@ jobs:
               [[ -z "$tag_ver" ]] && continue
               [[ "$tag" == *nightly* || "$tag" == *dev* ]] && continue
 
-              # Only report tags whose suffix matches one already in use
-              local tag_suffix="${tag#"$tag_ver"}"
-              [[ -z "$tag_suffix" ]] && tag_suffix="BARE"
+              # Only report tags whose normalized suffix matches one already in use
+              local tag_suffix
+              tag_suffix=$(normalize_suffix "${tag#"$tag_ver"}")
               local matched=false
               for s in $allowed_suffixes; do
                 if [[ "$tag_suffix" == "$s" ]]; then

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -31,13 +31,12 @@ jobs:
           SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
           # Extract unique image:tag pairs from both config files
+          # Track highest version per repo and the tag suffixes actually in use
           declare -A CURRENT_VERSIONS
-          declare -A REPO_CURRENT_TAGS
+          declare -A REPO_SUFFIXES
 
           while IFS= read -r img; do
-            # Skip non-Docker-Hub registries
             [[ "$img" == nvcr.io* ]] && continue
-            # Skip nightly/dev builds
             [[ "$img" == *nightly* || "$img" == *-dev* ]] && continue
 
             repo="${img%%:*}"
@@ -46,24 +45,30 @@ jobs:
             base_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
             [[ -z "$base_ver" ]] && continue
 
+            # Extract suffix after the version (e.g., "-cu130" from "v0.19.0-cu130")
+            suffix="${tag#"$base_ver"}"
+
             prev="${CURRENT_VERSIONS[$repo]:-}"
             if [[ -z "$prev" ]] || [[ "$(printf '%s\n%s\n' "$prev" "$base_ver" | sort -V | tail -1)" == "$base_ver" ]]; then
               CURRENT_VERSIONS[$repo]="$base_ver"
             fi
-            REPO_CURRENT_TAGS[$repo]="${REPO_CURRENT_TAGS[$repo]:-}${REPO_CURRENT_TAGS[$repo]:+, }$tag"
+            # Collect unique suffixes per repo (space-separated)
+            if [[ ! " ${REPO_SUFFIXES[$repo]:-} " == *" ${suffix} "* ]]; then
+              REPO_SUFFIXES[$repo]="${REPO_SUFFIXES[$repo]:-} ${suffix}"
+            fi
           done < <(grep -h '^\s*image:' .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml \
             | sed 's/.*image:\s*//; s/"//g; s/'"'"'//g' | sort -u)
 
           echo "=== Currently tracked repos ==="
           for repo in "${!CURRENT_VERSIONS[@]}"; do
-            echo "  $repo: ${CURRENT_VERSIONS[$repo]}"
+            echo "  $repo: ${CURRENT_VERSIONS[$repo]} (suffixes:${REPO_SUFFIXES[$repo]:-})"
           done
 
           FOUND_UPDATES=$(mktemp)
 
           check_dockerhub() {
-            local repo="$1" current_ver="$2" tag_pattern="$3"
-            echo "Checking $repo (current: $current_ver)..." >&2
+            local repo="$1" current_ver="$2" allowed_suffixes="$3"
+            echo "Checking $repo (current: $current_ver, suffixes:$allowed_suffixes)..." >&2
 
             local response
             response=$(curl -sf "https://hub.docker.com/v2/repositories/${repo}/tags?page_size=50&ordering=last_updated" 2>/dev/null) || {
@@ -71,16 +76,27 @@ jobs:
               return
             }
 
-            echo "$response" | jq -r --arg since "$SEVEN_DAYS_AGO" --arg pattern "$tag_pattern" '
+            echo "$response" | jq -r --arg since "$SEVEN_DAYS_AGO" '
               .results[]
               | select(.last_updated > $since)
-              | select(.name | test($pattern))
+              | select(.name | test("^v[0-9]"))
               | "\(.name)\t\(.last_updated)"
             ' 2>/dev/null | while IFS=$'\t' read -r tag updated; do
               local tag_ver
               tag_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
               [[ -z "$tag_ver" ]] && continue
               [[ "$tag" == *nightly* || "$tag" == *dev* ]] && continue
+
+              # Only report tags whose suffix matches one already in use
+              local tag_suffix="${tag#"$tag_ver"}"
+              local matched=false
+              for s in $allowed_suffixes; do
+                if [[ "$tag_suffix" == "$s" ]]; then
+                  matched=true
+                  break
+                fi
+              done
+              [[ "$matched" == false ]] && continue
 
               local higher
               higher=$(printf '%s\n%s\n' "$current_ver" "$tag_ver" | sort -V | tail -1)
@@ -93,15 +109,8 @@ jobs:
 
           for repo in "${!CURRENT_VERSIONS[@]}"; do
             current="${CURRENT_VERSIONS[$repo]}"
-            case "$repo" in
-              lmsysorg/sglang)       check_dockerhub "$repo" "$current" '^v[0-9]' >> "$FOUND_UPDATES" ;;
-              lmsysorg/sglang-rocm)  check_dockerhub "$repo" "$current" '^v[0-9]' >> "$FOUND_UPDATES" ;;
-              vllm/vllm-openai)      check_dockerhub "$repo" "$current" '^v[0-9]+\.[0-9]+\.[0-9]' >> "$FOUND_UPDATES" ;;
-              vllm/vllm-openai-rocm) check_dockerhub "$repo" "$current" '^v[0-9]+\.[0-9]+\.[0-9]' >> "$FOUND_UPDATES" ;;
-              rocm/atom)             check_dockerhub "$repo" "$current" 'atom' >> "$FOUND_UPDATES" ;;
-              rocm/sgl-dev)          check_dockerhub "$repo" "$current" 'sglang' >> "$FOUND_UPDATES" ;;
-              *)                     echo "Skipping unknown repo: $repo" >&2 ;;
-            esac
+            suffixes="${REPO_SUFFIXES[$repo]:-}"
+            check_dockerhub "$repo" "$current" "$suffixes" >> "$FOUND_UPDATES"
           done
 
           UPDATES=$(grep '|' "$FOUND_UPDATES" | sort -u || true)

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -2,8 +2,7 @@ name: Docker Tag Monitor
 
 on:
   schedule:
-    # Run weekly on Mondays at 6:00 UTC
-    - cron: '0 8 * * 6'
+    - cron: '0 7 * * 6'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -22,75 +21,154 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
 
-      - name: Check for Docker image updates via Claude
-        uses: anthropics/claude-code-action@beta
-        with:
-          direct_prompt: |
-            Check Docker Hub for new vLLM and SGLang releases and create an issue if updates are available.
+      - name: Check for new Docker image releases
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
 
-            ## Your Task
+          SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
-            1. **Check Docker Hub for latest releases:**
-               - SGLang CUDA: `lmsysorg/sglang` - tags matching `v*-cu*-amd64` (e.g., v0.5.8-cu129-amd64)
-               - SGLang ROCm: `lmsysorg/sglang` - tags matching `v*-rocm*-mi*` (e.g., v0.5.8-rocm700-mi35x)
-               - vLLM CUDA: `vllm/vllm-openai` - tags matching `v*.*.*` (e.g., v0.13.0)
-               - vLLM ROCm: `vllm/vllm-openai-rocm` - tags matching `v*.*.*` (e.g., v0.14.0)
+          # Extract unique image:tag pairs from both config files
+          declare -A CURRENT_VERSIONS
+          declare -A REPO_CURRENT_TAGS
 
-            2. **Compare with current configs:**
-               - Read `.github/configs/nvidia-master.yaml` for NVIDIA/CUDA images
-               - Read `.github/configs/amd-master.yaml` for AMD/ROCm images
-               - Extract current image versions being used
+          while IFS= read -r img; do
+            # Skip non-Docker-Hub registries
+            [[ "$img" == nvcr.io* ]] && continue
+            # Skip nightly/dev builds
+            [[ "$img" == *nightly* || "$img" == *-dev* ]] && continue
 
-            3. **If updates are available AND this is not a dry run (${{ inputs.dry_run }} == 'false'):**
-               Create a new GitHub issue with:
-               - Title: `[Auto] Docker Image Updates Available - YYYY-MM-DD`
-               - Labels: `docker-update`, `claude-task`
-               - Body containing:
-                 - Table of available updates (image, latest tag, current tags)
-                 - Links to Docker Hub for each image
-                 - An `@claude` mention at the end asking to update the configs
+            repo="${img%%:*}"
+            tag="${img#*:}"
 
-            4. **If dry run (${{ inputs.dry_run }} == 'true'):**
-               Just report what updates are available without creating an issue.
+            base_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
+            [[ -z "$base_ver" ]] && continue
 
-            ## Issue Body Template (when creating issue)
+            prev="${CURRENT_VERSIONS[$repo]:-}"
+            if [[ -z "$prev" ]] || [[ "$(printf '%s\n%s\n' "$prev" "$base_ver" | sort -V | tail -1)" == "$base_ver" ]]; then
+              CURRENT_VERSIONS[$repo]="$base_ver"
+            fi
+            REPO_CURRENT_TAGS[$repo]="${REPO_CURRENT_TAGS[$repo]:-}${REPO_CURRENT_TAGS[$repo]:+, }$tag"
+          done < <(grep -h '^\s*image:' .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml \
+            | sed 's/.*image:\s*//; s/"//g; s/'"'"'//g' | sort -u)
 
-            ```
-            ## Docker Image Updates Available
+          echo "=== Currently tracked repos ==="
+          for repo in "${!CURRENT_VERSIONS[@]}"; do
+            echo "  $repo: ${CURRENT_VERSIONS[$repo]}"
+          done
 
-            New release tags have been detected on Docker Hub.
+          FOUND_UPDATES=$(mktemp)
 
-            ### Updates Found
+          check_dockerhub() {
+            local repo="$1" current_ver="$2" tag_pattern="$3"
+            echo "Checking $repo (current: $current_ver)..." >&2
 
-            | Framework | Platform | Current | Latest | Docker Hub |
-            |-----------|----------|---------|--------|------------|
-            | ... | ... | ... | ... | [Link](...) |
+            local response
+            response=$(curl -sf "https://hub.docker.com/v2/repositories/${repo}/tags?page_size=50&ordering=last_updated" 2>/dev/null) || {
+              echo "  Failed to fetch tags for $repo" >&2
+              return
+            }
 
-            ---
+            echo "$response" | jq -r --arg since "$SEVEN_DAYS_AGO" --arg pattern "$tag_pattern" '
+              .results[]
+              | select(.last_updated > $since)
+              | select(.name | test($pattern))
+              | "\(.name)\t\(.last_updated)"
+            ' 2>/dev/null | while IFS=$'\t' read -r tag updated; do
+              local tag_ver
+              tag_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
+              [[ -z "$tag_ver" ]] && continue
+              [[ "$tag" == *nightly* || "$tag" == *dev* ]] && continue
 
-            @claude Please update the configurations:
+              local higher
+              higher=$(printf '%s\n%s\n' "$current_ver" "$tag_ver" | sort -V | tail -1)
+              if [[ "$higher" == "$tag_ver" && "$higher" != "$current_ver" ]]; then
+                echo "  Found update: $tag ($tag_ver > $current_ver)" >&2
+                echo "${repo}|${tag}|${tag_ver}|${current_ver}|${updated}"
+              fi
+            done
+          }
 
-            1. Update image tags in `.github/configs/nvidia-master.yaml` and/or `.github/configs/amd-master.yaml`
-            2. Add entries to `perf-changelog.yaml` documenting the version changes
-            3. Create a PR with these changes
+          for repo in "${!CURRENT_VERSIONS[@]}"; do
+            current="${CURRENT_VERSIONS[$repo]}"
+            case "$repo" in
+              lmsysorg/sglang)       check_dockerhub "$repo" "$current" '^v[0-9]' >> "$FOUND_UPDATES" ;;
+              lmsysorg/sglang-rocm)  check_dockerhub "$repo" "$current" '^v[0-9]' >> "$FOUND_UPDATES" ;;
+              vllm/vllm-openai)      check_dockerhub "$repo" "$current" '^v[0-9]+\.[0-9]+\.[0-9]' >> "$FOUND_UPDATES" ;;
+              vllm/vllm-openai-rocm) check_dockerhub "$repo" "$current" '^v[0-9]+\.[0-9]+\.[0-9]' >> "$FOUND_UPDATES" ;;
+              rocm/atom)             check_dockerhub "$repo" "$current" 'atom' >> "$FOUND_UPDATES" ;;
+              rocm/sgl-dev)          check_dockerhub "$repo" "$current" 'sglang' >> "$FOUND_UPDATES" ;;
+              *)                     echo "Skipping unknown repo: $repo" >&2 ;;
+            esac
+          done
 
-            Focus on updating single-node configurations. For each framework, check if there are multiple CUDA/ROCm versions available and choose appropriately based on current usage patterns in the configs.
-            ```
+          UPDATES=$(grep '|' "$FOUND_UPDATES" | sort -u || true)
+          rm -f "$FOUND_UPDATES"
 
-            ## Important Notes
+          if [[ -z "$UPDATES" ]]; then
+            echo "No new releases found in the last 7 days."
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            - Use `mcp__fetch__fetch` to check Docker Hub API: `https://hub.docker.com/v2/repositories/{repo}/tags?page_size=20&ordering=last_updated`
-            - Parse the JSON response to find matching version tags
-            - Compare semantic versions properly (v0.14.0 > v0.13.2)
-            - Only report genuine updates (newer versions than currently used)
-            - When checking SGLang, note that tags include CUDA version suffix (cu124, cu129) - compare the base version
+          echo "has_updates=true" >> "$GITHUB_OUTPUT"
 
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: sonnet
-          timeout_minutes: 10
-          allowed_tools: |
-            mcp__fetch__fetch
-            mcp__github__create_issue
-            Read
-            Glob
+          # Build issue body and write to file
+          BODY_FILE=$(mktemp)
+          {
+            echo "## Docker Image Updates Available"
+            echo ""
+            echo "New release tags have been detected on Docker Hub within the last 7 days."
+            echo ""
+            echo "### Updates Found"
+            echo ""
+            echo "| Image | New Tag | New Version | Current Version | Published |"
+            echo "|-------|---------|-------------|-----------------|-----------|"
+            while IFS='|' read -r repo tag tag_ver cur_ver updated; do
+              pub_date=$(echo "$updated" | cut -dT -f1)
+              echo "| \`$repo\` | \`$tag\` | $tag_ver | $cur_ver | $pub_date |"
+            done <<< "$UPDATES"
+            echo ""
+            echo "---"
+            echo ""
+            echo "@claude Please update the configurations:"
+            echo ""
+            echo "1. Update image tags in \`.github/configs/nvidia-master.yaml\` and/or \`.github/configs/amd-master.yaml\`"
+            echo "2. Add entries to \`perf-changelog.yaml\` documenting the version changes"
+            echo "3. Create a PR with these changes"
+            echo ""
+            echo "Focus on updating single-node configurations. For each framework, check if there are multiple CUDA/ROCm versions available and choose appropriately based on current usage patterns in the configs."
+          } > "$BODY_FILE"
+
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+
+          echo "=== Issue body ==="
+          cat "$BODY_FILE"
+
+      - name: Create issue for updates
+        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          BODY_FILE="${{ steps.check.outputs.body_file }}"
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "docker-update" --state open --json number --jq '.[0].number // empty')
+          if [[ -n "$EXISTING" ]]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "[Auto] Docker Image Updates Available - $DATE" \
+              --label "docker-update,claude-task" \
+              --body-file "$BODY_FILE"
+          fi
+
+      - name: Dry run output
+        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run == 'true'
+        run: |
+          echo "## Dry Run - Updates Found"
+          cat "${{ steps.check.outputs.body_file }}"

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -35,12 +35,16 @@ jobs:
           declare -A CURRENT_VERSIONS
           declare -A REPO_SUFFIXES
 
-          while IFS= read -r img; do
-            [[ "$img" == nvcr.io* ]] && continue
-            [[ "$img" == *nightly* || "$img" == *-dev* ]] && continue
+          # Only monitor these Docker Hub repos for updates
+          MONITORED_REPOS="lmsysorg/sglang lmsysorg/sglang-rocm vllm/vllm-openai vllm/vllm-openai-rocm"
 
+          while IFS= read -r img; do
             repo="${img%%:*}"
             tag="${img#*:}"
+
+            # Only track repos we want to auto-update
+            [[ ! " $MONITORED_REPOS " == *" $repo "* ]] && continue
+            [[ "$img" == *nightly* || "$img" == *-dev* ]] && continue
 
             base_ver=$(echo "$tag" | grep -oP 'v\d+\.\d+\.\d+(\.\w+)?' || true)
             [[ -z "$base_ver" ]] && continue
@@ -78,7 +82,7 @@ jobs:
             }
 
             echo "$response" | jq -r --arg since "$SEVEN_DAYS_AGO" '
-              .results[]
+              (.results // [])[]
               | select(.last_updated > $since)
               | select(.name | test("^v[0-9]"))
               | "\(.name)\t\(.last_updated)"
@@ -106,13 +110,13 @@ jobs:
                 echo "  Found update: $tag ($tag_ver > $current_ver)" >&2
                 echo "${repo}|${tag}|${tag_ver}|${current_ver}|${updated}"
               fi
-            done
+            done || true
           }
 
           for repo in "${!CURRENT_VERSIONS[@]}"; do
             current="${CURRENT_VERSIONS[$repo]}"
             suffixes="${REPO_SUFFIXES[$repo]:-}"
-            check_dockerhub "$repo" "$current" "$suffixes" >> "$FOUND_UPDATES"
+            check_dockerhub "$repo" "$current" "$suffixes" >> "$FOUND_UPDATES" || true
           done
 
           UPDATES=$(grep '|' "$FOUND_UPDATES" | sort -u || true)

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -148,7 +148,7 @@ jobs:
           cat "$BODY_FILE"
 
       - name: Create issue for updates
-        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run != 'true'
+        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - name: Dry run output
-        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run == 'true'
+        if: steps.check.outputs.has_updates == 'true' && inputs.dry_run == true
         run: |
           echo "## Dry Run - Updates Found"
           cat "${{ steps.check.outputs.body_file }}"

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -47,6 +47,7 @@ jobs:
 
             # Extract suffix after the version (e.g., "-cu130" from "v0.19.0-cu130")
             suffix="${tag#"$base_ver"}"
+            [[ -z "$suffix" ]] && suffix="BARE"
 
             prev="${CURRENT_VERSIONS[$repo]:-}"
             if [[ -z "$prev" ]] || [[ "$(printf '%s\n%s\n' "$prev" "$base_ver" | sort -V | tail -1)" == "$base_ver" ]]; then
@@ -89,6 +90,7 @@ jobs:
 
               # Only report tags whose suffix matches one already in use
               local tag_suffix="${tag#"$tag_ver"}"
+              [[ -z "$tag_suffix" ]] && tag_suffix="BARE"
               local matched=false
               for s in $allowed_suffixes; do
                 if [[ "$tag_suffix" == "$s" ]]; then


### PR DESCRIPTION
## Summary
- Replace `claude-code-action@beta` with a bash script that queries Docker Hub API directly — the action's "tag mode" cannot handle `schedule` events, which has caused this workflow to fail every week since March
- Script extracts current image versions from both master config YAMLs, checks Docker Hub for newer tags published in the last 7 days, and creates/updates a GitHub issue with `@claude` mention when updates are found
- Moves schedule to Friday 11pm PST (Saturday 07:00 UTC)
- Deduplicates issues by commenting on existing open `docker-update` issues instead of creating new ones

## Test plan
- [ ] Trigger workflow manually with dry_run=true to verify Docker Hub queries work
- [ ] Verify cron fires on schedule next Saturday
- [ ] Trigger workflow manually with dry_run=false to verify issue creation
