### PR TITLE
Nothing to see here

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1886,3 +1886,9 @@
     - "Image pinned to lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b"
     - "Adds SGLANG_OPT_* env knobs (SWA_SPLIT_LEAF_ON_INSERT, USE_JIT_NORM, USE_JIT_INDEXER_METADATA, USE_TOPK_V2, USE_CUSTOM_ALL_REDUCE_V2)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1187
+
+- config-keys:
+    - dsv4-fp4-b300-sglang-mtp
+  description:
+    - "Run evals for DeepSeek-V4-Pro FP4 B300 SGLang MTP (conc 8 now eligible after MIN_EVAL_CONC lowered to 8)"
+  evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1890,5 +1890,6 @@
 - config-keys:
     - dsv4-fp4-b300-sglang-mtp
   description:
-    - "Run evals for DeepSeek-V4-Pro FP4 B300 SGLang MTP (conc 8 now eligible after MIN_EVAL_CONC lowered to 8)"
+    - "Run evals for DSv4 FP4 B300 SGLang MTP"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1189
   evals-only: true

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -19,7 +19,7 @@ seq_len_stoi = {
     "8k1k": (8192, 1024)
 }
 
-MIN_EVAL_CONC = 16
+MIN_EVAL_CONC = 8
 
 # Reverse mapping for exp-name generation
 seq_len_itos = {v: k for k, v in seq_len_stoi.items()}

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -333,7 +333,7 @@ class TestMarkEvalEntries:
         result = mark_eval_entries(matrix_values)
 
         assert result[0]["run-eval"] is True
-        assert result[0]["eval-conc"] == 32
+        assert result[0]["eval-conc"] == 16
         assert result[1]["run-eval"] is False
 
     def test_marks_highest_and_median_conc(self):


### PR DESCRIPTION
## Summary
- Lowers `MIN_EVAL_CONC` from 16 → 8
- Adds `evals-only` perf-changelog entry for `dsv4-fp4-b300-sglang-mtp`
- Updates the test assertion for multinode eval-conc median to reflect the new threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)