### PR TITLE
fix: pin workflow checkouts to github.sha instead of github.ref

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
           clean: false
 
       - name: Cleanup stale eval outputs (pre-run)

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
           clean: false
 
       - name: Cleanup stale eval outputs (pre-run)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,6 +49,8 @@ jobs:
             - name: Checkout code (default)
               if: ${{ !inputs.ref || inputs.ref == '' }}
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                ref: ${{ github.sha }}
 
             - id: get-jobs
               run: |

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - id: gen
         name: Generate matrix via script
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
           clean: false
 
       - name: Launch + Profile (single-node sglang/vllm)


### PR DESCRIPTION
## Summary

- Sweep / e2e workflows fall back to `github.ref` on checkout, which is a moving pointer. Re-runs (and long-queued matrix jobs) end up checking out whatever HEAD currently points at instead of the commit that triggered the run — so a re-triggered sweep silently picks up newer code.
- Switch the fallback to `github.sha` in `benchmark-tmpl.yml`, `benchmark-multinode-tmpl.yml`, and the default-checkout step in `e2e-tests.yml`. `github.sha` is preserved across re-runs and inherited by reusable workflows from the caller.
- Re-applies the fix from 8456a8e4, which lived only on `chore/agentx-integration` and never reached `main`.

## Test plan

- [ ] Trigger a sweep on a PR, push another commit, then re-run the original sweep run — confirm the re-run checks out the original SHA (visible in the checkout step logs as `HEAD is now at <sha>`), not the newer commit.
- [ ] Trigger an e2e workflow_dispatch run, push a follow-up commit while jobs are queued, confirm later matrix jobs still use the dispatched SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)