### PR TITLE
Re-append kimik2.5-int4-b300-vllm changelog entry

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2131,3 +2131,12 @@
     - "Search-space: tp=8 and tp=4/ep=1 over conc 4-64, on both 1024/1024 and 8192/1024 ISL/OSL"
     - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057
+
+- config-keys:
+    - kimik2.5-int4-b300-vllm
+  description:
+    - "Add Kimi-K2.5 INT4 B300 vLLM benchmark"
+    - "Image: vllm/vllm-openai:v0.20.0-cu130"
+    - "Search-space: tp=8 and tp=4/ep=1 over conc 4-64, on both 1024/1024 and 8192/1024 ISL/OSL"
+    - "At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html does not have a B300-specific recipe, so this reuses the existing Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1057


### PR DESCRIPTION
## Summary
Re-appends the `kimik2.5-int4-b300-vllm` changelog entry at the bottom of `perf-changelog.yaml`. The entry is identical to the one merged in #1267.

The auto-merge of #1267 was performed by GitHub's internal `web-flow` user, and per GitHub Actions' documented security policy, push events created by `GITHUB_TOKEN` do not trigger downstream workflows. As a result, `run-sweep.yml` did not fire for the merge commit (`9c7fb6f3`) and no benchmark sweep ran for the new config. This duplicate entry produces a fresh diff against `perf-changelog.yaml` so `process_changelog.py` picks the config back up and the sweep runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)