### PR TITLE
Update minimaxm2.5-fp8-mi300x-vllm vLLM image to v0.20.2

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -660,7 +660,7 @@ minimaxm2.5-fp4-mi355x-vllm:
       - { tp: 4, conc-start: 4, conc-end: 64 }
 
 minimaxm2.5-fp8-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.16.0
+  image: vllm/vllm-openai-rocm:v0.20.2
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2343,3 +2343,9 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
+
+- config-keys:
+    - minimaxm2.5-fp8-mi300x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.16.0 to v0.20.2"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Update `minimaxm2.5-fp8-mi300x-vllm` image from `vllm/vllm-openai-rocm:v0.16.0` to `vllm/vllm-openai-rocm:v0.20.2`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)