### PR TITLE
Add B300 config: kimi-k2.5-int4-vllm (vLLM 0.20.0 + TP=4/EP=1 sweep)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2410,6 +2410,30 @@ kimik2.5-int4-b200-vllm:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
+# does not have a B300-specific recipe, so this config reuses the existing
+# Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
+kimik2.5-int4-b300-vllm:
+  image: vllm/vllm-openai:v0.20.0-cu130
+  model: moonshotai/Kimi-K2.5
+  model-prefix: kimik2.5
+  runner: b300
+  precision: int4
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+
 kimik2.5-int4-h200-vllm:
   image: vllm/vllm-openai:v0.16.0
   model: moonshotai/Kimi-K2.5

--- a/benchmarks/single_node/kimik2.5_int4_b300.sh
+++ b/benchmarks/single_node/kimik2.5_int4_b300.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
+# does not have a B300-specific recipe, so this script reuses the existing
+# Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+hf download "$MODEL"
+
+nvidia-smi
+
+export PYTHONNOUSERSITE=1
+export VLLM_USE_FLASHINFER_MOE_INT4=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve $MODEL --host 0.0.0.0 --port $PORT \
+--gpu-memory-utilization 0.95 \
+--tensor-parallel-size $TP \
+--max-model-len $MAX_MODEL_LEN \
+--max-num-seqs $CONC \
+--reasoning-parser kimi_k2 \
+--tool-call-parser kimi_k2 \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--trust-remote-code \
+--no-enable-prefix-caching > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,13 @@
 - config-keys:
+    - kimik2.5-int4-b300-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
+    - "Image: vllm/vllm-openai:v0.20.0-cu130"
+    - "Search-space: tp=8 and tp=4/ep=1 over conc 4-64, on both 1024/1024 and 8192/1024 ISL/OSL"
+    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057
+
+- config-keys:
     - 70b-fp8-*-vllm
   description:
     - 'Add compilation-config ''{"custom_ops": ["-rms_norm", "-quant_fp8", "-silu_and_mul"]}'' as extra config to all benchmarks/70b_fp8_mi*.sh scripts'

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,13 +1,4 @@
 - config-keys:
-    - kimik2.5-int4-b300-vllm
-  description:
-    - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
-    - "Image: vllm/vllm-openai:v0.20.0-cu130"
-    - "Search-space: tp=8 and tp=4/ep=1 over conc 4-64, on both 1024/1024 and 8192/1024 ISL/OSL"
-    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057
-
-- config-keys:
     - 70b-fp8-*-vllm
   description:
     - 'Add compilation-config ''{"custom_ops": ["-rms_norm", "-quant_fp8", "-silu_and_mul"]}'' as extra config to all benchmarks/70b_fp8_mi*.sh scripts'
@@ -2131,3 +2122,12 @@
     - "run_benchmark_serving uses --dsv4 (chat-formatted prompts) per the AGENTS.md MTP rule, since EAGLE acceptance regresses on raw random tokens"
     - "Search space mirrors the non-MTP H200 SGLang entry: TP=8 EP=1, conc 1 and 4-64 for both 1k1k and 8k1k, with spec-decoding: mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1265
+
+- config-keys:
+    - kimik2.5-int4-b300-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
+    - "Image: vllm/vllm-openai:v0.20.0-cu130"
+    - "Search-space: tp=8 and tp=4/ep=1 over conc 4-64, on both 1024/1024 and 8192/1024 ISL/OSL"
+    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057


### PR DESCRIPTION
> [!NOTE]
> Supersedes #1071 (which itself reopened #1057 after the #1070 revert). Opening fresh from `main` since the original branch's merge base had drifted — the b200 schema migrated from `seq-len-configs` to `scenarios.fixed-seq-len` between then and now — and a clean reopen reads more cleanly than a rebase.

## Summary
- Add `kimik2.5-int4-b300-vllm` benchmark config and the corresponding `benchmarks/single_node/kimik2.5_int4_b300.sh` launch script.
- At the time of submission, [the vLLM Kimi-K2.5 recipes page](https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html) does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
- Image: `vllm/vllm-openai:v0.20.0-cu130` — the original drafts (#1057, #1071) carried the `v0.19.0` placeholder while we waited; vLLM 0.20.0 has now shipped.
- Search-space per (ISL, OSL):
  - `{ tp: 8,         conc-start: 4, conc-end: 64 }`
  - `{ tp: 4, ep: 1,  conc-start: 4, conc-end: 64 }` (new — covers the lower-TP / expert-parallel variant on the same B300 nodes)
- `perf-changelog.yaml` entry added at the top, pointing at the original tracking PR #1057.

## Test plan
- [ ] CI config validation passes
- [ ] Run `kimik2.5-int4-b300-vllm` single-node benchmark on a B300 node and confirm the v0.20.0 image starts, both TP=8 and TP=4/EP=1 sweeps complete, and result files are produced for both ISL/OSL configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)