### PR TITLE
 Update DSV4 TRT fused MHC image

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2707,7 +2707,7 @@ dsv4-fp4-b300-vllm:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 2048, conc-end: 2048 }
 
 dsv4-fp4-b300-trt:
-  image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-4999884
+  image: ghcr.io#semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2707,7 +2707,7 @@ dsv4-fp4-b300-vllm:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 2048, conc-end: 2048 }
 
 dsv4-fp4-b300-trt:
-  image: ghcr.io#semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e
+  image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/single_node/dsv4_fp4_b300_trt.sh
+++ b/benchmarks/single_node/dsv4_fp4_b300_trt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # DeepSeek-V4-Pro single-node TRTLLM recipe for B300. The configured image
-# already contains NVIDIA/TensorRT-LLM@feat/deepseek_v4; do not build TRTLLM at
+# already contains a TensorRT-LLM DeepSeek-V4 build; do not build TRTLLM at
 # runtime from this benchmark path.
 
 source "$(dirname "$0")/../benchmark_lib.sh"
@@ -101,10 +101,7 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     MAX_NUM_TOKENS="$EVAL_MAX_MODEL_LEN"
 fi
 
-# DeepSeek-V4-Pro has hidden size 7168. The current TRTLLM fused-HC MHC
-# path corrupts eval generations for this shape; keep eval servers on the
-# unfused path until the fused kernel is guarded or supports 7168.
-export TRTLLM_MHC_ENABLE_FUSED_HC=0
+export TRTLLM_MHC_ENABLE_FUSED_HC="${TRTLLM_MHC_ENABLE_FUSED_HC:-1}"
 echo "TRTLLM_MHC_ENABLE_FUSED_HC: $TRTLLM_MHC_ENABLE_FUSED_HC"
 
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2154,4 +2154,5 @@
   description:
     - "Update the TensorRT-LLM DeepSeek-V4-Pro image to ghcr.io/semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e"
     - "Enable TRTLLM fused MHC by default now that the image includes the hidden-size 7168 fused-HC fix"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1270
+  evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2155,4 +2155,3 @@
     - "Update the TensorRT-LLM DeepSeek-V4-Pro image to ghcr.io/semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e"
     - "Enable TRTLLM fused MHC by default now that the image includes the hidden-size 7168 fused-HC fix"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1270
-  evals-only: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2148,3 +2148,10 @@
     - "Disable TRTLLM fused MHC hyper-connection for eval servers via TRTLLM_MHC_ENABLE_FUSED_HC=0 because the current fused kernel corrupts DeepSeek-V4-Pro hidden size 7168 generations"
     - "Keep this as eval-only PR validation until the TensorRT-LLM fused MHC kernel is guarded or supports hidden size 7168"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1233
+
+- config-keys:
+    - dsv4-fp4-b300-trt
+  description:
+    - "Update the TensorRT-LLM DeepSeek-V4-Pro image to ghcr.io/semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e"
+    - "Enable TRTLLM fused MHC by default now that the image includes the hidden-size 7168 fused-HC fix"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2152,6 +2152,6 @@
 - config-keys:
     - dsv4-fp4-b300-trt
   description:
-    - "Update the TensorRT-LLM DeepSeek-V4-Pro image to ghcr.io/semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e"
-    - "Enable TRTLLM fused MHC by default now that the image includes the hidden-size 7168 fused-HC fix"
+    - "Update the TensorRT-LLM DeepSeek-V4-Pro image to ghcr.io/semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715"
+    - "Enable TRTLLM fused MHC by default with the DeepSeek-V4 feature image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1270


### PR DESCRIPTION
# merged ✅  https://github.com/NVIDIA/TensorRT-LLM/pull/13710

## Summary
- Update `dsv4-fp4-b300-trt` to the TensorRT-LLM image with the fused MHC hidden-size 7168 fix.
- Re-enable TRTLLM fused MHC by default for the B300 DeepSeek-V4-Pro TRT recipe.

## TensorRT-LLM fork
- Branch: https://github.com/Oseltamivir/TensorRT-LLM/tree/fix/dsv4-pro-fused-mhc-hidden-7168
- Commit: https://github.com/Oseltamivir/TensorRT-LLM/commit/eb20e9e7f8bb476969994398500af8f3c5974d94
- Image: `ghcr.io/semianalysisai/trtllm-deepseek-v4:fix-mhc7168-eb20e9e`

## Validation
- `bash -n benchmarks/single_node/dsv4_fp4_b300_trt.sh`
- YAML load for `.github/configs/nvidia-master.yaml` and `perf-changelog.yaml`
- `python3 utils/matrix_logic/generate_sweep_configs.py test-config --config-keys dsv4-fp4-b300-trt --config-files .github/configs/nvidia-master.yaml`
