### PR TITLE
dsv4-fp4-mi355x-sglang: bump image to rocm720-mi35x-0363e6c-20260509-DSv4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1591,7 +1591,7 @@ dsv4-fp8-mi355x-sglang:
 # image tag, so bumping sglang is just an image tag bump here. Sweeps
 # DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:rocm720-mi35x-bfd32b6-20260507-DSv4
+  image: rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2335,4 +2335,4 @@
     - dsv4-fp4-mi355x-sglang
   description:
     - "Bump image to rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1308

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2330,3 +2330,9 @@
     - "Fix B200 Dynamo vLLM recipe benchmark concurrencies to match the nvidia-master.yaml search space"
     - "Propagate low-latency concurrencies 1/64/128, high-throughput concurrencies 1024/2048/4096/8192, and max-throughput concurrency 8192 into the srt-slurm recipe files"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1305
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "Bump image to rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4."
+  pr-link: TBD


### PR DESCRIPTION
## Summary
- Bump `dsv4-fp4-mi355x-sglang` image to `rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4` (one commit forward on amd/deepseek_v4)
- Add perf-changelog entry

## Test plan
- [ ] Full sweep on dsv4-fp4-mi355x-sglang via the `full-sweep-enabled` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)