### PR TITLE
[AMD][ROCM] Fix benchmark_serving Rust Tokenizer Crash via Direct transformers AutoTokenizer

### DIFF
--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -45,10 +45,20 @@ from backend_request_func import (ASYNC_REQUEST_FUNCS, RequestFuncInput,
 from tqdm.asyncio import tqdm
 from transformers import PreTrainedTokenizerBase
 
-try:
-    from vllm.transformers_utils.tokenizer import get_tokenizer
-except ImportError:
-    from backend_request_func import get_tokenizer
+def get_tokenizer(tokenizer_id, tokenizer_mode="auto", trust_remote_code=False, **kwargs):
+    """Load tokenizer directly via transformers, bypassing vllm's get_cached_tokenizer.
+
+    vllm's get_cached_tokenizer() accesses tokenizer.all_special_tokens_extended which
+    does not exist on Rust-backed TokenizersBackend (e.g. GLM-5). Using transformers
+    AutoTokenizer directly avoids that code path entirely.
+    """
+    from transformers import AutoTokenizer
+    use_fast = tokenizer_mode != "slow"
+    return AutoTokenizer.from_pretrained(
+        tokenizer_id,
+        use_fast=use_fast,
+        trust_remote_code=trust_remote_code,
+    )
 
 try:
     from vllm.utils import FlexibleArgumentParser


### PR DESCRIPTION
## Summary
- Replaces the vllm `get_tokenizer` import in `benchmark_serving.py` with a self-contained `get_tokenizer()` backed by `transformers.AutoTokenizer.from_pretrained()`.
- **Root cause**: vllm's `get_cached_tokenizer()` does a bare `tokenizer.all_special_tokens_extended` access. This attribute does not exist on Rust-backed `TokenizersBackend` (HuggingFace `tokenizers` library). Models with no Python slow tokenizer fallback (e.g. `amd/GLM-5-MXFP4`) crash with `AttributeError: TokenizersBackend has no attribute all_special_tokens_extended`. `--tokenizer-mode slow` is also insufficient — `use_fast=False` still returns `TokenizersBackend` for these models.
- **Crash site**: the benchmark **client** (`benchmark_serving.py`), not the SGLang server.
- **Fix**: `AutoTokenizer.from_pretrained()` always returns a proper Python-wrapped tokenizer, bypassing the vllm code path entirely. Fully API-compatible with all three call sites in `benchmark_serving.py` (`_init_tokenizer_worker`, `main`, `sample_random_requests`).
- Removes the vllm dependency from the benchmark client — `get_tokenizer` is no longer imported from vllm even when vllm is installed.

## Test plan
- [x] Fix verified on `lmsysorg/sglang-rocm:v0.5.10rc0-rocm700-mi35x-20260422` (vllm 0.9.2rc2) with `amd/GLM-5-MXFP4`, TP=8, MI355X — benchmark completes successfully (exit code 0).
- [x] Fix verified on `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi35x-20260428` with same model/config — benchmark completes successfully (exit code 0).
- [x] All three `get_tokenizer` call sites in `benchmark_serving.py` exercised without error.
- [ ] CI passes on MI355X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)