### PR TITLE
Add workflow inputs for moe-runner-backend, chunked-prefill-size, swa-full-tokens-ratio

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -38,6 +38,21 @@ on:
       dp-attn:
         required: true
         type: boolean
+      moe-runner-backend:
+        description: "Optional --moe-runner-backend value (e.g. flashinfer_mxfp4). Empty = unset; the benchmark script decides whether to require it."
+        required: false
+        type: string
+        default: ''
+      chunked-prefill-size:
+        description: "Optional --chunked-prefill-size value. Empty = unset; the benchmark script decides whether to require it."
+        required: false
+        type: string
+        default: ''
+      swa-full-tokens-ratio:
+        description: "Optional --swa-full-tokens-ratio value (e.g. 0.1). Empty = unset; the benchmark script decides whether to require it."
+        required: false
+        type: string
+        default: ''
       max-model-len:
         required: true
         type: string
@@ -84,6 +99,9 @@ env:
   TP: ${{ inputs.tp }}
   EP_SIZE: ${{ inputs.ep }}
   DP_ATTENTION: ${{ inputs.dp-attn }}
+  MOE_RUNNER_BACKEND: ${{ inputs.moe-runner-backend }}
+  CHUNKED_PREFILL_SIZE: ${{ inputs.chunked-prefill-size }}
+  SWA_FULL_TOKENS_RATIO: ${{ inputs.swa-full-tokens-ratio }}
   CONC: ${{ inputs.conc }}
   SPEC_DECODING: ${{ inputs.spec-decoding }}
   DISAGG: ${{ inputs.disagg }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -168,6 +168,9 @@ jobs:
             tp: ${{ matrix.config.tp }}
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
+            moe-runner-backend: ${{ matrix.config.moe-runner-backend }}
+            chunked-prefill-size: ${{ matrix.config.chunked-prefill-size }}
+            swa-full-tokens-ratio: ${{ matrix.config.swa-full-tokens-ratio }}
             conc: ${{ matrix.config.conc }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
@@ -198,6 +201,9 @@ jobs:
             tp: ${{ matrix.config.tp }}
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
+            moe-runner-backend: ${{ matrix.config.moe-runner-backend }}
+            chunked-prefill-size: ${{ matrix.config.chunked-prefill-size }}
+            swa-full-tokens-ratio: ${{ matrix.config.swa-full-tokens-ratio }}
             conc: ${{ matrix.config.conc }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -176,6 +176,9 @@ jobs:
             tp: ${{ matrix.config.tp }}
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
+            moe-runner-backend: ${{ matrix.config.moe-runner-backend }}
+            chunked-prefill-size: ${{ matrix.config.chunked-prefill-size }}
+            swa-full-tokens-ratio: ${{ matrix.config.swa-full-tokens-ratio }}
             conc: ${{ matrix.config.conc }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
@@ -217,6 +220,9 @@ jobs:
             tp: ${{ matrix.config.tp }}
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
+            moe-runner-backend: ${{ matrix.config.moe-runner-backend }}
+            chunked-prefill-size: ${{ matrix.config.chunked-prefill-size }}
+            swa-full-tokens-ratio: ${{ matrix.config.swa-full-tokens-ratio }}
             conc: ${{ matrix.config.conc }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -297,6 +297,9 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
+                    moe_runner_backend = bmk.get(Fields.MOE_RUNNER_BACKEND.value)
+                    chunked_prefill_size = bmk.get(Fields.CHUNKED_PREFILL_SIZE.value)
+                    swa_full_tokens_ratio = bmk.get(Fields.SWA_FULL_TOKENS_RATIO.value)
 
                     # Apply max-tp filter if specified
                     if args.max_tp is not None:
@@ -363,6 +366,12 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 entry[Fields.EP.value] = ep
                             if dp_attn is not None:
                                 entry[Fields.DP_ATTN.value] = dp_attn
+                            if moe_runner_backend is not None:
+                                entry[Fields.MOE_RUNNER_BACKEND.value] = str(moe_runner_backend)
+                            if chunked_prefill_size is not None:
+                                entry[Fields.CHUNKED_PREFILL_SIZE.value] = str(chunked_prefill_size)
+                            if swa_full_tokens_ratio is not None:
+                                entry[Fields.SWA_FULL_TOKENS_RATIO.value] = str(swa_full_tokens_ratio)
 
                             validate_matrix_entry(entry, is_multinode)
                             matrix_values.append(entry)
@@ -511,6 +520,9 @@ def generate_runner_model_sweep_config(args, all_config_data, runner_data):
             ep = highest_tp_bmk.get(Fields.EP.value)
             dp_attn = highest_tp_bmk.get(Fields.DP_ATTN.value)
             spec_decoding = highest_tp_bmk.get(Fields.SPEC_DECODING.value, "none")
+            moe_runner_backend = highest_tp_bmk.get(Fields.MOE_RUNNER_BACKEND.value)
+            chunked_prefill_size = highest_tp_bmk.get(Fields.CHUNKED_PREFILL_SIZE.value)
+            swa_full_tokens_ratio = highest_tp_bmk.get(Fields.SWA_FULL_TOKENS_RATIO.value)
 
             for node in runner_nodes:
                 entry = {
@@ -525,6 +537,9 @@ def generate_runner_model_sweep_config(args, all_config_data, runner_data):
                     Fields.TP.value: highest_tp,
                     Fields.EP.value: ep if ep is not None else 1,
                     Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
+                    Fields.MOE_RUNNER_BACKEND.value: str(moe_runner_backend) if moe_runner_backend is not None else '',
+                    Fields.CHUNKED_PREFILL_SIZE.value: str(chunked_prefill_size) if chunked_prefill_size is not None else '',
+                    Fields.SWA_FULL_TOKENS_RATIO.value: str(swa_full_tokens_ratio) if swa_full_tokens_ratio is not None else '',
                     Fields.SPEC_DECODING.value: spec_decoding,
                     Fields.CONC.value: conc_value,
                     Fields.MAX_MODEL_LEN.value: 2048,
@@ -628,6 +643,9 @@ def generate_test_config_sweep(args, all_config_data):
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
+                    moe_runner_backend = bmk.get(Fields.MOE_RUNNER_BACKEND.value)
+                    chunked_prefill_size = bmk.get(Fields.CHUNKED_PREFILL_SIZE.value)
+                    swa_full_tokens_ratio = bmk.get(Fields.SWA_FULL_TOKENS_RATIO.value)
 
                     # Get concurrency values
                     if Fields.CONC_LIST.value in bmk:
@@ -667,6 +685,9 @@ def generate_test_config_sweep(args, all_config_data):
                             Fields.MAX_MODEL_LEN.value: isl + osl + 256,
                             Fields.EP.value: ep if ep is not None else 1,
                             Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
+                            Fields.MOE_RUNNER_BACKEND.value: str(moe_runner_backend) if moe_runner_backend is not None else '',
+                            Fields.CHUNKED_PREFILL_SIZE.value: str(chunked_prefill_size) if chunked_prefill_size is not None else '',
+                            Fields.SWA_FULL_TOKENS_RATIO.value: str(swa_full_tokens_ratio) if swa_full_tokens_ratio is not None else '',
                             Fields.SPEC_DECODING.value: spec_decoding,
                             Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
                             Fields.DISAGG.value: disagg,

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -35,6 +35,9 @@ class Fields(Enum):
     CONC_LIST = 'conc-list'
     EP = 'ep'
     DP_ATTN = 'dp-attn'
+    MOE_RUNNER_BACKEND = 'moe-runner-backend'
+    CHUNKED_PREFILL_SIZE = 'chunked-prefill-size'
+    SWA_FULL_TOKENS_RATIO = 'swa-full-tokens-ratio'
 
     # Multinode-specific fields (when MULTINODE = true)
     SPEC_DECODING = 'spec-decoding'
@@ -86,6 +89,12 @@ class SingleNodeMatrixEntry(BaseModel):
     tp: int
     ep: int
     dp_attn: bool = Field(alias=Fields.DP_ATTN.value)
+    moe_runner_backend: str = Field(
+        default='', alias=Fields.MOE_RUNNER_BACKEND.value)
+    chunked_prefill_size: str = Field(
+        default='', alias=Fields.CHUNKED_PREFILL_SIZE.value)
+    swa_full_tokens_ratio: str = Field(
+        default='', alias=Fields.SWA_FULL_TOKENS_RATIO.value)
     conc: Union[int, List[int]]
     max_model_len: int = Field(alias=Fields.MAX_MODEL_LEN.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
@@ -208,6 +217,12 @@ class SingleNodeSearchSpaceEntry(BaseModel):
         default="none", alias=Fields.SPEC_DECODING.value)
     dp_attn: Optional[bool] = Field(
         default=None, alias=Fields.DP_ATTN.value)
+    moe_runner_backend: Optional[str] = Field(
+        default=None, alias=Fields.MOE_RUNNER_BACKEND.value)
+    chunked_prefill_size: Optional[str] = Field(
+        default=None, alias=Fields.CHUNKED_PREFILL_SIZE.value)
+    swa_full_tokens_ratio: Optional[str] = Field(
+        default=None, alias=Fields.SWA_FULL_TOKENS_RATIO.value)
     conc_start: Optional[int] = Field(
         default=None, alias=Fields.CONC_START.value)
     conc_end: Optional[int] = Field(


### PR DESCRIPTION
## Summary
- Add optional `moe-runner-backend`, `chunked-prefill-size`, and `swa-full-tokens-ratio` inputs to `benchmark-tmpl.yml` (all default to empty string)
- Map them to `MOE_RUNNER_BACKEND`, `CHUNKED_PREFILL_SIZE`, `SWA_FULL_TOKENS_RATIO` env vars
- Pass these fields through in `e2e-tests.yml` and `run-sweep.yml` `with:` blocks

## Why
The `issue_comment`-triggered `/sweep` workflow always uses workflow files from `main`. PR branches that add configs with these knobs (e.g. `knob_backup`) fail because the workflow files on `main` don't define or pass these inputs, so the env vars are empty at runtime.

This is a backwards-compatible change — all new inputs are `required: false` with `default: ''`, so existing configs are unaffected.

## Test plan
- [ ] Verify existing sweeps still work (no input is required, defaults to empty)
- [ ] After merge, `/sweep` on PRs using `moe-runner-backend` / `chunked-prefill-size` / `swa-full-tokens-ratio` should pass the values through correctly