### PR TITLE
ci: add daily runner offline digest workflow

### DIFF
--- a/.github/workflows/runner-offline-digest.yml
+++ b/.github/workflows/runner-offline-digest.yml
@@ -1,0 +1,103 @@
+name: Runner Offline Digest
+
+# Daily check that lists self-hosted runners reporting `offline` and posts
+# a summary + threaded details to Slack. No post when nothing is offline.
+#
+# Required secrets:
+#   RUNNERS_PAT      — PAT (or GitHub App token) with repo "Administration: Read"
+#                      so it can list self-hosted runners. The default GITHUB_TOKEN
+#                      cannot read this endpoint.
+#   SLACK_BOT_TOKEN  — Slack bot token with `chat:write`. The bot must be a member
+#                      of channel C09PULGMVNG.
+
+on:
+  schedule:
+    - cron: '13 14 * * *'  # daily 14:13 UTC ≈ 8:13 AM CST (9:13 AM CDT during DST)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List offline runners
+        id: runners
+        env:
+          GH_TOKEN: ${{ secrets.RUNNERS_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          RUNNERS=$(gh api --paginate "/repos/$REPO/actions/runners?per_page=100" --jq '.runners[]' | jq -s '.')
+          TOTAL=$(jq 'length' <<<"$RUNNERS")
+          OFFLINE=$(jq '[.[] | select(.status == "offline")]' <<<"$RUNNERS")
+          OFFLINE_COUNT=$(jq 'length' <<<"$OFFLINE")
+
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "offline_count=$OFFLINE_COUNT" >> "$GITHUB_OUTPUT"
+
+          echo "Total runners: $TOTAL"
+          echo "Offline runners: $OFFLINE_COUNT"
+
+          if [[ "$OFFLINE_COUNT" -gt 0 ]]; then
+            DETAIL=$(jq -r '
+              sort_by(.name) | .[] |
+              ([.labels[] | select(.type == "custom") | .name]) as $custom |
+              "• `\(.name)` (\(.os)) — labels: " +
+              (if ($custom | length) > 0 then $custom else [.labels[].name] end | join(", "))
+            ' <<<"$OFFLINE")
+            {
+              echo 'detail<<DETAIL_EOF'
+              echo "$DETAIL"
+              echo 'DETAIL_EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "$DETAIL"
+          fi
+
+      - name: Post Slack digest
+        if: steps.runners.outputs.offline_count != '0'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL: C09PULGMVNG
+          OFFLINE_COUNT: ${{ steps.runners.outputs.offline_count }}
+          TOTAL: ${{ steps.runners.outputs.total }}
+          DETAIL: ${{ steps.runners.outputs.detail }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          DATE=$(date -u +%Y-%m-%d)
+          PARENT_TEXT=":warning: *Runner digest — ${DATE}*: ${OFFLINE_COUNT}/${TOTAL} self-hosted runners offline in \`${REPO}\` (<${RUN_URL}|run>)"
+
+          parent_resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n --arg ch "$CHANNEL" --arg t "$PARENT_TEXT" '{channel: $ch, text: $t}')")
+
+          if [[ "$(jq -r '.ok' <<<"$parent_resp")" != "true" ]]; then
+            echo "Slack parent post failed: $parent_resp" >&2
+            exit 1
+          fi
+
+          THREAD_TS=$(jq -r '.ts' <<<"$parent_resp")
+
+          REPLY_TEXT=$(printf 'Offline runners:\n%s' "$DETAIL")
+
+          reply_resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$(jq -n \
+              --arg ch "$CHANNEL" \
+              --arg t "$REPLY_TEXT" \
+              --arg ts "$THREAD_TS" \
+              '{channel: $ch, text: $t, thread_ts: $ts}')")
+
+          if [[ "$(jq -r '.ok' <<<"$reply_resp")" != "true" ]]; then
+            echo "Slack thread reply failed: $reply_resp" >&2
+            exit 1
+          fi
+
+          echo "Posted parent + thread reply (ts=$THREAD_TS) to $CHANNEL"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/runner-offline-digest.yml` — a daily GitHub Actions job that lists self-hosted runners reporting `offline` and posts the result to Slack as a parent + threaded reply. No Slack post when zero are offline.

- **Schedule**: `13 14 * * *` (14:13 UTC ≈ 8:13 AM CST / 9:13 AM CDT). Off-minute is intentional — GitHub Actions cron is unreliable on the `:00` minute under load.
- **Manual trigger**: also via `workflow_dispatch`.
- **Slack channel**: `C09PULGMVNG` (`#inference-minecraft-hangout`). Hardcoded by ID so channel renames don't break it.
- **Label display**: shows custom labels per runner; falls back to all labels (`self-hosted`, OS, arch, …) when a runner has no custom labels, so the Slack line never ends in a dangling `labels: `.

## Required secrets
Both must exist on the repo before the workflow does anything useful:
- `RUNNERS_PAT` — fine-grained PAT with **Administration: Read** on `SemiAnalysisAI/InferenceX`. The default `GITHUB_TOKEN` cannot list self-hosted runners.
- `SLACK_BOT_TOKEN` — bot token for **InferenceX Bot** (App ID `A0AJZ4ALGEQ`) with the `chat:write` scope. The bot must be a member of `C09PULGMVNG` (already invited).

## Verified
Tested end-to-end on this branch via a temporary `push:` trigger (since reverted):
- ✅ Listed 115 runners, identified 3 offline (`gb300-nv_0/1/2`).
- ✅ Posted parent summary + threaded reply to `#inference-minecraft-hangout`.

## Test plan
- [ ] Confirm both secrets are set on `SemiAnalysisAI/InferenceX`.
- [ ] After merge, optionally trigger via Actions → "Runner Offline Digest" → "Run workflow" to confirm scheduling works from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
