### PR TITLE
Re-PR #1285: pure TP H200 vLLM DSv4 config + missing perf-changelog entry

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2647,11 +2647,13 @@ dsv4-fp8-h200-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256 }
 
 # MTP variant of dsv4-fp8-h200-vllm. Uses the canonical v0.20.1 image
 # (the non-MTP entry above is still on the deepseekv4-cu129 tag) and adds
@@ -2669,11 +2671,13 @@ dsv4-fp8-h200-vllm-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256, spec-decoding: mtp }
 
 # DeepSeek-V4-Pro H200 single-node with SGLang (Marlin FP8, TP-only).
 # Pinned to the h200-dgxc-slurm runner pool because the deepseek-v4-hopper

--- a/benchmarks/single_node/dsv4_fp8_h200.sh
+++ b/benchmarks/single_node/dsv4_fp8_h200.sh
@@ -9,6 +9,7 @@ source "$(dirname "$0")/../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    DP_ATTENTION \
     CONC \
     ISL \
     OSL \
@@ -37,20 +38,29 @@ else
     MAX_MODEL_LEN_ARG="--max-model-len 800000"
 fi
 
+# DP_ATTENTION=true runs DP-attention with expert parallel (DP size = TP);
+# DP_ATTENTION=false runs pure tensor parallel.
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
-# Per the recipe, run with EP + DP=8 (no --tensor-parallel-size flag). TP
-# from the search space is used only for GPU allocation by the runner and
-# as the DP size.
 set -x
 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --trust-remote-code \
 --kv-cache-dtype fp8 \
 --block-size 256 \
 --no-enable-prefix-caching \
---enable-expert-parallel \
---data-parallel-size $TP \
+"${PARALLEL_ARGS[@]}" \
+"${EP_ARGS[@]}" \
 $MAX_MODEL_LEN_ARG \
 --gpu-memory-utilization 0.95 \
 --max-num-seqs 512 \

--- a/benchmarks/single_node/dsv4_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp8_h200_mtp.sh
@@ -11,6 +11,7 @@ source "$(dirname "$0")/../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    DP_ATTENTION \
     CONC \
     ISL \
     OSL \
@@ -45,20 +46,29 @@ else
     MAX_MODEL_LEN_ARG="--max-model-len $MAX_MODEL_LEN"
 fi
 
+# DP_ATTENTION=true runs DP-attention with expert parallel (DP size = TP);
+# DP_ATTENTION=false runs pure tensor parallel.
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
-# Per the recipe, run with EP + DP=8 (no --tensor-parallel-size flag). TP
-# from the search space is used only for GPU allocation by the runner and
-# as the DP size.
 set -x
 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --trust-remote-code \
 --kv-cache-dtype fp8 \
 --block-size 256 \
 --no-enable-prefix-caching \
---enable-expert-parallel \
---data-parallel-size $TP \
+"${PARALLEL_ARGS[@]}" \
+"${EP_ARGS[@]}" \
 $MAX_MODEL_LEN_ARG \
 --gpu-memory-utilization 0.95 \
 --max-num-seqs 512 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2239,3 +2239,11 @@
     - "Mirror the B300 TRT launch path with OpenAI chat serving, FP8 KV cache, TRTLLM MoE, NCCL NVLS disabled by default, and fused MHC disabled for hidden size 7168 correctness"
     - "Update the B200 DGXC Slurm partition from removed gpu to gpu-2 so single-node B200 jobs can allocate"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1277
+
+- config-keys:
+    - dsv4-fp8-h200-vllm
+    - dsv4-fp8-h200-vllm-mtp
+  description:
+    - "Add pure TP (tp:8, ep:1) search-space row alongside the existing DP+EP row"
+    - "Raise conc-end from 64 to 256 on both 1k1k and 8k1k sweeps"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1287


### PR DESCRIPTION
## Disclaimer

The original PR #1285 ("Add pure TP configuration to H200 vLLM DSv4 deployment") landed
without a corresponding `perf-changelog.yaml` entry, which our policy requires for any
change that alters published benchmark configurations or sweep ranges.

It was reverted in #1286 and is being re-landed in this PR together with the missing
changelog entry. Code changes are otherwise identical to #1285.

## Dependencies

This PR depends on #1286 (the revert) merging first. Until that lands, the
GitHub diff against \`main\` will only show the new \`perf-changelog.yaml\` entry,
because the underlying code changes are still on \`main\` from #1285. Once #1286
merges, this PR's diff will reflect the full re-application plus the changelog entry.

## Summary

- Parameterize TP vs DP-attention + expert-parallel via \`DP_ATTENTION\` / \`EP_SIZE\` env vars in \`dsv4_fp8_h200{,_mtp}.sh\` (matching \`dsv4_fp4_b200_vllm.sh\`)
- Add pure TP search-space row (\`tp:8, ep:1, dp-attn:false\`) alongside the existing DP+EP row in \`nvidia-master.yaml\`
- Raise \`conc-end\` from 64 to 256 for both 1k1k and 8k1k sweeps on the existing DP+EP row
- Add \`perf-changelog.yaml\` entry referencing this PR

## Test plan

- [ ] #1286 merges first
- [ ] CI green on this PR
- [ ] Sweep results land on the configured runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)