### PR TITLE
Add evaluation visualizer link to sweep PR comment

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -428,10 +428,15 @@ jobs:
               with:
                   github-token: ${{ github.token }}
                   script: |
-                      const url = `https://inferencex.semianalysis.com/inference?unofficialRun=${context.runId}`;
+                      const inferenceUrl = `https://inferencex.semianalysis.com/inference?unofficialRun=${context.runId}`;
+                      const evaluationUrl = `https://inferencex.semianalysis.com/evaluation?unofficialRun=${context.runId}`;
+                      const body = [
+                          `see unofficial run visualizer at ${inferenceUrl}`,
+                          `see unofficial run visualizer at ${evaluationUrl}`,
+                      ].join('\n');
                       await github.rest.issues.createComment({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: context.issue.number,
-                          body: `see unofficial run visualizer at ${url}`,
+                          body,
                       });


### PR DESCRIPTION
## Summary
- Adds a second line to the sweep PR comment linking to the evaluation visualizer
- Comment body becomes:
  - `see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=<run_id>`
  - `see unofficial run visualizer at https://inferencex.semianalysis.com/evaluation?unofficialRun=<run_id>`

## Test plan
- [ ] Open a non-draft PR touching `perf-changelog.yaml` with `sweep-enabled` label
- [ ] After the sweep finishes, confirm the PR comment contains both lines and `unofficialRun=` matches the actual run ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)