### PR TITLE
Tune MiniMax MI355X vLLM scheduling thresholds

### DIFF
--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -47,7 +47,8 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
         export VLLM_ROCM_USE_AITER_MOE=0
-        echo "8k1k TP8/EP8: using block size 32, shuffle disabled, AITER MoE disabled, async scheduling enabled."
+        ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
+        echo "8k1k TP8/EP8: using block size 32, shuffle disabled, AITER MoE disabled, async scheduling disabled."
     elif (( CONC < 64 )); then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
         echo "8k1k c${CONC}: using block size 32, shuffle disabled, async scheduling disabled."

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -30,39 +30,40 @@ export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
 VLLM_BLOCK_SIZE=32
 ASYNC_SCHEDULING_ARGS=""
 
-if [[ "$ISL" == "1024" && "$OSL" == "1024" && "$TP" == "8" && "$EP_SIZE" == "8" ]] && (( CONC == 2 )); then
-    ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
-    echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 1k1k TP8/EP8 c2."
-elif [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
-    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
-    VLLM_BLOCK_SIZE=16
-
-    if (( CONC <= 128 )); then
+if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
+    if (( CONC == 2 )) && [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
-        echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 1k1k c${CONC}."
+        echo "1k1k TP8/EP8 c2: using block size 32, shuffle disabled, async scheduling disabled."
+    elif (( CONC <= 128 )); then
+        export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+        VLLM_BLOCK_SIZE=16
+        ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
+        echo "1k1k c${CONC}: using block size 16, shuffle enabled, async scheduling disabled."
     else
-        echo "Using shuffle KV cache layout with block size 16 and async scheduling for 1k1k c${CONC}."
+        export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+        VLLM_BLOCK_SIZE=16
+        echo "1k1k c${CONC}: using block size 16, shuffle enabled, async scheduling enabled."
     fi
-elif [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
-    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
-    VLLM_BLOCK_SIZE=32
-    echo "Disabling shuffle KV cache layout and using block size 32 for TP8/EP8."
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if (( CONC < 64 )); then
+    if [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
+        echo "8k1k TP8/EP8: using block size 32, shuffle disabled, async scheduling enabled."
+    elif (( CONC < 64 )); then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
-        echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 8k1k c${CONC}."
+        echo "8k1k c${CONC}: using block size 32, shuffle disabled, async scheduling disabled."
     elif (( CONC == 64 )); then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
         export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
         VLLM_BLOCK_SIZE=16
-        echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 8k1k c${CONC}."
+        echo "8k1k c64: using block size 16, shuffle enabled, async scheduling disabled."
     else
         export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
         VLLM_BLOCK_SIZE=16
-        echo "Using shuffle KV cache layout with block size 16 and async scheduling for 8k1k c${CONC}."
+        echo "8k1k c${CONC}: using block size 16, shuffle enabled, async scheduling enabled."
     fi
+elif [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
+    echo "TP8/EP8 fallback: using block size 32, shuffle disabled, async scheduling enabled."
 else
-    echo "Using baseline block size 32, shuffle disabled, and async scheduling for ISL=${ISL}, OSL=${OSL}, c${CONC}."
+    echo "Default policy for ISL=${ISL}, OSL=${OSL}, TP=${TP}, EP=${EP_SIZE}, CONC=${CONC}: using block size 32, shuffle disabled, async scheduling enabled."
 fi
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -62,10 +62,6 @@ elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
         VLLM_BLOCK_SIZE=16
         echo "8k1k c${CONC}: using block size 16, shuffle enabled, async scheduling enabled."
     fi
-elif [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
-    echo "TP8/EP8 fallback: using block size 32, shuffle disabled, async scheduling enabled."
-else
-    echo "Default policy for ISL=${ISL}, OSL=${OSL}, TP=${TP}, EP=${EP_SIZE}, CONC=${CONC}: using block size 32, shuffle disabled, async scheduling enabled."
 fi
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -31,9 +31,9 @@ VLLM_BLOCK_SIZE=32
 ASYNC_SCHEDULING_ARGS=""
 
 if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
-    if (( CONC == 2 )) && [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
+    if [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
-        echo "1k1k TP8/EP8 c2: using block size 32, shuffle disabled, async scheduling disabled."
+        echo "1k1k TP8/EP8: using block size 32, shuffle disabled, async scheduling disabled."
     elif (( CONC <= 128 )); then
         export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
         VLLM_BLOCK_SIZE=16

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -48,23 +48,18 @@ elif [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
     VLLM_BLOCK_SIZE=32
     echo "Disabling shuffle KV cache layout and using block size 32 for TP8/EP8."
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
-    if (( CONC <= 64 )); then
+    if (( CONC < 64 )); then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
-    fi
-
-    if (( CONC >= 64 )); then
+        echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 8k1k c${CONC}."
+    elif (( CONC == 64 )); then
+        ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
         export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
         VLLM_BLOCK_SIZE=16
-
-        if [[ -n "$ASYNC_SCHEDULING_ARGS" ]]; then
-            echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 8k1k c${CONC}."
-        else
-            echo "Using shuffle KV cache layout with block size 16 and async scheduling for 8k1k c${CONC}."
-        fi
-    elif [[ -n "$ASYNC_SCHEDULING_ARGS" ]]; then
-        echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 8k1k c${CONC}."
+        echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 8k1k c${CONC}."
     else
-        echo "Using baseline block size 32, shuffle disabled, and async scheduling for 8k1k c${CONC}."
+        export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+        VLLM_BLOCK_SIZE=16
+        echo "Using shuffle KV cache layout with block size 16 and async scheduling for 8k1k c${CONC}."
     fi
 else
     echo "Using baseline block size 32, shuffle disabled, and async scheduling for ISL=${ISL}, OSL=${OSL}, c${CONC}."

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -26,7 +26,49 @@ fi
 
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
+VLLM_BLOCK_SIZE=32
+ASYNC_SCHEDULING_ARGS=""
+
+if [[ "$ISL" == "1024" && "$OSL" == "1024" && "$TP" == "8" && "$EP_SIZE" == "8" ]] && (( CONC == 2 )); then
+    ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
+    echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 1k1k TP8/EP8 c2."
+elif [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
+    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+    VLLM_BLOCK_SIZE=16
+
+    if (( CONC <= 128 )); then
+        ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
+        echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 1k1k c${CONC}."
+    else
+        echo "Using shuffle KV cache layout with block size 16 and async scheduling for 1k1k c${CONC}."
+    fi
+elif [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
+    export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
+    VLLM_BLOCK_SIZE=32
+    echo "Disabling shuffle KV cache layout and using block size 32 for TP8/EP8."
+elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
+    if (( CONC <= 64 )); then
+        ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
+    fi
+
+    if (( CONC >= 64 )); then
+        export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1
+        VLLM_BLOCK_SIZE=16
+
+        if [[ -n "$ASYNC_SCHEDULING_ARGS" ]]; then
+            echo "Using shuffle KV cache layout with block size 16 and disabling async scheduling for 8k1k c${CONC}."
+        else
+            echo "Using shuffle KV cache layout with block size 16 and async scheduling for 8k1k c${CONC}."
+        fi
+    elif [[ -n "$ASYNC_SCHEDULING_ARGS" ]]; then
+        echo "Using baseline block size 32, shuffle disabled, and disabling async scheduling for 8k1k c${CONC}."
+    else
+        echo "Using baseline block size 32, shuffle disabled, and async scheduling for 8k1k c${CONC}."
+    fi
+else
+    echo "Using baseline block size 32, shuffle disabled, and async scheduling for ISL=${ISL}, OSL=${OSL}, c${CONC}."
+fi
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
@@ -52,9 +94,10 @@ $EP \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --kv-cache-dtype fp8 \
---block-size=32 \
+--block-size=$VLLM_BLOCK_SIZE \
 --no-enable-prefix-caching \
 --attention-backend "ROCM_AITER_FA" \
+$ASYNC_SCHEDULING_ARGS \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh
@@ -46,7 +46,8 @@ if [[ "$ISL" == "1024" && "$OSL" == "1024" ]]; then
     fi
 elif [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
     if [[ "$TP" == "8" && "$EP_SIZE" == "8" ]]; then
-        echo "8k1k TP8/EP8: using block size 32, shuffle disabled, async scheduling enabled."
+        export VLLM_ROCM_USE_AITER_MOE=0
+        echo "8k1k TP8/EP8: using block size 32, shuffle disabled, AITER MoE disabled, async scheduling enabled."
     elif (( CONC < 64 )); then
         ASYNC_SCHEDULING_ARGS="--no-async-scheduling"
         echo "8k1k c${CONC}: using block size 32, shuffle disabled, async scheduling disabled."

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2214,10 +2214,3 @@
     - "Bump --speculative-config num_speculative_tokens from 1 to 2 (`{\"method\":\"mtp\",\"num_speculative_tokens\":2}`)"
     - "Re-test whether H200 MTP kernels accept 2 draft tokens — Blackwell MTP runs at 2 (per @wzhao18's vLLM Blackwell MTP submission); checking if H200 has parity now"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1279
-
-- config-keys:
-    - minimaxm2.5-fp8-mi355x-vllm
-  description:
-    - "Disable async scheduling for the 1k1k TP8/EP8 path; disable both AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 and async scheduling for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
-    - "Local validation on vllm/vllm-openai-rocm:v0.19.0 completed the 8k1k TP8/EP8 CONC=2 serving benchmark; block_size=32 with shuffle disabled outperformed the tested shuffle-KV/block_size=16 variant"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1276

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2218,6 +2218,6 @@
 - config-keys:
     - minimaxm2.5-fp8-mi355x-vllm
   description:
-    - "Disable AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 and disable async scheduling for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
+    - "Disable async scheduling for the 1k1k TP8/EP8 path; disable both AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 and async scheduling for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
     - "Local validation on vllm/vllm-openai-rocm:v0.19.0 completed the 8k1k TP8/EP8 CONC=2 serving benchmark; block_size=32 with shuffle disabled outperformed the tested shuffle-KV/block_size=16 variant"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1276

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2218,6 +2218,6 @@
 - config-keys:
     - minimaxm2.5-fp8-mi355x-vllm
   description:
-    - "Disable AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
-    - "Local validation on vllm/vllm-openai-rocm:v0.19.0 completed the 8k1k TP8/EP8 CONC=2 serving benchmark after reproducing the GPU fault without this env override"
+    - "Disable AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 and disable async scheduling for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
+    - "Local validation on vllm/vllm-openai-rocm:v0.19.0 completed the 8k1k TP8/EP8 CONC=2 serving benchmark; block_size=32 with shuffle disabled outperformed the tested shuffle-KV/block_size=16 variant"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1276

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2214,3 +2214,10 @@
     - "Bump --speculative-config num_speculative_tokens from 1 to 2 (`{\"method\":\"mtp\",\"num_speculative_tokens\":2}`)"
     - "Re-test whether H200 MTP kernels accept 2 draft tokens — Blackwell MTP runs at 2 (per @wzhao18's vLLM Blackwell MTP submission); checking if H200 has parity now"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1279
+
+- config-keys:
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Disable AITER MoE via VLLM_ROCM_USE_AITER_MOE=0 for the 8k1k TP8/EP8 MiniMax-M2.5 FP8 MI355X vLLM path"
+    - "Local validation on vllm/vllm-openai-rocm:v0.19.0 completed the 8k1k TP8/EP8 CONC=2 serving benchmark after reproducing the GPU fault without this env override"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1276


### PR DESCRIPTION
## Summary

Tune the MiniMax-M2.5 FP8 MI355X vLLM launch policy for better throughput and stability across the 1k/1k and 8k/1k sweep points.

- Default initialized path remains `block-size=32`, shuffled KV cache disabled, async scheduling enabled.
- `1k/1k TP8/EP8`: keep `block-size=32` and shuffled KV cache disabled, and disable async scheduling.
- `1k/1k` non-TP8/EP8: use `block-size=16` with shuffled KV cache; disable async scheduling through c128.
- `8k/1k TP8/EP8`: keep `block-size=32`, shuffled KV cache disabled, disable AITER MoE with `VLLM_ROCM_USE_AITER_MOE=0`, and disable async scheduling.
- `8k/1k` non-TP8/EP8: disable async scheduling through c64; use shuffled KV cache with `block-size=16` at c64 and above.

## Throughput Comparison

Metric: `tput_per_gpu` only.

- Validation run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25449459268
- Baseline run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24006177731/attempts/7
- Compared benchmark points: 33/33 common rows
- Newly passing benchmark points: 1
- Improved: 32/33
- Regressed: 1/33
- Average delta: +6.4%
- Median delta: +6.3%

| ISL/OSL | TP/EP | Conc | Baseline | Validation | Delta |
|---|---:|---:|---:|---:|---:|
| 1k/1k | 2/2 | 2 | 175.6 | 196.7 | +12.1% |
| 1k/1k | 2/2 | 4 | 316.6 | 351.2 | +10.9% |
| 1k/1k | 2/2 | 8 | 551.1 | 558.8 | +1.4% |
| 1k/1k | 2/2 | 16 | 912.4 | 918.0 | +0.6% |
| 1k/1k | 2/2 | 32 | 1512.4 | 1615.8 | +6.8% |
| 1k/1k | 2/2 | 64 | 2283.1 | 2377.0 | +4.1% |
| 1k/1k | 2/2 | 128 | 3745.8 | 3844.7 | +2.6% |
| 1k/1k | 2/2 | 256 | 5459.7 | 5787.7 | +6.0% |
| 1k/1k | 2/2 | 512 | 8080.0 | 8346.7 | +3.3% |
| 1k/1k | 4/4 | 4 | 173.0 | 197.0 | +13.9% |
| 1k/1k | 4/4 | 8 | 329.8 | 357.2 | +8.3% |
| 1k/1k | 4/4 | 16 | 554.2 | 601.6 | +8.6% |
| 1k/1k | 4/4 | 32 | 976.6 | 1045.3 | +7.0% |
| 1k/1k | 4/4 | 64 | 1574.5 | 1672.4 | +6.2% |
| 1k/1k | 4/4 | 128 | 2620.1 | 2717.2 | +3.7% |
| 1k/1k | 4/4 | 256 | 3846.2 | 3971.7 | +3.3% |
| 1k/1k | 8/8 | 2 | 47.7 | 55.9 | +17.2% |
| 8k/1k | 2/2 | 2 | 712.6 | 820.5 | +15.1% |
| 8k/1k | 2/2 | 4 | 1320.6 | 1431.6 | +8.4% |
| 8k/1k | 2/2 | 8 | 2162.1 | 2183.4 | +1.0% |
| 8k/1k | 2/2 | 16 | 3378.7 | 3513.5 | +4.0% |
| 8k/1k | 2/2 | 32 | 4645.2 | 5070.8 | +9.2% |
| 8k/1k | 2/2 | 64 | 6495.4 | 6752.2 | +4.0% |
| 8k/1k | 2/2 | 128 | 8601.5 | 8852.3 | +2.9% |
| 8k/1k | 2/2 | 256 | 10391.0 | 10195.3 | -1.9% |
| 8k/1k | 4/4 | 4 | 730.2 | 807.3 | +10.6% |
| 8k/1k | 4/4 | 8 | 1291.4 | 1384.5 | +7.2% |
| 8k/1k | 4/4 | 16 | 2076.3 | 2241.0 | +7.9% |
| 8k/1k | 4/4 | 32 | 3314.3 | 3523.6 | +6.3% |
| 8k/1k | 4/4 | 64 | 4741.3 | 5088.2 | +7.3% |
| 8k/1k | 4/4 | 128 | 6719.6 | 6885.5 | +2.5% |
| 8k/1k | 4/4 | 256 | 8156.8 | 8391.9 | +2.9% |
| 8k/1k | 4/4 | 512 | 9136.0 | 9861.0 | +7.9% |
| 8k/1k | 8/8 | 2 | failed | 199.9 | newly passing |

## Testing

- `bash -n benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh`
- `git diff --check`
- Compared `results_bmk` artifacts from the validation and baseline runs above.
