### PR TITLE
Standardize eval score verification across workflow templates

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -241,7 +241,7 @@ jobs:
           if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
 
       - name: Verify eval scores
-        if: ${{ always() && inputs.eval-only }}
+        if: ${{ (success() || failure()) && inputs.eval-only }}
         run: python3 utils/evals/validate_scores.py
 
       - name: Cleanup eval outputs (post-upload)

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -193,7 +193,7 @@ jobs:
             fi
           fi
 
-      - name: Process results
+      - name: Process result
         if: ${{ !inputs.eval-only }}
         env:
           RUNNER_TYPE: ${{ inputs.runner }}
@@ -214,12 +214,20 @@ jobs:
             fi
           done
 
-      - name: Upload results
+      - name: Upload result
         if: ${{ !inputs.eval-only }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bmk_${{ env.RESULT_FILENAME }}
           path: agg_${{ env.RESULT_FILENAME }}_*.json
+
+      - name: Upload server logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: multinode_server_logs_${{ env.RESULT_FILENAME }}
+          path: multinode_server_logs.tar.gz
+          if-no-files-found: ignore
 
       - name: Upload eval results (if any)
         if: ${{ always() && (env.RUN_EVAL == 'true' || inputs.eval-only) }}
@@ -230,7 +238,7 @@ jobs:
             meta_env.json
             results*.json
             sample*.jsonl
-          if-no-files-found: ignore
+          if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
 
       - name: Verify eval scores
         if: ${{ inputs.eval-only }}
@@ -242,14 +250,6 @@ jobs:
           rm -f meta_env.json || true
           rm -f results*.json || true
           rm -f sample*.jsonl || true
-
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: multinode_server_logs_${{ env.RESULT_FILENAME }}
-          path: multinode_server_logs.tar.gz
-          if-no-files-found: ignore
 
       - name: Slurm cleanup (post-run)
         if: always()

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -241,7 +241,7 @@ jobs:
           if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
 
       - name: Verify eval scores
-        if: ${{ inputs.eval-only }}
+        if: ${{ always() && inputs.eval-only }}
         run: python3 utils/evals/validate_scores.py
 
       - name: Cleanup eval outputs (post-upload)

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -160,8 +160,6 @@ jobs:
               echo "Eval-only run failed: no results*.json files found." >&2
               exit 1
             fi
-            # Verify eval scores meet per-benchmark minimum thresholds
-            python3 utils/evals/validate_scores.py
           else
             FOUND_RESULT_FILE=
             for i in {1..10}; do
@@ -219,6 +217,10 @@ jobs:
             results*.json
             sample*.jsonl
           if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
+
+      - name: Verify eval scores
+        if: ${{ inputs.eval-only }}
+        run: python3 utils/evals/validate_scores.py
 
       - name: Cleanup eval outputs (post-upload)
         if: ${{ always() && (env.RUN_EVAL == 'true' || inputs.eval-only) }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -219,7 +219,7 @@ jobs:
           if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
 
       - name: Verify eval scores
-        if: ${{ inputs.eval-only }}
+        if: ${{ always() && inputs.eval-only }}
         run: python3 utils/evals/validate_scores.py
 
       - name: Cleanup eval outputs (post-upload)

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -219,7 +219,7 @@ jobs:
           if-no-files-found: ${{ inputs.eval-only && 'error' || 'ignore' }}
 
       - name: Verify eval scores
-        if: ${{ always() && inputs.eval-only }}
+        if: ${{ (success() || failure()) && inputs.eval-only }}
         run: python3 utils/evals/validate_scores.py
 
       - name: Cleanup eval outputs (post-upload)


### PR DESCRIPTION
## Summary
- Extract `validate_scores.py` from inline launch script into separate "Verify eval scores" step in `benchmark-tmpl.yml` (matching multinode template)
- Reorder multinode template: move "Upload server logs" before eval results upload (matching single-node step ordering)
- Fix `if-no-files-found` for eval results in multinode: error in eval-only mode instead of silently ignoring missing files
- Standardize step naming: "Process result" / "Upload result" across both templates

## Test plan
- [x] Single-node eval: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24755918780 — passed, "Verify eval scores" visible as separate step
- [x] Multi-node eval (4 jobs): https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24755919517 — all passed, "Verify eval scores" visible as separate step
- [x] actionlint passes on both templates (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)