### PR TITLE
[AMD][MI35X] 0503 MI355x DSV4

### DIFF
--- a/benchmarks/single_node/dsv4_fp4_mi355x_sglang.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_sglang.sh
@@ -53,7 +53,7 @@ PYEOF
 #                                    the swiglu_limit clamp in the triton
 #                                    MoE fallback path.
 export SGLANG_REASONING_EFFORT=max
-export SGLANG_OPT_USE_FUSED_COMPRESS=false
+export SGLANG_OPT_USE_FUSED_COMPRESS=true
 export SGLANG_OPT_USE_OLD_COMPRESSOR=true
 export SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false
 export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false
@@ -64,7 +64,7 @@ export SGLANG_OPT_USE_TILELANG_MHC_POST=false
 export SGLANG_ENABLE_THINKING=1
 export SGLANG_USE_AITER=1
 export SGLANG_USE_ROCM700A=1
-export SGLANG_TOPK_TRANSFORM_512_TORCH=1
+export SGLANG_TOPK_TRANSFORM_512_TORCH=0
 export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
 export SGLANG_DSV4_FP4_EXPERTS=True
 export SGLANG_OPT_DPSK_V4_RADIX=0

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2167,7 +2167,7 @@
   description:
     - "Flip SGLANG_TOPK_TRANSFORM_512_TORCH from 1 to 0. The indexer's top-k step now runs the tilelang kernel instead of the torch path."
     - "Flip SGLANG_OPT_USE_FUSED_COMPRESS from false to true. The DeepseekV4 compressor now goes through the fused triton path instead of the torch path."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1275
 
 - config-keys:
     - dsv4-fp4-gb200-dynamo-vllm-mtp2

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2165,6 +2165,15 @@
 - config-keys:
     - dsv4-fp4-mi355x-sglang
   description:
+    - "Bump image to rocm/sgl-dev:rocm720-mi35x-a8410de-20260502-DSv4 (one commit forward on amd/deepseek_v4: sglang PR #24249, fuse-compress-decode 0501)"
+    - "Drop the runtime sglang clone+pip overlay from benchmarks/single_node/dsv4_fp4_mi355x_sglang.sh — the new image bakes the same a8410de6 SHA the overlay was pinning, so the overlay is redundant. Future sglang bumps now go through an image tag bump"
+    - "Context: ep=8 dp-attn=true entries failed gsm8k eval after #1244 merged. PR sweep (run 25246535693) reported gsm8k strict-match=0.9318 because the launcher silently dropped --ep-size and sglang ran with ep_size=1 regardless of the matrix label; post-merge sweep (run 25262278289) ran with ep_size=8 and gsm8k strict-match dropped to 0.0000. The image bump is the candidate fix to verify on rerun"
+    - "ep=1 entries (dp-attn true and false) are unaffected by the EP=8 regression"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1266
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
     - "Flip SGLANG_TOPK_TRANSFORM_512_TORCH from 1 to 0. The indexer's top-k step now runs the tilelang kernel instead of the torch path."
     - "Flip SGLANG_OPT_USE_FUSED_COMPRESS from false to true. The DeepseekV4 compressor now goes through the fused triton path instead of the torch path."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1275

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2165,11 +2165,9 @@
 - config-keys:
     - dsv4-fp4-mi355x-sglang
   description:
-    - "Bump image to rocm/sgl-dev:rocm720-mi35x-a8410de-20260502-DSv4 (one commit forward on amd/deepseek_v4: sglang PR #24249, fuse-compress-decode 0501)"
-    - "Drop the runtime sglang clone+pip overlay from benchmarks/single_node/dsv4_fp4_mi355x_sglang.sh — the new image bakes the same a8410de6 SHA the overlay was pinning, so the overlay is redundant. Future sglang bumps now go through an image tag bump"
-    - "Context: ep=8 dp-attn=true entries failed gsm8k eval after #1244 merged. PR sweep (run 25246535693) reported gsm8k strict-match=0.9318 because the launcher silently dropped --ep-size and sglang ran with ep_size=1 regardless of the matrix label; post-merge sweep (run 25262278289) ran with ep_size=8 and gsm8k strict-match dropped to 0.0000. The image bump is the candidate fix to verify on rerun"
-    - "ep=1 entries (dp-attn true and false) are unaffected by the EP=8 regression"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1266
+    - "Flip SGLANG_TOPK_TRANSFORM_512_TORCH from 1 to 0. The indexer's top-k step now runs the tilelang kernel instead of the torch path."
+    - "Flip SGLANG_OPT_USE_FUSED_COMPRESS from false to true. The DeepseekV4 compressor now goes through the fused triton path instead of the torch path."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
 
 - config-keys:
     - dsv4-fp4-gb200-dynamo-vllm-mtp2


### PR DESCRIPTION
- Flip SGLANG_TOPK_TRANSFORM_512_TORCH from 1 to 0. The indexer's top-k step now runs the tilelang kernel instead of the torch path.
- Flip SGLANG_OPT_USE_FUSED_COMPRESS from false to true. The DeepseekV4 compressor now goes through the fused triton path instead of the torch path.