### PR TITLE
[AMD/MI355X] Remove atom-specific squash file deletion before import

### DIFF
--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -195,9 +195,6 @@ else
     srun --jobid=$JOB_ID bash -c "
         exec 9>\"$LOCK_FILE\"
         flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
-        if [[ \"$FRAMEWORK\" == \"atom\" ]]; then
-            rm -f \"$SQUASH_FILE\"
-        fi
         if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
             echo 'Squash file already exists and is valid, skipping import'
         else


### PR DESCRIPTION
Hi @functionstackx  @cquil11 

This is to prevent this errors. 

==
Your system tried to pull this image manifest from Docker registry (registry-1.docker.io) and got HTTP 429 Too Many Requests.
for ex,
these failing errors in https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24839994340/attempts/1
