### PR TITLE
Recommend CODEOWNERS review before core maintainer review in PR reminder

### DIFF
--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -44,6 +44,8 @@ jobs:
 
             **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.** A lot of the time, failures are just flakes and simply re-running the failed jobs will fix it. If re-running failed jobs is attempted, PR authors are responsible for ensuring it passes. See GitHub's docs on re-running failed jobs: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow
 
+            As a rule of thumb, generally, PR authors should request a review & get a PR approval from the respective companies' [CODEOWNERS](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) before requesting a review from core maintainers.
+
             If additional help is needed, PR authors can reach out to core maintainers over Slack.`.replace(/^            /gm, '');
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });


### PR DESCRIPTION
## Summary
- Adds a rule-of-thumb line to the PR recipe reminder bot comment directing authors to get approval from the respective companies' [CODEOWNERS](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) before requesting core-maintainer review.

## Test plan
- [ ] Open a PR touching one of the watched paths (`.github/configs/amd-master.yaml`, `.github/configs/nvidia-master.yaml`, `benchmarks/**`, or `perf-changelog.yaml`) and confirm the reminder comment renders the new line with a working CODEOWNERS link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)