### PR TITLE
Update qwen3.5-fp4-b300-sglang-mtp SGLang image to v0.5.11-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2375,7 +2375,7 @@ qwen3.5-fp4-b300-sglang:
       - { tp: 2, ep: 2, conc-start: 4, conc-end: 128 }
 
 qwen3.5-fp4-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  image: lmsysorg/sglang:v0.5.11-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2345,9 +2345,9 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
 
 - config-keys:
-    - qwen3.5-fp4-b300-sglang-mtp
+    - gptoss-fp4-h100-vllm
   description:
-    - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
+    - "Update vLLM image from v0.18.0 to v0.20.2"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
   
 - config-keys:
@@ -2355,5 +2355,3 @@
   description:
     - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1344
-
-    

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2343,3 +2343,9 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
+
+- config-keys:
+    - qwen3.5-fp4-b300-sglang-mtp
+  description:
+    - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Update `qwen3.5-fp4-b300-sglang-mtp` image from `lmsysorg/sglang:v0.5.10.post1-cu130` to `lmsysorg/sglang:v0.5.11-cu130`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)