### PR TITLE
Re-run qwen3.5-fp8-b200-sglang-mtp sweep after B200 partition change

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2247,3 +2247,9 @@
     - "Add pure TP (tp:8, ep:1) search-space row alongside the existing DP+EP row"
     - "Raise conc-end from 64 to 256 on both 1k1k and 8k1k sweeps"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1287
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang-mtp
+  description:
+    - "Re-run qwen3.5-fp8-b200-sglang-mtp sweep after the B200 DGXC Slurm partition change (gpu → gpu-2)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2252,4 +2252,4 @@
     - qwen3.5-fp8-b200-sglang-mtp
   description:
     - "Re-run qwen3.5-fp8-b200-sglang-mtp sweep after the B200 DGXC Slurm partition change (gpu → gpu-2)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1292


### PR DESCRIPTION
Re-running the qwen3.5-fp8-b200-sglang-mtp sweep because the B200 DGXC Slurm partition was changed (gpu → gpu-2).

Re-trigger didn't help because it used the same commit with wrong partition name. 

Old sweep based of `main` https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25342967860