### PR TITLE
Bump MI355X SLURM time-limit to 300m; retrigger dsv4-fp8-mi355x-sglang

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1786,3 +1786,11 @@
     - "Launch args match the provided vllm serve command, including FP4 indexer cache, FULL_AND_PIECEWISE cudagraph config, and max-num-batched-tokens 2048"
     - "1k1k uses --max-model-len 4096; 8k1k uses the workflow-provided benchmark context length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1144
+
+- config-keys:
+    - dsv4-fp8-mi355x-sglang
+  description:
+    - "Bump MI355X SLURM allocation from --time=180 to --time=300 in runners/launch_mi355x-amds.sh"
+    - "DSv4-Pro on MI355X exceeded the 3h cap (STEP CANCELLED DUE TO TIME LIMIT) due to ~30min MoE JIT compile plus slow torch-fallback kernels (SGLANG_HACK_FLASHMLA_BACKEND=torch et al.) from sgl-project/sglang#23608"
+    - "300 minutes matches the GH Actions outer timeout-minutes cap in benchmark-tmpl.yml"
+    - "Retriggering dsv4-fp8-mi355x-sglang"

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -186,7 +186,7 @@ else
     LOCK_FILE="${SQUASH_FILE}.lock"
 
     set -x
-    salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME"
+    salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=300 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -h -o %A | head -n1)
 
     srun --jobid=$JOB_ID bash -c "docker stop \$(docker ps -a -q)"


### PR DESCRIPTION
## Summary
- DSv4-Pro on MI355X was hitting `STEP CANCELLED DUE TO TIME LIMIT` at the 3h SLURM cap (e.g. `STEP 12903.2 ON mia1-p01-g19 CANCELLED AT 2026-04-25T02:52:29 DUE TO TIME LIMIT`). The combination of ~30min MoE JIT compile plus slow torch-fallback kernels (`SGLANG_HACK_FLASHMLA_BACKEND=torch` and the `SGLANG_OPT_*=false` set from [sgl-project/sglang#23608](https://github.com/sgl-project/sglang/pull/23608)) pushes 8k1k high-concurrency runs past 180m.
- Bump `runners/launch_mi355x-amds.sh:189` `--time=180` → `--time=300`. Matches the GH Actions outer `timeout-minutes: 300` in `benchmark-tmpl.yml` so we don't get cut off by the runner SLURM step before the workflow cap.
- Add `perf-changelog.yaml` entry against `dsv4-fp8-mi355x-sglang` to retrigger the benchmark.

For context, MI325X already uses `--time=480` for similar reasons (slow large-model runs). 300m is the more conservative bump that still makes the SLURM cap match the outer GH cap.

## Test plan
- [ ] CI re-runs `dsv4-fp8-mi355x-sglang` 8k1k high-concurrency configs without the time-limit cancel
- [ ] Other MI355X configs (e.g. `dsr1-*-mi355x-*`) continue to pass — they were comfortably under 180m before, so a higher cap is a no-op for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)