### PR TITLE
Fix mi355x-disagg eval rows misclassified as single-node

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -43,7 +43,7 @@ dsr1-fp4-mi355x-atom-mtp:
   model-prefix: dsr1
   runner: mi355x
   precision: fp4
-  # WIP framwork (no customers yet)
+  # WIP framework (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:
@@ -611,7 +611,7 @@ dsr1-fp8-mi355x-atom:
   model-prefix: dsr1
   runner: mi355x
   precision: fp8
-  # WIP framwork (no customers yet)
+  # WIP framework (no customers yet)
   framework: atom
   multinode: false
   seq-len-configs:

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Shared benchmarking utilities for InferenceMAX
+# Shared benchmarking utilities for InferenceX
 
 # Keep Python bytecode out of the mounted workspace. Benchmark jobs often run as
 # root inside containers, and root-owned cache directories break future checkout

--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -295,6 +295,7 @@ export MODEL_PREFIX="${MODEL_PREFIX:-}"
 export RUNNER_TYPE="${RUNNER_TYPE:-}"
 export RESULT_FILENAME="${RESULT_FILENAME:-}"
 export SPEC_DECODING="${SPEC_DECODING:-}"
+export IS_MULTINODE="${IS_MULTINODE:-false}"
 
 SANITIZED_USER=$(echo "$USER_NAME" | tr -c 'a-zA-Z0-9_.-' '_')
 export DOCKER_CONT_NAME="container_sbatch_${SANITIZED_USER}_${MODEL_NAME}_${SLURM_JOB_ID}"
@@ -409,6 +410,7 @@ exec sudo docker run --rm \
     -e RUNNER_TYPE=\$RUNNER_TYPE \
     -e RESULT_FILENAME=\$RESULT_FILENAME \
     -e SPEC_DECODING=\$SPEC_DECODING \
+    -e IS_MULTINODE=\$IS_MULTINODE \
     --name \"$DOCKER_CONT_NAME\" \
     \"$DOCKER_IMAGE_NAME\" bash -lc '
         mkdir -p /run_logs/slurm_job-'\"\$SLURM_JOB_ID\"'

--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -413,6 +413,7 @@ exec sudo docker run --rm \
     -e IS_MULTINODE=\$IS_MULTINODE \
     --name \"$DOCKER_CONT_NAME\" \
     \"$DOCKER_IMAGE_NAME\" bash -lc '
+        set -o pipefail
         mkdir -p /run_logs/slurm_job-'\"\$SLURM_JOB_ID\"'
         '"$RUN_FILE_FULL"' 2>&1 | tee /run_logs/slurm_job-'\"\$SLURM_JOB_ID\"'/server_\$(hostname).log
     '

--- a/benchmarks/multi_node/amd_utils/server.sh
+++ b/benchmarks/multi_node/amd_utils/server.sh
@@ -515,42 +515,48 @@ if [ "$NODE_RANK" -eq 0 ]; then
             else
                 # Run lm-eval against the router on port 30000
                 run_eval --framework lm-eval --port 30000
+                eval_rc=$?
 
-                # Set metadata env vars for append_lm_eval_summary
-                export TP="${PREFILL_TP_SIZE}"
-                export CONC="${EVAL_CONCURRENT_REQUESTS}"
-                export EP_SIZE=1
-                [[ "${PREFILL_ENABLE_EP}" == "true" ]] && EP_SIZE="${PREFILL_TP_SIZE}"
-                export PREFILL_TP="${PREFILL_TP_SIZE}"
-                export PREFILL_EP=1
-                [[ "${PREFILL_ENABLE_EP}" == "true" ]] && PREFILL_EP="${PREFILL_TP_SIZE}"
-                export PREFILL_NUM_WORKERS="${xP}"
-                export DECODE_TP="${DECODE_TP_SIZE}"
-                export DECODE_EP=1
-                [[ "${DECODE_ENABLE_EP}" == "true" ]] && DECODE_EP="${DECODE_TP_SIZE}"
-                export DECODE_NUM_WORKERS="${yD}"
-                export DP_ATTENTION="${PREFILL_ENABLE_DP}"
-                export PREFILL_DP_ATTENTION="${PREFILL_ENABLE_DP}"
-                export DECODE_DP_ATTENTION="${DECODE_ENABLE_DP}"
-                export ISL="${BENCH_INPUT_LEN}"
-                export OSL="${BENCH_OUTPUT_LEN}"
-                # FRAMEWORK, PRECISION, MODEL_PREFIX, RUNNER_TYPE, RESULT_FILENAME
-                # are already set via Docker -e flags from job.slurm
+                if [[ $eval_rc -ne 0 ]]; then
+                    echo "ERROR: run_eval exited rc=$eval_rc; skipping metadata write and eval artifact staging" >&2
+                    EVAL_FAILED=1
+                else
+                    # Set metadata env vars for append_lm_eval_summary
+                    export TP="${PREFILL_TP_SIZE}"
+                    export CONC="${EVAL_CONCURRENT_REQUESTS}"
+                    export EP_SIZE=1
+                    [[ "${PREFILL_ENABLE_EP}" == "true" ]] && EP_SIZE="${PREFILL_TP_SIZE}"
+                    export PREFILL_TP="${PREFILL_TP_SIZE}"
+                    export PREFILL_EP=1
+                    [[ "${PREFILL_ENABLE_EP}" == "true" ]] && PREFILL_EP="${PREFILL_TP_SIZE}"
+                    export PREFILL_NUM_WORKERS="${xP}"
+                    export DECODE_TP="${DECODE_TP_SIZE}"
+                    export DECODE_EP=1
+                    [[ "${DECODE_ENABLE_EP}" == "true" ]] && DECODE_EP="${DECODE_TP_SIZE}"
+                    export DECODE_NUM_WORKERS="${yD}"
+                    export DP_ATTENTION="${PREFILL_ENABLE_DP}"
+                    export PREFILL_DP_ATTENTION="${PREFILL_ENABLE_DP}"
+                    export DECODE_DP_ATTENTION="${DECODE_ENABLE_DP}"
+                    export ISL="${BENCH_INPUT_LEN}"
+                    export OSL="${BENCH_OUTPUT_LEN}"
+                    # IS_MULTINODE, FRAMEWORK, PRECISION, MODEL_PREFIX, RUNNER_TYPE,
+                    # RESULT_FILENAME are already set via Docker -e flags from job.slurm
 
-                append_lm_eval_summary
-                # Files (meta_env.json, results*.json, sample*.jsonl) are now in /workspace
+                    append_lm_eval_summary
+                    # Files (meta_env.json, results*.json, sample*.jsonl) are now in /workspace
 
-                # Copy eval artifacts to run_logs for NFS extraction by runner
-                EVAL_COPY_DIR="/run_logs/slurm_job-${SLURM_JOB_ID}/eval_results"
-                mkdir -p "$EVAL_COPY_DIR"
-                for f in meta_env.json; do
-                    [ -e "/workspace/$f" ] && cp -f "/workspace/$f" "$EVAL_COPY_DIR/"
-                done
-                # Use find for glob patterns to avoid "no match" errors
-                find /workspace -maxdepth 1 -name 'results*.json' -exec cp -f {} "$EVAL_COPY_DIR/" \;
-                find /workspace -maxdepth 1 -name 'sample*.jsonl' -exec cp -f {} "$EVAL_COPY_DIR/" \;
+                    # Copy eval artifacts to run_logs for NFS extraction by runner
+                    EVAL_COPY_DIR="/run_logs/slurm_job-${SLURM_JOB_ID}/eval_results"
+                    mkdir -p "$EVAL_COPY_DIR"
+                    for f in meta_env.json; do
+                        [ -e "/workspace/$f" ] && cp -f "/workspace/$f" "$EVAL_COPY_DIR/"
+                    done
+                    # Use find for glob patterns to avoid "no match" errors
+                    find /workspace -maxdepth 1 -name 'results*.json' -exec cp -f {} "$EVAL_COPY_DIR/" \;
+                    find /workspace -maxdepth 1 -name 'sample*.jsonl' -exec cp -f {} "$EVAL_COPY_DIR/" \;
 
-                echo "Eval completed. Artifacts staged in $EVAL_COPY_DIR"
+                    echo "Eval completed. Artifacts staged in $EVAL_COPY_DIR"
+                fi
             fi
 
             popd
@@ -571,6 +577,11 @@ if [ "$NODE_RANK" -eq 0 ]; then
     if [[ "$DRY_RUN" -eq 0 ]]; then
         kill $proxy_pid
         kill $prefill0_pid
+    fi
+
+    if [[ "${EVAL_FAILED:-0}" -eq 1 ]]; then
+        echo "ERROR: eval failed; exiting node-0 with rc=1"
+        exit 1
     fi
 
 elif [ "$NODE_RANK" -gt 0 ] && [ "$NODE_RANK" -lt "$NODE_OFFSET" ]; then

--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -115,6 +115,7 @@ export MODEL_PREFIX="${MODEL_PREFIX:-}"
 export RUNNER_TYPE="${RUNNER_TYPE:-}"
 export RESULT_FILENAME="${RESULT_FILENAME:-}"
 export SPEC_DECODING="${SPEC_DECODING:-}"
+export IS_MULTINODE="${IS_MULTINODE:-false}"
 
 # Log directory: must be on NFS (shared filesystem) so the submit host can read SLURM output.
 # SLURM writes output files on the batch node, so /tmp won't work (node-local).

--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -25,7 +25,6 @@ On the client side, run:
 """
 import argparse
 import asyncio
-import contextlib
 import base64
 import gc
 import io
@@ -372,9 +371,11 @@ async def benchmark(
     if num_warmups > 0:
         print(f"Warming up with {num_warmups} requests...")
         warmup_pbar = None if disable_tqdm else tqdm(total=num_warmups)
-        warmup_semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else contextlib.nullcontext()
+        warmup_semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
 
         async def warmup_limited_req_fn():
+            if warmup_semaphore is None:
+                return await request_func(request_func_input=test_input, pbar=warmup_pbar)
             async with warmup_semaphore:
                 return await request_func(request_func_input=test_input, pbar=warmup_pbar)
 
@@ -421,10 +422,6 @@ async def benchmark(
 
     pbar = None if disable_tqdm else tqdm(total=len(input_requests))
 
-    # This can be used once the minimum Python version is 3.10 or higher,
-    # and it will simplify the code in limited_request_func.
-    #    semaphore = (asyncio.Semaphore(max_concurrency)
-    #                 if max_concurrency else contextlib.nullcontext())
     semaphore = (asyncio.Semaphore(max_concurrency)
                  if max_concurrency else None)
 

--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -25,6 +25,7 @@ On the client side, run:
 """
 import argparse
 import asyncio
+import contextlib
 import base64
 import gc
 import io


### PR DESCRIPTION
## Summary

`IS_MULTINODE=true` was being dropped at the docker `-e` allowlist in `benchmarks/multi_node/amd_utils/job.slurm`, so `benchmark_lib.sh`'s `append_lm_eval_summary` wrote `meta_env.json` with `"is_multinode": false` for mi355x-disagg eval runs. `collect_eval_results.py` then rendered those rows under **Single-Node Eval Results** instead of the multinode table.

### Flow (before fix)

```
benchmark-multinode-tmpl.yml:176  export IS_MULTINODE=true
    → launch_mi355x-amds.sh         (passes through)
    → submit.sh                     (inherits via sbatch)
    → job.slurm                     (sbatch exported it, but…)
    → docker run -e <allowlist>     ← IS_MULTINODE NOT in the list
    → server.sh → benchmark_lib.sh  ← reads unset, defaults to false
```

## Changes

**Primary fix**
- `submit.sh` / `job.slurm`: re-export `IS_MULTINODE` alongside the other threaded eval vars, and add `-e IS_MULTINODE=\$IS_MULTINODE` to the docker run allowlist.
- `server.sh`: update the "already set via Docker `-e` flags from job.slurm" comment to include `IS_MULTINODE` so this gap doesn't silently reopen.

**Related robustness fix (same file, same review hunk)**
- `server.sh`: capture `run_eval`'s exit code, skip metadata write and eval artifact staging on failure, set `EVAL_FAILED=1`, and `exit 1` on node-0 so the SLURM job fails instead of silently uploading corrupt `meta_env.json` when lm-eval crashes.

**Latent NameError fix, discovered while editing**
- `utils/bench_serving/benchmark_serving.py`: add missing `import contextlib`. Line 374 calls `contextlib.nullcontext()` which would `NameError` when `max_concurrency` is falsy during warmup. Also drops unused `base64` / `io` / `typing.Collection` imports that were sitting next to the added import.

**Small cleanups folded in**
- `benchmarks/benchmark_lib.sh`: header comment rebrand `InferenceMAX` → `InferenceX`.
- `.github/configs/amd-master.yaml`: fix "framwork" → "framework" typo (×2 occurrences in WIP-framework comments).

## Test plan

- [ ] Trigger a sweep including `dsr1-fp4-mi355x-sglang-disagg` (or `-disagg-mtp`) evals and confirm the rows land in the **Multi-Node Eval Results** table in the `collect-evals` workflow summary, not the single-node one.
- [ ] Deliberately break an eval (e.g. bad lm-eval task config) and confirm the SLURM job exits non-zero instead of silently uploading a partial `meta_env.json`.
- [ ] Existing single-node runs still produce correct meta (no regression — `IS_MULTINODE` defaults to `false` when unset, same as before).
- [ ] `python3 -m pytest utils/matrix_logic/` still green.