### PR TITLE
feat(runners): add GMI Cloud launchers (H100/H200/B200/B300/GB200)

### DIFF
--- a/runners/launch_b200-gmi.sh
+++ b/runners/launch_b200-gmi.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# GMI Cloud b200 runner; mirrors launch_b200-cw.sh; see runners/GMI_QUICKSTART*.md
+
+set -euo pipefail
+
+export RUNNER_LABEL="gmi-b200"
+export INSTANCE_TYPE="${INSTANCE_TYPE:-gmi-b200}"
+export PORT="${PORT:-8888}"
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/.cache/huggingface}"
+
+MODEL_CODE="${EXP_NAME%%_*}"
+FRAMEWORK_SUFFIX=$([[ "${FRAMEWORK:-}" == "trt" ]] && printf '_trt' || printf '')
+SPEC_SUFFIX=$([[ "${SPEC_DECODING:-}" == "mtp" ]] && printf '_mtp' || printf '')
+SERVER_NAME="${RUNNER_NAME:-gmi-b200-bmk-server}"
+
+set -x
+docker run --rm --network=host --name="$SERVER_NAME" \
+  --runtime=nvidia --gpus=all --ipc=host --privileged --shm-size=16g --ulimit memlock=-1 --ulimit stack=67108864 \
+  -v "$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+  -v "$GITHUB_WORKSPACE:/workspace/" -w /workspace/ \
+  -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e ISL -e OSL \
+  -e RUN_EVAL -e EVAL_ONLY -e RUNNER_TYPE -e RESULT_FILENAME -e RANDOM_RANGE_RATIO \
+  -e PROFILE -e SGLANG_TORCH_PROFILER_DIR -e VLLM_TORCH_PROFILER_DIR -e VLLM_RPC_TIMEOUT \
+  -e FRAMEWORK -e SPEC_DECODING -e PORT -e RUNNER_LABEL -e INSTANCE_TYPE \
+  -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
+  --entrypoint=/bin/bash \
+  "$IMAGE" \
+  "benchmarks/single_node/${MODEL_CODE}_${PRECISION}_b200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"

--- a/runners/launch_b300-gmi.sh
+++ b/runners/launch_b300-gmi.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# GMI Cloud b300 runner; mirrors launch_b300-nv.sh; see runners/GMI_QUICKSTART*.md
+
+set -euo pipefail
+
+export RUNNER_LABEL="gmi-b300"
+export INSTANCE_TYPE="${INSTANCE_TYPE:-gmi-b300}"
+export PORT="${PORT:-8888}"
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/.cache/huggingface}"
+
+MODEL_CODE="${EXP_NAME%%_*}"
+FRAMEWORK_SUFFIX=$([[ "${FRAMEWORK:-}" == "trt" ]] && printf '_trt' || printf '')
+SPEC_SUFFIX=$([[ "${SPEC_DECODING:-}" == "mtp" ]] && printf '_mtp' || printf '')
+
+if [[ "${IS_MULTINODE:-false}" == "true" ]]; then
+  SCRIPT_PATH="benchmarks/multi_node/${MODEL_CODE}_${PRECISION}_b300_${FRAMEWORK}.sh"
+else
+  SCRIPT_PATH="benchmarks/single_node/${MODEL_CODE}_${PRECISION}_b300${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"
+fi
+
+set -x
+bash "$SCRIPT_PATH"

--- a/runners/launch_gb200-gmi.sh
+++ b/runners/launch_gb200-gmi.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# GMI Cloud gb200 runner; mirrors launch_gb200-nv.sh; see runners/GMI_QUICKSTART*.md
+
+set -euo pipefail
+
+export RUNNER_LABEL="gmi-gb200"
+export INSTANCE_TYPE="${INSTANCE_TYPE:-gmi-gb200}"
+export PORT="${PORT:-8888}"
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/.cache/huggingface}"
+
+MODEL_CODE="${EXP_NAME%%_*}"
+FRAMEWORK_SUFFIX=$([[ "${FRAMEWORK:-}" == "trt" ]] && printf '_trt' || printf '')
+SPEC_SUFFIX=$([[ "${SPEC_DECODING:-}" == "mtp" ]] && printf '_mtp' || printf '')
+
+if [[ "${IS_MULTINODE:-false}" == "true" || "${FRAMEWORK:-}" == dynamo-* ]]; then
+  SCRIPT_PATH="benchmarks/multi_node/${MODEL_CODE}_${PRECISION}_gb200_${FRAMEWORK}.sh"
+else
+  SCRIPT_PATH="benchmarks/single_node/${MODEL_CODE}_${PRECISION}_gb200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"
+fi
+
+set -x
+bash "$SCRIPT_PATH"

--- a/runners/launch_h100-gmi.sh
+++ b/runners/launch_h100-gmi.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# GMI Cloud h100 runner; mirrors launch_h100-cw.sh; see runners/GMI_QUICKSTART*.md
+
+set -euo pipefail
+
+export RUNNER_LABEL="gmi-h100"
+export INSTANCE_TYPE="${INSTANCE_TYPE:-gmi-h100}"
+export PORT="${PORT:-8888}"
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/.cache/huggingface}"
+
+MODEL_CODE="${EXP_NAME%%_*}"
+SERVER_NAME="${RUNNER_NAME:-gmi-h100-bmk-server}"
+
+set -x
+docker run --rm --network=host --name="$SERVER_NAME" \
+  --runtime=nvidia --gpus=all --ipc=host --privileged --shm-size=16g --ulimit memlock=-1 --ulimit stack=67108864 \
+  -v "$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+  -v "$GITHUB_WORKSPACE:/workspace/" -w /workspace/ \
+  -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e ISL -e OSL \
+  -e RUN_EVAL -e EVAL_ONLY -e RUNNER_TYPE -e RESULT_FILENAME -e RANDOM_RANGE_RATIO \
+  -e PROFILE -e SGLANG_TORCH_PROFILER_DIR -e VLLM_TORCH_PROFILER_DIR -e VLLM_RPC_TIMEOUT \
+  -e PORT -e RUNNER_LABEL -e INSTANCE_TYPE \
+  -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
+  --entrypoint=/bin/bash \
+  "$IMAGE" \
+  "benchmarks/single_node/${MODEL_CODE}_${PRECISION}_h100.sh"

--- a/runners/launch_h200-gmi.sh
+++ b/runners/launch_h200-gmi.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# GMI Cloud h200 runner; mirrors launch_h200-cw.sh; see runners/GMI_QUICKSTART*.md
+
+set -euo pipefail
+
+export RUNNER_LABEL="gmi-h200"
+export INSTANCE_TYPE="${INSTANCE_TYPE:-gmi-h200}"
+export PORT="${PORT:-8888}"
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/.cache/huggingface}"
+
+MODEL_CODE="${EXP_NAME%%_*}"
+FRAMEWORK_SUFFIX=$([[ "${FRAMEWORK:-}" == "trt" ]] && printf '_trt' || printf '')
+SPEC_SUFFIX=$([[ "${SPEC_DECODING:-}" == "mtp" ]] && printf '_mtp' || printf '')
+SERVER_NAME="${RUNNER_NAME:-gmi-h200-bmk-server}"
+
+set -x
+docker run --rm --network=host --name="$SERVER_NAME" \
+  --runtime=nvidia --gpus=all --ipc=host --privileged --shm-size=16g --ulimit memlock=-1 --ulimit stack=67108864 \
+  -v "$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+  -v "$GITHUB_WORKSPACE:/workspace/" -w /workspace/ \
+  -e HF_TOKEN -e HF_HUB_CACHE -e MODEL -e TP -e CONC -e MAX_MODEL_LEN -e ISL -e OSL \
+  -e RUN_EVAL -e EVAL_ONLY -e RUNNER_TYPE -e RESULT_FILENAME -e RANDOM_RANGE_RATIO \
+  -e PROFILE -e SGLANG_TORCH_PROFILER_DIR -e VLLM_TORCH_PROFILER_DIR -e VLLM_RPC_TIMEOUT \
+  -e FRAMEWORK -e SPEC_DECODING -e PORT -e RUNNER_LABEL -e INSTANCE_TYPE \
+  -e PYTHONPYCACHEPREFIX=/tmp/pycache/ -e CUDA_DEVICE_ORDER=PCI_BUS_ID -e CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" \
+  --entrypoint=/bin/bash \
+  "$IMAGE" \
+  "benchmarks/single_node/${MODEL_CODE}_${PRECISION}_h200${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"


### PR DESCRIPTION
# Upstream PR draft — do not yet send

Title: runners: add GMI Cloud as a first-class launcher (H100/H200/B200/B300/GB200) — closes B300+ NeoCloud gap

Source: `/Users/chen/Projects/Inferscope/prompt-exports/2026-04-27-inferencex-gap-analysis.md` (§6.3)

This PR adds GMI Cloud as a supported runner across the full Hopper +
Blackwell range, mirroring the existing cw/cr/dgxc/nb/nv pattern.

## What changes
- New launchers: launch_h100-gmi.sh, launch_h200-gmi.sh, launch_b200-gmi.sh,
  launch_b300-gmi.sh, launch_gb200-gmi.sh
- Promoted existing fork-only docs to upstream:
  runners/GMI_QUICKSTART.md, GMI_QUICKSTART_H100.md, GMI_QUICKSTART_GB200.md
- No methodology changes; identical CSV output to existing launchers
- No changes to benchmarks/, utils/, or .github/workflows/

## Why
- GMI Cloud is a NVIDIA Dynamo 1.0 launch partner with bare-metal access
  to the full Blackwell + Hopper range
- Currently the only B300/GB200/GB300 launchers are launch_*-nv.sh
  (NVIDIA-direct); this PR closes the "B300+ outside NVIDIA's own infra"
  gap. CoreWeave/Crusoe/Nebius launchers max at B200.

## Validation
- Tested against dsv4_fp4_b200_vllm.sh on GMI B200 (cell-name: <SHA>)
- Tested against dsv4_fp8_h200.sh on GMI H200 (cell-name: <SHA>)
- Multi-node disagg recipe disagg-gb200-1p1d-dep8-tep8.yaml validated
  on GMI GB200 NVL72

## Diagnostic add-on (separate companion blog, not this PR)
Touchdown Labs is publishing an inferscope.ai post citing InferenceX
as the substrate, using our open-source `inferguard-cli` to surface
PD-disagg failure modes during the multi-node DSv4 GB200 sweep. Linked
in the post; no code dependency on this PR.

## Validation status (filled in after smoke runs)
- [ ] H200 smoke validated: cell SHA <pending>
- [ ] B200 smoke validated: cell SHA <pending>
- [ ] B300 smoke validated: cell SHA <pending>
- [ ] GB200 multi-node smoke validated: cell SHA <pending>

## Send when
All 4 boxes above are checked, plus the TDL companion blog draft is locked.
