### PR TITLE
Avoid cancelling sweeps on reuse label events

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -2,7 +2,15 @@ name: "Run Sweep"
 run-name: Run Sweep - ${{ github.event.pull_request.title || github.event.head_commit.message }}
 
 concurrency:
-    group: sweep-${{ github.event.pull_request.number || github.sha }}
+    group: >-
+        sweep-${{ github.event.pull_request.number || github.sha }}-${{
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+          github.event.label.name != 'sweep-enabled' &&
+          github.event.label.name != 'full-sweep-enabled' &&
+          github.run_id ||
+          'active'
+        }}
     cancel-in-progress: true
 
 on:


### PR DESCRIPTION
## Summary
- Put non-sweep pull request label events in a unique no-op concurrency group.
- Preserve the shared `sweep-<pr>-active` group for real sweep triggers so synchronize, ready-for-review, and sweep-label changes still cancel stale sweep runs.
- Prevent adding `reuse-full-sweep-results` from cancelling an already-running sweep on the same PR.

## Validation
- `actionlint .github/workflows/run-sweep.yml`
