### PR TITLE
Remove --disable-log-requests from vLLM benchmark scripts

### DIFF
--- a/benchmarks/single_node/gptoss_fp4_b200.sh
+++ b/benchmarks/single_node/gptoss_fp4_b200.sh
@@ -58,8 +58,7 @@ vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --config config.yaml \
 --gpu-memory-utilization 0.9 \
 --tensor-parallel-size $TP \
---max-num-seqs 512 \
---disable-log-requests > $SERVER_LOG 2>&1 &
+--max-num-seqs 512 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/kimik2.5_int4_b200.sh
+++ b/benchmarks/single_node/kimik2.5_int4_b200.sh
@@ -43,7 +43,6 @@ vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --tool-call-parser kimi_k2 \
 --compilation_config.pass_config.fuse_allreduce_rms true \
 --trust-remote-code \
---disable-log-requests \
 --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/kimik2.5_int4_h200.sh
+++ b/benchmarks/single_node/kimik2.5_int4_h200.sh
@@ -45,8 +45,7 @@ vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --tool-call-parser kimi_k2 \
 --compilation_config.pass_config.fuse_allreduce_rms true \
 --trust-remote-code \
---no-enable-prefix-caching \
---disable-log-requests > $SERVER_LOG 2>&1 &
+--no-enable-prefix-caching > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/minimaxm2.5_fp8_mi300x.sh
+++ b/benchmarks/single_node/minimaxm2.5_fp8_mi300x.sh
@@ -41,7 +41,6 @@ vllm serve $MODEL --port $PORT \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size=32 \
---disable-log-requests \
 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 


### PR DESCRIPTION
## Summary
- Newer vLLM releases removed `--disable-log-requests` (request logging is now off by default; opt in with `--enable-log-requests`). Passing the old flag fails immediately with `vllm: error: unrecognized arguments: --disable-log-requests` ([example CI failure](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25763443921/job/75670395630)).
- Drops the flag from the four remaining single-node benchmark scripts: `gptoss_fp4_b200.sh`, `kimik2.5_int4_b200.sh`, `kimik2.5_int4_h200.sh`, `minimaxm2.5_fp8_mi300x.sh`.
- Behavior matches the prior intent — logging stays off, no opt-in added.

## Test plan
- [ ] Re-run the failing benchmark job(s) and confirm `vllm serve` starts without the argparse error.
- [ ] Spot-check server logs to confirm per-request logging is not emitted.

## Out of scope
- `perf-changelog.yaml` mentions of the flag are historical PR descriptions — left untouched.
- `utils/bench_serving/benchmark_serving.py` docstring still references the flag; it is vendored upstream vLLM code, left to avoid future merge conflicts.