### PR TITLE
dsv4-fp4-b300-vllm: bump to vllm v0.20.0, deep_gemm_mega_moe MoE

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2515,7 +2515,7 @@ dsv4-fp8-h200-vllm:
 # field, so dp-attn=true is used as the existing vLLM script switch for DP4
 # layouts on 4 allocated GPUs.
 dsv4-fp4-b300-vllm:
-  image: vllm/vllm-openai:deepseekv4-cu130
+  image: vllm/vllm-openai:v0.20.0-cu130
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_vllm.sh
@@ -42,8 +42,15 @@ if [ "${EP_SIZE:-1}" -gt 1 ]; then
     EP_ARGS=(--enable-expert-parallel)
 fi
 
+# Mega-MoE backend and the lower GMU only kick in on the DP-attn path,
+# per the vLLM v0.20.0 DeepSeek-V4-Pro recipe. All configs share the
+# FULL_AND_PIECEWISE compilation config.
+GMU_ARGS=()
+MOE_ARGS=()
 if [ "${DP_ATTENTION}" = "true" ]; then
     MAX_NUM_BATCHED_TOKENS=2048
+    GMU_ARGS=(--gpu-memory-utilization 0.85)
+    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
 else
     MAX_NUM_BATCHED_TOKENS=$(( ISL * 2 ))
 fi
@@ -66,15 +73,16 @@ start_gpu_monitor
 
 set -x
 vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
-    "${PARALLEL_ARGS[@]}" \
-    --pipeline-parallel-size 1 \
-    --kv-cache-dtype fp8 \
     --trust-remote-code \
+    --kv-cache-dtype fp8 \
     --block-size 256 \
     --no-enable-prefix-caching \
+    "${PARALLEL_ARGS[@]}" \
     "${EP_ARGS[@]}" \
+    "${GMU_ARGS[@]}" \
+    "${MOE_ARGS[@]}" \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
-    --attention_config.use_fp4_indexer_cache True \
+    --attention_config.use_fp4_indexer_cache=True \
     --tokenizer-mode deepseek_v4 \
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1969,3 +1969,11 @@
     - "Keeps the three validated 8k/1k points: low-latency 1P/1D TP8 conc=1, mid-curve 1P/1D DEP8 conc=256, and max-tpt 3P/1D DEP8 conc=4096"
     - "All three recipes run NATS/etcd on a dedicated infra node and use compute-node local NVMe model weights via /mnt/numa1/models/deepseek-v4-pro/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1163
+
+- config-keys:
+    - dsv4-fp4-b300-vllm
+  description:
+    - "Pin image to vllm/vllm-openai:v0.20.0-cu130 (was floating deepseekv4-cu130 tag); DeepGEMM is preinstalled in this image"
+    - "Use --attention_config.use_fp4_indexer_cache=True and --compilation-config {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} for all configs"
+    - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true per the v0.20.0 recipe"
+    - "Drop --pipeline-parallel-size 1; keep --no-enable-prefix-caching and --max-cudagraph-capture-size 2048"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1977,3 +1977,4 @@
     - "Use --attention_config.use_fp4_indexer_cache=True and --compilation-config {\"cudagraph_mode\": \"FULL_AND_PIECEWISE\", \"custom_ops\": [\"all\"]} for all configs"
     - "Gate --moe-backend deep_gemm_mega_moe and --gpu-memory-utilization 0.85 on DP_ATTENTION=true per the v0.20.0 recipe"
     - "Drop --pipeline-parallel-size 1; keep --no-enable-prefix-caching and --max-cudagraph-capture-size 2048"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1220


### PR DESCRIPTION
## Summary
Mirror of #1204 for the b300 launcher.

- Pin `dsv4-fp4-b300-vllm` image to `vllm/vllm-openai:v0.20.0-cu130` (canonical v0.20.0 tag) — replaces the floating `deepseekv4-cu130` tag. DeepGEMM is preinstalled in this image, so no `install_deepgemm.sh` step is needed at benchmark time.
- All configs share `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'` and `--attention_config.use_fp4_indexer_cache=True`.
- **Gate `--moe-backend deep_gemm_mega_moe` and `--gpu-memory-utilization 0.85` on `DP_ATTENTION=true`** per the v0.20.0 recipe. The two flags travel together via `MOE_ARGS` / `GMU_ARGS`.
- Drop `--pipeline-parallel-size 1` (no longer in the v0.20.0 recipe). Retain `--no-enable-prefix-caching` and `--max-cudagraph-capture-size 2048`.
- B300-specific logic preserved: `PARALLEL_ARGS` switching on `DP_ATTENTION`, `MAX_NUM_BATCHED_TOKENS=2048` on the DP-attn path, `BENCHMARK_MAX_MODEL_LEN`/`EVAL_ONLY` blocks.

### Resulting flag matrix

| search-space entry | DP_ATTENTION | EP | compile-config | moe-backend | gpu-mem-util |
| --- | --- | --- | --- | --- | --- |
| `{tp:4}` / `{tp:8}` | false | – | `FULL_AND_PIECEWISE,custom_ops:all` | (default) | (default) |
| `{tp:4, ep:4, dp-attn:true}` | true | enabled | `FULL_AND_PIECEWISE,custom_ops:all` | `deep_gemm_mega_moe` | `0.85` |
| `{tp:8, ep:8, dp-attn:true}` | true | enabled | `FULL_AND_PIECEWISE,custom_ops:all` | `deep_gemm_mega_moe` | `0.85` |

`PARALLEL_ARGS` / `EP_ARGS` / `GMU_ARGS` / `MOE_ARGS` arrays are preserved so the existing `DP_ATTENTION` / `EP_SIZE` search-space branching drives the right flags cleanly.

Adds a `perf-changelog.yaml` entry to trigger the affected configs (pr-link to be filled in via follow-up commit once this PR has a number).

## Test plan
- [ ] Trigger the `dsv4-fp4-b300-vllm` benchmark workflow on a B300 runner and confirm the engine starts and the sweep completes for at least one cell in each row of the matrix above.
- [ ] Confirm the `v0.20.0-cu130` image pulls and DeepGEMM is already importable inside the container (no install step at runtime).
- [ ] Spot-check `server.log` per branch:
  - DP_ATTENTION=false (any CONC, any EP): no `--moe-backend`, no `--gpu-memory-utilization`.
  - DP_ATTENTION=true: `--moe-backend deep_gemm_mega_moe --gpu-memory-utilization 0.85`.
  - All branches: `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'`, `--no-enable-prefix-caching`, `--max-cudagraph-capture-size 2048`, no `--pipeline-parallel-size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)