### PR TITLE
dsv4-fp4-b300-vllm: bump to vllm v0.20.0, deep_gemm_mega_moe MoE

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2513,7 +2513,7 @@ dsv4-fp8-h200-vllm:
 # field, so dp-attn=true is used as the existing vLLM script switch for DP4
 # layouts on 4 allocated GPUs.
 dsv4-fp4-b300-vllm:
-  image: vllm/vllm-openai:deepseekv4-cu130
+  image: vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2513,7 +2513,7 @@ dsv4-fp8-h200-vllm:
 # field, so dp-attn=true is used as the existing vLLM script switch for DP4
 # layouts on 4 allocated GPUs.
 dsv4-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404
+  image: vllm/vllm-openai:v0.20.0-cu130
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
@@ -23,11 +23,6 @@ fi
 
 nvidia-smi
 
-# install_deepgemm.sh git-clones the DeepGEMM repo, but the v0.20.0
-# vllm image ships without git — install it first.
-apt-get update && apt-get install -y --no-install-recommends git
-bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
-
 hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
@@ -41,7 +41,7 @@ fi
 
 EP_ARGS=()
 if [ "${EP_SIZE:-1}" -gt 1 ]; then
-    EP_ARGS=(--enable-expert-parallel)
+    EP_ARGS=(--enable-expert-parallel --moe-backend deep_gemm_mega_moe)
 fi
 
 if [ "${DP_ATTENTION}" = "true" ]; then
@@ -76,7 +76,6 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     "${EP_ARGS[@]}" \
     --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --attention_config.use_fp4_indexer_cache=True \
-    --moe-backend deep_gemm_mega_moe \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \

--- a/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
@@ -23,6 +23,9 @@ fi
 
 nvidia-smi
 
+# install_deepgemm.sh git-clones the DeepGEMM repo, but the v0.20.0
+# vllm image ships without git — install it first.
+apt-get update && apt-get install -y --no-install-recommends git
 bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
 
 hf download "$MODEL"

--- a/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
@@ -23,6 +23,8 @@ fi
 
 nvidia-smi
 
+bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)
+
 hf download "$MODEL"
 
 SERVER_LOG=/workspace/server.log
@@ -66,20 +68,19 @@ start_gpu_monitor
 
 set -x
 vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
-    "${PARALLEL_ARGS[@]}" \
-    --pipeline-parallel-size 1 \
-    --kv-cache-dtype fp8 \
     --trust-remote-code \
+    --kv-cache-dtype fp8 \
     --block-size 256 \
     --no-enable-prefix-caching \
+    "${PARALLEL_ARGS[@]}" \
     "${EP_ARGS[@]}" \
-    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
-    --attention_config.use_fp4_indexer_cache True \
+    --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --attention_config.use_fp4_indexer_cache=True \
+    --moe-backend deep_gemm_mega_moe \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \
     --reasoning-parser deepseek_v4 \
-    --max-cudagraph-capture-size 2048 \
     --max-model-len "$SERVE_MAX_MODEL_LEN" \
     --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1924,6 +1924,7 @@
   description:
     - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
     - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
-    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"}, use --attention_config.use_fp4_indexer_cache=True, add --moe-backend deep_gemm_mega_moe"
+    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
+    - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1206

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1918,3 +1918,12 @@
     - "Three CONC bands: A=TP8 (1-8), B=TP4 (16-128), C=DP4 dp-attn (64-512); B/C overlap at conc 64,128"
     - "Configs: 1k1k and 8k1k, no validation.py / launcher / yaml-field changes (knob-free)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1180
+
+- config-keys:
+    - dsv4-fp4-b300-vllm
+  description:
+    - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
+    - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
+    - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"}, use --attention_config.use_fp4_indexer_cache=True, add --moe-backend deep_gemm_mega_moe"
+    - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1922,8 +1922,7 @@
 - config-keys:
     - dsv4-fp4-b300-vllm
   description:
-    - "Pin image to vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404 (was floating deepseekv4-cu130 tag)"
-    - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
+    - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
     - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"} and use --attention_config.use_fp4_indexer_cache=True"
     - "Bundle --moe-backend deep_gemm_mega_moe into EP_ARGS so it only applies when EP is enabled (EP_SIZE>1)"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1926,4 +1926,4 @@
     - "Install DeepGEMM via vllm v0.20.0 tools/install_deepgemm.sh before engine launch"
     - "Switch compilation-config to {\"mode\": 0, \"cudagraph_mode\": \"FULL_DECODE_ONLY\"}, use --attention_config.use_fp4_indexer_cache=True, add --moe-backend deep_gemm_mega_moe"
     - "Drop --pipeline-parallel-size 1 and --max-cudagraph-capture-size 2048 (no longer in v0.20.0 recipe); keep --no-enable-prefix-caching"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1206


### PR DESCRIPTION
## Summary
B300 counterpart of #1204.

- Pin `dsv4-fp4-b300-vllm` to `vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404` (replaces floating `deepseekv4-cu130` tag).
- Install DeepGEMM from the v0.20.0 tools script before launching the engine: `bash <(curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.20.0/tools/install_deepgemm.sh)`.
- Update launch flags to the v0.20.0 DeepSeek-V4-Pro recipe: new `compilation-config` (`{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}`), `--attention_config.use_fp4_indexer_cache=True`, add `--moe-backend deep_gemm_mega_moe`. Drop `--pipeline-parallel-size 1` and `--max-cudagraph-capture-size 2048`.
- Keep `--no-enable-prefix-caching` to match the other vLLM single-node benchmark scripts.
- `PARALLEL_ARGS` / `EP_ARGS` arrays are preserved so the existing `DP_ATTENTION` / `EP_SIZE` search-space branching still drives `--tensor-parallel-size` / `--data-parallel-size` / `--enable-expert-parallel`.
- Adds a `perf-changelog.yaml` entry to trigger the affected configs.

## Test plan
- [ ] Trigger the `dsv4-fp4-b300-vllm` benchmark workflow on a B300 runner and confirm the engine starts and the sweep completes for at least one (ISL, OSL, CONC, DP_ATTENTION) cell.
- [ ] Confirm the v0.20.0 image pulls and `install_deepgemm.sh` succeeds inside the container.
- [ ] Spot-check `server.log` for the new flags (`--moe-backend deep_gemm_mega_moe`, new `--compilation-config`, `--attention_config.use_fp4_indexer_cache=True`) and that `--no-enable-prefix-caching` is still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)