### PR TITLE
Add vllm dsv4 b200 MTP configs 0.20 with megamoe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1727,6 +1727,29 @@ dsv4-fp4-b200-vllm:
     - { tp: 8, conc-start: 1, conc-end: 32 }
     - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 1024 }
 
+# MTP variant of dsv4-fp4-b200-vllm. Mirrors the base search space and adds
+# --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.
+dsv4-fp4-b200-vllm-mtp:
+  image: vllm/vllm-openai:v0.20.0-cu130
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: b200-dsv4
+  precision: fp4
+  framework: vllm
+  multinode: false
+  seq-len-configs:
+  - isl: 1024
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+    - { tp: 8, ep: 8, conc-start: 128, conc-end: 128, spec-decoding: mtp }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 4096, spec-decoding: mtp }
+  - isl: 8192
+    osl: 1024
+    search-space:
+    - { tp: 8, conc-start: 1, conc-end: 32, spec-decoding: mtp }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 1024, spec-decoding: mtp }
+
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4
 # B200 SGLang recipe as-is until B300-specific tuning is available.

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1747,8 +1747,10 @@ dsv4-fp4-b200-vllm-mtp:
   - isl: 8192
     osl: 1024
     search-space:
-    - { tp: 8, conc-start: 1, conc-end: 32, spec-decoding: mtp }
-    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 1024, spec-decoding: mtp }
+    # 8k/1k TP=8 caps at conc=16 (not 32) to avoid OOM observed at conc=32:
+    # https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25134892257/job/73670854021
+    - { tp: 8, conc-start: 1, conc-end: 16, spec-decoding: mtp }
+    - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 256, spec-decoding: mtp }
 
 # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/DeepSeek/DeepSeek-R1
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm_mtp.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# DeepSeek-V4-Pro B200 single-node vLLM MTP variant of dsv4_fp4_b200_vllm.sh.
+# Adds --speculative-config '{"method":"mtp","num_speculative_tokens":2}' and
+# routes prompts through chat-formatted encoding via --dsv4 (required for
+# meaningful MTP acceptance numbers).
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+hf download "$MODEL"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# DeepSeek-V4-Pro weights are large; engine startup can exceed the default
+# 600s. Give it an hour to load.
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+# Mega-MoE backend and the lower GMU only kick in on the DP-attn path,
+# per the vLLM v0.20.0 DeepSeek-V4-Pro recipe. All configs share the
+# FULL_AND_PIECEWISE compilation config.
+GMU_ARGS=()
+MOE_ARGS=()
+if [ "${DP_ATTENTION}" = "true" ]; then
+    GMU_ARGS=(--gpu-memory-utilization 0.85)
+    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
+fi
+
+MAX_NUM_BATCHED_TOKENS=$(( ISL * 2 ))
+BENCHMARK_MAX_MODEL_LEN="$MAX_MODEL_LEN"
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    EVAL_MAX_MODEL_LEN=$(compute_eval_context_length "$MODEL" "$BENCHMARK_MAX_MODEL_LEN")
+    export EVAL_MAX_MODEL_LEN
+    SERVE_MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+else
+    SERVE_MAX_MODEL_LEN="$BENCHMARK_MAX_MODEL_LEN"
+fi
+
+# use 2 speculative tokens for all configs for now
+NUM_SPEC_TOKENS=2
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
+    --trust-remote-code \
+    --kv-cache-dtype fp8 \
+    --block-size 256 \
+    --no-enable-prefix-caching \
+    "${PARALLEL_ARGS[@]}" \
+    "${EP_ARGS[@]}" \
+    "${GMU_ARGS[@]}" \
+    "${MOE_ARGS[@]}" \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
+    --attention_config.use_fp4_indexer_cache=True \
+    --tokenizer-mode deepseek_v4 \
+    --tool-call-parser deepseek_v4 \
+    --enable-auto-tool-choice \
+    --reasoning-parser deepseek_v4 \
+    --max-cudagraph-capture-size 2048 \
+    --speculative-config "{\"method\": \"mtp\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS}" \
+    --max-model-len "$SERVE_MAX_MODEL_LEN" \
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+# MTP acceptance rate degrades on raw random tokens; --dsv4 routes prompts
+# through chat-formatted encoding as required for speculative decoding benchmarks.
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code \
+    --dsv4
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/dsv4_fp4_b200_vllm_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_b200_vllm_mtp.sh
@@ -49,7 +49,7 @@ fi
 GMU_ARGS=()
 MOE_ARGS=()
 if [ "${DP_ATTENTION}" = "true" ]; then
-    GMU_ARGS=(--gpu-memory-utilization 0.85)
+    GMU_ARGS=(--gpu-memory-utilization 0.95)
     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
 fi
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2011,4 +2011,4 @@
     - dsv4-fp4-b200-vllm-mtp
   description:
     - "Add preliminary vLLM MTP configs for DeepSeek-V4-Pro on B200"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1230

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2006,3 +2006,9 @@
     - "Change image to vllm/vllm-openai:v0.20.0-cu130"
     - "Use Mega MoE for DEP configs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1221
+
+- config-keys:
+    - dsv4-fp4-b200-vllm-mtp
+  description:
+    - "Add preliminary vLLM MTP configs for DeepSeek-V4-Pro on B200"
+  pr-link: TBD


### PR DESCRIPTION
## Summary

Add vLLM Multi-Token Prediction (MTP) benchmark configuration for **DeepSeek-V4-Pro** on **NVIDIA B200** runners. Mirrors the B300 MTP pattern from #1210 applied to the B200 vLLM recipe.

### Changes

- **New config `dsv4-fp4-b200-vllm-mtp`** in `nvidia-master.yaml`
  - FP4 precision with FP8 KV cache, image `vllm/vllm-openai:v0.20.0-cu130`
  - Speculative decoding via MTP with 2 speculative tokens
  - Search space mirrors `dsv4-fp4-b200-vllm` for 1k/1k; 8k/1k is trimmed to avoid OOM (TP=8 capped at conc=16, TP=8 EP=8 DP-attn capped at conc=256)
- **New benchmark script** `benchmarks/single_node/dsv4_fp4_b200_vllm_mtp.sh`
  - Based on the STP variant `dsv4_fp4_b200_vllm.sh` with MTP additions per #1210:
    - `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'`
    - `--dsv4` flag on `bench serve` for chat-formatted prompts (required for meaningful MTP acceptance rate)
    - `--max-num-batched-tokens` set to `ISL * 2`
  - Retains the B200-specific DP-attention path (mega-MoE backend); GMU bumped from 0.85 to 0.95 for MTP
- **Perf changelog** entry added for `dsv4-fp4-b200-vllm-mtp`

## Follow-ups

- [ ] Debug 8k/1k TP=8 OOM at conc=32 (currently capped at conc=16): https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25134892257/job/73670854021
- [ ] Investigate whether `num_speculative_tokens=1` is better than `=2` for 8k/1k DP-attn above conc=256

## Test plan

- [ ] Trigger sweep on b200-dsv4 runner pool and verify the MTP server starts
- [ ] Confirm acceptance rate is non-trivial under `--dsv4` (vs raw random tokens)
- [ ] Compare TPS against `dsv4-fp4-b200-vllm` baseline at matching TP/EP/conc points

🤖 Generated with [Claude Code](https://claude.com/claude-code)
