### PR TITLE
[codex] Use PR41015 fix setup for GB200 MTP2 high throughput

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe-mtp2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe-mtp2.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260426"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-pr41015-fp4-fix.sh
 
 slurm:
   time_limit: "8:00:00"


### PR DESCRIPTION
## Summary

- Point the GB200 DeepSeek-V4-Pro MTP2 high-throughput srt-slurm recipe at `vllm-container-deps-pr41015-fp4-fix.sh`.
- Keep the change limited to the c1024 high-throughput MTP2 recipe; the patch script itself is expected to come from the checked-out `aflowers/vllm-gb200-v0.20.0` srt-slurm branch.

## Why

This lets the InferenceX rerun use the srt-slurm PR41015 FP4 revert wrapper that recovered the GB200 MTP2 throughput regression in SA testing.

## Validation

- Parsed the edited YAML and confirmed `setup_script` resolves to `vllm-container-deps-pr41015-fp4-fix.sh`.
- Confirmed the target srt-slurm branch contains `configs/patches/vllm-container-deps-pr41015-fp4-fix.sh` and `configs/patches/vllm_revert_pr41015_fp4_cvt.py`.
- Ran `bash -n` on the srt-slurm wrapper and `python3 -m py_compile` on the patch helper.