### PR TITLE
[NVIDIA] chore: B300 single node DeepSeek v4 SGLang LOW LATENCY ONLY

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1802,7 +1802,7 @@ dsr1-fp8-b300-sglang:
 # until a B300-specific recipe ships. Prefix caching is disabled.
 # Parallelisms and concurrency ranges mirror dsv4-fp4-b200-vllm.
 dsv4-fp4-b300-sglang:
-  image: lmsysorg/sglang:deepseek-v4-blackwell
+  image: cquil/sglang-deepseek-v4-bw-ultra:v1
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1796,11 +1796,9 @@ dsr1-fp8-b300-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 32 }
 
-# NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-# lists B200 (not B300) as the Blackwell target. This config reuses the
-# B200 Pro FP4 Max-Throughput recipe (DP=8 + DeepEP, no MTP) on B300
-# until a B300-specific recipe ships. Prefix caching is disabled.
-# Parallelisms and concurrency ranges mirror dsv4-fp4-b200-vllm.
+# NOTE: Low-latency fallback (TP=8, EP=1, no DP-attn, no DeepEP) while
+# the DeepEP FP8 weight-postprocess path is broken for DeepSeek-V4-Pro
+# on B300. Re-introduce balanced/max-throughput rows once fixed upstream.
 dsv4-fp4-b300-sglang:
   image: lmsysorg/sglang:deepseek-v4-b300
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1802,7 +1802,7 @@ dsr1-fp8-b300-sglang:
 # until a B300-specific recipe ships. Prefix caching is disabled.
 # Parallelisms and concurrency ranges mirror dsv4-fp4-b200-vllm.
 dsv4-fp4-b300-sglang:
-  image: cquil/sglang-deepseek-v4-bw-ultra:v1
+  image: yhyang201/sglang-b300:v3
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1809,33 +1809,22 @@ dsv4-fp4-b300-sglang:
   precision: fp4
   framework: sglang
   multinode: false
-  # Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-  # are selected inside benchmarks/single_node/dsv4_fp4_b300.sh by CONC:
-  #   low-latency    (CONC <= 32):       TP-only
-  #   balanced       (32 < CONC <= 128): + DP-attn
-  #   max-throughput (CONC > 128):       + DP-attn
-  # Split so result filenames (ep=, dpa=) accurately reflect the recipe.
-  # ep is implicit in sglang: --moe-a2a-backend deepep forces ep_size=tp_size,
-  # while low-latency leaves ep_size at the default of 1.
+  # TODO(Cam): low-latency recipe only (TP-only, no DP-attn, no DeepEP)
+  # while the DeepEP FP8 weight-postprocess path is broken for this
+  # checkpoint on B300 (RuntimeError: Recipe must be a list/tuple of 3
+  # integers. raised from sglang.srt.layers.quantization.fp8
+  # .process_weights_after_loading_block_quant). Full concurrency sweep
+  # retained; revert to the recipe-per-CONC split on chore/dsv4-sgl-b300
+  # once sglang can load the checkpoint under --moe-a2a-backend deepep.
   seq-len-configs:
   - isl: 1024
     osl: 1024
     search-space:
-    # low-latency
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    # balanced
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
-    # max-throughput
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    # low-latency
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-    # balanced
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
-    # max-throughput
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 512 }
 
 qwen3.5-bf16-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1798,11 +1798,12 @@ dsr1-fp8-b300-sglang:
 
 # NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
 # lists B200 (not B300) as the Blackwell target. This config reuses the
-# B200 Flash FP4 Low-Latency recipe on B300 until a B300-specific recipe
-# ships. Speculative decoding (EAGLE) and prefix caching are disabled.
+# B200 Pro FP4 Max-Throughput recipe (DP=8 + DeepEP, no MTP) on B300
+# until a B300-specific recipe ships. Prefix caching is disabled.
+# Parallelisms and concurrency ranges mirror dsv4-fp4-b200-vllm.
 dsv4-fp4-b300-sglang:
   image: lmsysorg/sglang:deepseek-v4-blackwell
-  model: deepseek-ai/DeepSeek-V4-Flash
+  model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300
   precision: fp4
@@ -1812,11 +1813,11 @@ dsv4-fp4-b300-sglang:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 512 }
 
 qwen3.5-bf16-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1809,15 +1809,33 @@ dsv4-fp4-b300-sglang:
   precision: fp4
   framework: sglang
   multinode: false
+  # Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
+  # are selected inside benchmarks/single_node/dsv4_fp4_b300.sh by CONC:
+  #   low-latency    (CONC <= 32):       TP-only
+  #   balanced       (32 < CONC <= 128): + DP-attn
+  #   max-throughput (CONC > 128):       + DP-attn
+  # Split so result filenames (ep=, dpa=) accurately reflect the recipe.
+  # ep is implicit in sglang: --moe-a2a-backend deepep forces ep_size=tp_size,
+  # while low-latency leaves ep_size at the default of 1.
   seq-len-configs:
   - isl: 1024
     osl: 1024
     search-space:
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 1024 }
+    # low-latency
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    # balanced
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
+    # max-throughput
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 512 }
+    # low-latency
+    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    # balanced
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
+    # max-throughput
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 qwen3.5-bf16-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1796,6 +1796,28 @@ dsr1-fp8-b300-sglang:
     - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
     - { tp: 4, ep: 1, conc-start: 4, conc-end: 32 }
 
+# NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
+# lists B200 (not B300) as the Blackwell target. This config reuses the
+# B200 Flash FP4 Low-Latency recipe on B300 until a B300-specific recipe
+# ships. Speculative decoding (EAGLE) and prefix caching are disabled.
+dsv4-fp4-b300-sglang:
+  image: lmsysorg/sglang:deepseek-v4-blackwell
+  model: deepseek-ai/DeepSeek-V4-Flash
+  model-prefix: dsv4
+  runner: b300
+  precision: fp4
+  framework: sglang
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 4, ep: 4, conc-start: 4, conc-end: 128 }
+
 qwen3.5-bf16-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e
   model: Qwen/Qwen3.5-397B-A17B

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1802,7 +1802,7 @@ dsr1-fp8-b300-sglang:
 # until a B300-specific recipe ships. Prefix caching is disabled.
 # Parallelisms and concurrency ranges mirror dsv4-fp4-b200-vllm.
 dsv4-fp4-b300-sglang:
-  image: yhyang201/sglang-b300:v3
+  image: lmsysorg/sglang:deepseek-v4-b300
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -23,7 +23,11 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL"
+# The B300 runner overrides MODEL to a pre-staged /data/models path, so skip
+# `hf download`. Only fetch when MODEL looks like a HF repo ID.
+if [[ "$MODEL" != /* ]]; then
+    hf download "$MODEL"
+fi
 
 nvidia-smi
 

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -50,46 +50,20 @@ fi
 
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
-# Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-# (spec-decoding / MTP and prefix-caching flags dropped for the baseline):
-#   - low-latency    (CONC <= 32):        TP-only, chunked-prefill, disable autotune
-#   - balanced       (32 < CONC <= 128):  + DP-attn, max-running-requests=128
-#   - max-throughput (CONC > 128):        + DP-attn, max-running-requests=256
-DEEPEP_CONFIG='{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
-
-if [[ $CONC -le 32 ]]; then
-    RECIPE=low-latency
-    RECIPE_FLAGS=(
-        --moe-runner-backend flashinfer_mxfp4
-        --chunked-prefill-size 4096
-        --disable-flashinfer-autotune
-        --mem-fraction-static 0.82
-    )
-elif [[ $CONC -le 128 ]]; then
-    RECIPE=balanced
-    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
-    RECIPE_FLAGS=(
-        --dp-size "$TP"
-        --enable-dp-attention
-        --moe-a2a-backend deepep
-        --deepep-config "$DEEPEP_CONFIG"
-        --mem-fraction-static 0.82
-        --cuda-graph-max-bs 64
-        --max-running-requests 128
-    )
-else
-    RECIPE=max-throughput
-    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
-    RECIPE_FLAGS=(
-        --dp-size "$TP"
-        --enable-dp-attention
-        --moe-a2a-backend deepep
-        --deepep-config "$DEEPEP_CONFIG"
-        --mem-fraction-static 0.82
-        --cuda-graph-max-bs 64
-        --max-running-requests 256
-    )
-fi
+# TODO(Cam): hardcoded to the low-latency recipe at every CONC until the
+# DeepEP FP8 weight-postprocess path is fixed for this checkpoint on B300
+# (RuntimeError: Recipe must be a list/tuple of 3 integers. raised from
+# sglang.srt.layers.quantization.fp8.process_weights_after_loading_block_quant).
+# Restore the CONC-based low-latency / balanced / max-throughput dispatch
+# on chore/dsv4-sgl-b300 once sglang can load the checkpoint under
+# --moe-a2a-backend deepep.
+RECIPE=low-latency
+RECIPE_FLAGS=(
+    --moe-runner-backend flashinfer_mxfp4
+    --chunked-prefill-size 4096
+    --disable-flashinfer-autotune
+    --mem-fraction-static 0.82
+)
 echo "Recipe: $RECIPE (CONC=$CONC)"
 
 set -x

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -61,15 +61,17 @@ fi
 start_gpu_monitor
 
 set -x
-PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
---trust-remote-code \
---tensor-parallel-size=$TP --ep-size $EP_SIZE $DP_ATTN_ARGS \
---moe-a2a-backend deepep \
---deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
---mem-fraction-static 0.82 \
---cuda-graph-max-bs 64 \
---max-running-requests 256 \
---disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+PYTHONNOUSERSITE=1 sglang serve \
+    --model-path $MODEL \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --trust-remote-code \
+    --tp $TP \
+    --moe-runner-backend flashinfer_mxfp4 \
+    --mem-fraction-static 0.82 \
+    --chunked-prefill-size 4096 \
+    --disable-flashinfer-autotune \
+    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 # NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-# only ships a B200 recipe for Blackwell. This script reuses the B200 Flash
-# FP4 Low-Latency recipe as-is on B300 until a B300-specific recipe ships.
-# Speculative decoding (EAGLE) and prefix caching are disabled per request.
+# only ships a B200 recipe for Blackwell. This script reuses the B200
+# DeepSeek-V4-Pro Max-Throughput recipe (DP=8 + DeepEP, no MTP) as-is on
+# B300 until a B300-specific recipe ships. Parallelism and concurrency
+# ranges mirror dsv4-fp4-b200-vllm. Prefix caching is disabled.
 
 source "$(dirname "$0")/../benchmark_lib.sh"
 
@@ -15,7 +16,8 @@ check_env_vars \
     OSL \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME \
-    EP_SIZE
+    EP_SIZE \
+    DP_ATTENTION
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -26,11 +28,17 @@ hf download "$MODEL"
 nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-echo "TP: $TP, EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+echo "TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+DP_ATTN_ARGS=""
+if [ "$DP_ATTENTION" = "true" ]; then
+    DP_ATTN_ARGS="--data-parallel-size $TP --enable-dp-attention"
+fi
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -43,10 +51,12 @@ start_gpu_monitor
 set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
---tensor-parallel-size=$TP --ep-size $EP_SIZE \
---moe-runner-backend flashinfer_mxfp4 \
---chunked-prefill-size 4096 \
---disable-flashinfer-autotune \
+--tensor-parallel-size=$TP --ep-size $EP_SIZE $DP_ATTN_ARGS \
+--moe-a2a-backend deepep \
+--deepep-config '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}' \
+--mem-fraction-static 0.82 \
+--cuda-graph-max-bs 64 \
+--max-running-requests 256 \
 --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
+# only ships a B200 recipe for Blackwell. This script reuses the B200 Flash
+# FP4 Low-Latency recipe as-is on B300 until a B300-specific recipe ships.
+# Speculative decoding (EAGLE) and prefix caching are disabled per request.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+echo "TP: $TP, EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
+--trust-remote-code \
+--tensor-parallel-size=$TP --ep-size $EP_SIZE \
+--moe-runner-backend flashinfer_mxfp4 \
+--chunked-prefill-size 4096 \
+--disable-flashinfer-autotune \
+--disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# NOTE: https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-# only ships a B200 recipe for Blackwell. This script reuses the B200
-# DeepSeek-V4-Pro Max-Throughput recipe (DP=8 + DeepEP, no MTP) as-is on
-# B300 until a B300-specific recipe ships. Parallelism and concurrency
-# ranges mirror dsv4-fp4-b200-vllm. Prefix caching is disabled.
-
 source "$(dirname "$0")/../benchmark_lib.sh"
 
 check_env_vars \
@@ -15,9 +9,7 @@ check_env_vars \
     ISL \
     OSL \
     RANDOM_RANGE_RATIO \
-    RESULT_FILENAME \
-    EP_SIZE \
-    DP_ATTENTION
+    RESULT_FILENAME
 
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -32,25 +24,23 @@ fi
 nvidia-smi
 
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
-export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
 
-# The deepseek-v4-blackwell image bakes CUDA_VISIBLE_DEVICES=4,5,6,7 into its ENV,
-# which masks half of the 8 GPUs Slurm allocates us. Clear it so TP=8 can bind to
-# all ranks.
+# The deepseek-v4 sglang images (lmsysorg/sglang:deepseek-v4-blackwell and its
+# B300 forks) bake CUDA_VISIBLE_DEVICES=4,5,6,7 into their ENV, which masks half
+# of the 8 GPUs Slurm allocates us. Clear it so TP=8 can bind to all ranks.
 unset CUDA_VISIBLE_DEVICES
 
-# The runner mounts this repo at a non-/workspace path for the deepseek-v4-blackwell
-# image (it installs sglang editable under /workspace/sglang, which our bind-mount
-# would hide), so write artefacts relative to $PWD instead of a hard-coded /workspace.
+# TODO(Cam): the deepseek-v4 sglang images install sglang editable at
+# /workspace/sglang/python; prior sglang tags used /sgl-workspace/sglang.
+# The runner mounts our repo at a non-/workspace path for these images so the
+# editable install stays visible. Paths in this script are $PWD-relative for
+# that reason. Drop the runner conditional once lmsys moves sglang back out of
+# /workspace.
+
 SERVER_LOG="$PWD/server.log"
 PORT=${PORT:-8888}
 
-echo "TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL"
-
-DP_ATTN_ARGS=""
-if [ "$DP_ATTENTION" = "true" ]; then
-    DP_ATTN_ARGS="--data-parallel-size $TP --enable-dp-attention"
-fi
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -58,7 +48,49 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
 fi
 
-start_gpu_monitor
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
+
+# Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
+# (spec-decoding / MTP and prefix-caching flags dropped for the baseline):
+#   - low-latency    (CONC <= 32):        TP-only, chunked-prefill, disable autotune
+#   - balanced       (32 < CONC <= 128):  + DP-attn, max-running-requests=128
+#   - max-throughput (CONC > 128):        + DP-attn, max-running-requests=256
+DEEPEP_CONFIG='{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
+
+if [[ $CONC -le 32 ]]; then
+    RECIPE=low-latency
+    RECIPE_FLAGS=(
+        --moe-runner-backend flashinfer_mxfp4
+        --chunked-prefill-size 4096
+        --disable-flashinfer-autotune
+        --mem-fraction-static 0.82
+    )
+elif [[ $CONC -le 128 ]]; then
+    RECIPE=balanced
+    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+    RECIPE_FLAGS=(
+        --dp-size "$TP"
+        --enable-dp-attention
+        --moe-a2a-backend deepep
+        --deepep-config "$DEEPEP_CONFIG"
+        --mem-fraction-static 0.82
+        --cuda-graph-max-bs 64
+        --max-running-requests 128
+    )
+else
+    RECIPE=max-throughput
+    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
+    RECIPE_FLAGS=(
+        --dp-size "$TP"
+        --enable-dp-attention
+        --moe-a2a-backend deepep
+        --deepep-config "$DEEPEP_CONFIG"
+        --mem-fraction-static 0.82
+        --cuda-graph-max-bs 64
+        --max-running-requests 256
+    )
+fi
+echo "Recipe: $RECIPE (CONC=$CONC)"
 
 set -x
 PYTHONNOUSERSITE=1 sglang serve \
@@ -67,11 +99,8 @@ PYTHONNOUSERSITE=1 sglang serve \
     --port $PORT \
     --trust-remote-code \
     --tp $TP \
-    --moe-runner-backend flashinfer_mxfp4 \
-    --mem-fraction-static 0.82 \
-    --chunked-prefill-size 4096 \
-    --disable-flashinfer-autotune \
-    --disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --disable-radix-cache \
+    "${RECIPE_FLAGS[@]}" $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 
@@ -86,7 +115,7 @@ run_benchmark_serving \
     --input-len "$ISL" \
     --output-len "$OSL" \
     --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts "$((CONC * 10))" \
+    --num-prompts $((CONC * 10)) \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir "$PWD/"

--- a/benchmarks/single_node/dsv4_fp4_b300.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300.sh
@@ -30,7 +30,15 @@ nvidia-smi
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
 
-SERVER_LOG=/workspace/server.log
+# The deepseek-v4-blackwell image bakes CUDA_VISIBLE_DEVICES=4,5,6,7 into its ENV,
+# which masks half of the 8 GPUs Slurm allocates us. Clear it so TP=8 can bind to
+# all ranks.
+unset CUDA_VISIBLE_DEVICES
+
+# The runner mounts this repo at a non-/workspace path for the deepseek-v4-blackwell
+# image (it installs sglang editable under /workspace/sglang, which our bind-mount
+# would hide), so write artefacts relative to $PWD instead of a hard-coded /workspace.
+SERVER_LOG="$PWD/server.log"
 PORT=${PORT:-8888}
 
 echo "TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL"
@@ -75,7 +83,7 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir "$PWD/"
 
 if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1749,10 +1749,10 @@
 - config-keys:
     - dsv4-fp4-b300-sglang
   description:
-    - "Add DeepSeek-V4-Pro FP4 B300 SGLang benchmark"
-    - "Image: lmsysorg/sglang:deepseek-v4-blackwell"
-    - "Model: deepseek-ai/DeepSeek-V4-Pro (FP4 MoE experts + FP8 attention/dense)"
-    - "Reuses the B200 Pro Max-Throughput recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4 on B300 until a B300-specific recipe ships"
-    - "DP=8 + DeepEP, prefix caching disabled, no speculative decoding"
-    - "Parallelism (TP=8/EP=8/dp-attn=true) and concurrency ranges (4-1024 for 1k1k, 4-512 for 8k1k) mirror dsv4-fp4-b200-vllm"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1132
+    - "Add DeepSeek-V4-Pro FP4 B300 SGLang benchmark (low-latency fallback)"
+    - "Image: lmsysorg/sglang:deepseek-v4-b300"
+    - "Model: deepseek-ai/DeepSeek-V4-Pro"
+    - "Low-latency only (TP=8, EP=1, no DP-attn, no DeepEP) — DeepEP FP8 weight-postprocess path is broken for this checkpoint on B300"
+    - "Prefix caching disabled, no speculative decoding"
+    - "Configs: 1k1k conc 4-1024, 8k1k conc 4-512"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1143

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1725,7 +1725,7 @@
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1040
   
-- config-keys:  
+- config-keys:
     - glm5.1-fp4-mi355x-atom
   description:
     - "Add GLM-5.1 MXFP4 single-node MI355X ATOM benchmark"
@@ -1733,3 +1733,14 @@
     - "TP=2 and TP=4, concurrency 4-256 for 1k1k and 8k1k sequence lengths"
     - "Add --max-num-seqs and --gpu-memory-utilization 0.9 to server launch"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1043
+
+- config-keys:
+    - dsv4-fp4-b300-sglang
+  description:
+    - "Add DeepSeek-V4-Flash FP4 B300 SGLang benchmark"
+    - "Image: lmsysorg/sglang:deepseek-v4-blackwell"
+    - "Model: deepseek-ai/DeepSeek-V4-Flash (FP4 MoE experts + FP8 attention/dense)"
+    - "Reuses the B200 Flash Low-Latency recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4 on B300 until a B300-specific recipe ships"
+    - "Speculative decoding (EAGLE) and prefix caching disabled"
+    - "TP=4/EP=4, concurrency 4-128 for 1k1k and 8k1k"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1737,10 +1737,10 @@
 - config-keys:
     - dsv4-fp4-b300-sglang
   description:
-    - "Add DeepSeek-V4-Flash FP4 B300 SGLang benchmark"
+    - "Add DeepSeek-V4-Pro FP4 B300 SGLang benchmark"
     - "Image: lmsysorg/sglang:deepseek-v4-blackwell"
-    - "Model: deepseek-ai/DeepSeek-V4-Flash (FP4 MoE experts + FP8 attention/dense)"
-    - "Reuses the B200 Flash Low-Latency recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4 on B300 until a B300-specific recipe ships"
-    - "Speculative decoding (EAGLE) and prefix caching disabled"
-    - "TP=4/EP=4, concurrency 4-128 for 1k1k and 8k1k"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+    - "Model: deepseek-ai/DeepSeek-V4-Pro (FP4 MoE experts + FP8 attention/dense)"
+    - "Reuses the B200 Pro Max-Throughput recipe from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4 on B300 until a B300-specific recipe ships"
+    - "DP=8 + DeepEP, prefix caching disabled, no speculative decoding"
+    - "Parallelism (TP=8/EP=8/dp-attn=true) and concurrency ranges (4-1024 for 1k1k, 4-512 for 8k1k) mirror dsv4-fp4-b200-vllm"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1132

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1725,7 +1725,7 @@
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1040
   
-- config-keys:
+- config-keys:  
     - glm5.1-fp4-mi355x-atom
   description:
     - "Add GLM-5.1 MXFP4 single-node MI355X ATOM benchmark"

--- a/runners/launch_b200-dgxc-slurm.sh
+++ b/runners/launch_b200-dgxc-slurm.sh
@@ -249,8 +249,7 @@ EOF
 
 else
 
-    HF_HUB_CACHE_MOUNT="/scratch/fsw/models"
-    export MODEL="$HF_HUB_CACHE_MOUNT/${MODEL#*/}"
+    HF_HUB_CACHE_MOUNT="/scratch/fsw/gharunners/hf-hub-cache"
     SQUASH_FILE="/home/sa-shared/containers/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
@@ -276,7 +275,7 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
         --container-workdir=/workspace/ \
         --no-container-entrypoint --export=ALL,PORT=8888 \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -263,13 +263,13 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
-    # TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell (and its B300-recompiled
-    # fork cquil/sglang-deepseek-v4-bw-ultra) installs sglang editable at
-    # /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang),
+    # TODO(Cam): the deepseek-v4 sglang images (lmsysorg/sglang:deepseek-v4-blackwell
+    # and its B300-recompiled forks like yhyang201/sglang-b300) install sglang
+    # editable at /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang),
     # so the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install
     # and breaks `import sglang`. Mount these images at /ix instead; drop the
     # conditional once the image stops installing editable under /workspace.
-    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* ]]; then
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* || "$IMAGE" == *sglang-b300* ]]; then
         CONTAINER_MOUNT_DIR=/ix
     else
         CONTAINER_MOUNT_DIR=/workspace

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -277,6 +277,14 @@ else
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --nodelist=b300-[001-006,008-012,017-020] -N 1 --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
+    # Stale pyxis scratch from prior jobs with reused SLURM job IDs breaks the
+    # next container srun with
+    #   error: pyxis: mkdir: cannot create directory
+    #       '/scratch/data/user-$UID/pyxis_$JOBID.0/data': File exists
+    # If /scratch is shared across b300 nodes this cleanup works; if it's
+    # node-local it's a harmless no-op.
+    rm -rf "/scratch/data/user-$(id -u)/pyxis_${JOB_ID}."* 2>/dev/null || true
+
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
         --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -269,7 +269,7 @@ else
     # so the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install
     # and breaks `import sglang`. Mount these images at /ix instead; drop the
     # conditional once the image stops installing editable under /workspace.
-    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* || "$IMAGE" == *sglang-b300* ]]; then
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* || "$IMAGE" == *deepseek-v4-b300* || "$IMAGE" == *sglang-b300* ]]; then
         CONTAINER_MOUNT_DIR=/ix
     else
         CONTAINER_MOUNT_DIR=/workspace

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -255,16 +255,29 @@ else
     if [[ "$MODEL" == "Qwen/Qwen3.5-397B-A17B-FP8" ]]; then
         export MODEL="/scratch/models/${MODEL#*/}"
     fi
-    SQUASH_FILE="/data/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    SQUASH_FILE="/data/home/sa-shared/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+    LOCK_FILE="${SQUASH_FILE}.lock"
+
+    # Import the squash file on the head node (outside any srun) under flock.
+    # Parallel GH jobs target the same shared squash path; flock serializes
+    # imports so only one job pulls and writes the file while the rest wait.
+    (
+        exec 9>"$LOCK_FILE"
+        flock -w 600 9 || { echo "Failed to acquire lock for $SQUASH_FILE" >&2; exit 1; }
+        if unsquashfs -l "$SQUASH_FILE" > /dev/null 2>&1; then
+            echo "Squash file already exists and is valid, skipping import"
+        else
+            rm -f "$SQUASH_FILE"
+            enroot import -o "$SQUASH_FILE" "docker://$IMAGE"
+        fi
+    )
 
     # Pin to one of the known-good B300 nodes; others have hardware/network
     # issues that cause benchmarks to hang or fail to start.
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --nodelist=b300-[001-006,008-012,017-020] -N 1 --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
-
-    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -263,12 +263,13 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
-    # TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell installs sglang editable at
-    # /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang), so
-    # the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install and
-    # breaks `import sglang`. Mount this one image at /ix instead; drop the
+    # TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell (and its B300-recompiled
+    # fork cquil/sglang-deepseek-v4-bw-ultra) installs sglang editable at
+    # /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang),
+    # so the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install
+    # and breaks `import sglang`. Mount these images at /ix instead; drop the
     # conditional once the image stops installing editable under /workspace.
-    if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* ]]; then
         CONTAINER_MOUNT_DIR=/ix
     else
         CONTAINER_MOUNT_DIR=/workspace

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -254,22 +254,28 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
+    # Import the squash file on the host (outside SLURM) rather than inside an
+    # srun step. Running two srun steps (one import, one benchmark) in the same
+    # allocation trips a pyxis namespace collision on this cluster:
+    #   error: pyxis: mkdir: cannot create directory
+    #       '/scratch/data/user-$UID/pyxis_$JOBID.1/data': File exists
+    # Collapsing to a single srun (the benchmark) avoids it entirely. flock
+    # serializes concurrent imports of the same squash by parallel GH jobs.
+    (
+        exec 9>"$LOCK_FILE"
+        flock -w 600 9 || { echo "Failed to acquire lock for $SQUASH_FILE" >&2; exit 1; }
+        if unsquashfs -l "$SQUASH_FILE" > /dev/null 2>&1; then
+            echo "Squash file already exists and is valid, skipping import"
+        else
+            rm -f "$SQUASH_FILE"
+            enroot import -o "$SQUASH_FILE" "docker://$IMAGE"
+        fi
+    )
+
     # Pin to one of the known-good B300 nodes; others have hardware/network
     # issues that cause benchmarks to hang or fail to start.
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --nodelist=b300-[001-006,008-012,017-020] -N 1 --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
-
-    # Use flock to serialize concurrent imports to the same squash file
-    srun --jobid=$JOB_ID bash -c "
-        exec 9>\"$LOCK_FILE\"
-        flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
-        if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
-            echo 'Squash file already exists and is valid, skipping import'
-        else
-            rm -f \"$SQUASH_FILE\"
-            enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
-        fi
-    "
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -248,14 +248,8 @@ find . -name '.nfs*' -delete 2>/dev/null || true
 
 else
 
-    HF_HUB_CACHE_MOUNT="/scratch/models"
-    # Qwen3.5-397B-A17B-FP8 is pre-staged under /scratch/models on the B300 cluster,
-    # so point MODEL at the local copy. Other models fall through and use `hf download`
-    # against the mounted cache from their benchmark script.
-    if [[ "$MODEL" == "Qwen/Qwen3.5-397B-A17B-FP8" ]]; then
-        export MODEL="/scratch/models/${MODEL#*/}"
-    fi
-    SQUASH_FILE="/data/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    HF_HUB_CACHE_MOUNT="/data/home/sa-shared/gharunners/hf-hub-cache"
+    SQUASH_FILE="/data/home/sa-shared/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
@@ -279,7 +273,7 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
         --no-container-mount-home \
         --container-workdir=/workspace/ \
         --no-container-entrypoint --export=ALL,PORT=8888 \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -260,6 +260,17 @@ else
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     LOCK_FILE="${SQUASH_FILE}.lock"
 
+    # TODO(Cam): lmsysorg/sglang:deepseek-v4-blackwell installs sglang editable at
+    # /workspace/sglang/python (prior sglang tags used /sgl-workspace/sglang), so
+    # the default $GITHUB_WORKSPACE:/workspace/ bind-mount masks the install and
+    # breaks `import sglang`. Mount this one image at /ix instead; drop the
+    # conditional once the image stops installing editable under /workspace.
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* ]]; then
+        CONTAINER_MOUNT_DIR=/ix
+    else
+        CONTAINER_MOUNT_DIR=/workspace
+    fi
+
     # Import the squash file on the head node (outside any srun) under flock.
     # Parallel GH jobs target the same shared squash path; flock serializes
     # imports so only one job pulls and writes the file while the rest wait.
@@ -281,9 +292,9 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
+        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
         --no-container-mount-home \
-        --container-workdir=/workspace/ \
+        --container-workdir=$CONTAINER_MOUNT_DIR \
         --no-container-entrypoint --export=ALL,PORT=8888 \
         bash benchmarks/single_node/${EXP_NAME%%_*}_${PRECISION}_b300${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh
 

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -266,10 +266,7 @@ else
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
     # Use flock to serialize concurrent imports to the same squash file
-    # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes
     srun --jobid=$JOB_ID bash -c "
-        export ENROOT_CACHE_PATH=\$HOME/.cache/enroot
-        mkdir -p \$ENROOT_CACHE_PATH
         exec 9>\"$LOCK_FILE\"
         flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
         if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -258,13 +258,27 @@ else
     SQUASH_FILE="/data/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+    LOCK_FILE="${SQUASH_FILE}.lock"
 
     # Pin to one of the known-good B300 nodes; others have hardware/network
     # issues that cause benchmarks to hang or fail to start.
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --nodelist=b300-[001-006,008-012,017-020] -N 1 --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
-    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
+    # Use flock to serialize concurrent imports to the same squash file
+    # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes
+    srun --jobid=$JOB_ID bash -c "
+        export ENROOT_CACHE_PATH=\$HOME/.cache/enroot
+        mkdir -p \$ENROOT_CACHE_PATH
+        exec 9>\"$LOCK_FILE\"
+        flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
+        if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
+            echo 'Squash file already exists and is valid, skipping import'
+        else
+            rm -f \"$SQUASH_FILE\"
+            enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
+        fi
+    "
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -248,12 +248,15 @@ find . -name '.nfs*' -delete 2>/dev/null || true
 
 else
 
-    HF_HUB_CACHE_MOUNT="/scratch/models"
-    # Qwen3.5-397B-A17B-FP8 is pre-staged under /scratch/models on the B300 cluster,
-    # so point MODEL at the local copy. Other models fall through and use `hf download`
-    # against the mounted cache from their benchmark script.
+    # Pre-staged models on the B300 cluster live under /data/models. Point MODEL
+    # at the local copy so the benchmark skips `hf download` and reads from the
+    # mounted dir. Other models fall through and use `hf download` from their
+    # benchmark script.
+    HF_HUB_CACHE_MOUNT="/data/models"
     if [[ "$MODEL" == "Qwen/Qwen3.5-397B-A17B-FP8" ]]; then
-        export MODEL="/scratch/models/${MODEL#*/}"
+        export MODEL="$HF_HUB_CACHE_MOUNT/${MODEL#*/}"
+    elif [[ "$MODEL_PREFIX" == "dsv4" ]]; then
+        export MODEL="$HF_HUB_CACHE_MOUNT/dsv4-pro"
     fi
     SQUASH_FILE="/data/home/sa-shared/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -248,46 +248,27 @@ find . -name '.nfs*' -delete 2>/dev/null || true
 
 else
 
-    HF_HUB_CACHE_MOUNT="/data/home/sa-shared/gharunners/hf-hub-cache"
-    SQUASH_FILE="/data/home/sa-shared/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    HF_HUB_CACHE_MOUNT="/scratch/models"
+    # Qwen3.5-397B-A17B-FP8 is pre-staged under /scratch/models on the B300 cluster,
+    # so point MODEL at the local copy. Other models fall through and use `hf download`
+    # against the mounted cache from their benchmark script.
+    if [[ "$MODEL" == "Qwen/Qwen3.5-397B-A17B-FP8" ]]; then
+        export MODEL="/scratch/models/${MODEL#*/}"
+    fi
+    SQUASH_FILE="/data/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
-    LOCK_FILE="${SQUASH_FILE}.lock"
-
-    # Import the squash file on the host (outside SLURM) rather than inside an
-    # srun step. Running two srun steps (one import, one benchmark) in the same
-    # allocation trips a pyxis namespace collision on this cluster:
-    #   error: pyxis: mkdir: cannot create directory
-    #       '/scratch/data/user-$UID/pyxis_$JOBID.1/data': File exists
-    # Collapsing to a single srun (the benchmark) avoids it entirely. flock
-    # serializes concurrent imports of the same squash by parallel GH jobs.
-    (
-        exec 9>"$LOCK_FILE"
-        flock -w 600 9 || { echo "Failed to acquire lock for $SQUASH_FILE" >&2; exit 1; }
-        if unsquashfs -l "$SQUASH_FILE" > /dev/null 2>&1; then
-            echo "Squash file already exists and is valid, skipping import"
-        else
-            rm -f "$SQUASH_FILE"
-            enroot import -o "$SQUASH_FILE" "docker://$IMAGE"
-        fi
-    )
 
     # Pin to one of the known-good B300 nodes; others have hardware/network
     # issues that cause benchmarks to hang or fail to start.
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --nodelist=b300-[001-006,008-012,017-020] -N 1 --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
-    # Stale pyxis scratch from prior jobs with reused SLURM job IDs breaks the
-    # next container srun with
-    #   error: pyxis: mkdir: cannot create directory
-    #       '/scratch/data/user-$UID/pyxis_$JOBID.0/data': File exists
-    # If /scratch is shared across b300 nodes this cleanup works; if it's
-    # node-local it's a harmless no-op.
-    rm -rf "/scratch/data/user-$(id -u)/pyxis_${JOB_ID}."* 2>/dev/null || true
+    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT \
         --no-container-mount-home \
         --container-workdir=/workspace/ \
         --no-container-entrypoint --export=ALL,PORT=8888 \


### PR DESCRIPTION
## Summary

Fallback branch off \`chore/dsv4-sgl-b300\`. Strips the balanced and max-throughput rows from the \`dsv4-fp4-b300-sglang\` search-space so only the low-latency (TP-only) recipe runs.

## Why

Every \`sglang serve\` launch with \`--moe-a2a-backend deepep\` against \`deepseek-ai/DeepSeek-V4-Pro\` on \`lmsysorg/sglang:deepseek-v4-b300\` fails during model load with:

\`\`\`
RuntimeError: Recipe must be a list/tuple of 3 integers.
  File "sglang/srt/layers/quantization/fp8.py", line 957,
    in process_weights_after_loading_block_quant
\`\`\`

Confirmed in run [24911516760](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24911516760) — every \`dpa=true\` job (CONC 64–1024 on both ISL) hits the same traceback at the same line, while every \`dpa=false\` (low-latency) job passes load and runs.

## Matrix

\`generate_sweep_configs.py --runner-type b300 --model-prefix dsv4\` yields 8 entries, all \`tp=8 ep=1 dpa=false\`, CONC ∈ {4, 8, 16, 32} for both 1k1k and 8k1k.

## Follow-up

Re-introduce the balanced and max-throughput rows on [#1132](https://github.com/SemiAnalysisAI/InferenceX/pull/1132) once the FP8+DeepEP weight-postprocess issue is fixed upstream.

## Test plan
- [x] \`generate_sweep_configs.py\` → 8 matrix entries, all dpa=false
- [x] \`pytest utils/matrix_logic/\`
- [ ] Sweep run completes without the FP8 DeepEP traceback