### PR TITLE
Test sweep: gptoss FP4 H100 vLLM (verify visualizer comment)

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2063,3 +2063,9 @@
     - "Recipes cover 8k/1k aggregate TP8 low-latency conc=1, low-latency bridge 1P DEP8 + 4D TP8 no-offload conc=16/32/64, mid 1P/1D DEP8 MegaMOE conc=128, and high-throughput 2P/1D DEP8 MegaMOE conc=1024"
     - "All recipes enable FP4 indexer cache and speculative-config mtp with num_speculative_tokens=2"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1242
+
+- config-keys:
+    - gptoss-fp4-h100-vllm
+  description:
+    - "Re-run GPT-OSS FP4 H100 vLLM sweep to validate unofficial-run-visualizer PR comment posts on completion"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING


### PR DESCRIPTION
## Summary
- Adds a single-config changelog entry for `gptoss-fp4-h100-vllm`
- Test PR to verify the new `comment-unofficial-run-visualizer` job posts a PR comment after the sweep completes

## Test plan
- [ ] Mark ready for review and add `sweep-enabled` label
- [ ] Wait for `Run Sweep` workflow to finish
- [ ] Confirm a comment appears: `see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=<run_id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)