### PR TITLE
chore: update b300-nv slurm partition to batch_All

### DIFF
--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # System-specific configuration for B300 NV Slurm cluster
-SLURM_PARTITION="batch_1"
+SLURM_PARTITION="batch_All"
 SLURM_ACCOUNT="benchmark"
 
 set -x


### PR DESCRIPTION
## Summary
- Update `SLURM_PARTITION` in `runners/launch_b300-nv.sh` from `batch_1` to `batch_All`.

## Test plan
- [ ] Confirm B300 NV Slurm jobs schedule on the `batch_All` partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)