### PR TITLE
dsv4-b300-sglang: floor max-running-requests at 30

### DIFF
--- a/benchmarks/single_node/dsv4_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_sglang.sh
@@ -110,7 +110,7 @@ PYTHONNOUSERSITE=1 sglang serve \
     --port $PORT \
     --trust-remote-code \
     --tp $TP \
-    --max-running-requests "$((CONC * 3 / 2))" \
+    --max-running-requests "$(( CONC * 3 / 2 > 30 ? CONC * 3 / 2 : 30 ))" \
     --mem-fraction-static "$MEM_FRACTION_STATIC" \
     --swa-full-tokens-ratio "$SWA_FULL_TOKENS_RATIO" \
     "${PARALLEL_ARGS[@]}" $EVAL_CONTEXT_ARGS >> $SERVER_LOG 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1862,3 +1862,10 @@
     - "Restore the recipe-per-CONC split (low-latency / balanced / max-throughput) on top of the low-latency-only fallback from #1143; the DeepEP FP8 weight-postprocess path is fixed, so the high-throughput scenario runs again"
     - "Recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1158
+
+- config-keys:
+    - dsv4-fp4-b300-sglang
+  description:
+    - "Restore the recipe-per-CONC split (low-latency / balanced / max-throughput) on top of the low-latency-only fallback from #1143; the DeepEP FP8 weight-postprocess path is fixed, so the high-throughput scenario runs again"
+    - "Recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1172


### PR DESCRIPTION
## Summary
- Apply a floor of 30 to `--max-running-requests` in the DSV4 B300 SGLang benchmark script
- Changes `CONC * 3 / 2` to `max(30, CONC * 3 / 2)` so low-concurrency runs (e.g. CONC=16 → 24) don't starve the scheduler

## Test plan
- [ ] Verify low-concurrency runs (CONC <= 20) use max-running-requests=30
- [ ] Verify higher concurrency runs are unaffected (e.g. CONC=128 → 192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)