### PR TITLE
feat(agentx): make HF trace dataset configurable via AGENTIC_HF_DATASET

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -892,7 +892,7 @@ ensure_hf_cli() {
 }
 
 resolve_trace_source() {
-    local dataset="semianalysisai/cc-traces-weka-042026"
+    local dataset="${AGENTIC_HF_DATASET:-semianalysisai/cc-traces-weka-042026}"
     TRACE_SOURCE_FLAG="--hf-dataset $dataset"
     echo "Loading traces from Hugging Face dataset: $dataset"
     # Pre-download the dataset into the shared HF_HUB_CACHE (same mount used


### PR DESCRIPTION
## What\n- Make the AgentX HF trace dataset configurable in \ via \.\n- Keep the existing default dataset unchanged when the variable is unset.\n\n## Why\n- Allows testing alternative trace packs without maintaining a forked benchmark library.\n\n## Scope\n- Zero methodology change: replay flow and helpers remain unchanged.\n- Default behavior is preserved.