### PR TITLE
Add DSv4 FP8 H200 SGLang MTP benchmark

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2628,6 +2628,30 @@ dsv4-fp8-h200-sglang:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 1 }
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
 
+# MTP variant of dsv4-fp8-h200-sglang. Mirrors the non-MTP recipe (same image,
+# runner pool, search space) and adds EAGLE speculative decoding via
+# --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
+dsv4-fp8-h200-sglang-mtp:
+  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: h200-dgxc
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 1, spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 1, spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
   # DeepSeek-V4-Pro B300 single-node aggregate recipe from the submitted B300
   # pareto sweep. The single-node schema has no explicit data-parallel-size
   # field, so dp-attn=true is used as the existing vLLM script switch for DP4

--- a/benchmarks/single_node/dsv4_fp8_h200_sglang_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp8_h200_sglang_mtp.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+SERVER_LOG="$PWD/server.log"
+PORT=${PORT:-8888}
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
+
+set -x
+PYTHONNOUSERSITE=1 sglang serve \
+    --model-path $MODEL \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --trust-remote-code \
+    --tp $TP \
+    --moe-runner-backend marlin \
+    --chunked-prefill-size 4096 \
+    --disable-flashinfer-autotune \
+    --disable-radix-cache \
+    --mem-fraction-static 0.88 \
+    --max-running-requests "$(( CONC * 3 / 2 > 8 ? CONC * 3 / 2 : 8 ))" \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    $EVAL_CONTEXT_ARGS >> $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
+# <bos><User>...<Assistant><think> framing DeepSeek-V4-Pro expects. The DSv4-Pro
+# tokenizer ships without a jinja chat_template, so plain --use-chat-template
+# would crash; --dsv4 sidesteps that and satisfies the AGENTS.md rule that all
+# MTP scripts must benchmark against chat-formatted inputs (EAGLE acceptance
+# silently regresses on raw random tokens).
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $((CONC * 10)) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir "$PWD/" \
+    --dsv4
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2121,4 +2121,4 @@
     - "EAGLE speculative decoding chain: --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4"
     - "run_benchmark_serving uses --dsv4 (chat-formatted prompts) per the AGENTS.md MTP rule, since EAGLE acceptance regresses on raw random tokens"
     - "Search space mirrors the non-MTP H200 SGLang entry: TP=8 EP=1, conc 1 and 4-64 for both 1k1k and 8k1k, with spec-decoding: mtp"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1265

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2113,3 +2113,12 @@
     - "Search space: TP=8 EP=1, conc 1 and 4-64 for both 1k1k and 8k1k"
     - "Pinned to the h200-dgxc runner pool (new runners.yaml group); launch_h200-dgxc-slurm.sh extended to support framework-tagged script names and mount /ix instead of /workspace for the deepseek-v4-hopper image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1264
+
+- config-keys:
+    - dsv4-fp8-h200-sglang-mtp
+  description:
+    - "Add DeepSeek-V4-Pro FP8 H200 single-node SGLang MTP variant (mirrors dsv4-fp8-h200-sglang)"
+    - "EAGLE speculative decoding chain: --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4"
+    - "run_benchmark_serving uses --dsv4 (chat-formatted prompts) per the AGENTS.md MTP rule, since EAGLE acceptance regresses on raw random tokens"
+    - "Search space mirrors the non-MTP H200 SGLang entry: TP=8 EP=1, conc 1 and 4-64 for both 1k1k and 8k1k, with spec-decoding: mtp"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- Adds `dsv4-fp8-h200-sglang-mtp`, the MTP variant of `dsv4-fp8-h200-sglang` (#1264).
- Same image (`lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc…`), same `h200-dgxc` runner pool, same search space (TP=8 EP=1, conc 1 and 4-64 for 1k1k and 8k1k) — search-space entries gain `spec-decoding: mtp`.
- New launcher script `benchmarks/single_node/dsv4_fp8_h200_sglang_mtp.sh` mirrors the non-MTP one with the EAGLE speculative-decoding flags appended:
  - `--speculative-algorithm EAGLE`
  - `--speculative-num-steps 3`
  - `--speculative-eagle-topk 1`
  - `--speculative-num-draft-tokens 4`
- The (3,1,4) chain matches the existing `dsv4-fp4-b300-sglang-mtp` TP-only path.
- Per the AGENTS.md rule for `*_mtp.sh` scripts, `run_benchmark_serving` is invoked with `--dsv4` so prompts are chat-formatted (the canonical DSv4-Pro tokenizer ships no jinja chat template, so plain `--use-chat-template` would crash; `--dsv4` routes through `encoding_dsv4.py` from #1153).
- Script lookup resolves correctly via the framework-tagged + `_mtp` suffix logic that already landed in `launch_h200-dgxc-slurm.sh` from #1264.
- `perf-changelog.yaml` updated; PR-link backfilled to #1265.

## Test plan
- [ ] CI sweep on the new `dsv4-fp8-h200-sglang-mtp` recipe lands on `h200-dgxc` and produces results
- [ ] Verify EAGLE acceptance rate is reasonable (compare vs non-MTP TPS at matching concurrencies)
- [ ] Confirm the (3,1,4) EAGLE chain is the right starting point on H200 (vs. e.g. (1,1,2) at higher concurrencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)