### PR TITLE
Comment unofficial run visualizer link on sweep PRs

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -402,3 +402,36 @@ jobs:
                         "run-attempt": "${{ github.run_attempt }}"
                       }
                     }'
+
+    comment-unofficial-run-visualizer:
+        needs:
+            [
+                collect-results,
+                collect-evals,
+                calc-success-rate,
+                upload-changelog-metadata,
+            ]
+        if: >-
+            always() &&
+            github.event_name == 'pull_request' &&
+            !github.event.pull_request.draft &&
+            (
+              contains(github.event.pull_request.labels.*.name, 'sweep-enabled') ||
+              contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled')
+            )
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Comment unofficial run visualizer link on PR
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+              with:
+                  github-token: ${{ github.token }}
+                  script: |
+                      const url = `https://inferencex.semianalysis.com/inference?unofficialRun=${context.runId}`;
+                      await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          body: `see unofficial run visualizer at ${url}`,
+                      });


### PR DESCRIPTION
## Summary
- Adds a `comment-unofficial-run-visualizer` job to `.github/workflows/run-sweep.yml`
- Triggers on PRs with `sweep-enabled` or `full-sweep-enabled` labels (non-draft) after `collect-results`, `collect-evals`, `calc-success-rate`, and `upload-changelog-metadata` finish
- Posts a PR comment: `see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=<github.run_id>`

## Test plan
- [ ] Open a draft PR touching `perf-changelog.yaml` — job should be skipped
- [ ] Mark ready for review and add `sweep-enabled` — job should run after the four `needs` jobs and post the comment
- [ ] Verify the link's `unofficialRun=` value matches the actual workflow run ID
- [ ] Confirm `always()` causes the comment to post even if some upstream jobs fail/skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)