### PR TITLE
dsv4-fp4-mi355x-atom: size --max-num-seqs to CONC with floor of 4

### DIFF
--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom.sh
@@ -205,13 +205,15 @@ set -x
 
 BLOCK_SIZE=${BLOCK_SIZE:-16}
 # --enforce-eager is required: ROCm/ATOM#650 (PR1 skeleton) has no CUDAGraph
-# support yet (deferred to a follow-up PR). max-num-seqs uses the ATOM
-# default (512) — matches every other ATOM benchmark script in the repo.
-# The PR1 kv_cache[:1,...] hardcode in deepseek_v4.py means any forward
-# with batch>1 silently corrupts non-slot-0 lanes; this risk activates
-# whenever the scheduler assembles batch>1, regardless of the explicit
-# max-num-seqs value, so pinning it to 4 (the PR's offline repro value)
-# offered no protective benefit. eval (gsm8k) at conc>1 is the canary.
+# support yet (deferred to a follow-up PR). max-num-seqs is sized to the
+# client concurrency with a floor at 4 — the ATOM default (512) makes the
+# KV/GDN-mamba allocator overshoot the GPU budget ("GDN mamba tensor
+# exceeds available KV budget"), and using 1 hangs warmup at 0% GPU. 4
+# is the minimum we've seen complete warmup successfully (also the PR's
+# offline repro value). The PR1 kv_cache[:1,...] hardcode in
+# deepseek_v4.py means any forward with batch>1 silently corrupts
+# non-slot-0 lanes; eval (gsm8k) at conc>1 is the canary.
+MAX_NUM_SEQS=$(( CONC < 4 ? 4 : CONC ))
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
     --server-port $PORT \
@@ -219,6 +221,7 @@ python3 -m atom.entrypoints.openai_server \
     --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN $EP \
     --block-size $BLOCK_SIZE \
     --enforce-eager \
+    --max-num-seqs $MAX_NUM_SEQS \
     --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1844,3 +1844,14 @@
     - "Pinned to PR1 limitations: single-sequence kv_cache hardcode, --enforce-eager required, ATOM_USE_TRITON_MOE=1 (aiter fused_moe broken on gfx950)"
     - "Sweep will expand to TP=4/8 conc 4–256 once ROCm/ATOM PR3 (multi-request) and PR4 (CUDAGraph) land"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1165
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom
+  description:
+    - "Add DeepSeek-V4-Pro FP4 MI355X ATOM Day-0 marker (single-sequence, TP=8, conc=1)"
+    - "Image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post (matches qwen3.5-fp8-mi355x-atom base); ROCm/ATOM#650 overlaid at runtime via pip install --no-deps -e . from a pinned PR SHA (cdbff35) inside the benchmark script"
+    - "triton_kernels is missing from the release image (build-stage path /triton-test/python/triton_kernels/ is cleaned up); the script falls back to ROCm/triton@e491726 (RI3.5.x), which has matmul_ogs.py and routing.py (PR #650 imports both — upstream triton-lang/triton refactored matmul_ogs into matmul.py and removed routing) plus CDNA4MXScaleLayout and a target_info.py compatible with the image's bundled triton"
+    - "Model: deepseek-ai/DeepSeek-V4-Pro (same canonical checkpoint used by dsv4-fp4-b300-vllm); compatibility with PR #650's WeightsMapper not yet verified — first run will tell us"
+    - "Pinned to PR1 limitations: single-sequence kv_cache hardcode, --enforce-eager required, ATOM_USE_TRITON_MOE=1 (aiter fused_moe broken on gfx950)"
+    - "Sweep will expand to TP=4/8 conc 4–256 once ROCm/ATOM PR3 (multi-request) and PR4 (CUDAGraph) land"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1170


### PR DESCRIPTION
## Summary

Follow-up to #1165 (dsv4-fp4-mi355x-atom Day-0). Fixes a runtime crash and enables higher-concurrency sweep entries to actually saturate the scheduler.

The first run after #1165 hit:
```
RuntimeError: GDN mamba tensor (0.00GB for 0 slots) exceeds available KV budget (-18.74GB).
Reduce --max-num-seqs or increase gpu_memory_utilization.
```

This was because removing the explicit `--max-num-seqs 4` in #1165 fell back to ATOM's default of 512, which makes the KV / GDN-mamba allocator overshoot the per-GPU memory budget at our `--max-model-len 2304`.

## Change

Set `--max-num-seqs` per-config to `max(CONC, 4)`:

```bash
MAX_NUM_SEQS=$(( CONC < 4 ? 4 : CONC ))
```

| CONC | MAX_NUM_SEQS |
|---|---|
| 1 | 4 |
| 4 | 4 |
| 16 | 16 |
| 32 | 32 |

## Why these specific bounds

- **Floor of 4**: `--max-num-seqs 1` was previously observed to hang warmup at 0% GPU. 4 is the minimum value we've seen reach a running server, also the value AMD used in PR #650's offline repro.
- **Match CONC for higher entries**: lets conc=16 and conc=32 sweep entries actually saturate the scheduler instead of being throttled at a fixed ceiling.
- **No perf loss for conc=1**: the client only ever has 1 in flight there, so max-num-seqs of 4 vs 1 is identical wall-clock.

## kv_cache[:1,...] risk recap (unchanged from #1165)

ROCm/ATOM#650 PR1 still has `self.kv_cache[:1, ...]` hardcoded in `deepseek_v4.py`. Any forward with batch>1 silently corrupts non-slot-0 lanes. Higher max-num-seqs increases the chance the scheduler assembles a batch>1 forward when conc>1 from the client. **eval (gsm8k) at conc>1 is the canary** — accuracy collapse vs conc=1 indicates the corruption is biting. Throughput numbers alone won't catch it.

## Test plan

- [ ] CI re-runs the dsv4-fp4-mi355x-atom sweep and reaches steady-state without the GDN-mamba budget error
- [ ] gsm8k eval at conc=4/16/32 produces accuracy comparable to conc=1 (canary for kv_cache[:1] silent corruption)