### PR TITLE
Allow pinned reusable sweep runs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -180,30 +180,39 @@ test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvi
 
 ## Reusing an Approved PR Full Sweep
 
-If a PR has already run the full untrimmed sweep, a maintainer can avoid running
-the same sweep again after merge by leaving the full-sweep label on the PR:
+If a PR has already run the full untrimmed sweep (`full-sweep-enabled` label),
+a maintainer can avoid running the same sweep again after merge by leaving a
+PR comment before merging:
 
-- `full-sweep-enabled`
+```
+/reuse-sweep-run
+```
 
-A maintainer must also pin the reusable source run with a PR comment before
-merging:
+That reuses the latest successful `run-sweep.yml` `pull_request` run for the
+PR's current head SHA. If the PR was rebased or had to merge `main` after the
+successful sweep — so the current head no longer has a matching run — pin the
+source run explicitly:
 
 ```
 /reuse-sweep-run <run_id>
 ```
 
-The comment is the reuse authorization, so adding it does not trigger or cancel a
-PR sweep. On the push-to-main run, `run-sweep.yml` resolves the merged PR from
-the merge commit, verifies that the pinned run is a successful `pull_request`
+The comment is the reuse authorization, so adding it does not trigger or cancel
+a PR sweep. On the push-to-main run, `run-sweep.yml` resolves the merged PR
+from the merge commit, verifies the source run is a successful `pull_request`
 `run-sweep.yml` run for the same PR, downloads the ingest-relevant artifacts,
 validates that `results_bmk` covers the merge run's expected benchmark matrix,
 and uploads them as `reused-ingest-artifacts`. The normal database ingest then
 publishes those artifacts with the merge run's changelog metadata.
 
-Reuse fails closed: if the comment is present but the full-sweep label, pinned
-PR run, or artifacts cannot be validated, the push-to-main workflow fails
-instead of falling back to a cluster sweep. Without the comment, the push-to-main
-workflow runs the normal full sweep.
+Only comments from `OWNER`, `MEMBER`, or `COLLABORATOR` users authorize reuse.
+The most recent matching comment wins, so a maintainer can supersede an earlier
+pin by leaving a new `/reuse-sweep-run [<run_id>]` comment.
+
+Reuse fails closed: if the comment is present but the `full-sweep-enabled`
+label, source PR run, or artifacts cannot be validated, the push-to-main
+workflow fails instead of falling back to a cluster sweep. Without the comment,
+the push-to-main workflow runs the normal full sweep.
 
 ## Validation Architecture
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -181,21 +181,29 @@ test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvi
 ## Reusing an Approved PR Full Sweep
 
 If a PR has already run the full untrimmed sweep, a maintainer can avoid running
-the same sweep again after merge by leaving both labels on the PR before merging:
+the same sweep again after merge by leaving the full-sweep label on the PR:
 
 - `full-sweep-enabled`
-- `reuse-full-sweep-results`
 
-On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
-commit, finds the latest successful PR `Run Sweep` run for that exact PR head
-SHA, downloads the ingest-relevant artifacts, validates that `results_bmk`
-covers the merge run's expected benchmark matrix, and uploads them as
-`reused-ingest-artifacts`. The normal database ingest then publishes those
-artifacts with the merge run's changelog metadata.
+A maintainer must also pin the reusable source run with a PR comment before
+merging:
 
-Reuse fails closed: if the label is present but the matching PR run or artifacts
-cannot be validated, the push-to-main workflow fails instead of falling back to a
-cluster sweep.
+```
+/reuse-sweep-run <run_id>
+```
+
+The comment is the reuse authorization, so adding it does not trigger or cancel a
+PR sweep. On the push-to-main run, `run-sweep.yml` resolves the merged PR from
+the merge commit, verifies that the pinned run is a successful `pull_request`
+`run-sweep.yml` run for the same PR, downloads the ingest-relevant artifacts,
+validates that `results_bmk` covers the merge run's expected benchmark matrix,
+and uploads them as `reused-ingest-artifacts`. The normal database ingest then
+publishes those artifacts with the merge run's changelog metadata.
+
+Reuse fails closed: if the comment is present but the full-sweep label, pinned
+PR run, or artifacts cannot be validated, the push-to-main workflow fails
+instead of falling back to a cluster sweep. Without the comment, the push-to-main
+workflow runs the normal full sweep.
 
 ## Validation Architecture
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2348,4 +2348,4 @@
     - gptoss-fp4-h100-vllm
   description:
     - "Update vLLM image from v0.18.0 to v0.20.2"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1334

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -3,7 +3,7 @@
 
 This script is used by ``run-sweep.yml`` on push-to-main runs.  It only enables
 reuse when the merge commit maps unambiguously to one pull request and a human
-has left both the full-sweep label and the reuse authorization label on that PR.
+has left the full-sweep label plus a maintainer reuse command on that PR.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -19,6 +20,7 @@ from typing import Any
 
 
 API_BASE = "https://api.github.com"
+DEFAULT_ALLOWED_AUTHOR_ASSOCIATIONS = ("OWNER", "MEMBER", "COLLABORATOR")
 
 
 def github_api(
@@ -60,7 +62,12 @@ def paginated_github_api(
         if params:
             page_params.update(params)
         data = github_api(repo, path, token, page_params)
-        items = data.get(item_key, data if isinstance(data, list) else [])
+        if isinstance(data, list):
+            items = data
+        elif isinstance(data, dict):
+            items = data.get(item_key, [])
+        else:
+            items = []
         if not isinstance(items, list):
             raise RuntimeError(f"GitHub API {path} returned an unexpected shape")
         out.extend(items)
@@ -109,29 +116,76 @@ def result(
     }
 
 
-def find_latest_successful_run(
+def find_authorized_reuse_run_id(
+    repo: str,
+    pr_number: int,
+    token: str,
+    command: str,
+    allowed_author_associations: set[str],
+) -> int | None:
+    """Return the latest maintainer-authorized pinned source run ID, if any."""
+    command_pattern = re.compile(rf"(?m)^\s*{re.escape(command)}\s+(\d+)\s*$")
+    comments = paginated_github_api(
+        repo,
+        f"/issues/{pr_number}/comments",
+        token,
+        "",
+    )
+    comments.sort(key=lambda comment: str(comment.get("created_at") or ""))
+    for comment in reversed(comments):
+        association = str(comment.get("author_association") or "")
+        if association not in allowed_author_associations:
+            continue
+        body = str(comment.get("body") or "")
+        matches = command_pattern.findall(body)
+        if matches:
+            return int(matches[-1])
+    return None
+
+
+def workflow_path(workflow_id: str) -> str:
+    """Return the Actions run path expected for a workflow id/path."""
+    if workflow_id.startswith(".github/"):
+        return workflow_id
+    return f".github/workflows/{workflow_id}"
+
+
+def run_pr_numbers(run: dict[str, Any]) -> set[int]:
+    """Return pull request numbers associated with an Actions run."""
+    numbers: set[int] = set()
+    for pull in run.get("pull_requests", []) or []:
+        if isinstance(pull, dict) and isinstance(pull.get("number"), int):
+            numbers.add(int(pull["number"]))
+    return numbers
+
+
+def validate_reusable_run(
     repo: str,
     workflow_id: str,
-    head_sha: str,
+    pr_number: int,
+    run: dict[str, Any],
     token: str,
-) -> dict[str, Any] | None:
-    """Return the latest successful PR run for the exact source head SHA."""
-    encoded_workflow = urllib.parse.quote(workflow_id, safe="")
-    runs = paginated_github_api(
-        repo,
-        f"/actions/workflows/{encoded_workflow}/runs",
-        token,
-        "workflow_runs",
-        {
-            "event": "pull_request",
-            "head_sha": head_sha,
-            "status": "completed",
-        },
-    )
-    for run in runs:
-        if run.get("conclusion") == "success" and run.get("head_sha") == head_sha:
-            return run
-    return None
+) -> None:
+    """Fail closed unless an Actions run is a valid reusable source run."""
+    run_id = int(run["id"])
+    if run.get("event") != "pull_request":
+        raise RuntimeError(f"Reusable source run {run_id} is not a pull_request run.")
+    if run.get("status") != "completed" or run.get("conclusion") != "success":
+        raise RuntimeError(f"Reusable source run {run_id} did not complete successfully.")
+    expected_path = workflow_path(workflow_id)
+    run_path = str(run.get("path") or "")
+    if run_path and run_path != expected_path:
+        raise RuntimeError(
+            f"Reusable source run {run_id} is from {run_path}, expected {expected_path}."
+        )
+    if pr_number not in run_pr_numbers(run):
+        raise RuntimeError(f"Reusable source run {run_id} is not associated with PR #{pr_number}.")
+
+    names = artifact_names(repo, run_id, token)
+    if "results_bmk" not in names and "eval_results_all" not in names:
+        raise RuntimeError(
+            f"Reusable source run {run_id} has no results_bmk or eval_results_all artifact."
+        )
 
 
 def artifact_names(repo: str, run_id: int, token: str) -> set[str]:
@@ -156,14 +210,24 @@ def main() -> int:
     parser.add_argument("--event-name", required=True)
     parser.add_argument("--ref", required=True)
     parser.add_argument("--workflow-id", default="run-sweep.yml")
-    parser.add_argument("--reuse-label", default="reuse-full-sweep-results")
     parser.add_argument("--full-sweep-label", default="full-sweep-enabled")
+    parser.add_argument("--pinned-run-command", default="/reuse-sweep-run")
+    parser.add_argument(
+        "--allowed-author-associations",
+        default=",".join(DEFAULT_ALLOWED_AUTHOR_ASSOCIATIONS),
+        help="Comma-separated GitHub author_association values allowed to pin a source run.",
+    )
     parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
     args = parser.parse_args()
 
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
         raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required")
+    allowed_author_associations = {
+        value.strip()
+        for value in args.allowed_author_associations.split(",")
+        if value.strip()
+    }
 
     if args.event_name != "push" or args.ref != "refs/heads/main":
         outputs = result(enabled=False, reason="not a push to main")
@@ -179,17 +243,26 @@ def main() -> int:
         return 0
 
     if len(pulls) > 1:
-        detailed_prs = [
-            github_api(args.repo, f"/pulls/{int(pr['number'])}", token)
-            for pr in pulls
-            if pr.get("number")
-        ]
-        any_reuse = args.reuse_label in set().union(*(label_names(pr) for pr in detailed_prs))
-        if any_reuse:
+        pinned_prs: list[tuple[int, int]] = []
+        for pr in pulls:
+            if not pr.get("number"):
+                continue
+            pr_number = int(pr["number"])
+            pinned_run_id = find_authorized_reuse_run_id(
+                args.repo,
+                pr_number,
+                token,
+                args.pinned_run_command,
+                allowed_author_associations,
+            )
+            if pinned_run_id:
+                pinned_prs.append((pr_number, pinned_run_id))
+        if pinned_prs:
             numbers = ", ".join(str(pr.get("number")) for pr in pulls)
+            pinned = ", ".join(f"#{number} -> {run_id}" for number, run_id in pinned_prs)
             raise RuntimeError(
                 f"Commit {args.commit_sha} maps to multiple PRs ({numbers}); "
-                f"refusing to reuse artifacts."
+                f"found reuse authorization on {pinned}; refusing to reuse artifacts."
             )
         outputs = result(enabled=False, reason="multiple associated pull requests")
         write_outputs(args.github_output, outputs)
@@ -197,51 +270,47 @@ def main() -> int:
         return 0
 
     pr_number = int(pulls[0]["number"])
-    pr = github_api(args.repo, f"/pulls/{pr_number}", token)
-    labels = label_names(pr)
-    if args.reuse_label not in labels:
+    pinned_run_id = find_authorized_reuse_run_id(
+        args.repo,
+        pr_number,
+        token,
+        args.pinned_run_command,
+        allowed_author_associations,
+    )
+    if not pinned_run_id:
         outputs = result(
             enabled=False,
-            reason=f"PR #{pr_number} does not have {args.reuse_label}",
+            reason=f"PR #{pr_number} has no {args.pinned_run_command} authorization",
             source_pr_number=str(pr_number),
         )
         write_outputs(args.github_output, outputs)
         print(json.dumps(outputs, indent=2))
         return 0
 
+    pr = github_api(args.repo, f"/pulls/{pr_number}", token)
+    labels = label_names(pr)
     if args.full_sweep_label not in labels:
         raise RuntimeError(
-            f"PR #{pr_number} has {args.reuse_label} but not {args.full_sweep_label}."
+            f"PR #{pr_number} has {args.pinned_run_command} authorization but not "
+            f"{args.full_sweep_label}."
         )
     if not pr.get("merged_at"):
         raise RuntimeError(f"PR #{pr_number} is not marked as merged.")
 
-    head_sha = str(pr.get("head", {}).get("sha") or "")
-    if not head_sha:
-        raise RuntimeError(f"PR #{pr_number} has no head SHA.")
-
-    run = find_latest_successful_run(args.repo, args.workflow_id, head_sha, token)
-    if not run:
-        raise RuntimeError(
-            f"PR #{pr_number} is approved for reuse, but no successful "
-            f"{args.workflow_id} pull_request run was found for {head_sha}."
-        )
+    run = github_api(args.repo, f"/actions/runs/{pinned_run_id}", token)
+    reason = f"PR #{pr_number} approved reusable full sweep from pinned run {pinned_run_id}"
 
     run_id = int(run["id"])
-    names = artifact_names(args.repo, run_id, token)
-    if "results_bmk" not in names and "eval_results_all" not in names:
-        raise RuntimeError(
-            f"Reusable source run {run_id} has no results_bmk or eval_results_all artifact."
-        )
+    validate_reusable_run(args.repo, args.workflow_id, pr_number, run, token)
 
     outputs = result(
         enabled=True,
-        reason=f"PR #{pr_number} approved reusable full sweep",
+        reason=reason,
         source_run_id=str(run_id),
         source_run_attempt=str(run.get("run_attempt") or "1"),
         source_run_url=str(run.get("html_url") or ""),
         source_pr_number=str(pr_number),
-        source_head_sha=head_sha,
+        source_head_sha=str(run.get("head_sha") or ""),
     )
     write_outputs(args.github_output, outputs)
     print(json.dumps(outputs, indent=2))

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -2,8 +2,10 @@
 """Find an approved pull-request sweep run that can be reused after merge.
 
 This script is used by ``run-sweep.yml`` on push-to-main runs.  It only enables
-reuse when the merge commit maps unambiguously to one pull request and a human
-has left the full-sweep label plus a maintainer reuse command on that PR.
+reuse when the merge commit maps unambiguously to one pull request and a
+maintainer has left a ``/reuse-sweep-run`` comment on that PR.  The comment
+may include a specific source run ID; without one, the latest successful
+``pull_request`` ``run-sweep.yml`` run for the PR head is used.
 """
 
 from __future__ import annotations
@@ -116,15 +118,20 @@ def result(
     }
 
 
-def find_authorized_reuse_run_id(
+def find_reuse_authorization(
     repo: str,
     pr_number: int,
     token: str,
     command: str,
     allowed_author_associations: set[str],
-) -> int | None:
-    """Return the latest maintainer-authorized pinned source run ID, if any."""
-    command_pattern = re.compile(rf"(?m)^\s*{re.escape(command)}\s+(\d+)\s*$")
+) -> tuple[bool, int | None]:
+    """Find the most recent maintainer-authorized reuse comment on a PR.
+
+    Returns ``(authorized, pinned_run_id)``.  ``pinned_run_id`` is ``None`` when
+    the comment had no run ID argument — the caller should resolve the source
+    run from the PR head SHA in that case.
+    """
+    command_pattern = re.compile(rf"(?m)^\s*{re.escape(command)}(?:\s+(\d+))?\s*$")
     comments = paginated_github_api(
         repo,
         f"/issues/{pr_number}/comments",
@@ -138,8 +145,36 @@ def find_authorized_reuse_run_id(
             continue
         body = str(comment.get("body") or "")
         matches = command_pattern.findall(body)
-        if matches:
-            return int(matches[-1])
+        if not matches:
+            continue
+        # The last matching command in this comment is the maintainer's final intent.
+        last = matches[-1]
+        return True, int(last) if last else None
+    return False, None
+
+
+def find_latest_successful_run(
+    repo: str,
+    workflow_id: str,
+    head_sha: str,
+    token: str,
+) -> dict[str, Any] | None:
+    """Return the latest successful PR sweep run for the given head SHA."""
+    encoded_workflow = urllib.parse.quote(workflow_id, safe="")
+    runs = paginated_github_api(
+        repo,
+        f"/actions/workflows/{encoded_workflow}/runs",
+        token,
+        "workflow_runs",
+        {
+            "event": "pull_request",
+            "head_sha": head_sha,
+            "status": "completed",
+        },
+    )
+    for run in runs:
+        if run.get("conclusion") == "success" and run.get("head_sha") == head_sha:
+            return run
     return None
 
 
@@ -243,26 +278,26 @@ def main() -> int:
         return 0
 
     if len(pulls) > 1:
-        pinned_prs: list[tuple[int, int]] = []
+        authorized_prs: list[int] = []
         for pr in pulls:
             if not pr.get("number"):
                 continue
             pr_number = int(pr["number"])
-            pinned_run_id = find_authorized_reuse_run_id(
+            authorized, _ = find_reuse_authorization(
                 args.repo,
                 pr_number,
                 token,
                 args.pinned_run_command,
                 allowed_author_associations,
             )
-            if pinned_run_id:
-                pinned_prs.append((pr_number, pinned_run_id))
-        if pinned_prs:
+            if authorized:
+                authorized_prs.append(pr_number)
+        if authorized_prs:
             numbers = ", ".join(str(pr.get("number")) for pr in pulls)
-            pinned = ", ".join(f"#{number} -> {run_id}" for number, run_id in pinned_prs)
+            authorized = ", ".join(f"#{n}" for n in authorized_prs)
             raise RuntimeError(
                 f"Commit {args.commit_sha} maps to multiple PRs ({numbers}); "
-                f"found reuse authorization on {pinned}; refusing to reuse artifacts."
+                f"found reuse authorization on {authorized}; refusing to reuse artifacts."
             )
         outputs = result(enabled=False, reason="multiple associated pull requests")
         write_outputs(args.github_output, outputs)
@@ -270,14 +305,14 @@ def main() -> int:
         return 0
 
     pr_number = int(pulls[0]["number"])
-    pinned_run_id = find_authorized_reuse_run_id(
+    authorized, pinned_run_id = find_reuse_authorization(
         args.repo,
         pr_number,
         token,
         args.pinned_run_command,
         allowed_author_associations,
     )
-    if not pinned_run_id:
+    if not authorized:
         outputs = result(
             enabled=False,
             reason=f"PR #{pr_number} has no {args.pinned_run_command} authorization",
@@ -297,8 +332,21 @@ def main() -> int:
     if not pr.get("merged_at"):
         raise RuntimeError(f"PR #{pr_number} is not marked as merged.")
 
-    run = github_api(args.repo, f"/actions/runs/{pinned_run_id}", token)
-    reason = f"PR #{pr_number} approved reusable full sweep from pinned run {pinned_run_id}"
+    if pinned_run_id is not None:
+        run = github_api(args.repo, f"/actions/runs/{pinned_run_id}", token)
+        reason = f"PR #{pr_number} approved reusable full sweep from pinned run {pinned_run_id}"
+    else:
+        head_sha = str(pr.get("head", {}).get("sha") or "")
+        if not head_sha:
+            raise RuntimeError(f"PR #{pr_number} has no head SHA.")
+        run = find_latest_successful_run(args.repo, args.workflow_id, head_sha, token)
+        if not run:
+            raise RuntimeError(
+                f"PR #{pr_number} has {args.pinned_run_command} authorization but no "
+                f"successful {args.workflow_id} pull_request run was found for {head_sha}; "
+                f"pin a specific run with `{args.pinned_run_command} <run_id>`."
+            )
+        reason = f"PR #{pr_number} approved reusable full sweep from latest run on {head_sha}"
 
     run_id = int(run["id"])
     validate_reusable_run(args.repo, args.workflow_id, pr_number, run, token)

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import find_reusable_sweep_run as reuse
+
+
+def test_find_authorized_reuse_run_id_uses_latest_allowed_comment(monkeypatch) -> None:
+    def fake_paginated_github_api(*args, **kwargs):
+        return [
+            {
+                "created_at": "2026-05-13T00:00:00Z",
+                "author_association": "MEMBER",
+                "body": "/reuse-sweep-run 111",
+            },
+            {
+                "created_at": "2026-05-13T00:01:00Z",
+                "author_association": "CONTRIBUTOR",
+                "body": "/reuse-sweep-run 222",
+            },
+            {
+                "created_at": "2026-05-13T00:02:00Z",
+                "author_association": "OWNER",
+                "body": "approved\n/reuse-sweep-run 333",
+            },
+        ]
+
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+
+    assert (
+        reuse.find_authorized_reuse_run_id(
+            "SemiAnalysisAI/InferenceX",
+            1321,
+            "token",
+            "/reuse-sweep-run",
+            {"OWNER", "MEMBER", "COLLABORATOR"},
+        )
+        == 333
+    )
+
+
+def test_find_authorized_reuse_run_id_ignores_inline_mentions(monkeypatch) -> None:
+    def fake_paginated_github_api(*args, **kwargs):
+        return [
+            {
+                "created_at": "2026-05-13T00:00:00Z",
+                "author_association": "OWNER",
+                "body": "please run /reuse-sweep-run 111 after merge",
+            },
+        ]
+
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+
+    assert (
+        reuse.find_authorized_reuse_run_id(
+            "SemiAnalysisAI/InferenceX",
+            1321,
+            "token",
+            "/reuse-sweep-run",
+            {"OWNER", "MEMBER", "COLLABORATOR"},
+        )
+        is None
+    )
+
+
+def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+
+    reuse.validate_reusable_run(
+        "SemiAnalysisAI/InferenceX",
+        "run-sweep.yml",
+        1321,
+        {
+            "id": 25763404168,
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "success",
+            "path": ".github/workflows/run-sweep.yml",
+            "pull_requests": [{"number": 1321}],
+        },
+        "token",
+    )
+
+
+def test_validate_reusable_run_rejects_wrong_pr(monkeypatch) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+
+    try:
+        reuse.validate_reusable_run(
+            "SemiAnalysisAI/InferenceX",
+            "run-sweep.yml",
+            1321,
+            {
+                "id": 25763404168,
+                "event": "pull_request",
+                "status": "completed",
+                "conclusion": "success",
+                "path": ".github/workflows/run-sweep.yml",
+                "pull_requests": [{"number": 9999}],
+            },
+            "token",
+        )
+    except RuntimeError as error:
+        assert "not associated with PR #1321" in str(error)
+    else:
+        raise AssertionError("expected wrong-PR run to be rejected")
+
+
+def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) -> None:
+    comments = [
+        {
+            "created_at": "2026-05-13T00:00:00Z",
+            "author_association": "OWNER",
+            "body": "/reuse-sweep-run 25763404168",
+        },
+    ]
+    run = {
+        "id": 25763404168,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "path": ".github/workflows/run-sweep.yml",
+        "pull_requests": [{"number": 1321}],
+        "run_attempt": 1,
+        "html_url": "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25763404168",
+        "head_sha": "abc123",
+    }
+
+    def fake_github_api(repo, path, token, params=None):
+        if path == "/commits/merge-sha/pulls":
+            return [{"number": 1321}]
+        if path == "/pulls/1321":
+            return {
+                "merged_at": "2026-05-13T00:01:00Z",
+                "labels": [{"name": "full-sweep-enabled"}],
+            }
+        if path == "/actions/runs/25763404168":
+            return run
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        if path == "/issues/1321/comments":
+            return comments
+        if path == "/actions/runs/25763404168/artifacts":
+            return [{"name": "results_bmk"}]
+        raise AssertionError(f"unexpected paginated GitHub API path: {path}")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "github_api", fake_github_api)
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "merge-sha",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "true"
+    assert outputs["reuse-source-run-id"] == "25763404168"
+    assert outputs["reuse-source-pr-number"] == "1321"
+    assert outputs["reuse-source-head-sha"] == "abc123"
+
+
+def test_main_disables_reuse_without_pinned_comment(monkeypatch, tmp_path) -> None:
+    def fake_github_api(repo, path, token, params=None):
+        if path == "/commits/merge-sha/pulls":
+            return [{"number": 1321}]
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        if path == "/issues/1321/comments":
+            return []
+        raise AssertionError(f"unexpected paginated GitHub API path: {path}")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "github_api", fake_github_api)
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "merge-sha",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "false"
+    assert outputs["reuse-source-pr-number"] == "1321"
+    assert outputs["reuse-reason"] == "PR #1321 has no /reuse-sweep-run authorization"

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import find_reusable_sweep_run as reuse
 
 
-def test_find_authorized_reuse_run_id_uses_latest_allowed_comment(monkeypatch) -> None:
+def test_find_reuse_authorization_uses_latest_allowed_comment(monkeypatch) -> None:
     def fake_paginated_github_api(*args, **kwargs):
         return [
             {
@@ -25,19 +25,63 @@ def test_find_authorized_reuse_run_id_uses_latest_allowed_comment(monkeypatch) -
 
     monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
 
-    assert (
-        reuse.find_authorized_reuse_run_id(
-            "SemiAnalysisAI/InferenceX",
-            1321,
-            "token",
-            "/reuse-sweep-run",
-            {"OWNER", "MEMBER", "COLLABORATOR"},
-        )
-        == 333
-    )
+    assert reuse.find_reuse_authorization(
+        "SemiAnalysisAI/InferenceX",
+        1321,
+        "token",
+        "/reuse-sweep-run",
+        {"OWNER", "MEMBER", "COLLABORATOR"},
+    ) == (True, 333)
 
 
-def test_find_authorized_reuse_run_id_ignores_inline_mentions(monkeypatch) -> None:
+def test_find_reuse_authorization_accepts_command_without_run_id(monkeypatch) -> None:
+    def fake_paginated_github_api(*args, **kwargs):
+        return [
+            {
+                "created_at": "2026-05-13T00:00:00Z",
+                "author_association": "OWNER",
+                "body": "/reuse-sweep-run",
+            },
+        ]
+
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+
+    assert reuse.find_reuse_authorization(
+        "SemiAnalysisAI/InferenceX",
+        1321,
+        "token",
+        "/reuse-sweep-run",
+        {"OWNER", "MEMBER", "COLLABORATOR"},
+    ) == (True, None)
+
+
+def test_find_reuse_authorization_lets_newer_no_arg_unpin_older_pin(monkeypatch) -> None:
+    def fake_paginated_github_api(*args, **kwargs):
+        return [
+            {
+                "created_at": "2026-05-13T00:00:00Z",
+                "author_association": "OWNER",
+                "body": "/reuse-sweep-run 111",
+            },
+            {
+                "created_at": "2026-05-13T00:01:00Z",
+                "author_association": "OWNER",
+                "body": "/reuse-sweep-run",
+            },
+        ]
+
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+
+    assert reuse.find_reuse_authorization(
+        "SemiAnalysisAI/InferenceX",
+        1321,
+        "token",
+        "/reuse-sweep-run",
+        {"OWNER", "MEMBER", "COLLABORATOR"},
+    ) == (True, None)
+
+
+def test_find_reuse_authorization_ignores_inline_mentions(monkeypatch) -> None:
     def fake_paginated_github_api(*args, **kwargs):
         return [
             {
@@ -49,16 +93,13 @@ def test_find_authorized_reuse_run_id_ignores_inline_mentions(monkeypatch) -> No
 
     monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
 
-    assert (
-        reuse.find_authorized_reuse_run_id(
-            "SemiAnalysisAI/InferenceX",
-            1321,
-            "token",
-            "/reuse-sweep-run",
-            {"OWNER", "MEMBER", "COLLABORATOR"},
-        )
-        is None
-    )
+    assert reuse.find_reuse_authorization(
+        "SemiAnalysisAI/InferenceX",
+        1321,
+        "token",
+        "/reuse-sweep-run",
+        {"OWNER", "MEMBER", "COLLABORATOR"},
+    ) == (False, None)
 
 
 def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> None:
@@ -131,6 +172,7 @@ def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) ->
             return {
                 "merged_at": "2026-05-13T00:01:00Z",
                 "labels": [{"name": "full-sweep-enabled"}],
+                "head": {"sha": "abc123"},
             }
         if path == "/actions/runs/25763404168":
             return run
@@ -139,6 +181,78 @@ def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) ->
     def fake_paginated_github_api(repo, path, token, item_key, params=None):
         if path == "/issues/1321/comments":
             return comments
+        if path == "/actions/runs/25763404168/artifacts":
+            return [{"name": "results_bmk"}]
+        raise AssertionError(f"unexpected paginated GitHub API path: {path}")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "github_api", fake_github_api)
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "merge-sha",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "true"
+    assert outputs["reuse-source-run-id"] == "25763404168"
+    assert outputs["reuse-source-pr-number"] == "1321"
+    assert outputs["reuse-source-head-sha"] == "abc123"
+
+
+def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path) -> None:
+    comments = [
+        {
+            "created_at": "2026-05-13T00:00:00Z",
+            "author_association": "OWNER",
+            "body": "/reuse-sweep-run",
+        },
+    ]
+    run = {
+        "id": 25763404168,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "path": ".github/workflows/run-sweep.yml",
+        "pull_requests": [{"number": 1321}],
+        "run_attempt": 1,
+        "html_url": "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25763404168",
+        "head_sha": "abc123",
+    }
+
+    def fake_github_api(repo, path, token, params=None):
+        if path == "/commits/merge-sha/pulls":
+            return [{"number": 1321}]
+        if path == "/pulls/1321":
+            return {
+                "merged_at": "2026-05-13T00:01:00Z",
+                "labels": [{"name": "full-sweep-enabled"}],
+                "head": {"sha": "abc123"},
+            }
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        if path == "/issues/1321/comments":
+            return comments
+        if path == "/actions/workflows/run-sweep.yml/runs":
+            assert params["head_sha"] == "abc123"
+            return [run]
         if path == "/actions/runs/25763404168/artifacts":
             return [{"name": "results_bmk"}]
         raise AssertionError(f"unexpected paginated GitHub API path: {path}")


### PR DESCRIPTION
## Summary
- Replace the separate `reuse-full-sweep-results` label with an authorized `/reuse-sweep-run <run_id>` PR comment.
- Require `full-sweep-enabled` plus the pinned maintainer comment before a push-to-main run can reuse artifacts.
- Validate pinned runs fail-closed: they must be successful `pull_request` `run-sweep.yml` runs for the same PR and have ingest artifacts before normal artifact validation runs.
- Document the comment-based workflow and that no comment means the normal push-to-main full sweep still runs.

## Validation
- `python3 -m py_compile utils/find_reusable_sweep_run.py utils/validate_reusable_sweep_artifacts.py`
- `python3 -m pytest utils/test_find_reusable_sweep_run.py utils/test_validate_reusable_sweep_artifacts.py -q`
- `actionlint .github/workflows/run-sweep.yml`
