### PR TITLE
Cancel in-flight Run Sweep on PR merge

### DIFF
--- a/.github/workflows/cancel-sweep-on-merge.yml
+++ b/.github/workflows/cancel-sweep-on-merge.yml
@@ -1,0 +1,36 @@
+name: "Cancel Sweep on PR Merge"
+
+on:
+    pull_request:
+        types: [closed]
+        paths:
+            - "perf-changelog.yaml"
+
+jobs:
+    cancel-sweep:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+        steps:
+            - name: Cancel in-flight Run Sweep runs for this PR's branch
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  BRANCH: ${{ github.event.pull_request.head.ref }}
+              run: |
+                  set -euo pipefail
+                  cancelled=0
+                  for status in in_progress queued waiting; do
+                      ids=$(gh api "repos/${REPO}/actions/workflows/run-sweep.yml/runs" \
+                          -f "event=pull_request" \
+                          -f "branch=${BRANCH}" \
+                          -f "status=${status}" \
+                          --jq '.workflow_runs[].id')
+                      for run_id in $ids; do
+                          echo "Cancelling ${status} run ${run_id}"
+                          gh run cancel "${run_id}" --repo "${REPO}" || true
+                          cancelled=$((cancelled + 1))
+                      done
+                  done
+                  echo "Cancelled ${cancelled} sweep run(s) for branch ${BRANCH}."


### PR DESCRIPTION
## Summary
- Add `.github/workflows/cancel-sweep-on-merge.yml` that fires on `pull_request: closed` (merged=true) for PRs touching `perf-changelog.yaml`, and uses `gh run cancel` to terminate any in-flight (`in_progress`, `queued`, `waiting`) `run-sweep.yml` runs on the PR's head branch.
- Self-contained workflow, no edits to the existing concurrency expression on `run-sweep.yml`.

## Reproduction
[Run 25781240028](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25781240028): PR #1330 merged at 05:56:01Z; the `pull_request` sweep that started 8 seconds earlier kept running on PR-allocated runners until cancelled manually. This workflow auto-cancels that case.

## Notes
- Scoped to `paths: [perf-changelog.yaml]` to match `run-sweep.yml`'s own trigger filter.
- Uses `github.token` with `permissions: actions: write`; no PAT needed.
- Only fires on merged closes — abandoning a PR without merging leaves the sweep alone (it'll finish or hit its own timeout).