### PR TITLE
test(sweep): verify sweep-enabled label behavior (do not merge)

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1726,3 +1726,10 @@
     - "TP=2 and TP=4, concurrency 4-256 for 1k1k and 8k1k sequence lengths"
     - "Add --max-num-seqs and --gpu-memory-utilization 0.9 to server launch"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1043
+
+- config-keys:
+    - dsr1-fp4-b200-sglang
+  description:
+    - "TEST PR — verifies sweep-enabled label trim + full-sweep-enabled label + reject on both labels"
+    - "Not intended to merge. Close after CI verification."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pulls


### PR DESCRIPTION
## Purpose
Throwaway test PR that verifies the sweep-label flow added in #1123. **Do not merge** — close once CI behavior is confirmed. The changelog entry targets `dsr1-fp4-b200-sglang`; it is deliberately not describing a real perf change.

## Dry-run expectations
Running `process_changelog.py` locally on this diff:

| Mode | 1k1k entries | 8k1k entries | Total |
|---|---|---|---|
| Full (no `--trim-conc`) | 12 | 9 | **21** |
| Trimmed (`--trim-conc`) | 2 | 2 | **4** |

Trimmed conc values (`max(conc)` per `(isl, tp)` group):
- 1k1k tp=4 → 128, tp=8 → 128
- 8k1k tp=4 → 128, tp=8 → 16

## What to verify

1. **`sweep-enabled` alone** — setup job runs, emits 4-entry matrix, downstream `sweep-single-node-*` jobs dispatch 4 benchmark runs.
2. **Add `full-sweep-enabled` on top** — the `Reject conflicting sweep labels` step fails with the expected `::error::` annotation. Workflow re-triggers on the `labeled` event.
3. **Remove `sweep-enabled`, keep `full-sweep-enabled`** — `unlabeled` event re-triggers the workflow. Setup job runs with full sweep (21-entry matrix).
4. **Remove both** — workflow triggers one more time via `unlabeled`; setup job's `if:` gate skips (no sweep labels present), so no benchmarks dispatch.

## Close-out
Close without merging. The real PR #1123 already landed the behavior; this branch only exists to exercise the label flow on real CI.