### PR TITLE
Security: Arbitrary file overwrite risk from unsanitized output filename argument

### DIFF
--- a/utils/collect_results.py
+++ b/utils/collect_results.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 results_dir = Path(sys.argv[1])
-exp_name = sys.argv[2]
+exp_name = Path(sys.argv[2]).name
 
 agg_results = []
 for result_path in results_dir.rglob(f'*.json'):


### PR DESCRIPTION
## Summary

Security: Arbitrary file overwrite risk from unsanitized output filename argument

## Problem

**Severity**: `Low` | **File**: `utils/collect_results.py:L7`

`exp_name` from CLI arguments is interpolated directly into an output filename (`agg_{exp_name}.json`). If `exp_name` includes path separators or traversal sequences, the script may write outside the intended directory and overwrite unintended files.

## Solution

Validate `exp_name` with a strict allowlist (alphanumeric, `_`, `-`), or use `Path(exp_name).name` to strip path components, then write only within a dedicated output directory.

## Changes

- `utils/collect_results.py` (modified)