### PR TITLE
dsv4-fp8-h200-vllm-mtp: bump num_speculative_tokens 1 → 2

### DIFF
--- a/benchmarks/single_node/dsv4_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp8_h200_mtp.sh
@@ -2,7 +2,7 @@
 
 # DeepSeek-V4-Pro H200 vLLM MTP variant of the recipe at
 # https://vllm.ai/blog/deepseek-v4. Mirrors dsv4_fp8_h200.sh but adds
-# --speculative-config '{"method":"mtp","num_speculative_tokens":1}' and
+# --speculative-config '{"method":"mtp","num_speculative_tokens":2}' and
 # routes prompts through chat-formatted encoding via --dsv4 (required for
 # meaningful MTP acceptance numbers per AGENTS.md).
 
@@ -65,7 +65,7 @@ $MAX_MODEL_LEN_ARG \
 --max-num-batched-tokens 512 \
 --no-enable-flashinfer-autotune \
 --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
---speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
+--speculative-config '{"method":"mtp","num_speculative_tokens":2}' \
 --tokenizer-mode deepseek_v4 \
 --tool-call-parser deepseek_v4 \
 --enable-auto-tool-choice \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2207,3 +2207,10 @@
     - "run_benchmark_serving uses --dsv4 (chat-formatted prompts) per the AGENTS.md MTP rule, since EAGLE-style speculative decoding regresses acceptance on raw random tokens"
     - "Search space mirrors the non-MTP H200 entry: TP=8, EP=8, DP-attn=true, CONC 4-64 for both 1k1k and 8k1k, with spec-decoding: mtp"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1222
+
+- config-keys:
+    - dsv4-fp8-h200-vllm-mtp
+  description:
+    - "Bump --speculative-config num_speculative_tokens from 1 to 2 (`{\"method\":\"mtp\",\"num_speculative_tokens\":2}`)"
+    - "Re-test whether H200 MTP kernels accept 2 draft tokens — Blackwell MTP runs at 2 (per @wzhao18's vLLM Blackwell MTP submission); checking if H200 has parity now"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2213,4 +2213,4 @@
   description:
     - "Bump --speculative-config num_speculative_tokens from 1 to 2 (`{\"method\":\"mtp\",\"num_speculative_tokens\":2}`)"
     - "Re-test whether H200 MTP kernels accept 2 draft tokens — Blackwell MTP runs at 2 (per @wzhao18's vLLM Blackwell MTP submission); checking if H200 has parity now"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1279


### PR DESCRIPTION
## Summary
Bump `num_speculative_tokens` from 1 to 2 in the `dsv4-fp8-h200-vllm-mtp` recipe.

- Single change: `--speculative-config '{"method":"mtp","num_speculative_tokens":1}'` → `'{"method":"mtp","num_speculative_tokens":2}'` in `benchmarks/single_node/dsv4_fp8_h200_mtp.sh`.
- Companion comment in the script header is updated to match.
- Adds a `perf-changelog.yaml` entry to trigger the new sweep.

## Context
The original PR (#1222) landed at `num_speculative_tokens=1` because the recipe says H200 MTP kernels only support 1 draft token. Inferact folks indicated H200 kernels now support 2, and Blackwell MTP runs at 2 per @wzhao18's vLLM Blackwell MTP submission. This PR re-tests that assumption on H200. If acceptance / throughput look healthy, we keep 2; otherwise we revert.

## Test plan
- [ ] Trigger the `dsv4-fp8-h200-vllm-mtp` benchmark workflow on an H200 runner and confirm the engine starts and the sweep completes for at least one cell from each of the two `seq-len-configs`.
- [ ] `server.log` shows `--speculative-config '{"method":"mtp","num_speculative_tokens":2}'`.
- [ ] Acceptance rate is in a sane range and throughput at the same concurrency points beats the `num_speculative_tokens=1` numbers from the #1222 sweep — otherwise the kernel-support assumption was wrong and we revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
