### PR TITLE
fix(runners): pin GPU type and drop --exclusive for H100/H200 CW

### DIFF
--- a/runners/launch_h100-cw.sh
+++ b/runners/launch_h100-cw.sh
@@ -7,7 +7,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:h100:$TP --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"

--- a/runners/launch_h200-cw.sh
+++ b/runners/launch_h200-cw.sh
@@ -13,7 +13,7 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:h200:$TP --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Summary
- Pin `--gres=gpu:h100:$TP` and `--gres=gpu:h200:$TP` so salloc requests the right GPU type on CW partitions
- Drop `--exclusive` so allocations are allowed under the CW partition's sharing policy

## Test plan
- [ ] Run runner model sweep workflow against `launch_h100-cw.sh` and `launch_h200-cw.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)