### PR TITLE
[DEBUG] remove qwen3.5-fp8-mi355x-atom perf-changelog entry

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1437,14 +1437,6 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1036
 
 - config-keys:
-    - qwen3.5-fp8-mi355x-atom
-    - qwen3.5-fp8-mi355x-atom-mtp
-  description:
-    - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1040
-
-
-- config-keys:
     - qwen3.5-fp4-mi355x-sglang
   description:
     - "Update SGLang image from 'lmsysorg/sglang:v0.5.10-rocm720-mi35x' to 'rocm/sgl-dev:v0.5.10rc0-rocm720-mi35x-20260413'"


### PR DESCRIPTION
Hi @functionstackx @cquil11 

this PR is to resolve this issue: 
https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24868987151/job/72811203316

and https://github.com/SemiAnalysisAI/InferenceX/blob/main/utils/process_changelog.py
is incompatible with this mis-aligned **config-keys:** key

<img width="677" height="274" alt="image" src="https://github.com/user-attachments/assets/4ac051e1-1bea-4829-b7b2-c7f6d76ae9a9" />

So once you merge this, then I'll add them back again. (without mis-aligment)

==
## Summary
- Removes a duplicate `perf-changelog.yaml` entry for `qwen3.5-fp8-mi355x-atom` and `qwen3.5-fp8-mi355x-atom-mtp` that was accidentally included alongside the existing entry referencing PR #1040.

## Test plan
- [ ] Verify `perf-changelog.yaml` no longer has duplicate entries for `qwen3.5-fp8-mi355x-atom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)