### PR TITLE
Reuse approved full sweep artifacts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -178,6 +178,25 @@ test-config --config-keys dsr1-fp4-b200-sglang gptoss* --config-files .github/co
 test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvidia-master.yaml
 ```
 
+## Reusing an Approved PR Full Sweep
+
+If a PR has already run the full untrimmed sweep, a maintainer can avoid running
+the same sweep again after merge by leaving both labels on the PR before merging:
+
+- `full-sweep-enabled`
+- `reuse-full-sweep-results`
+
+On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
+commit, finds the latest successful PR `Run Sweep` run for that exact PR head
+SHA, downloads the ingest-relevant artifacts, validates that `results_bmk`
+covers the merge run's expected benchmark matrix, and uploads them as
+`reused-ingest-artifacts`. The normal database ingest then publishes those
+artifacts with the merge run's changelog metadata.
+
+Reuse fails closed: if the label is present but the matching PR run or artifacts
+cannot be validated, the push-to-main workflow fails instead of falling back to a
+cluster sweep.
+
 ## Validation Architecture
 
 The benchmarking system uses a strict validation methodology to ensure correctness at every stage. This is implemented in `utils/matrix_logic/validation.py` using Pydantic models.

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -55,6 +55,12 @@ jobs:
             )
         outputs:
             search-space-config: ${{ steps.setup.outputs.search-space-config }}
+            reuse-enabled: ${{ steps.setup.outputs.reuse-enabled }}
+            reuse-source-run-id: ${{ steps.setup.outputs.reuse-source-run-id }}
+            reuse-source-run-attempt: ${{ steps.setup.outputs.reuse-source-run-attempt }}
+            reuse-source-run-url: ${{ steps.setup.outputs.reuse-source-run-url }}
+            reuse-source-pr-number: ${{ steps.setup.outputs.reuse-source-pr-number }}
+            reuse-source-head-sha: ${{ steps.setup.outputs.reuse-source-head-sha }}
         steps:
             - name: Reject conflicting sweep labels
               if: >-
@@ -72,6 +78,7 @@ jobs:
 
             - id: setup
               env:
+                  GH_TOKEN: ${{ github.token }}
                   TRIM_CONC: >-
                       ${{
                         github.event_name == 'pull_request' &&
@@ -101,10 +108,16 @@ jobs:
                   CONFIG_JSON=$("${CMD[@]}")
 
                   echo "search-space-config=$CONFIG_JSON" >> "$GITHUB_OUTPUT"
+                  python3 "${GITHUB_WORKSPACE}/utils/find_reusable_sweep_run.py" \
+                    --repo "${{ github.repository }}" \
+                    --commit-sha "${{ github.sha }}" \
+                    --event-name "${{ github.event_name }}" \
+                    --ref "${{ github.ref }}" \
+                    --workflow-id "run-sweep.yml"
 
     sweep-multi-node-1k1k:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['1k1k']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['1k1k']) != 'null' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
         name: multi-node 1k1k /
         strategy:
@@ -142,7 +155,7 @@ jobs:
 
     sweep-multi-node-8k1k:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['8k1k']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['8k1k']) != 'null' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
         name: multi-node 8k1k /
         strategy:
@@ -154,7 +167,7 @@ jobs:
 
     sweep-single-node-1k1k:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).single_node['1k1k']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).single_node['1k1k']) != 'null' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
         name: single-node 1k1k /
         strategy:
@@ -183,7 +196,7 @@ jobs:
 
     sweep-single-node-8k1k:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).single_node['8k1k']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).single_node['8k1k']) != 'null' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
         name: single-node 8k1k /
         strategy:
@@ -195,7 +208,7 @@ jobs:
 
     sweep-agentic:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) != 'null' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
         name: agentic /
         strategy:
@@ -221,13 +234,13 @@ jobs:
             osl: '0'
             max-model-len: '0'
             spec-decoding: 'none'
-            disagg: 'false'
+            disagg: ${{ 'false' }}
             run-eval: false
             scenario-type: agentic-coding
 
     sweep-multi-node-agentic:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) != 'null' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
         name: multi-node agentic /
         strategy:
@@ -266,7 +279,7 @@ jobs:
 
     sweep-evals:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).evals) != '[]' && toJson(fromJson(needs.setup.outputs.search-space-config).evals) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).evals) != '[]' && toJson(fromJson(needs.setup.outputs.search-space-config).evals) != 'null' }}
         uses: ./.github/workflows/benchmark-tmpl.yml
         name: eval /
         strategy:
@@ -296,7 +309,7 @@ jobs:
 
     sweep-multi-node-evals:
         needs: setup
-        if: ${{ toJson(fromJson(needs.setup.outputs.search-space-config).multinode_evals) != '[]' && toJson(fromJson(needs.setup.outputs.search-space-config).multinode_evals) != 'null' }}
+        if: ${{ needs.setup.outputs.reuse-enabled != 'true' && toJson(fromJson(needs.setup.outputs.search-space-config).multinode_evals) != '[]' && toJson(fromJson(needs.setup.outputs.search-space-config).multinode_evals) != 'null' }}
         uses: ./.github/workflows/benchmark-multinode-tmpl.yml
         name: multi-node eval /
         strategy:
@@ -365,6 +378,70 @@ jobs:
         uses: ./.github/workflows/collect-evals.yml
         secrets: inherit
 
+    reuse-ingest-artifacts:
+        needs: setup
+        if: ${{ needs.setup.outputs.reuse-enabled == 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Download reusable source artifacts
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+                  SOURCE_RUN_ID: ${{ needs.setup.outputs.reuse-source-run-id }}
+              run: |
+                  gh run download "$SOURCE_RUN_ID" \
+                    --repo "${{ github.repository }}" \
+                    -D source-artifacts
+
+                  # Keep only artifacts consumed by the official ingest path.
+                  # The merge run uploads its own changelog metadata; reusable
+                  # benchmark/eval rows are attributed to the source PR sweep.
+                  rm -rf source-artifacts/changelog-metadata
+                  for artifact_dir in source-artifacts/*; do
+                      [ -e "$artifact_dir" ] || continue
+                      name=$(basename "$artifact_dir")
+                      case "$name" in
+                          results_bmk|eval_results_all|run-stats|bmk_*|eval_*|server_logs_*|multinode_server_logs_*|agentic_aggregated)
+                              ;;
+                          *)
+                              rm -rf "$artifact_dir"
+                              ;;
+                      esac
+                  done
+
+                  mkdir -p source-artifacts/reused-ingest-metadata
+                  cat > source-artifacts/reused-ingest-metadata/reuse_source_run.json <<'JSON'
+                  {
+                    "source_run_id": "${{ needs.setup.outputs.reuse-source-run-id }}",
+                    "source_run_attempt": "${{ needs.setup.outputs.reuse-source-run-attempt }}",
+                    "source_run_url": "${{ needs.setup.outputs.reuse-source-run-url }}",
+                    "source_pr_number": "${{ needs.setup.outputs.reuse-source-pr-number }}",
+                    "source_head_sha": "${{ needs.setup.outputs.reuse-source-head-sha }}",
+                    "ingest_run_id": "${{ github.run_id }}",
+                    "ingest_run_attempt": "${{ github.run_attempt }}",
+                    "ingest_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                  JSON
+
+                  echo "Reusing artifacts from $SOURCE_RUN_ID:"
+                  find source-artifacts -maxdepth 1 -mindepth 1 -type d -printf '  %f\n' | sort
+
+            - name: Validate reusable artifacts
+              run: |
+                  cat <<'CONFIGEOF' > _full_config.json
+                  ${{ needs.setup.outputs.search-space-config }}
+                  CONFIGEOF
+                  python3 utils/validate_reusable_sweep_artifacts.py \
+                    --config-json _full_config.json \
+                    --artifacts-dir source-artifacts
+
+            - name: Upload reusable ingest artifacts
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: reused-ingest-artifacts
+                  path: source-artifacts/*
+
     upload-changelog-metadata:
         needs: [setup, collect-results]
         if: ${{ always() && needs.setup.result == 'success' }}
@@ -410,7 +487,7 @@ jobs:
               run: pip install PyGithub
 
             - name: Calculate success rate
-              run: python3 utils/calc_success_rate.py $STATS_FILENAME
+              run: python3 utils/calc_success_rate.py "$STATS_FILENAME"
 
             - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
@@ -445,7 +522,7 @@ jobs:
               run: pip install psycopg2-binary tabulate
 
             - name: Compare results against main
-              run: python3 utils/compare_results.py results/ >> $GITHUB_STEP_SUMMARY
+              run: python3 utils/compare_results.py results/ >> "$GITHUB_STEP_SUMMARY"
 
     trigger-ingest:
         needs:
@@ -454,12 +531,17 @@ jobs:
                 collect-evals,
                 calc-success-rate,
                 upload-changelog-metadata,
+                reuse-ingest-artifacts,
             ]
         if: >-
             always() &&
             github.event_name == 'push' &&
             github.ref == 'refs/heads/main' &&
-            (needs.collect-results.result != 'skipped' || needs.collect-evals.result != 'skipped')
+            (
+              needs.collect-results.result != 'skipped' ||
+              needs.collect-evals.result != 'skipped' ||
+              needs.reuse-ingest-artifacts.result == 'success'
+            )
         runs-on: ubuntu-latest
         steps:
             - name: Trigger database ingest

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Find an approved pull-request sweep run that can be reused after merge.
+
+This script is used by ``run-sweep.yml`` on push-to-main runs.  It only enables
+reuse when the merge commit maps unambiguously to one pull request and a human
+has left both the full-sweep label and the reuse authorization label on that PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+API_BASE = "https://api.github.com"
+
+
+def github_api(
+    repo: str,
+    path: str,
+    token: str,
+    params: dict[str, str] | None = None,
+) -> Any:
+    """Call the GitHub REST API and return decoded JSON."""
+    query = f"?{urllib.parse.urlencode(params)}" if params else ""
+    request = urllib.request.Request(
+        f"{API_BASE}/repos/{repo}{path}{query}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub API {path} failed: HTTP {exc.code}: {body}") from exc
+
+
+def paginated_github_api(
+    repo: str,
+    path: str,
+    token: str,
+    item_key: str,
+    params: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch all pages from a GitHub REST list endpoint."""
+    out: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        page_params = {"per_page": "100", "page": str(page)}
+        if params:
+            page_params.update(params)
+        data = github_api(repo, path, token, page_params)
+        items = data.get(item_key, data if isinstance(data, list) else [])
+        if not isinstance(items, list):
+            raise RuntimeError(f"GitHub API {path} returned an unexpected shape")
+        out.extend(items)
+        if len(items) < 100:
+            return out
+        page += 1
+
+
+def label_names(pr: dict[str, Any]) -> set[str]:
+    """Return label names from a pull request payload."""
+    return {
+        str(label.get("name"))
+        for label in pr.get("labels", [])
+        if isinstance(label, dict) and label.get("name")
+    }
+
+
+def write_outputs(path: str | None, outputs: dict[str, str]) -> None:
+    """Write outputs for GitHub Actions."""
+    if not path:
+        return
+    with open(path, "a") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def result(
+    *,
+    enabled: bool,
+    reason: str,
+    source_run_id: str = "",
+    source_run_attempt: str = "",
+    source_run_url: str = "",
+    source_pr_number: str = "",
+    source_head_sha: str = "",
+) -> dict[str, str]:
+    """Build the result payload."""
+    return {
+        "reuse-enabled": "true" if enabled else "false",
+        "reuse-source-run-id": source_run_id,
+        "reuse-source-run-attempt": source_run_attempt,
+        "reuse-source-run-url": source_run_url,
+        "reuse-source-pr-number": source_pr_number,
+        "reuse-source-head-sha": source_head_sha,
+        "reuse-reason": reason,
+    }
+
+
+def find_latest_successful_run(
+    repo: str,
+    workflow_id: str,
+    head_sha: str,
+    token: str,
+) -> dict[str, Any] | None:
+    """Return the latest successful PR run for the exact source head SHA."""
+    encoded_workflow = urllib.parse.quote(workflow_id, safe="")
+    runs = paginated_github_api(
+        repo,
+        f"/actions/workflows/{encoded_workflow}/runs",
+        token,
+        "workflow_runs",
+        {
+            "event": "pull_request",
+            "head_sha": head_sha,
+            "status": "completed",
+        },
+    )
+    for run in runs:
+        if run.get("conclusion") == "success" and run.get("head_sha") == head_sha:
+            return run
+    return None
+
+
+def artifact_names(repo: str, run_id: int, token: str) -> set[str]:
+    """Return artifact names from a workflow run."""
+    artifacts = paginated_github_api(
+        repo,
+        f"/actions/runs/{run_id}/artifacts",
+        token,
+        "artifacts",
+    )
+    return {
+        str(artifact.get("name"))
+        for artifact in artifacts
+        if isinstance(artifact, dict) and artifact.get("name")
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--workflow-id", default="run-sweep.yml")
+    parser.add_argument("--reuse-label", default="reuse-full-sweep-results")
+    parser.add_argument("--full-sweep-label", default="full-sweep-enabled")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required")
+
+    if args.event_name != "push" or args.ref != "refs/heads/main":
+        outputs = result(enabled=False, reason="not a push to main")
+        write_outputs(args.github_output, outputs)
+        print(json.dumps(outputs, indent=2))
+        return 0
+
+    pulls = github_api(args.repo, f"/commits/{args.commit_sha}/pulls", token)
+    if not isinstance(pulls, list) or len(pulls) == 0:
+        outputs = result(enabled=False, reason="no associated pull request")
+        write_outputs(args.github_output, outputs)
+        print(json.dumps(outputs, indent=2))
+        return 0
+
+    if len(pulls) > 1:
+        detailed_prs = [
+            github_api(args.repo, f"/pulls/{int(pr['number'])}", token)
+            for pr in pulls
+            if pr.get("number")
+        ]
+        any_reuse = args.reuse_label in set().union(*(label_names(pr) for pr in detailed_prs))
+        if any_reuse:
+            numbers = ", ".join(str(pr.get("number")) for pr in pulls)
+            raise RuntimeError(
+                f"Commit {args.commit_sha} maps to multiple PRs ({numbers}); "
+                f"refusing to reuse artifacts."
+            )
+        outputs = result(enabled=False, reason="multiple associated pull requests")
+        write_outputs(args.github_output, outputs)
+        print(json.dumps(outputs, indent=2))
+        return 0
+
+    pr_number = int(pulls[0]["number"])
+    pr = github_api(args.repo, f"/pulls/{pr_number}", token)
+    labels = label_names(pr)
+    if args.reuse_label not in labels:
+        outputs = result(
+            enabled=False,
+            reason=f"PR #{pr_number} does not have {args.reuse_label}",
+            source_pr_number=str(pr_number),
+        )
+        write_outputs(args.github_output, outputs)
+        print(json.dumps(outputs, indent=2))
+        return 0
+
+    if args.full_sweep_label not in labels:
+        raise RuntimeError(
+            f"PR #{pr_number} has {args.reuse_label} but not {args.full_sweep_label}."
+        )
+    if not pr.get("merged_at"):
+        raise RuntimeError(f"PR #{pr_number} is not marked as merged.")
+
+    head_sha = str(pr.get("head", {}).get("sha") or "")
+    if not head_sha:
+        raise RuntimeError(f"PR #{pr_number} has no head SHA.")
+
+    run = find_latest_successful_run(args.repo, args.workflow_id, head_sha, token)
+    if not run:
+        raise RuntimeError(
+            f"PR #{pr_number} is approved for reuse, but no successful "
+            f"{args.workflow_id} pull_request run was found for {head_sha}."
+        )
+
+    run_id = int(run["id"])
+    names = artifact_names(args.repo, run_id, token)
+    if "results_bmk" not in names and "eval_results_all" not in names:
+        raise RuntimeError(
+            f"Reusable source run {run_id} has no results_bmk or eval_results_all artifact."
+        )
+
+    outputs = result(
+        enabled=True,
+        reason=f"PR #{pr_number} approved reusable full sweep",
+        source_run_id=str(run_id),
+        source_run_attempt=str(run.get("run_attempt") or "1"),
+        source_run_url=str(run.get("html_url") or ""),
+        source_pr_number=str(pr_number),
+        source_head_sha=head_sha,
+    )
+    write_outputs(args.github_output, outputs)
+    print(json.dumps(outputs, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from validate_reusable_sweep_artifacts import (
+    expected_eval_artifact_prefixes,
+    validate_eval_artifacts,
+)
+
+
+def write_eval_aggregate(root: Path) -> None:
+    eval_dir = root / "eval_results_all"
+    eval_dir.mkdir()
+    (eval_dir / "agg_eval_all.json").write_text(json.dumps([{"task": "gsm8k"}]))
+
+
+def single_eval_entry(conc: int) -> dict:
+    return {
+        "exp-name": "gptoss_8k1k",
+        "precision": "fp4",
+        "framework": "vllm",
+        "tp": 2,
+        "ep": 1,
+        "dp-attn": False,
+        "disagg": False,
+        "spec-decoding": "none",
+        "conc": conc,
+    }
+
+
+def test_eval_validation_requires_raw_result_dirs_not_eval_debug_dirs(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "evals": [single_eval_entry(32), single_eval_entry(64)],
+        "multinode_evals": [],
+    }
+    prefixes = expected_eval_artifact_prefixes(config)
+    write_eval_aggregate(tmp_path)
+
+    (tmp_path / "eval_server_logs_gptoss_8k1k_runner").mkdir()
+    (tmp_path / "eval_gpu_metrics_gptoss_8k1k_runner").mkdir()
+    (tmp_path / f"{prefixes[0]}h100-dgxc-slurm_00").mkdir()
+
+    errors = validate_eval_artifacts(tmp_path, prefixes)
+
+    assert "missing 1 expected raw eval result artifact dir(s)" in errors
+    assert f"  missing eval artifact prefix: {prefixes[1]}" in errors
+
+
+def test_eval_validation_accepts_all_expected_raw_result_dirs(tmp_path: Path) -> None:
+    config = {
+        "evals": [single_eval_entry(32), single_eval_entry(64)],
+        "multinode_evals": [],
+    }
+    prefixes = expected_eval_artifact_prefixes(config)
+    write_eval_aggregate(tmp_path)
+    for index, prefix in enumerate(prefixes):
+        (tmp_path / f"{prefix}h100-dgxc-slurm_{index:02d}").mkdir()
+
+    assert validate_eval_artifacts(tmp_path, prefixes) == []

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Validate that reused sweep artifacts match the current merge-run matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FIXED_SEQ_KEYS = ("1k1k", "8k1k")
+
+
+def as_bool(value: Any) -> bool:
+    """Parse booleans stored as bools or strings."""
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() == "true"
+
+
+def as_int(value: Any, default: int = 0) -> int:
+    """Parse integers from workflow/JSON values."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def bool_str(value: Any) -> str:
+    """Render booleans as GitHub Actions does in filenames."""
+    return "true" if as_bool(value) else "false"
+
+
+def load_json(path: Path) -> Any:
+    """Load a JSON file."""
+    with open(path) as handle:
+        return json.load(handle)
+
+
+def expected_benchmark_keys(config: dict[str, Any]) -> set[tuple[Any, ...]]:
+    """Build expected benchmark identity keys from process_changelog output."""
+    expected: set[tuple[Any, ...]] = set()
+
+    for seq_key in FIXED_SEQ_KEYS:
+        for entry in config.get("single_node", {}).get(seq_key, []) or []:
+            expected.add(
+                (
+                    "single",
+                    entry["runner"],
+                    entry["model-prefix"],
+                    entry["framework"],
+                    entry["precision"],
+                    entry.get("spec-decoding", "none"),
+                    as_bool(entry.get("disagg", False)),
+                    as_int(entry["isl"]),
+                    as_int(entry["osl"]),
+                    as_int(entry["tp"]),
+                    as_int(entry.get("ep", 1)),
+                    as_bool(entry.get("dp-attn", False)),
+                    as_int(entry["conc"]),
+                )
+            )
+
+        for entry in config.get("multi_node", {}).get(seq_key, []) or []:
+            prefill = entry["prefill"]
+            decode = entry["decode"]
+            decode_workers = as_int(decode.get("num-worker", 0))
+            expected_decode_tp = as_int(decode.get("tp", 0)) if decode_workers > 0 else 0
+            expected_decode_ep = as_int(decode.get("ep", 0)) if decode_workers > 0 else 0
+            for conc in entry["conc"]:
+                expected.add(
+                    (
+                        "multi",
+                        entry["runner"],
+                        entry["model-prefix"],
+                        entry["framework"],
+                        entry["precision"],
+                        entry.get("spec-decoding", "none"),
+                        as_bool(entry.get("disagg", False)),
+                        as_int(entry["isl"]),
+                        as_int(entry["osl"]),
+                        as_int(prefill.get("tp", 0)),
+                        as_int(prefill.get("ep", 1)),
+                        as_bool(prefill.get("dp-attn", False)),
+                        as_int(prefill.get("num-worker", 0)),
+                        expected_decode_tp,
+                        expected_decode_ep,
+                        as_bool(decode.get("dp-attn", False)),
+                        decode_workers,
+                        as_int(conc),
+                    )
+                )
+
+    return expected
+
+
+def actual_benchmark_keys(artifacts_dir: Path) -> set[tuple[Any, ...]]:
+    """Build actual benchmark identity keys from results_bmk/agg_bmk.json."""
+    actual: set[tuple[Any, ...]] = set()
+    results_dir = artifacts_dir / "results_bmk"
+    for path in results_dir.glob("*.json"):
+        data = load_json(path)
+        rows = data if isinstance(data, list) else [data]
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if row.get("scenario_type") == "agentic-coding":
+                continue
+            if as_bool(row.get("is_multinode", False)):
+                actual.add(
+                    (
+                        "multi",
+                        row.get("hw"),
+                        row.get("infmax_model_prefix"),
+                        row.get("framework"),
+                        row.get("precision"),
+                        row.get("spec_decoding", "none"),
+                        as_bool(row.get("disagg", False)),
+                        as_int(row.get("isl")),
+                        as_int(row.get("osl")),
+                        as_int(row.get("prefill_tp")),
+                        as_int(row.get("prefill_ep", 1)),
+                        as_bool(row.get("prefill_dp_attention", False)),
+                        as_int(row.get("prefill_num_workers", 0)),
+                        as_int(row.get("decode_tp")),
+                        as_int(row.get("decode_ep", 1)),
+                        as_bool(row.get("decode_dp_attention", False)),
+                        as_int(row.get("decode_num_workers", 0)),
+                        as_int(row.get("conc")),
+                    )
+                )
+            else:
+                actual.add(
+                    (
+                        "single",
+                        row.get("hw"),
+                        row.get("infmax_model_prefix"),
+                        row.get("framework"),
+                        row.get("precision"),
+                        row.get("spec_decoding", "none"),
+                        as_bool(row.get("disagg", False)),
+                        as_int(row.get("isl")),
+                        as_int(row.get("osl")),
+                        as_int(row.get("tp")),
+                        as_int(row.get("ep", 1)),
+                        as_bool(row.get("dp_attention", False)),
+                        as_int(row.get("conc")),
+                    )
+                )
+    return actual
+
+
+def expected_eval_jobs(config: dict[str, Any]) -> int:
+    """Count expected eval-only matrix jobs."""
+    return len(config.get("evals", []) or []) + len(config.get("multinode_evals", []) or [])
+
+
+def expected_eval_artifact_prefixes(config: dict[str, Any]) -> list[str]:
+    """Build expected raw eval result artifact prefixes from matrix entries."""
+    prefixes: list[str] = []
+    for entry in config.get("evals", []) or []:
+        exp_name = entry["exp-name"]
+        prefixes.append(
+            f"eval_{exp_name}_{exp_name}_{entry['precision']}_{entry['framework']}_"
+            f"tp{as_int(entry['tp'])}-ep{as_int(entry.get('ep', 1))}-"
+            f"dpa{bool_str(entry.get('dp-attn', False))}_"
+            f"disagg-{bool_str(entry.get('disagg', False))}_"
+            f"spec-{entry.get('spec-decoding', 'none')}_conc{as_int(entry['conc'])}_"
+        )
+
+    for entry in config.get("multinode_evals", []) or []:
+        exp_name = entry["exp-name"]
+        prefill = entry["prefill"]
+        decode = entry["decode"]
+        conc = "x".join(str(as_int(value)) for value in entry["conc"])
+        prefixes.append(
+            f"eval_{exp_name}_{exp_name}_{entry['precision']}_{entry['framework']}_"
+            f"prefill-tp{as_int(prefill['tp'])}-ep{as_int(prefill.get('ep', 1))}-"
+            f"dp{bool_str(prefill.get('dp-attn', False))}-"
+            f"nw{as_int(prefill.get('num-worker', 0))}_"
+            f"decode-tp{as_int(decode.get('tp', 0))}-ep{as_int(decode.get('ep', 0))}-"
+            f"dp{bool_str(decode.get('dp-attn', False))}-"
+            f"nw{as_int(decode.get('num-worker', 0))}_"
+            f"disagg-{bool_str(entry.get('disagg', False))}_"
+            f"spec-{entry.get('spec-decoding', 'none')}_conc{conc}_"
+        )
+    return prefixes
+
+
+def validate_eval_artifacts(artifacts_dir: Path, expected_prefixes: list[str]) -> list[str]:
+    """Validate eval aggregate/raw artifacts when eval jobs are expected."""
+    if not expected_prefixes:
+        return []
+
+    errors: list[str] = []
+    eval_agg_files = list((artifacts_dir / "eval_results_all").glob("*.json"))
+    if not eval_agg_files:
+        errors.append("missing eval_results_all aggregate artifact")
+    else:
+        row_count = 0
+        for path in eval_agg_files:
+            data = load_json(path)
+            if isinstance(data, list):
+                row_count += len(data)
+        if row_count == 0:
+            errors.append("eval_results_all contains no rows")
+
+    raw_eval_dirs = [
+        path.name
+        for path in artifacts_dir.iterdir()
+        if path.is_dir() and path.name.startswith("eval_") and path.name != "eval_results_all"
+    ]
+    missing = [
+        prefix
+        for prefix in expected_prefixes
+        if not any(name.startswith(prefix) for name in raw_eval_dirs)
+    ]
+    if missing:
+        errors.append(
+            f"missing {len(missing)} expected raw eval result artifact dir(s)"
+        )
+        for prefix in sorted(missing)[:20]:
+            errors.append(f"  missing eval artifact prefix: {prefix}")
+        if len(missing) > 20:
+            errors.append(f"  ... and {len(missing) - 20} more")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config-json", required=True, type=Path)
+    parser.add_argument("--artifacts-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    config = load_json(args.config_json)
+    if not isinstance(config, dict):
+        raise ValueError("config JSON must be an object")
+    if not args.artifacts_dir.is_dir():
+        raise ValueError(f"artifacts directory does not exist: {args.artifacts_dir}")
+
+    errors: list[str] = []
+    expected_bmk = expected_benchmark_keys(config)
+    actual_bmk = actual_benchmark_keys(args.artifacts_dir)
+    expected_eval_prefixes = expected_eval_artifact_prefixes(config)
+
+    if expected_bmk:
+        if not actual_bmk:
+            errors.append("missing results_bmk benchmark aggregate artifact")
+        missing = expected_bmk - actual_bmk
+        if missing:
+            errors.append(
+                f"reused benchmark artifacts are missing {len(missing)} expected row(s)"
+            )
+            for key in sorted(missing)[:20]:
+                errors.append(f"  missing: {key}")
+            if len(missing) > 20:
+                errors.append(f"  ... and {len(missing) - 20} more")
+
+    errors.extend(validate_eval_artifacts(args.artifacts_dir, expected_eval_prefixes))
+
+    if errors:
+        print("Reusable sweep artifact validation failed:", file=sys.stderr)
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(
+        "Reusable sweep artifacts validated: "
+        f"{len(expected_bmk)} benchmark row(s), {expected_eval_jobs(config)} eval job(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `reuse-full-sweep-results` as a maintainer authorization label for push-to-main sweep reuse.
- Resolve the merged PR, require `full-sweep-enabled`, find the latest successful PR `Run Sweep` run for the exact head SHA, and skip hardware jobs when reuse is approved.
- Download ingest-relevant source artifacts, validate benchmark coverage against the merge-run matrix, and upload them as `reused-ingest-artifacts` alongside merge-run changelog metadata.
- Include `reused-ingest-metadata/reuse_source_run.json` with the source run ID, attempt, URL, PR number, and merge/mock run ID so the app can link public reused results to the original sweep.
- Companion app change: https://github.com/SemiAnalysisAI/InferenceX-app/pull/340

## Validation
- `python3 -m py_compile utils/find_reusable_sweep_run.py utils/validate_reusable_sweep_artifacts.py`
- `python3 -m pytest utils/test_validate_reusable_sweep_artifacts.py -q`
- `python3 utils/validate_reusable_sweep_artifacts.py --config-json /tmp/pr1334_config.json --artifacts-dir /tmp/pr1334-artifacts`
- `actionlint .github/workflows/run-sweep.yml`
- Confirmed source run metadata is available for PR #1334 run `25763435778` (`pull_request`, `success`, attempt `1`).
