### PR TITLE
AGENTS.md: document sweep-enabled vs full-sweep-enabled PR labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,8 +170,22 @@ When working with benchmark configurations, use these valid values:
 ### Git
 
 - Conventional commit messages
-- Use `[skip-sweep]` in commit message to skip benchmarks
+- Use `[skip-sweep]` in commit message to skip benchmarks (push-to-main only)
 - Changes to `perf-changelog.yaml` trigger benchmark runs
+
+### Pull Request Sweep Labels
+
+PRs do **not** run the sweep automatically — `run-sweep.yml` is gated on a label. Pick exactly one of the two; setting both is rejected by the workflow.
+
+| Label | Behavior | When to use |
+|-------|----------|-------------|
+| `sweep-enabled` | Runs the sweep with `--trim-conc`: each parallelism config is reduced to its single highest configured concurrency point. | Default for most PRs — validates the change runs end-to-end without consuming the full cluster. |
+| `full-sweep-enabled` | Runs the full intermediate concurrency sweep, identical to a push-to-main run. | Use when intermediate concurrency points actually matter for the PR (e.g., a recipe change expected to shift the throughput/latency curve, not just its endpoints). |
+
+Notes:
+- The two labels are mutually exclusive — `run-sweep.yml`'s `setup` job fails fast with an explicit error if both are present.
+- Push-to-main always runs the full (untrimmed) sweep unless `[skip-sweep]` is in the commit message; the trim only applies to PR runs that opt in via `sweep-enabled`.
+- The trimming logic lives in `trim_conc()` in `utils/process_changelog.py` — single-node entries are grouped by every non-`conc` field and only the highest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[max(conc)]`.
 
 ## Common Tasks
 


### PR DESCRIPTION
## Summary
- Adds a **Pull Request Sweep Labels** section to `AGENTS.md` distinguishing `sweep-enabled` (runs `run-sweep.yml` with `--trim-conc`, keeping only the highest concurrency point per parallelism config) from `full-sweep-enabled` (runs the full intermediate concurrency sweep, identical to push-to-main).
- Notes the two labels are mutually exclusive — `run-sweep.yml`'s `setup` job fails fast if both are set.
- Clarifies that `[skip-sweep]` only applies to push-to-main, not PRs (PRs simply don't run a sweep without a label).
- Cross-references `trim_conc()` in `utils/process_changelog.py` so the implementation can be found from the docs.

No code changes; documentation only.

## Test plan
- [ ] Eyeball the rendered table on the PR page.
- [ ] Confirm the described behavior matches `.github/workflows/run-sweep.yml` (label gating in `setup.if`, conflict-rejection step, `TRIM_CONC` env var) and `utils/process_changelog.py` (`trim_conc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)