### PR TITLE
[NVIDIA][SGLang][redo PR] B200 DeepSeek v4 FP4 SGLang: recipe-per-CONC split

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1670,7 +1670,7 @@ dsr1-fp4-b200-sglang:
     - { tp: 8, ep: 8, conc-start: 4, conc-end: 16 }
 
 dsv4-fp4-b200-sglang:
-  image: lmsysorg/sglang:deepseek-v4-blackwell
+  image: lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200-dsv4
@@ -1690,7 +1690,7 @@ dsv4-fp4-b200-sglang:
     osl: 1024
     search-space:
     # low-latency
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 1, conc-start: 1, conc-end: 32 }
     # balanced
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
     # max-throughput
@@ -1699,7 +1699,7 @@ dsv4-fp4-b200-sglang:
     osl: 1024
     search-space:
     # low-latency
-    - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+    - { tp: 8, ep: 1, conc-start: 1, conc-end: 32 }
     # balanced
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
     # max-throughput

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1677,32 +1677,33 @@ dsv4-fp4-b200-sglang:
   precision: fp4
   framework: sglang
   multinode: false
-  # Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-  # are selected inside benchmarks/single_node/dsv4_fp4_b200.sh by CONC:
-  #   low-latency    (CONC <= 32):       TP-only
-  #   balanced       (32 < CONC <= 128): + DP-attn
-  #   max-throughput (CONC > 128):       + DP-attn
-  # Split so result filenames (ep=, dpa=) accurately reflect the recipe.
+  # Two recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
+  # are selected inside benchmarks/single_node/dsv4_fp4_b200.sh by DP_ATTENTION:
+  #   low-latency  (DP_ATTENTION=false): TP-only, flashinfer_mxfp4
+  #   DP-attention  (DP_ATTENTION=true):  DP-attn + DeepEP + mega_moe opts
+  # The DP-attention recipe covers both "balanced" (conc 64-128) and
+  # "max-throughput" (conc 256+) CONC ranges with identical flags;
+  # only --max-running-requests scales with CONC.
   # ep is implicit in sglang: --moe-a2a-backend deepep forces ep_size=tp_size,
   # while low-latency leaves ep_size at the default of 1.
   seq-len-configs:
   - isl: 1024
     osl: 1024
     search-space:
-    # low-latency
+    # low-latency (DP_ATTENTION=false)
     - { tp: 8, ep: 1, conc-start: 1, conc-end: 32 }
-    # balanced
+    # DP-attention (DP_ATTENTION=true) — balanced CONC range
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
-    # max-throughput
+    # DP-attention (DP_ATTENTION=true) — max-throughput CONC range
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
   - isl: 8192
     osl: 1024
     search-space:
-    # low-latency
+    # low-latency (DP_ATTENTION=false)
     - { tp: 8, ep: 1, conc-start: 1, conc-end: 32 }
-    # balanced
+    # DP-attention (DP_ATTENTION=true) — balanced CONC range
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 128 }
-    # max-throughput
+    # DP-attention (DP_ATTENTION=true) — max-throughput CONC range
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -90,6 +90,7 @@ PYTHONNOUSERSITE=1 sglang serve \
     --port $PORT \
     --trust-remote-code \
     --tp $TP \
+    --disable-radix-cache \
     --max-running-requests "$((CONC * 3 / 2))" \
     --mem-fraction-static 0.90 \
     --swa-full-tokens-ratio 0.1 \

--- a/benchmarks/single_node/dsv4_fp4_b200.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    DP_ATTENTION \
     CONC \
     ISL \
     OSL \
@@ -19,7 +20,13 @@ hf download "$MODEL"
 
 nvidia-smi
 
+# Common SGLANG env vars (apply to every config).
 export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+export SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT=1
+export SGLANG_OPT_USE_JIT_NORM=1
+export SGLANG_OPT_USE_JIT_INDEXER_METADATA=1
+export SGLANG_OPT_USE_TOPK_V2=1
+export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1
 
 # TODO(Cam): the lmsysorg/sglang:deepseek-v4-blackwell image installs sglang
 # editable at /workspace/sglang/python; prior sglang tags used /sgl-workspace/sglang.
@@ -30,7 +37,7 @@ export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
 SERVER_LOG="$PWD/server.log"
 PORT=${PORT:-8888}
 
-echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+echo "TP: $TP, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL"
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -40,47 +47,41 @@ fi
 
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
-# Three recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4
-# (spec-decoding / MTP and prefix-caching flags dropped for the baseline):
-#   - low-latency    (CONC <= 32):        TP-only, chunked-prefill, disable autotune
-#   - balanced       (32 < CONC <= 128):  + DP-attn, max-running-requests=128
-#   - max-throughput (CONC > 128):        + DP-attn, max-running-requests=256
+# Pick the parallelism + MoE backend based on DP_ATTENTION (mirrors the vllm
+# script's pattern). DP-attention turns on EP-MoE (deepep) and the related
+# mega_moe optimizations; single-instance uses flashinfer_mxfp4.
 DEEPEP_CONFIG='{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
 
-if [[ $CONC -le 32 ]]; then
-    RECIPE=low-latency
-    RECIPE_FLAGS=(
-        --moe-runner-backend flashinfer_mxfp4
-        --chunked-prefill-size 4096
-        --disable-flashinfer-autotune
-        --mem-fraction-static 0.82
-    )
-elif [[ $CONC -le 128 ]]; then
-    RECIPE=balanced
-    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
-    RECIPE_FLAGS=(
+if [ "${DP_ATTENTION}" = "true" ]; then
+    export SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE=1
+    export SGLANG_OPT_FIX_HASH_MEGA_MOE=1
+    export SGLANG_OPT_USE_FAST_MASK_EP=1
+    export SGLANG_OPT_FIX_MEGA_MOE_MEMORY=1
+    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=4096
+    export SGLANG_OPT_FIX_NEXTN_MEGA_MOE=1
+    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=0
+    PARALLEL_ARGS=(
         --dp-size "$TP"
         --enable-dp-attention
         --moe-a2a-backend deepep
         --deepep-config "$DEEPEP_CONFIG"
-        --mem-fraction-static 0.82
-        --cuda-graph-max-bs 64
-        --max-running-requests 128
+        --chunked-prefill-size 32768
     )
 else
-    RECIPE=max-throughput
-    export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256
-    RECIPE_FLAGS=(
-        --dp-size "$TP"
-        --enable-dp-attention
-        --moe-a2a-backend deepep
-        --deepep-config "$DEEPEP_CONFIG"
-        --mem-fraction-static 0.82
-        --cuda-graph-max-bs 64
-        --max-running-requests 256
+    PARALLEL_ARGS=(
+        --moe-runner-backend flashinfer_mxfp4
+        --chunked-prefill-size 8192
+        --disable-flashinfer-autotune
     )
 fi
-echo "Recipe: $RECIPE (CONC=$CONC)"
+
+# Print all SGLANG_* env vars to both the CI step log and server.log so the
+# launch config is auditable from the result artifact alone.
+{
+    echo "=== SGLANG_* env vars at launch ==="
+    env | grep -E '^SGLANG_' | sort
+    echo "==================================="
+} | tee "$SERVER_LOG"
 
 set -x
 PYTHONNOUSERSITE=1 sglang serve \
@@ -89,8 +90,10 @@ PYTHONNOUSERSITE=1 sglang serve \
     --port $PORT \
     --trust-remote-code \
     --tp $TP \
-    --disable-radix-cache \
-    "${RECIPE_FLAGS[@]}" $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --max-running-requests "$((CONC * 3 / 2))" \
+    --mem-fraction-static 0.90 \
+    --swa-full-tokens-ratio 0.1 \
+    "${PARALLEL_ARGS[@]}" $EVAL_CONTEXT_ARGS >> $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1869,3 +1869,11 @@
     - "ISL=8192: TP4 conc 4-64; DP4 (dp-attn) conc 128-1024; DP8 (dp-attn) conc 1024-8192"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1155
 
+- config-keys:
+    - dsv4-fp4-b200-sglang
+  description:
+    - "Recipe-per-CONC dispatch for DeepSeek-V4-Pro on B200, selected inside dsv4_fp4_b200.sh by DP_ATTENTION knob: low-latency (TP=8, EP=1) for conc 1-32, balanced (TP=8, EP=8, DP-attn) for conc 64-128, max-throughput (TP=8, EP=8, DP-attn + DeepEP) for conc 256-{512,1024}"
+    - "Recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
+    - "Image pinned to lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b"
+    - "Adds SGLANG_OPT_* env knobs (SWA_SPLIT_LEAF_ON_INSERT, USE_JIT_NORM, USE_JIT_INDEXER_METADATA, USE_TOPK_V2, USE_CUSTOM_ALL_REDUCE_V2)"
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1872,7 +1872,7 @@
 - config-keys:
     - dsv4-fp4-b200-sglang
   description:
-    - "Recipe-per-CONC dispatch for DeepSeek-V4-Pro on B200, selected inside dsv4_fp4_b200.sh by DP_ATTENTION knob: low-latency (TP=8, EP=1) for conc 1-32, balanced (TP=8, EP=8, DP-attn) for conc 64-128, max-throughput (TP=8, EP=8, DP-attn + DeepEP) for conc 256-{512,1024}"
+    - "Two-recipe dispatch for DeepSeek-V4-Pro on B200, selected by DP_ATTENTION knob: low-latency (TP=8, EP=1, flashinfer_mxfp4) for conc 1-32, DP-attention (TP=8, EP=8, DP-attn + DeepEP + mega_moe) for conc 64-{512,1024}. The DP-attention recipe uses identical flags across balanced and max-throughput CONC ranges; only --max-running-requests scales with CONC."
     - "Recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
     - "Image pinned to lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b"
     - "Adds SGLANG_OPT_* env knobs (SWA_SPLIT_LEAF_ON_INSERT, USE_JIT_NORM, USE_JIT_INDEXER_METADATA, USE_TOPK_V2, USE_CUSTOM_ALL_REDUCE_V2)"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1876,4 +1876,5 @@
     - "Recipes from https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4"
     - "Image pinned to lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b"
     - "Adds SGLANG_OPT_* env knobs (SWA_SPLIT_LEAF_ON_INSERT, USE_JIT_NORM, USE_JIT_INDEXER_METADATA, USE_TOPK_V2, USE_CUSTOM_ALL_REDUCE_V2)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1187
 


### PR DESCRIPTION
## Summary
Mirror of #1185 for the b200 side. Re-applies the b200-specific changes from #1158 in a single commit on top of the #1186 baseline.

## What's included (the b200 part of #1158)
- Image pinned to `lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4...`
- `nvidia-master.yaml`: low-latency rows get `conc-start: 1` (was 4) for both 1k1k and 8k1k
- `dsv4_fp4_b200.sh`:
  - New `DP_ATTENTION` env knob in `check_env_vars`
  - Common `SGLANG_OPT_*` env block (SWA_SPLIT_LEAF_ON_INSERT, USE_JIT_NORM, USE_JIT_INDEXER_METADATA, USE_TOPK_V2, USE_CUSTOM_ALL_REDUCE_V2)
  - Recipe-per-CONC dispatch (low-latency / balanced / max-throughput) selected by `DP_ATTENTION` + `CONC`

## Files
- `.github/configs/nvidia-master.yaml` — `dsv4-fp4-b200-sglang` block updated.
- `benchmarks/single_node/dsv4_fp4_b200.sh` — recipe dispatch logic.
- `perf-changelog.yaml` — single new entry to trigger the sweep.

## Test plan
- [ ] Sweep run on B200 completes end-to-end across all three recipes.
- [ ] Result filenames carry `ep=`/`dpa=` suffixes that distinguish the recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)