### PR TITLE
Switch dsv4 B200 SGLang to DeepEP dp-attention recipe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1681,11 +1681,11 @@ dsv4-fp4-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 1024 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 512 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512 }
 
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1671,7 +1671,7 @@ dsr1-fp4-b200-sglang:
 
 dsv4-fp4-b200-sglang:
   image: lmsysorg/sglang:deepseek-v4-blackwell
-  model: deepseek-ai/DeepSeek-V4-Flash
+  model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200
   precision: fp4
@@ -1681,11 +1681,11 @@ dsv4-fp4-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 512 }
 
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1681,11 +1681,11 @@ dsv4-fp4-b200-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 1024 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 1024, spec-decoding: "mtp" }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: "mtp" }
 
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1669,6 +1669,24 @@ dsr1-fp4-b200-sglang:
     - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 16 }
 
+dsv4-fp4-b200-sglang:
+  image: lmsysorg/sglang:deepseek-v4-blackwell
+  model: deepseek-ai/DeepSeek-V4-Flash
+  model-prefix: dsv4
+  runner: b200
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 32 }
+
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4
 # B200 SGLang recipe as-is until B300-specific tuning is available.

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 --ep-size $EP_SIZE \
+--moe-runner-backend flashinfer_mxfp4 --moe-a2a-backend deepep \
+--chunked-prefill-size 4096 --disable-flashinfer-autotune \
+--scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $((CONC * 10)) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -46,22 +46,30 @@ fi
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
 set -x
-PYTHONNOUSERSITE=1 \
 SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1 \
 SGLANG_OPT_USE_TOPK_V2=1 \
+SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1 \
+SGLANG_OPT_USE_FAST_MASK_EP=1 \
+SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1 \
+SGLANG_OPT_FIX_HASH_MEGA_MOE=1 \
+SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=256 \
+SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256 \
 SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
 sglang serve \
   --trust-remote-code \
-  --model-path $MODEL \
+  --model-path deepseek-ai/DeepSeek-V4-Pro \
   --tp 8 \
-  --moe-runner-backend flashinfer_mxfp4 \
+  --dp 8 \
+  --enable-dp-attention \
+  --moe-a2a-backend deepep \
   --speculative-algo EAGLE \
-  --speculative-num-steps 3 \
+  --speculative-num-steps 1 \
   --speculative-eagle-topk 1 \
-  --speculative-num-draft-tokens 4 \
-  --chunked-prefill-size 4096 \
-  --disable-flashinfer-autotune \
+  --speculative-num-draft-tokens 2 \
   --mem-fraction-static 0.82 \
+  --cuda-graph-max-bs 64 \
+  --max-running-requests 128 \
+  --deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
   --host 0.0.0.0 \
   --port $PORT > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -23,9 +23,11 @@ export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 
 # TODO(Cam): sloppy workaround -- the lmsysorg/sglang:deepseek-v4-blackwell image
 # installs sglang editable at /workspace/sglang/python, which the runner's
-# $GITHUB_WORKSPACE:/workspace/ bind-mount masks. Reinstalling from PyPI drops any
-# custom patches baked into the image's local sglang source. Revert once lmsys
-# ships an image that installs sglang outside /workspace (or non-editable).
+# $GITHUB_WORKSPACE:/workspace/ bind-mount masks. Uninstall the broken editable
+# link, then reinstall from PyPI (drops any custom patches baked into the
+# image's local sglang source). Revert once lmsys ships an image that installs
+# sglang outside /workspace (or non-editable).
+pip uninstall -y sglang 2>/dev/null || true
 pip install --no-deps --quiet sglang
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -21,7 +21,14 @@ nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 
-SERVER_LOG="$PWD/server.log"
+# TODO(Cam): sloppy workaround -- the lmsysorg/sglang:deepseek-v4-blackwell image
+# installs sglang editable at /workspace/sglang/python, which the runner's
+# $GITHUB_WORKSPACE:/workspace/ bind-mount masks. Reinstalling from PyPI drops any
+# custom patches baked into the image's local sglang source. Revert once lmsys
+# ships an image that installs sglang outside /workspace (or non-editable).
+pip install --no-deps --quiet sglang
+
+SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
 echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
@@ -32,7 +39,7 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
 fi
 
-start_gpu_monitor --output "$PWD/gpu_metrics.csv"
+start_gpu_monitor
 
 set -x
 sglang serve --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
@@ -57,7 +64,7 @@ run_benchmark_serving \
     --num-prompts $((CONC * 10)) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir "$PWD/"
+    --result-dir /workspace/
 
 if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT"

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -46,11 +46,24 @@ fi
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
 set -x
-PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
---tp $TP \
---moe-runner-backend flashinfer_mxfp4 \
---mem-fraction-static 0.82 \
---disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+PYTHONNOUSERSITE=1 \
+SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1 \
+SGLANG_OPT_USE_TOPK_V2=1 \
+SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
+sglang serve \
+  --trust-remote-code \
+  --model-path $MODEL \
+  --tp 8 \
+  --moe-runner-backend flashinfer_mxfp4 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --chunked-prefill-size 4096 \
+  --disable-flashinfer-autotune \
+  --mem-fraction-static 0.82 \
+  --host 0.0.0.0 \
+  --port $PORT > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -21,7 +21,7 @@ nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG="$PWD/server.log"
 PORT=${PORT:-8888}
 
 echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
@@ -32,7 +32,7 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
 fi
 
-start_gpu_monitor
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
 set -x
 sglang serve --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
@@ -57,7 +57,7 @@ run_benchmark_serving \
     --num-prompts $((CONC * 10)) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir "$PWD/"
 
 if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT"

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -35,7 +35,7 @@ fi
 start_gpu_monitor
 
 set -x
-PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+sglang serve --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
 --tp $TP \
 --moe-runner-backend flashinfer_mxfp4 \
 --mem-fraction-static 0.82 \

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -9,9 +9,7 @@ check_env_vars \
     ISL \
     OSL \
     RANDOM_RANGE_RATIO \
-    RESULT_FILENAME \
-    EP_SIZE \
-    DP_ATTENTION
+    RESULT_FILENAME
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -26,17 +24,7 @@ export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-if [[ $CONC -ge 16 ]]; then
-  SCHEDULER_RECV_INTERVAL=30
-else
-  SCHEDULER_RECV_INTERVAL=10
-fi
-echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL, TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
-
-DP_ATTN_ARGS=""
-if [[ "$DP_ATTENTION" == "true" ]]; then
-  DP_ATTN_ARGS="--enable-dp-attention --dp-size $TP"
-fi
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -48,11 +36,9 @@ start_gpu_monitor
 
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
---tensor-parallel-size=$TP --ep-size $EP_SIZE $DP_ATTN_ARGS \
---moe-runner-backend flashinfer_mxfp4 --moe-a2a-backend deepep \
+--tp $TP \
+--moe-runner-backend flashinfer_mxfp4 \
 --mem-fraction-static 0.82 \
---chunked-prefill-size 4096 --disable-flashinfer-autotune \
---scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
 --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -21,16 +21,13 @@ nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 
-# TODO(Cam): sloppy workaround -- the lmsysorg/sglang:deepseek-v4-blackwell image
-# installs sglang editable at /workspace/sglang/python, which the runner's
-# $GITHUB_WORKSPACE:/workspace/ bind-mount masks. Uninstall the broken editable
-# link, then reinstall from PyPI (drops any custom patches baked into the
-# image's local sglang source). Revert once lmsys ships an image that installs
-# sglang outside /workspace (or non-editable).
-pip uninstall -y sglang 2>/dev/null || true
-pip install --no-deps --quiet sglang
+# TODO(Cam): the lmsysorg/sglang:deepseek-v4-blackwell image installs sglang
+# editable at /workspace/sglang/python; prior sglang tags used /sgl-workspace/sglang.
+# The runner mounts our repo at a non-/workspace path for this image so the editable
+# install stays visible. Paths in this script are $PWD-relative for that reason.
+# Drop the runner conditional once lmsys moves sglang back out of /workspace.
 
-SERVER_LOG=/workspace/server.log
+SERVER_LOG="$PWD/server.log"
 PORT=${PORT:-8888}
 
 echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
@@ -41,10 +38,10 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
 fi
 
-start_gpu_monitor
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
 set -x
-sglang serve --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
 --tp $TP \
 --moe-runner-backend flashinfer_mxfp4 \
 --mem-fraction-static 0.82 \
@@ -66,7 +63,7 @@ run_benchmark_serving \
     --num-prompts $((CONC * 10)) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir "$PWD/"
 
 if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT"

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -10,7 +10,8 @@ check_env_vars \
     OSL \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME \
-    EP_SIZE
+    EP_SIZE \
+    DP_ATTENTION
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -30,7 +31,12 @@ if [[ $CONC -ge 16 ]]; then
 else
   SCHEDULER_RECV_INTERVAL=10
 fi
-echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL, TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
+
+DP_ATTN_ARGS=""
+if [[ "$DP_ATTENTION" == "true" ]]; then
+  DP_ATTN_ARGS="--enable-dp-attention --dp-size $TP"
+fi
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -42,8 +48,9 @@ start_gpu_monitor
 
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
---tensor-parallel-size=$TP --data-parallel-size=1 --ep-size $EP_SIZE \
+--tensor-parallel-size=$TP --ep-size $EP_SIZE $DP_ATTN_ARGS \
 --moe-runner-backend flashinfer_mxfp4 --moe-a2a-backend deepep \
+--mem-fraction-static 0.82 \
 --chunked-prefill-size 4096 --disable-flashinfer-autotune \
 --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
 --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -21,6 +21,11 @@ nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 
+# The deepseek-v4-blackwell image bakes CUDA_VISIBLE_DEVICES=4,5,6,7 into its ENV,
+# which masks half of the 8 GPUs Slurm allocates us. Clear it so TP=8 can bind to
+# all ranks.
+unset CUDA_VISIBLE_DEVICES
+
 # TODO(Cam): the lmsysorg/sglang:deepseek-v4-blackwell image installs sglang
 # editable at /workspace/sglang/python; prior sglang tags used /sgl-workspace/sglang.
 # The runner mounts our repo at a non-/workspace path for this image so the editable

--- a/benchmarks/single_node/dsv4_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_mtp.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+
+# The deepseek-v4-blackwell image bakes CUDA_VISIBLE_DEVICES=4,5,6,7 into its ENV,
+# which masks half of the 8 GPUs Slurm allocates us. Clear it so TP=8 can bind to
+# all ranks.
+unset CUDA_VISIBLE_DEVICES
+
+# TODO(Cam): the lmsysorg/sglang:deepseek-v4-blackwell image installs sglang
+# editable at /workspace/sglang/python; prior sglang tags used /sgl-workspace/sglang.
+# The runner mounts our repo at a non-/workspace path for this image so the editable
+# install stays visible. Paths in this script are $PWD-relative for that reason.
+# Drop the runner conditional once lmsys moves sglang back out of /workspace.
+
+SERVER_LOG="$PWD/server.log"
+PORT=${PORT:-8888}
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
+
+set -x
+PYTHONNOUSERSITE=1 \
+SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1 \
+SGLANG_OPT_USE_TOPK_V2=1 \
+SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
+sglang serve \
+  --trust-remote-code \
+  --model-path $MODEL \
+  --tp 8 \
+  --moe-runner-backend flashinfer_mxfp4 \
+  --speculative-algo EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --chunked-prefill-size 4096 \
+  --disable-flashinfer-autotune \
+  --mem-fraction-static 0.82 \
+  --host 0.0.0.0 \
+  --port $PORT > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $((CONC * 10)) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir "$PWD/" \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,13 @@
 - config-keys:
+    - dsv4-fp4-b200-sglang
+  description:
+    - "Add DeepSeek-V4-Flash single-node B200 SGLang benchmark (TP4, FP4 MoE + FP8 dense)"
+    - "Container: lmsysorg/sglang:deepseek-v4-blackwell"
+    - "Recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
+    - "Prefix caching and speculative decoding disabled for baseline numbers"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+
+- config-keys:
     - dsr1-fp8-h100-dynamo-trt
     - dsr1-fp8-h100-dynamo-sglang
   description:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,11 +1,12 @@
 - config-keys:
     - dsv4-fp4-b200-sglang
   description:
-    - "Add DeepSeek-V4-Flash single-node B200 SGLang benchmark (TP4, FP4 MoE + FP8 dense)"
+    - "Add DeepSeek-V4-Pro single-node B200 SGLang benchmark (TP8, EP8, dp-attention)"
     - "Container: lmsysorg/sglang:deepseek-v4-blackwell"
     - "Recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
+    - "Parallelism and sweep conc ranges match the dsv4-fp4-b200-vllm config"
     - "Prefix caching and speculative decoding disabled for baseline numbers"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1131
 
 - config-keys:
     - dsr1-fp8-h100-dynamo-trt

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -249,8 +249,7 @@ EOF
 
 else
 
-    HF_HUB_CACHE_MOUNT="/scratch/fsw/models"
-    export MODEL="$HF_HUB_CACHE_MOUNT/${MODEL#*/}"
+    HF_HUB_CACHE_MOUNT="/scratch/fsw/gharunners/hf-hub-cache"
     SQUASH_FILE="/home/sa-shared/containers/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
@@ -276,7 +275,7 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
         --container-workdir=/workspace/ \
         --no-container-entrypoint --export=ALL,PORT=8888 \

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -255,6 +255,17 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
+    # TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell installs sglang editable at
+    # /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang), so
+    # the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install and
+    # breaks `import sglang`. Mount this one image at /ix instead; drop the
+    # conditional once the image stops installing editable under /workspace.
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
+        CONTAINER_MOUNT_DIR=/ix
+    else
+        CONTAINER_MOUNT_DIR=/workspace
+    fi
+
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
@@ -275,9 +286,9 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
-        --container-workdir=/workspace/ \
+        --container-workdir=$CONTAINER_MOUNT_DIR \
         --no-container-entrypoint --export=ALL,PORT=8888 \
         bash benchmarks/single_node/${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh
 fi

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -255,6 +255,15 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
+    # The deepseek-v4-blackwell image installs sglang editable at /workspace/sglang/python,
+    # which our usual $GITHUB_WORKSPACE:/workspace/ bind-mount would mask. Mount under /ix for
+    # this image so the in-image sglang source stays visible.
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
+        CONTAINER_MOUNT_DIR=/ix
+    else
+        CONTAINER_MOUNT_DIR=/workspace
+    fi
+
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
@@ -275,9 +284,9 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
-        --container-workdir=/workspace/ \
+        --container-workdir=$CONTAINER_MOUNT_DIR \
         --no-container-entrypoint --export=ALL,PORT=8888 \
         bash benchmarks/single_node/${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh
 fi

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -255,15 +255,6 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
-    # The deepseek-v4-blackwell image installs sglang editable at /workspace/sglang/python,
-    # which our usual $GITHUB_WORKSPACE:/workspace/ bind-mount would mask. Mount under /ix for
-    # this image so the in-image sglang source stays visible.
-    if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
-        CONTAINER_MOUNT_DIR=/ix
-    else
-        CONTAINER_MOUNT_DIR=/workspace
-    fi
-
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
@@ -284,9 +275,9 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
-        --container-workdir=$CONTAINER_MOUNT_DIR \
+        --container-workdir=/workspace/ \
         --no-container-entrypoint --export=ALL,PORT=8888 \
         bash benchmarks/single_node/${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh
 fi

--- a/runners/launch_b200-nb.sh
+++ b/runners/launch_b200-nb.sh
@@ -7,14 +7,25 @@ SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
 
 UCX_NET_DEVICES=eth0
 
+# TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell installs sglang editable at
+# /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang), so
+# the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install and
+# breaks `import sglang`. Mount this one image at /ix instead; drop the
+# conditional once the image stops installing editable under /workspace.
+if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
+    CONTAINER_MOUNT_DIR=/ix
+else
+    CONTAINER_MOUNT_DIR=/workspace
+fi
+
 set -x
 srun --partition=$PARTITION --gres=gpu:$TP --exclusive --job-name="$RUNNER_NAME" \
 --container-image=$IMAGE \
 --container-name=$(echo "$IMAGE" | sed 's/[\/:@#]/_/g')-${USER} \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+--container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
 --no-container-mount-home \
 --container-remap-root \
 --container-writable \
---container-workdir=/workspace/ \
+--container-workdir=$CONTAINER_MOUNT_DIR \
 --no-container-entrypoint --export=ALL,PORT=8888,UCX_NET_DEVICES=$UCX_NET_DEVICES \
 bash benchmarks/single_node/${EXP_NAME%%_*}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh

--- a/runners/launch_b200-nb.sh
+++ b/runners/launch_b200-nb.sh
@@ -21,7 +21,6 @@ fi
 set -x
 srun --partition=$PARTITION --gres=gpu:$TP --exclusive --job-name="$RUNNER_NAME" \
 --container-image=$IMAGE \
---container-name=$(echo "$IMAGE" | sed 's/[\/:@#]/_/g')-${USER} \
 --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
 --no-container-mount-home \
 --container-remap-root \


### PR DESCRIPTION
## Summary
- Replace dsv4 B200 SGLang launch command with DeepEP + dp-attention recipe
- Switch from TP8 flashinfer_mxfp4 to TP8/DP8 with `--moe-a2a-backend deepep` and `--enable-dp-attention`
- Reduce EAGLE spec decoding from 3 steps / 4 draft tokens to 1 step / 2 draft tokens
- Add mega-MOE optimizations (SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE, SGLANG_OPT_USE_FAST_MASK_EP, etc.)
- Add DeepEP dispatch/combine config with 96 SMs

## Test plan
- [ ] Sweep run produces results for 1k/1k and 8k/1k ISL/OSL on B200

🤖 Generated with [Claude Code](https://claude.com/claude-code)