### PR TITLE
Update qwen3.5-bf16-mi300x-sglang SGLang image to v0.5.11-rocm720-mi30x

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -162,7 +162,7 @@ qwen3.5-bf16-mi355x-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-bf16-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.11-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2343,3 +2343,9 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 MI355X ATOM benchmark configs with and without MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1310
+
+- config-keys:
+    - qwen3.5-bf16-mi300x-sglang
+  description:
+    - "Update SGLang image from v0.5.10-rocm720-mi30x to v0.5.11-rocm720-mi30x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Update `qwen3.5-bf16-mi300x-sglang` image from `lmsysorg/sglang:v0.5.10-rocm720-mi30x` to `lmsysorg/sglang:v0.5.11-rocm720-mi30x`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)