### PR TITLE
fix(agentic): revert image bumps and drop agentic-coding on 5 entries

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -704,7 +704,7 @@ minimaxm2.5-fp8-mi325x-vllm:
       - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.19.1
+  image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x
@@ -727,18 +727,9 @@ gptoss-fp4-mi300x-vllm:
       - { tp: 2, conc-start: 4, conc-end: 64 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 1, conc-end: 16 }
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      # offloading=none covers low + mid concurrency (no KV pressure → no need to offload)
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      # offloading=cpu covers mid + high concurrency where KV pressure exceeds GPU; overlap at 64 for crossover
-      - { tp: 4, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 8, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
 
 gptoss-fp4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.19.1
+  image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi325x
@@ -761,13 +752,6 @@ gptoss-fp4-mi325x-vllm:
       - { tp: 2, conc-start: 4, conc-end: 8 }
       - { tp: 4, conc-start: 4, conc-end: 8 }
       - { tp: 8, conc-start: 4, conc-end: 16 }
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 4, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 8, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
 
 gptoss-fp4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.17.0

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2428,7 +2428,7 @@ kimik2.5-int4-h200-vllm:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.19.1
+  image: vllm/vllm-openai:v0.17.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b200
@@ -2447,11 +2447,6 @@ kimik2.5-fp4-b200-vllm:
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64, 128] }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -3915,7 +3910,7 @@ minimaxm2.5-fp4-b300-vllm:
       - { tp: 8, conc-start: 4, conc-end: 4 }
 
 gptoss-fp4-h100-vllm:
-  image: vllm/vllm-openai:v0.19.1
+  image: vllm/vllm-openai:v0.18.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h100
@@ -3936,15 +3931,6 @@ gptoss-fp4-h100-vllm:
       - { tp: 2, conc-start: 4, conc-end: 64 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 16 }
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 2, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 2, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 4, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 8, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
 
 minimaxm2.5-fp8-h100-vllm:
   image: vllm/vllm-openai:v0.18.0
@@ -4128,7 +4114,7 @@ gptoss-fp4-h200-trt:
       - { tp: 8, ep: 8, dp-attn: false, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-h200-vllm:
-  image: vllm/vllm-openai:v0.19.1
+  image: vllm/vllm-openai:v0.18.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h200
@@ -4151,17 +4137,6 @@ gptoss-fp4-h200-vllm:
       - { tp: 2, conc-start: 4, conc-end: 64 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 32 }
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 2, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 1, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 2, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 4, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 8, offloading: cpu, conc-list: [64, 96, 128, 192, 256] }
 
 minimaxm2.5-fp8-h200-vllm:
   image: vllm/vllm-openai:v0.18.0


### PR DESCRIPTION
The agentx v0.1 merge (#1201) inadvertently bumped image versions on five master-yaml entries to vllm-openai:v0.19.1 to satisfy the KV-offload floor needed by the new scenarios.agentic-coding sweeps. The intent of that PR was schema/indentation refactor only; image bumps are a functional change that should be carried by their own PR alongside any model-specific validation.

Restore each of these five entries to its pre-merge image and drop the scenarios.agentic-coding sub-block (the agentic sweeps depend on v0.19.1 and would surface HMA + flashinfer assertion bugs on the older images, so dropping the block is the only consistent revert):

  nvidia-master.yaml
    gptoss-fp4-h100-vllm:    v0.19.1 -> v0.18.0
    gptoss-fp4-h200-vllm:    v0.19.1 -> v0.18.0
    kimik2.5-fp4-b200-vllm:  v0.19.1 -> v0.17.0

  amd-master.yaml
    gptoss-fp4-mi300x-vllm:  v0.19.1 -> v0.17.0  (rocm)
    gptoss-fp4-mi325x-vllm:  v0.19.1 -> v0.17.0  (rocm)

After this change a schema-aware diff (pre-merge vs HEAD, folding scenarios.fixed-seq-len back into seq-len-configs and ignoring intentional agentic-coding additions) reports zero field-level diffs across all 86 NVIDIA + 47 AMD entries — the v0.1 merge becomes purely a schema/indentation refactor as originally intended.

Three agentic-coding scenarios remain on main (dsr1-fp4-b200-sglang, dsr1-fp4-b200-dynamo-trt, dsr1-fp4-mi355x-sglang); those entries already ran on v0.19+ pre-merge so no revert is needed.

Validated: all 151 matrix_logic tests pass; both master yamls parse cleanly under SingleNodeMasterConfigEntry / MultiNodeMasterConfigEntry.