### PR TITLE
Update gptoss-fp4-mi300x-vllm vLLM image to v0.20.2

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -702,7 +702,7 @@ minimaxm2.5-fp8-mi325x-vllm:
       - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.17.0
+  image: vllm/vllm-openai-rocm:v0.20.2
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2343,3 +2343,9 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.17.0 to v0.20.2"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Update `gptoss-fp4-mi300x-vllm` image from `vllm/vllm-openai-rocm:v0.17.0` to `vllm/vllm-openai-rocm:v0.20.2`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)