### PR TITLE
[NV] update minimaxm2.5 fp4 b300 vllm

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3592,21 +3592,19 @@ minimaxm2.5-fp4-b300-vllm:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 4, conc-end: 4 }
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 2, ep: 2, conc-start: 128, conc-end: 256 }
-    - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
-    - { tp: 4, ep: 4, conc-start: 32, conc-end: 128 }
-    - { tp: 8, conc-start: 4, conc-end: 4 }
+    - { tp: 1, conc-start: 4, conc-end: 8 }
+    - { tp: 2, ep: 2, conc-start: 128, conc-end: 128 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 256, conc-end: 2048 }
+    - { tp: 4, conc-start: 8, conc-end: 8 }
+    - { tp: 4, ep: 4, conc-start: 64, conc-end: 128 }
+    - { tp: 8, conc-start: 4, conc-end: 8 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 1, conc-start: 4, conc-end: 32 }
-    - { tp: 1, conc-start: 256, conc-end: 512 }
-    - { tp: 2, conc-start: 4, conc-end: 512 }
-    - { tp: 2, ep: 2, conc-start: 128, conc-end: 512 }
-    - { tp: 4, conc-start: 4, conc-end: 512 }
+    - { tp: 1, conc-start: 4, conc-end: 256 }
+    - { tp: 1, conc-start: 1024, conc-end: 1024 }
+    - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
+    - { tp: 4, conc-start: 4, conc-end: 8 }
     - { tp: 8, conc-start: 4, conc-end: 4 }
 
 gptoss-fp4-h100-vllm:

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3602,7 +3602,6 @@ minimaxm2.5-fp4-b300-vllm:
     osl: 1024
     search-space:
     - { tp: 1, conc-start: 4, conc-end: 256 }
-    - { tp: 1, conc-start: 1024, conc-end: 1024 }
     - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
     - { tp: 4, conc-start: 4, conc-end: 8 }
     - { tp: 8, conc-start: 4, conc-end: 4 }

--- a/benchmarks/single_node/minimaxm2.5_fp4_b300.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp4_b300.sh
@@ -29,6 +29,8 @@ hf download "$MODEL"
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
+export VLLM_FLOAT32_MATMUL_PRECISION=high
+
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
 elif [ "$EP_SIZE" -gt 1 ]; then

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1651,4 +1651,4 @@
     - minimaxm2.5-fp4-b300-vllm
   description:
     - "Add VLLM_FLOAT32_MATMUL_PRECISION=high, update search space concurrency ranges"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1107

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1646,3 +1646,9 @@
   description:
     - "Add kv-cache-dtype fp8, max-cudagraph-capture-size 2048, max-num-batched-tokens, and stream-interval 20 to server launch args"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1047
+
+- config-keys:
+    - minimaxm2.5-fp4-b300-vllm
+  description:
+    - "Add VLLM_FLOAT32_MATMUL_PRECISION=high, update search space concurrency ranges"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

Update MiniMax-M2.5 FP4 B300 vLLM benchmark configuration with optimized search space and precision settings.

### Changes

**Benchmark script (`benchmarks/single_node/minimaxm2.5_fp4_b300.sh`)**
- Add `VLLM_FLOAT32_MATMUL_PRECISION=high` environment variable to improve numerical precision during matmul operations

**Search space (`nvidia-master.yaml` — `minimaxm2.5-fp4-b300-vllm`)**

*ISL=1024, OSL=1024:*
- Expand TP=1 concurrency range from `4-4` → `4-8`
- Replace TP=2 non-EP configs with TP=2/EP=2 dp-attn config at `conc 256-2048`
- Narrow TP=2/EP=2 non-dp-attn to `conc 128` only
- Narrow TP=4 non-EP from `4-512` → `8-8`
- Expand TP=8 concurrency from `4-4` → `4-8`
- Remove standalone TP=2 (no EP) and TP=2/EP=2/dp-attn at `conc 512` entries

*ISL=8192, OSL=1024:*
- Consolidate TP=1 range from two entries (`4-32`, `256-512`) → `4-256` + `1024`
- Replace TP=2 and TP=2/EP=2 entries with TP=2/EP=2/dp-attn at `conc 512`
- Narrow TP=4 from `4-512` → `4-8`

**Changelog (`perf-changelog.yaml`)**
- Add entry documenting the precision and search space changes