### PR TITLE
Validate reuse run against PR commit history

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2355,3 +2355,9 @@
   description:
     - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1321
+
+- config-keys:
+    - dsr1-fp4-b300-sglang
+  description:
+    - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.11-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1321

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -185,13 +185,27 @@ def workflow_path(workflow_id: str) -> str:
     return f".github/workflows/{workflow_id}"
 
 
-def run_pr_numbers(run: dict[str, Any]) -> set[int]:
-    """Return pull request numbers associated with an Actions run."""
-    numbers: set[int] = set()
-    for pull in run.get("pull_requests", []) or []:
-        if isinstance(pull, dict) and isinstance(pull.get("number"), int):
-            numbers.add(int(pull["number"]))
-    return numbers
+def pr_commit_shas(repo: str, pr_number: int, token: str) -> set[str]:
+    """Return the set of commit SHAs currently on a PR.
+
+    The Actions ``run.pull_requests`` field is dynamically recomputed and only
+    lists PRs whose *current* head matches the run's ``head_sha``.  After any
+    additional commit lands on the PR (e.g. a ``main`` merge to resolve a
+    ``perf-changelog.yaml`` conflict), the pinned source run drops out of that
+    field even though its commit is still part of the PR.  Checking the PR
+    commit list directly survives that case.
+    """
+    commits = paginated_github_api(
+        repo,
+        f"/pulls/{pr_number}/commits",
+        token,
+        "",
+    )
+    return {
+        str(commit.get("sha"))
+        for commit in commits
+        if isinstance(commit, dict) and commit.get("sha")
+    }
 
 
 def validate_reusable_run(
@@ -213,8 +227,15 @@ def validate_reusable_run(
         raise RuntimeError(
             f"Reusable source run {run_id} is from {run_path}, expected {expected_path}."
         )
-    if pr_number not in run_pr_numbers(run):
-        raise RuntimeError(f"Reusable source run {run_id} is not associated with PR #{pr_number}.")
+    run_head_sha = str(run.get("head_sha") or "")
+    if not run_head_sha:
+        raise RuntimeError(f"Reusable source run {run_id} has no head_sha.")
+    pr_shas = pr_commit_shas(repo, pr_number, token)
+    if run_head_sha not in pr_shas:
+        raise RuntimeError(
+            f"Reusable source run {run_id} head {run_head_sha} is not in PR #{pr_number}'s "
+            f"commit list; pin a run whose commit is still part of the PR."
+        )
 
     names = artifact_names(repo, run_id, token)
     if "results_bmk" not in names and "eval_results_all" not in names:

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -104,6 +104,7 @@ def test_find_reuse_authorization_ignores_inline_mentions(monkeypatch) -> None:
 
 def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> None:
     monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
 
     reuse.validate_reusable_run(
         "SemiAnalysisAI/InferenceX",
@@ -115,14 +116,50 @@ def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> No
             "status": "completed",
             "conclusion": "success",
             "path": ".github/workflows/run-sweep.yml",
+            "head_sha": "abc123",
             "pull_requests": [{"number": 1321}],
         },
         "token",
     )
 
 
-def test_validate_reusable_run_rejects_wrong_pr(monkeypatch) -> None:
+def test_validate_reusable_run_accepts_run_for_older_pr_commit(monkeypatch) -> None:
+    """Regression: pinned run survives an additional commit landing on the PR.
+
+    GitHub recomputes ``run.pull_requests`` to empty once the PR head moves past
+    the run's commit, but the run's commit is still part of the PR's history and
+    should remain reusable.
+    """
     monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(
+        reuse,
+        "pr_commit_shas",
+        lambda *args: {
+            "e36afac48cc6165f4e1f8ea7e1977b01ef29787c",
+            "5c7d7df8ce125e6c725eb37db123269380b7c97d",
+        },
+    )
+
+    reuse.validate_reusable_run(
+        "SemiAnalysisAI/InferenceX",
+        "run-sweep.yml",
+        1321,
+        {
+            "id": 25763404168,
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "success",
+            "path": ".github/workflows/run-sweep.yml",
+            "head_sha": "e36afac48cc6165f4e1f8ea7e1977b01ef29787c",
+            "pull_requests": [],
+        },
+        "token",
+    )
+
+
+def test_validate_reusable_run_rejects_run_for_orphaned_commit(monkeypatch) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"def456"})
 
     try:
         reuse.validate_reusable_run(
@@ -135,14 +172,15 @@ def test_validate_reusable_run_rejects_wrong_pr(monkeypatch) -> None:
                 "status": "completed",
                 "conclusion": "success",
                 "path": ".github/workflows/run-sweep.yml",
-                "pull_requests": [{"number": 9999}],
+                "head_sha": "abc123",
+                "pull_requests": [],
             },
             "token",
         )
     except RuntimeError as error:
-        assert "not associated with PR #1321" in str(error)
+        assert "is not in PR #1321's commit list" in str(error)
     else:
-        raise AssertionError("expected wrong-PR run to be rejected")
+        raise AssertionError("expected orphaned-commit run to be rejected")
 
 
 def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) -> None:
@@ -181,6 +219,8 @@ def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) ->
     def fake_paginated_github_api(repo, path, token, item_key, params=None):
         if path == "/issues/1321/comments":
             return comments
+        if path == "/pulls/1321/commits":
+            return [{"sha": "abc123"}]
         if path == "/actions/runs/25763404168/artifacts":
             return [{"name": "results_bmk"}]
         raise AssertionError(f"unexpected paginated GitHub API path: {path}")
@@ -250,6 +290,8 @@ def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path
     def fake_paginated_github_api(repo, path, token, item_key, params=None):
         if path == "/issues/1321/comments":
             return comments
+        if path == "/pulls/1321/commits":
+            return [{"sha": "abc123"}]
         if path == "/actions/workflows/run-sweep.yml/runs":
             assert params["head_sha"] == "abc123"
             return [run]


### PR DESCRIPTION
## Summary
- Fix `validate_reusable_run` to check the PR's commit list instead of `run.pull_requests`. The Actions API recomputes `run.pull_requests` to only list PRs whose *current* head matches the run's `head_sha`, so any additional commit landing on the PR after a successful sweep (e.g. a `main` merge to resolve `perf-changelog.yaml`) caused the merge-to-main run to fail with `Reusable source run X is not associated with PR #N` even when the run's commit was still part of the PR.
- Add `pr_commit_shas(repo, pr_number, token)` and require the run's `head_sha` to appear in that set.

## Reproduction
[Run 25780315195 / job 75721286155](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25780315195/job/75721286155):
- PR #1321 head = `5c7d7df8…` (final), `e36afac4…` (run's head, now older)
- Pinned source run `25763404168` was for `e36afac4…`
- `gh api repos/SemiAnalysisAI/InferenceX/actions/runs/25763404168 --jq .pull_requests` → `[]`
- Old check rejected; new check passes because `e36afac4…` is in `/pulls/1321/commits`.

## Validation
- `python3 -m pytest utils/test_find_reusable_sweep_run.py -q` (10 passed; includes a new regression test for this exact scenario plus an "orphaned commit" rejection test).
- `python3 -m py_compile utils/find_reusable_sweep_run.py`