### PR TITLE
Fix B200 Dynamo vLLM recipe concurrencies

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -7958,7 +7958,7 @@ dsv4-fp4-b200-dynamo-vllm:
       search-space:
       # B200 adaptation of the DSV4 GB200 vLLM disagg recipes. Each worker
       # maps to one full 8-GPU B200 node.
-      - conc-list: [1, 64, 128]
+      - conc-list: [1, 16, 32, 64, 128]
         prefill:
           num-worker: 1
           tp: 8
@@ -7971,7 +7971,7 @@ dsv4-fp4-b200-dynamo-vllm:
           tp: 8
           ep: 1
           dp-attn: false
-      - conc-list: [1024, 2048, 4096, 8192]
+      - conc-list: [256, 512, 1024]
         prefill:
           num-worker: 2
           tp: 8
@@ -7984,7 +7984,7 @@ dsv4-fp4-b200-dynamo-vllm:
           tp: 8
           ep: 8
           dp-attn: true
-      - conc-list: [8192]
+      - conc-list: [8192, 12345]
         prefill:
           num-worker: 3
           tp: 8

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-high-tpt-megamoe.yaml
@@ -122,7 +122,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "4096"
+  concurrencies: "1024x2048x4096x8192"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-high-tpt-megamoe.yaml
@@ -122,7 +122,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1024x2048x4096x8192"
+  concurrencies: "256x512x1024"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
@@ -124,7 +124,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1x64x128"
+  concurrencies: "1x16x32x64x128"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
@@ -124,7 +124,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1"
+  concurrencies: "1x64x128"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-max-tpt-megamoe.yaml
@@ -122,7 +122,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "4096"
+  concurrencies: "8192"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-max-tpt-megamoe.yaml
@@ -122,7 +122,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "8192"
+  concurrencies: "8192x12345"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2323,3 +2323,10 @@
     - "Turn off explicit deep_gemm_mega_moe backend selection in B300 Dynamo vLLM throughput recipes"
     - "Let vLLM choose the MoE backend automatically to avoid CUDA symmetric-memory rendezvous failures during startup"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1304
+
+- config-keys:
+    - dsv4-fp4-b200-dynamo-vllm
+  description:
+    - "Fix B200 Dynamo vLLM recipe benchmark concurrencies to match the nvidia-master.yaml search space"
+    - "Propagate low-latency concurrencies 1/64/128, high-throughput concurrencies 1024/2048/4096/8192, and max-throughput concurrency 8192 into the srt-slurm recipe files"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1305


### PR DESCRIPTION
## Summary
- Sync the PR1303 B200 Dynamo vLLM recipe benchmark concurrencies with `.github/configs/nvidia-master.yaml`.
- Update the low-latency, high-throughput, and max-throughput recipe files so srt-slurm actually runs every configured concurrency point.
- Append a `perf-changelog.yaml` entry for `dsv4-fp4-b200-dynamo-vllm` so the PR sweep targets this config.

## Root Cause
- `nvidia-master.yaml` exported `CONC_LIST`, but the B200 Slurm launcher applies the recipe file directly. The recipe-local `benchmark.concurrencies` values therefore controlled the actual benchmark run and only covered a subset of the configured concurrencies.

## Validation
- `python utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/nvidia-master.yaml --framework dynamo-vllm --model-prefix dsv4 --runner-type b200-multinode --multi-node`
- `python utils/matrix_logic/generate_sweep_configs.py test-config --config-files .github/configs/nvidia-master.yaml --config-keys dsv4-fp4-b200-dynamo-vllm`
- `python utils/process_changelog.py --base-ref origin/main --head-ref HEAD --changelog-file perf-changelog.yaml`
- `git diff --check origin/main..HEAD`