### PR TITLE
Update glm5-fp4-b300-sglang SGLang image to v0.5.11-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2252,7 +2252,7 @@ glm5-fp4-b200-sglang-mtp:
   # does not have a B300-specific recipe, so this config reuses the existing
   # GLM-5 FP4 B200 SGLang recipe as-is until B300-specific tuning is available.
 glm5-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  image: lmsysorg/sglang:v0.5.11-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2343,3 +2343,9 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
+
+- config-keys:
+    - glm5-fp4-b300-sglang
+  description:
+    - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Update `glm5-fp4-b300-sglang` image from `lmsysorg/sglang:v0.5.10.post1-cu130` to `lmsysorg/sglang:v0.5.11-cu130`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)