### PR TITLE
[WIP] Allow overriding srt-slurm repo/ref at the launcher level

### DIFF
--- a/.github/configs/srt-slurm-validation.yaml
+++ b/.github/configs/srt-slurm-validation.yaml
@@ -1,0 +1,31 @@
+# Minimal config for validating NVIDIA/srt-slurm#41 end-to-end on GB200.
+# Referenced explicitly via --config-files on a one-off workflow_dispatch;
+# NOT picked up by normal sweeps (they run against nvidia-master.yaml).
+# Mirrors the cheapest entry from dsr1-fp8-gb200-dynamo-trt in nvidia-master.yaml.
+dsr1-fp8-gb200-dynamo-trt:
+  image: nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: gb200
+  precision: fp8
+  framework: dynamo-trt
+  multinode: true
+  disagg: true
+  seq-len-configs:
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - conc-list: [63]
+      prefill:
+        num-worker: 1
+        tp: 8
+        ep: 8
+        dp-attn: true
+        additional-settings:
+        # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/trtllm/gb200-fp8/8k1k/stp/ctx1_gen3_tep8_batch16_eplb0_mtp0_63.yaml
+        - "CONFIG_FILE=recipes/trtllm/gb200-fp8/8k1k/stp/ctx1_gen3_tep8_batch16_eplb0_mtp0_63.yaml"
+      decode:
+        num-worker: 3
+        tp: 8
+        ep: 8
+        dp-attn: false

--- a/.github/configs/srt-slurm-validation.yaml
+++ b/.github/configs/srt-slurm-validation.yaml
@@ -1,13 +1,16 @@
 # Minimal config for validating NVIDIA/srt-slurm#41 end-to-end on GB200.
 # Referenced explicitly via --config-files on a one-off workflow_dispatch;
 # NOT picked up by normal sweeps (they run against nvidia-master.yaml).
-# Mirrors the cheapest entry from dsr1-fp8-gb200-dynamo-trt in nvidia-master.yaml.
-dsr1-fp8-gb200-dynamo-trt:
+# Uses dsr1-fp4-dynamo-trt, which the launcher maps to
+# /mnt/lustre01/models/deepseek-r1-0528-fp4-v2/ (present on both the GH
+# runner and compute nodes, so preflight passes). Smallest 8k1k trtllm
+# recipe at 1P+8D (no zip_override, nginx-sqsh alias matches launcher).
+dsr1-fp4-gb200-dynamo-trt:
   image: nvcr.io#nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
-  model: deepseek-ai/DeepSeek-R1-0528
+  model: nvidia/DeepSeek-R1-0528-NVFP4-v2
   model-prefix: dsr1
   runner: gb200
-  precision: fp8
+  precision: fp4
   framework: dynamo-trt
   multinode: true
   disagg: true
@@ -15,17 +18,17 @@ dsr1-fp8-gb200-dynamo-trt:
   - isl: 8192
     osl: 1024
     search-space:
-    - conc-list: [63]
+    - conc-list: [24]
       prefill:
         num-worker: 1
-        tp: 8
-        ep: 8
+        tp: 4
+        ep: 4
         dp-attn: true
         additional-settings:
-        # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/trtllm/gb200-fp8/8k1k/stp/ctx1_gen3_tep8_batch16_eplb0_mtp0_63.yaml
-        - "CONFIG_FILE=recipes/trtllm/gb200-fp8/8k1k/stp/ctx1_gen3_tep8_batch16_eplb0_mtp0_63.yaml"
+        # https://github.com/NVIDIA/srt-slurm/blob/main/recipes/trtllm/gb200-fp4/8k1k/stp/ctx1_gen4_tep8_batch1_eplb0_mtp0.yaml
+        - "CONFIG_FILE=recipes/trtllm/gb200-fp4/8k1k/stp/ctx1_gen4_tep8_batch1_eplb0_mtp0.yaml"
       decode:
-        num-worker: 3
+        num-worker: 4
         tp: 8
         ep: 8
         dp-attn: false

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -95,6 +95,16 @@ on:
         description: "Git ref (branch/sha) to checkout"
         required: false
         type: string
+      srt-slurm-repo:
+        description: "Override srt-slurm clone URL (leave empty to use launcher default)"
+        required: false
+        type: string
+        default: ""
+      srt-slurm-ref:
+        description: "Override srt-slurm git ref (branch/sha; leave empty to use launcher default)"
+        required: false
+        type: string
+        default: ""
 
 env:
   RANDOM_RANGE_RATIO: 0.8
@@ -125,6 +135,11 @@ env:
   DECODE_TP: ${{ inputs.decode-tp }}
   DECODE_EP: ${{ inputs.decode-ep }}
   DECODE_DP_ATTN: ${{ inputs.decode-dp-attn }}
+
+  # Optional override for which srt-slurm repo/ref the launcher clones.
+  # Leave empty to use the launcher's built-in defaults per framework.
+  SRT_SLURM_REPO: ${{ inputs.srt-slurm-repo }}
+  SRT_SLURM_REF: ${{ inputs.srt-slurm-ref }}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,16 @@ on:
                 description: "Ref (branch/sha) to checkout for generating configs"
                 required: false
                 type: string
+            srt-slurm-repo:
+                description: "Override srt-slurm clone URL (leave empty to use launcher default)"
+                required: false
+                type: string
+                default: ""
+            srt-slurm-ref:
+                description: "Override srt-slurm git ref (branch/sha; leave empty to use launcher default)"
+                required: false
+                type: string
+                default: ""
     workflow_call:
         inputs:
             generate-cli-command:
@@ -30,6 +40,16 @@ on:
                 description: "Ref (branch/sha) to checkout for generating configs"
                 required: false
                 type: string
+            srt-slurm-repo:
+                description: "Override srt-slurm clone URL (leave empty to use launcher default)"
+                required: false
+                type: string
+                default: ""
+            srt-slurm-ref:
+                description: "Override srt-slurm git ref (branch/sha; leave empty to use launcher default)"
+                required: false
+                type: string
+                default: ""
 
 jobs:
     get-jobs:
@@ -102,6 +122,8 @@ jobs:
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             run-eval: false
             ref: ${{ inputs.ref }}
+            srt-slurm-repo: ${{ inputs.srt-slurm-repo }}
+            srt-slurm-ref: ${{ inputs.srt-slurm-ref }}
 
     test-sweep-multi-node-evals:
         needs: get-jobs
@@ -143,6 +165,8 @@ jobs:
             eval-only: true
             eval-conc: ${{ matrix.config.eval-conc }}
             ref: ${{ inputs.ref }}
+            srt-slurm-repo: ${{ inputs.srt-slurm-repo }}
+            srt-slurm-ref: ${{ inputs.srt-slurm-ref }}
 
     test-sweep-single-node:
         needs: get-jobs

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -134,19 +134,26 @@ if [ -d "$SRT_REPO_DIR" ]; then
     rm -rf "$SRT_REPO_DIR"
 fi
 
+# Allow SRT_SLURM_REPO / SRT_SLURM_REF to override the default clone source
+# (useful for testing WIP branches like the generalized lm-eval-main).
 if [[ $FRAMEWORK == "dynamo-vllm" ]]; then
-    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
-    cd "$SRT_REPO_DIR"
-    git checkout sa-submission-q2-2026
+    DEFAULT_SRT_REPO="https://github.com/NVIDIA/srt-slurm.git"
+    DEFAULT_SRT_REF="sa-submission-q2-2026"
 elif [[ $FRAMEWORK == "dynamo-trt" && $MODEL_PREFIX == "kimik2.5" ]]; then
-    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
-    cd "$SRT_REPO_DIR"
-    git checkout sa-submission-q2-2026
+    DEFAULT_SRT_REPO="https://github.com/NVIDIA/srt-slurm.git"
+    DEFAULT_SRT_REF="sa-submission-q2-2026"
 else
-    git clone https://github.com/ishandhanani/srt-slurm.git "$SRT_REPO_DIR"
-    cd "$SRT_REPO_DIR"
-    git checkout sa-submission-q1-2026
+    DEFAULT_SRT_REPO="https://github.com/ishandhanani/srt-slurm.git"
+    DEFAULT_SRT_REF="sa-submission-q1-2026"
 fi
+
+SRT_SLURM_REPO="${SRT_SLURM_REPO:-$DEFAULT_SRT_REPO}"
+SRT_SLURM_REF="${SRT_SLURM_REF:-$DEFAULT_SRT_REF}"
+
+echo "Cloning ${SRT_SLURM_REPO} @ ${SRT_SLURM_REF}"
+git clone "$SRT_SLURM_REPO" "$SRT_REPO_DIR"
+cd "$SRT_REPO_DIR"
+git checkout "$SRT_SLURM_REF"
 
 echo "Installing srtctl..."
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -197,7 +204,10 @@ cat srtslurm.yaml
 echo "Running make setup..."
 make setup ARCH=aarch64
 
-# Export eval-related env vars for srt-slurm post-benchmark eval
+# Export eval-related env vars for srt-slurm post-benchmark eval.
+# LM_EVAL_WORKSPACE is what the generalized srt-slurm reads; INFMAX_WORKSPACE
+# is kept for compatibility with older srt-slurm branches (sa-submission-*).
+export LM_EVAL_WORKSPACE="$GITHUB_WORKSPACE"
 export INFMAX_WORKSPACE="$GITHUB_WORKSPACE"
 
 echo "Submitting job with srtctl..."


### PR DESCRIPTION
## Summary

- Adds `SRT_SLURM_REPO` / `SRT_SLURM_REF` env-var override in `runners/launch_gb200-nv.sh` so a `workflow_dispatch` can test a WIP srt-slurm fork/branch without touching production defaults.
- Exports `LM_EVAL_WORKSPACE=$GITHUB_WORKSPACE` alongside the existing `INFMAX_WORKSPACE` so the launcher is forward-compatible with the generalized lm-eval runner in [NVIDIA/srt-slurm#41](https://github.com/NVIDIA/srt-slurm/pull/41) (which reads `LM_EVAL_WORKSPACE`) while legacy `sa-submission-*` branches keep working (they read `INFMAX_WORKSPACE`).
- Plumbs `srt-slurm-repo` and `srt-slurm-ref` as optional inputs through `e2e-tests.yml` → `benchmark-multinode-tmpl.yml` so the override can be set at dispatch time.
- Adds `.github/configs/srt-slurm-validation.yaml`, a single-entry sweep config mirroring the cheapest `dsr1-fp8-gb200-dynamo-trt` entry so the validation dispatch runs exactly one eval job instead of the full gb200 matrix.

## Why

NVIDIA/srt-slurm#41 generalizes the lm-eval runner so it no longer requires SA-specific infra (the reviewer's ask on #12). Before switching defaults, we want to validate the generalized version end-to-end on GB200 with the existing InferenceX eval harness. This PR adds that knob and leaves every existing code path unchanged.

## How to test

```
gh workflow run e2e-tests.yml \
  --repo SemiAnalysisAI/InferenceX \
  --ref srt-slurm-override \
  -f generate-cli-command='full-sweep --config-files .github/configs/srt-slurm-validation.yaml --evals-only --runner-type gb200 --multi-node' \
  -f test-name='srt-slurm generalized lm-eval validation' \
  -f srt-slurm-repo='https://github.com/Oseltamivir/srt-slurm-nvidia.git' \
  -f srt-slurm-ref='lm-eval-main'
```

Runs exactly one eval-only job: `dsr1_8k1k dynamo-trt fp8 | P(tp8/ep8/dptrue/nw1) D(tp8/ep8/dpfalse/nw3) | disagg-true spec-none conc-63 | eval-only`. Clones the generalized srt-slurm fork (`Oseltamivir/srt-slurm-nvidia@lm-eval-main`) instead of the default `NVIDIA/srt-slurm@sa-submission-q2-2026`.

## Scope / non-goals

- Only `launch_gb200-nv.sh` is updated. The other NVIDIA launchers (`launch_{b200,b300,gb300,h100,h200}-*.sh`) keep their current `sa-submission-q2-2026` clone and can be updated in a follow-up once the smoke test passes.
- Defaults are deliberately unchanged: no env vars set → identical behavior to today.
- `srt-slurm-validation.yaml` is a test fixture referenced only by explicit `--config-files` in the dispatch command above; no automated workflow picks it up.