### PR TITLE
[NV] minimaxm2.5 fp8 b300 vllm update

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3538,15 +3538,16 @@ minimaxm2.5-fp8-b300-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
-    - { tp: 2, ep: 2, conc-start: 512, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 128 }
     - { tp: 4, ep: 4, conc-start: 256, conc-end: 512 }
+    - { tp: 2, ep: 2, conc-start: 512, conc-end: 1024 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 1024, conc-end: 2048 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
+    - { tp: 1, conc-start: 4, conc-end: 16 }
+    - { tp: 2, conc-start: 64, conc-end: 256 }
+    - { tp: 4, conc-start: 4, conc-end: 8 }
 
 minimaxm2.5-fp4-b200-vllm:
   image: vllm/vllm-openai:v0.19.0-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3541,7 +3541,7 @@ minimaxm2.5-fp8-b300-vllm:
     - { tp: 4, conc-start: 4, conc-end: 128 }
     - { tp: 4, ep: 4, conc-start: 256, conc-end: 512 }
     - { tp: 2, ep: 2, conc-start: 512, conc-end: 1024 }
-    - { tp: 2, ep: 2, dp-attn: true, conc-start: 1024, conc-end: 2048 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 1024, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:

--- a/benchmarks/single_node/minimaxm2.5_fp8_b300.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_b300.sh
@@ -28,7 +28,7 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-export VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "$EP_SIZE" -gt 1 ]; then
   EP=" --enable-expert-parallel"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1651,4 +1651,4 @@
     - minimaxm2.5-fp8-b300-vllm
   description:
     - "Add VLLM_FLOAT32_MATMUL_PRECISION=high, remove VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1106

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1646,3 +1646,9 @@
   description:
     - "Add kv-cache-dtype fp8, max-cudagraph-capture-size 2048, max-num-batched-tokens, and stream-interval 20 to server launch args"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1047
+
+- config-keys:
+    - minimaxm2.5-fp8-b300-vllm
+  description:
+    - "Add VLLM_FLOAT32_MATMUL_PRECISION=high, remove VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

Updates the MiniMax-M2.5 FP8 B300 vLLM benchmark configuration and environment variables:

- **Environment variable change**: Replace `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl` with `VLLM_FLOAT32_MATMUL_PRECISION=high` in the benchmark script
- **Search-space overhaul (1k/1k)**: Restructure TP/EP/concurrency sweep — use TP=4 at low concurrency (4–128), TP=4 EP=4 at mid concurrency (256–512), TP=2 EP=2 at high concurrency (512–1024), and add TP=2 EP=2 with `dp-attn` at very high concurrency (1024–2048)
- **Search-space overhaul (8k/1k)**: Replace broad TP=2/TP=4 sweeps with targeted configs — TP=1 at low concurrency (4–16), TP=2 at mid concurrency (64–256), and TP=4 at low concurrency (4–8)
- **Changelog**: Add `perf-changelog.yaml` entry documenting the env var changes

## Changed Files

| File | Change |
|------|--------|
| `benchmarks/single_node/minimaxm2.5_fp8_b300.sh` | Swap env var from `VLLM_FLASHINFER_ALLREDUCE_BACKEND=mnnvl` to `VLLM_FLOAT32_MATMUL_PRECISION=high` |
| `.github/configs/nvidia-master.yaml` | Revise search-space for `minimaxm2.5-fp8-b300-vllm` (both 1k/1k and 8k/1k) |
| `perf-changelog.yaml` | Add changelog entry for this PR |

## Test Plan

- [ ] Run e2e benchmarks for `minimaxm2.5-fp8-b300-vllm` to validate new search-space configurations
- [ ] Verify the `VLLM_FLOAT32_MATMUL_PRECISION=high` env var produces expected performance results
- [ ] Confirm dp-attn config at high concurrency (1024–2048) works correctly