### PR TITLE
dsv4-fp4-b200-vllm: bump to vllm v0.20.0, deep_gemm_mega_moe MoE

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1707,7 +1707,7 @@ dsv4-fp4-b200-sglang:
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 dsv4-fp4-b200-vllm:
-  image: vllm/vllm-openai:deepseekv4-cu130
+  image: vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200-dsv4

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1707,7 +1707,7 @@ dsv4-fp4-b200-sglang:
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 dsv4-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404
+  image: vllm/vllm-openai:v0.20.0-cu130
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200-dsv4

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -23,6 +23,9 @@ fi
 
 nvidia-smi
 
+# install_deepgemm.sh git-clones the DeepGEMM repo, but the v0.20.0
+# vllm image ships without git — install it first.
+apt-get update && apt-get install -y --no-install-recommends git
 bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
 
 hf download "$MODEL"

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -76,6 +76,7 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     --trust-remote-code \
     --kv-cache-dtype fp8 \
     --block-size 256 \
+    --no-enable-prefix-caching \
     "${PARALLEL_ARGS[@]}" \
     "${EP_ARGS[@]}" \
     "${GMU_ARGS[@]}" \

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -23,8 +23,6 @@ fi
 
 nvidia-smi
 
-bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
-
 hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -90,6 +90,7 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \
     --reasoning-parser deepseek_v4 \
+    --max-cudagraph-capture-size 2048 \
     --max-model-len "$SERVE_MAX_MODEL_LEN" \
     --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &
 

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -42,19 +42,14 @@ if [ "${EP_SIZE:-1}" -gt 1 ]; then
     EP_ARGS=(--enable-expert-parallel)
 fi
 
-# DP-attn switches both the MoE backend and the cudagraph mode per the
-# vLLM v0.20.0 DeepSeek-V4-Pro recipe:
-#   - TP-only / TP+EP (DP_ATTENTION=false): default MoE backend,
-#     compile-config = {"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}
-#   - DP-attn + EP   (DP_ATTENTION=true):  --moe-backend deep_gemm_mega_moe,
-#     compile-config = {"cudagraph_mode": "FULL_AND_PIECEWISE", "custom_ops": ["all"]}
+# Mega-MoE backend and the lower GMU only kick in for high-concurrency
+# DP-attn runs (CONC >= 256), per the vLLM v0.20.0 DeepSeek-V4-Pro recipe.
+# All configs share the FULL_AND_PIECEWISE compilation config.
 GMU_ARGS=()
 MOE_ARGS=()
-COMPILATION_CONFIG='{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
-if [ "${DP_ATTENTION}" = "true" ]; then
+if [ "${DP_ATTENTION}" = "true" ] && [ "${CONC}" -ge 256 ]; then
     GMU_ARGS=(--gpu-memory-utilization 0.85)
     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
-    COMPILATION_CONFIG='{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
 fi
 
 if [ "${ISL}" -eq 8192 ] && [ "${CONC}" -le 128 ]; then
@@ -89,7 +84,7 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     "${EP_ARGS[@]}" \
     "${GMU_ARGS[@]}" \
     "${MOE_ARGS[@]}" \
-    --compilation-config "$COMPILATION_CONFIG" \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
     --attention_config.use_fp4_indexer_cache=True \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -42,12 +42,12 @@ if [ "${EP_SIZE:-1}" -gt 1 ]; then
     EP_ARGS=(--enable-expert-parallel)
 fi
 
-# Mega-MoE backend and the lower GMU only kick in for high-concurrency
-# DP-attn runs (CONC >= 256), per the vLLM v0.20.0 DeepSeek-V4-Pro recipe.
-# All configs share the FULL_AND_PIECEWISE compilation config.
+# Mega-MoE backend and the lower GMU only kick in on the DP-attn path,
+# per the vLLM v0.20.0 DeepSeek-V4-Pro recipe. All configs share the
+# FULL_AND_PIECEWISE compilation config.
 GMU_ARGS=()
 MOE_ARGS=()
-if [ "${DP_ATTENTION}" = "true" ] && [ "${CONC}" -ge 256 ]; then
+if [ "${DP_ATTENTION}" = "true" ]; then
     GMU_ARGS=(--gpu-memory-utilization 0.85)
     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
 fi

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -23,6 +23,8 @@ fi
 
 nvidia-smi
 
+bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
+
 hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
@@ -71,21 +73,19 @@ start_gpu_monitor
 
 set -x
 vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
-    "${PARALLEL_ARGS[@]}" \
-    --pipeline-parallel-size 1 \
-    --kv-cache-dtype fp8 \
     --trust-remote-code \
+    --kv-cache-dtype fp8 \
     --block-size 256 \
-    --no-enable-prefix-caching \
+    "${PARALLEL_ARGS[@]}" \
     "${EP_ARGS[@]}" \
     "${GMU_ARGS[@]}" \
-    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
-    --attention_config.use_fp4_indexer_cache True \
+    --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --attention_config.use_fp4_indexer_cache=True \
+    --moe-backend deep_gemm_mega_moe \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \
     --reasoning-parser deepseek_v4 \
-    --max-cudagraph-capture-size 2048 \
     --max-model-len "$SERVE_MAX_MODEL_LEN" \
     --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &
 

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -23,9 +23,6 @@ fi
 
 nvidia-smi
 
-# install_deepgemm.sh git-clones the DeepGEMM repo, but the v0.20.0
-# vllm image ships without git — install it first.
-apt-get update && apt-get install -y --no-install-recommends git
 bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
 
 hf download "$MODEL"

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -41,7 +41,7 @@ fi
 
 EP_ARGS=()
 if [ "${EP_SIZE:-1}" -gt 1 ]; then
-    EP_ARGS=(--enable-expert-parallel)
+    EP_ARGS=(--enable-expert-parallel --moe-backend deep_gemm_mega_moe)
 fi
 
 GMU_ARGS=()
@@ -82,7 +82,6 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     "${GMU_ARGS[@]}" \
     --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --attention_config.use_fp4_indexer_cache=True \
-    --moe-backend deep_gemm_mega_moe \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm.sh
@@ -39,12 +39,22 @@ fi
 
 EP_ARGS=()
 if [ "${EP_SIZE:-1}" -gt 1 ]; then
-    EP_ARGS=(--enable-expert-parallel --moe-backend deep_gemm_mega_moe)
+    EP_ARGS=(--enable-expert-parallel)
 fi
 
+# DP-attn switches both the MoE backend and the cudagraph mode per the
+# vLLM v0.20.0 DeepSeek-V4-Pro recipe:
+#   - TP-only / TP+EP (DP_ATTENTION=false): default MoE backend,
+#     compile-config = {"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}
+#   - DP-attn + EP   (DP_ATTENTION=true):  --moe-backend deep_gemm_mega_moe,
+#     compile-config = {"cudagraph_mode": "FULL_AND_PIECEWISE", "custom_ops": ["all"]}
 GMU_ARGS=()
+MOE_ARGS=()
+COMPILATION_CONFIG='{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'
 if [ "${DP_ATTENTION}" = "true" ]; then
     GMU_ARGS=(--gpu-memory-utilization 0.85)
+    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
+    COMPILATION_CONFIG='{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}'
 fi
 
 if [ "${ISL}" -eq 8192 ] && [ "${CONC}" -le 128 ]; then
@@ -78,7 +88,8 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     "${EP_ARGS[@]}" \
     "${GMU_ARGS[@]}" \
-    --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    "${MOE_ARGS[@]}" \
+    --compilation-config "$COMPILATION_CONFIG" \
     --attention_config.use_fp4_indexer_cache=True \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1957,7 +1957,7 @@
     - dsv4-fp4-b200-vllm
   description:
     - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
-    - "Use --attention_config.use_fp4_indexer_cache=True"
-    - "Split compilation-config and MoE backend by DP_ATTENTION per the v0.20.0 recipe: TP-only / TP+EP (DP_ATTENTION=false) -> {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} with default MoE backend; DP-attn+EP (DP_ATTENTION=true) -> {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} with --moe-backend deep_gemm_mega_moe"
+    - "Use --attention_config.use_fp4_indexer_cache=True and --compilation-config {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} for all configs"
+    - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true AND CONC>=256 (the high-throughput DP-attn band) per the v0.20.0 recipe"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1958,6 +1958,7 @@
   description:
     - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
     - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
-    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"}, use --attention_config.use_fp4_indexer_cache=True, add --moe-backend deep_gemm_mega_moe"
+    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
+    - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1956,7 +1956,7 @@
 - config-keys:
     - dsv4-fp4-b200-vllm
   description:
-    - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
+    - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag)"
     - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
     - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
     - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1956,8 +1956,7 @@
 - config-keys:
     - dsv4-fp4-b200-vllm
   description:
-    - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag)"
-    - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
+    - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
     - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
     - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1959,5 +1959,5 @@
     - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
     - "Use --attention_config.use_fp4_indexer_cache=True and --compilation-config {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} for all configs"
     - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true per the v0.20.0 recipe"
-    - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
+    - "Drop --pipeline-parallel-size 1; keep --no-enable-prefix-caching and --max-cudagraph-capture-size 2048"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1928,7 +1928,7 @@
     - "Search space: TP=8, concurrency 4-64, 1k1k and 8k1k"
     - "MI355X runner updated to resolve framework-specific script names (dsv4_fp8_mi355x_vllm.sh) with fallback to generic names"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1188
- 
+
 - config-keys:
     - dsv4-fp4-b300-sglang
   description:
@@ -1952,3 +1952,12 @@
   description:
     - "Add preliminary vLLM MTP configs for DeepSeek-V4-Pro on B300"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1210
+
+- config-keys:
+    - dsv4-fp4-b200-vllm
+  description:
+    - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
+    - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
+    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"}, use --attention_config.use_fp4_indexer_cache=True, add --moe-backend deep_gemm_mega_moe"
+    - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1957,7 +1957,7 @@
     - dsv4-fp4-b200-vllm
   description:
     - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
-    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
-    - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"
+    - "Use --attention_config.use_fp4_indexer_cache=True"
+    - "Split compilation-config and MoE backend by DP_ATTENTION per the v0.20.0 recipe: TP-only / TP+EP (DP_ATTENTION=false) -> {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} with default MoE backend; DP-attn+EP (DP_ATTENTION=true) -> {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} with --moe-backend deep_gemm_mega_moe"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1958,6 +1958,6 @@
   description:
     - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
     - "Use --attention_config.use_fp4_indexer_cache=True and --compilation-config {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} for all configs"
-    - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true AND CONC>=256 (the high-throughput DP-attn band) per the v0.20.0 recipe"
+    - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true per the v0.20.0 recipe"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching to match other vLLM B200 scripts"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1204


### PR DESCRIPTION
## Summary
- Pin `dsv4-fp4-b200-vllm` image to `vllm/vllm-openai:v0.20.0-cu130` (canonical v0.20.0 tag) — replaces the floating `deepseekv4-cu130` tag. DeepGEMM is preinstalled in this image, so no `install_deepgemm.sh` step is needed at benchmark time.
- All configs share `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'` and `--attention_config.use_fp4_indexer_cache=True`.
- **Gate `--moe-backend deep_gemm_mega_moe` and `--gpu-memory-utilization 0.85` on `DP_ATTENTION=true`** per the v0.20.0 recipe. The two flags travel together via `MOE_ARGS` / `GMU_ARGS`.
- Drop `--pipeline-parallel-size 1` (no longer in the v0.20.0 recipe). Retain `--no-enable-prefix-caching` (so cross-request cache hits don't skew steady-state throughput) and `--max-cudagraph-capture-size 2048` (preserve cudagraph coverage at the top of the search space).

### Resulting flag matrix

| search-space entry | DP_ATTENTION | EP | compile-config | moe-backend | gpu-mem-util |
| --- | --- | --- | --- | --- | --- |
| `{tp:8}` | false | – | `FULL_AND_PIECEWISE,custom_ops:all` | (default) | (default) |
| `{tp:8, ep:8}` (1k1k @ 128) | false | enabled | `FULL_AND_PIECEWISE,custom_ops:all` | (default) | (default) |
| `{tp:8, ep:8, dp-attn:true}` | true | enabled | `FULL_AND_PIECEWISE,custom_ops:all` | `deep_gemm_mega_moe` | `0.85` |

`PARALLEL_ARGS` / `EP_ARGS` / `GMU_ARGS` / `MOE_ARGS` arrays are preserved so the existing `DP_ATTENTION` / `EP_SIZE` search-space branching drives the right flags cleanly.

Adds a `perf-changelog.yaml` entry to trigger the affected configs.

## Test plan
- [ ] Trigger the `dsv4-fp4-b200-vllm` benchmark workflow on a B200 runner and confirm the engine starts and the sweep completes for at least one cell in each row of the matrix above.
- [ ] Confirm the `v0.20.0-cu130` image pulls and DeepGEMM is already importable inside the container (no install step at runtime).
- [ ] Spot-check `server.log` to verify the right flags are logged per branch:
  - DP_ATTENTION=false (any CONC, any EP): no `--moe-backend`, no `--gpu-memory-utilization`.
  - DP_ATTENTION=true: `--moe-backend deep_gemm_mega_moe --gpu-memory-utilization 0.85`.
  - All branches: `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'`, `--no-enable-prefix-caching`, `--max-cudagraph-capture-size 2048`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)