### PR TITLE
gb300-cw: point dsv4 weights at compute-node /scratch NVMe

### DIFF
--- a/runners/launch_gb300-cw.sh
+++ b/runners/launch_gb300-cw.sh
@@ -8,10 +8,9 @@
 set -x
 
 if [[ $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "dsv4" && $PRECISION == "fp4" ]]; then
-    # Weights staged on the shared VAST mount; no compute-node-local
-    # NVMe on cw. The exact upstream recipes refer to this model as
-    # `dspro`.
-    export MODEL_PATH="/mnt/vast/models/dsv4/"
+    # Weights staged on compute-node-local NVMe at /scratch/models/dsv4/.
+    # The exact upstream recipes refer to this model as `dspro`.
+    export MODEL_PATH="/scratch/models/dsv4/"
 else
     echo "Unsupported model prefix/precision/framework combination on gb300-cw: $MODEL_PREFIX/$PRECISION/$FRAMEWORK. Currently supported: dsv4/fp4/dynamo-sglang"
     exit 1


### PR DESCRIPTION
## Summary

- CoreWeave GB300 compute nodes now have local NVMe scratch with DeepSeek-V4 weights staged at `/scratch/models/dsv4/`.
- Switch `MODEL_PATH` in `runners/launch_gb300-cw.sh` from the shared `/mnt/vast/models/dsv4/` mount to the local NVMe path.
- Update the surrounding comment which previously claimed "no compute-node-local NVMe on cw".

Other `/mnt/vast` references in the launcher (squash files, Dynamo wheels cache) are unchanged — only the model location moved.

## Test plan

- [ ] Re-run a `dsv4-fp4-gb300-dynamo-sglang` recipe on gb300-cw and confirm the workers load weights from `/scratch/models/dsv4/`.