### PR TITLE
benchmark_serving: fail run when request failure rate exceeds 5%

### DIFF
--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -900,6 +900,16 @@ def main(args: argparse.Namespace):
             json.dump(result_json, outfile)
         save_to_pytorch_benchmark_format(args, result_json, file_name)
 
+    max_failure_rate = 0.05
+    completed = benchmark_result["completed"]
+    failure_rate = 1 - completed / args.num_prompts
+    if failure_rate > max_failure_rate:
+        raise SystemExit(
+            f"FAIL: request failure rate {failure_rate:.1%} exceeds "
+            f"{max_failure_rate:.0%} threshold "
+            f"({completed}/{args.num_prompts} completed)"
+        )
+
 
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(


### PR DESCRIPTION
## Summary
- Add a hardcoded 5% per-request failure-rate gate in `utils/bench_serving/benchmark_serving.py`. After the benchmark finishes and the result JSON is written, the script computes `failure_rate = 1 - completed / num_prompts` and `raise SystemExit(...)` if it exceeds 5%.
- Placed after the result-file write and `save_to_pytorch_benchmark_format` so the artifact still uploads when the gate fires — failed runs remain debuggable.
- No new CLI argument; the threshold is fixed at 5%.

## Why
Today the only failure signal that survives to the run level is `calc_success_rate.py`, which rolls up GitHub Actions job conclusions. A benchmark that quietly fails a chunk of requests still reports SUCCESS because `benchmark_serving.py` only warns when 100% of requests fail. This gate forces the job to fail when partial failures cross 5%.

## Test plan
- [ ] Trigger a sweep that produces a healthy run; verify job still succeeds and result JSON is uploaded as before.
- [ ] Trigger (or simulate) a run with >5% request failures; verify the job fails after the artifact is uploaded and the SystemExit message reports the rate.