### PR TITLE
No-arg /reuse-sweep-run matches any commit on the PR

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2367,3 +2367,9 @@
   description:
     - "Update SGLang image from v0.5.10.post1 to v0.5.11"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1347
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-mtp
+  description:
+    - "Rerun update SGLang image from v0.5.10.post1 to v0.5.11"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1347

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -153,13 +153,20 @@ def find_reuse_authorization(
     return False, None
 
 
-def find_latest_successful_run(
+def find_latest_successful_pr_run(
     repo: str,
     workflow_id: str,
-    head_sha: str,
+    head_branch: str,
+    valid_shas: set[str],
     token: str,
 ) -> dict[str, Any] | None:
-    """Return the latest successful PR sweep run for the given head SHA."""
+    """Latest successful PR sweep run whose head_sha is in ``valid_shas``.
+
+    Filters by branch (rather than head SHA) so that runs for earlier commits
+    on the PR remain discoverable after an additional commit lands on it.
+    """
+    if not head_branch or not valid_shas:
+        return None
     encoded_workflow = urllib.parse.quote(workflow_id, safe="")
     runs = paginated_github_api(
         repo,
@@ -168,12 +175,15 @@ def find_latest_successful_run(
         "workflow_runs",
         {
             "event": "pull_request",
-            "head_sha": head_sha,
+            "branch": head_branch,
             "status": "completed",
         },
     )
+    # GitHub returns runs newest-first.
     for run in runs:
-        if run.get("conclusion") == "success" and run.get("head_sha") == head_sha:
+        if run.get("conclusion") != "success":
+            continue
+        if str(run.get("head_sha") or "") in valid_shas:
             return run
     return None
 
@@ -357,17 +367,24 @@ def main() -> int:
         run = github_api(args.repo, f"/actions/runs/{pinned_run_id}", token)
         reason = f"PR #{pr_number} approved reusable full sweep from pinned run {pinned_run_id}"
     else:
-        head_sha = str(pr.get("head", {}).get("sha") or "")
-        if not head_sha:
-            raise RuntimeError(f"PR #{pr_number} has no head SHA.")
-        run = find_latest_successful_run(args.repo, args.workflow_id, head_sha, token)
+        head_branch = str(pr.get("head", {}).get("ref") or "")
+        pr_shas = pr_commit_shas(args.repo, pr_number, token)
+        if not pr_shas:
+            raise RuntimeError(f"PR #{pr_number} has no commits.")
+        run = find_latest_successful_pr_run(
+            args.repo, args.workflow_id, head_branch, pr_shas, token
+        )
         if not run:
             raise RuntimeError(
                 f"PR #{pr_number} has {args.pinned_run_command} authorization but no "
-                f"successful {args.workflow_id} pull_request run was found for {head_sha}; "
-                f"pin a specific run with `{args.pinned_run_command} <run_id>`."
+                f"successful {args.workflow_id} pull_request run was found for any of "
+                f"its {len(pr_shas)} commit(s); pin a specific run with "
+                f"`{args.pinned_run_command} <run_id>`."
             )
-        reason = f"PR #{pr_number} approved reusable full sweep from latest run on {head_sha}"
+        reason = (
+            f"PR #{pr_number} approved reusable full sweep from latest run on "
+            f"{run.get('head_sha')}"
+        )
 
     run_id = int(run["id"])
     validate_reusable_run(args.repo, args.workflow_id, pr_number, run, token)

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -283,7 +283,7 @@ def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path
             return {
                 "merged_at": "2026-05-13T00:01:00Z",
                 "labels": [{"name": "full-sweep-enabled"}],
-                "head": {"sha": "abc123"},
+                "head": {"sha": "abc123", "ref": "feature-branch"},
             }
         raise AssertionError(f"unexpected GitHub API path: {path}")
 
@@ -293,7 +293,7 @@ def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path
         if path == "/pulls/1321/commits":
             return [{"sha": "abc123"}]
         if path == "/actions/workflows/run-sweep.yml/runs":
-            assert params["head_sha"] == "abc123"
+            assert params["branch"] == "feature-branch"
             return [run]
         if path == "/actions/runs/25763404168/artifacts":
             return [{"name": "results_bmk"}]
@@ -328,6 +328,92 @@ def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path
     assert outputs["reuse-source-run-id"] == "25763404168"
     assert outputs["reuse-source-pr-number"] == "1321"
     assert outputs["reuse-source-head-sha"] == "abc123"
+
+
+def test_main_no_arg_picks_run_for_older_pr_commit(monkeypatch, tmp_path) -> None:
+    """Regression: no-arg /reuse-sweep-run finds a run for an earlier PR commit.
+
+    After a sweep succeeds on commit A, an additional commit B can land on the
+    PR (e.g. a main merge to resolve perf-changelog.yaml). The current head is
+    now B; no sweep ever ran for B, but A's run is still reusable.
+    """
+    comments = [
+        {
+            "created_at": "2026-05-13T00:00:00Z",
+            "author_association": "OWNER",
+            "body": "/reuse-sweep-run",
+        },
+    ]
+    older_run = {
+        "id": 25763466401,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "path": ".github/workflows/run-sweep.yml",
+        "pull_requests": [],
+        "run_attempt": 1,
+        "html_url": "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25763466401",
+        "head_sha": "f6b43f745a7df3653d677b30372b05d3bec6f153",
+    }
+
+    def fake_github_api(repo, path, token, params=None):
+        if path == "/commits/merge-sha/pulls":
+            return [{"number": 1347}]
+        if path == "/pulls/1347":
+            return {
+                "merged_at": "2026-05-13T00:01:00Z",
+                "labels": [{"name": "full-sweep-enabled"}],
+                "head": {
+                    "sha": "f862cb8b126e2437ee793951919f40c23bba3a6f",
+                    "ref": "claude/issue-1154-qwen3.5-fp8-h200-sglang-mtp",
+                },
+            }
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        if path == "/issues/1347/comments":
+            return comments
+        if path == "/pulls/1347/commits":
+            return [
+                {"sha": "f6b43f745a7df3653d677b30372b05d3bec6f153"},
+                {"sha": "f862cb8b126e2437ee793951919f40c23bba3a6f"},
+            ]
+        if path == "/actions/workflows/run-sweep.yml/runs":
+            assert params["branch"] == "claude/issue-1154-qwen3.5-fp8-h200-sglang-mtp"
+            return [older_run]
+        if path == "/actions/runs/25763466401/artifacts":
+            return [{"name": "results_bmk"}]
+        raise AssertionError(f"unexpected paginated GitHub API path: {path}")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "github_api", fake_github_api)
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "merge-sha",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "true"
+    assert outputs["reuse-source-run-id"] == "25763466401"
+    assert outputs["reuse-source-pr-number"] == "1347"
+    assert outputs["reuse-source-head-sha"] == "f6b43f745a7df3653d677b30372b05d3bec6f153"
 
 
 def test_main_disables_reuse_without_pinned_comment(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Fix the no-arg `/reuse-sweep-run` lookup to accept a successful sweep run on **any** commit that's currently part of the PR, not just the PR's latest head SHA. Same root cause as #1366: after an extra commit lands on the PR (e.g. a `main` merge to resolve `perf-changelog.yaml`), `find_latest_successful_run` searched by the new head and missed the run that ran on the earlier commit.
- Replace `find_latest_successful_run(head_sha=…)` with `find_latest_successful_pr_run(head_branch=…, valid_shas=…)`. Filter workflow runs by branch, then take the newest successful run whose `head_sha` is in the PR's commit list (the same source-of-truth `validate_reusable_run` uses post-#1366).

## Reproduction
[Run 25780497720 on PR #1347](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25780315195/job/75721286155):
- PR #1347 head = `f862cb8b…`; PR commits = [`f6b43f74…`, `f862cb8b…`]
- Successful sweep run `25763466401` was for `f6b43f74…`
- Old lookup queried `?head_sha=f862cb8b…` → no match → "no successful run was found"
- New lookup queries `?branch=claude/issue-1154-…` and accepts any `head_sha` in PR commits → finds `25763466401`

## Audit
After this change, every place that consumes a SHA in `find_reusable_sweep_run.py` uses one of:
1. The PR's commit history via `pr_commit_shas` (no-arg lookup and `validate_reusable_run`), or
2. The source `run.head_sha` itself for downstream attribution.

No remaining code path compares the run's head against `pr.head.sha` or the dynamic `run.pull_requests` field. Remaining failure modes — force-pushed rebase that orphans the run's commit, or zero successful runs on any current PR commit — fail closed with explicit error messages that name the fix (`pin a specific run with /reuse-sweep-run <run_id>`).

## Validation
- `python3 -m pytest utils/test_find_reusable_sweep_run.py -q` (11 passed; includes new `test_main_no_arg_picks_run_for_older_pr_commit` mirroring PR #1347's exact SHAs)
- `python3 -m py_compile utils/find_reusable_sweep_run.py`