### PR TITLE
Misc touchups

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -221,27 +221,7 @@ jobs:
 
             ## Updating perf-changelog.yaml
 
-            When making changes to benchmark scripts or master config files that affect image tags, environment variables, or configuration parameters, you MUST add an entry to `perf-changelog.yaml`.
-
-            **When to update perf-changelog.yaml:**
-            - Updating image tags in `.github/configs/*-master.yaml` or `benchmarks/*.sh` scripts
-            - Adding or modifying environment variables in benchmark configurations
-            - Changing configuration parameters that affect performance
-
-            **Entry format:**
-            ```yaml
-            - config-keys:
-                - dsr1-fp8-*-vllm  # Use wildcards to match multiple configs
-              description:
-                - "Update vLLM image from v0.11.2 to v0.13.0"
-                - "Add VLLM_MXFP4_USE_MARLIN=1 environment variable"
-              pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-            ```
-
-            **Guidelines:**
-            - Use wildcards (`*`) in config-keys to match multiple related configurations
-            - Each description item should be a concise change summary
-            - The pr-link should reference the PR number (use XXX as placeholder until PR is created)
+            See `AGENTS.md` → "Updating Docker Images" for entry format and rules. Required whenever you change image tags, env vars, or perf-affecting params in `.github/configs/*-master.yaml` or `benchmarks/*.sh`. Use `XXX` as the PR-link placeholder until the PR exists.
 
             ## Spawning Additional Workers:
             You CAN spawn additional Claude workers by commenting "@claude" with a specific task.
@@ -272,8 +252,7 @@ jobs:
 
             ### Additional Knowledge
             - MI355 is gfx950 not gfx1201
-            - **STP (Single Token Prediction)**: Standard autoregressive decoding — one token per forward pass. No speculative decoding or MTP. Benchmarks labeled "STP only" use vanilla decoding.
-            - **MTP (Multi-Token Prediction)**: Predicts multiple tokens per forward pass using speculative decoding (e.g., EAGLE, NEXTN).
+            - STP/MTP terminology: see `AGENTS.md` → "Terminology"
 
             ### Expert Parallelism in Benchmark Scripts
             vLLM and SGLang handle expert parallelism differently. When writing or reviewing benchmark scripts for MoE models:

--- a/.github/workflows/docker-tag-monitor.yml
+++ b/.github/workflows/docker-tag-monitor.yml
@@ -1,6 +1,14 @@
 name: Docker Tag Monitor
 
-# trigger: re-run after token/allowed_bots fix
+# Downstream merge note (human-only — intentionally NOT in the @claude prompt):
+#   Once the per-config-key PRs this workflow asks Claude to open have a
+#   green run-sweep.yml run and the `full-sweep-enabled` label, merge them
+#   with `utils/merge_with_reuse.sh <pr-number>` instead of the GitHub UI.
+#   That script posts /reuse-sweep-run, auto-resolves perf-changelog.yaml
+#   conflicts, cancels the merge-triggered sweep, and squash-merges with
+#   --admin so the post-merge run-sweep run reuses the PR's prior sweep.
+#   Claude doesn't have admin merge rights and shouldn't be told about this
+#   path — it's a maintainer-only finalization step.
 
 on:
   schedule:
@@ -207,29 +215,29 @@ jobs:
             echo "2. Add entries to \`perf-changelog.yaml\` documenting the version changes"
             echo "3. For each eligible config-key, push a branch and actually open a PR — do not stop at the \"Create a pull request for ...\" remote hint that \`git push\` prints. Run \`gh pr create\` (or the equivalent MCP tool) and verify the returned PR URL. Link every PR back to this issue in a comment."
             echo ""
-            echo "**PR title / commit message formatting:** Multi-line titles and bodies MUST use a heredoc, not \`\\n\` escapes and not \`\$'...'\` ANSI-C quoting. Last run produced commits literally starting with \`\$\` and containing \`\\n\\n\` as text because of mis-quoted ANSI-C strings. Use this pattern instead:"
+            echo "**Required PR label:** Every PR you open from this issue MUST carry the \`full-sweep-enabled\` label. Apply it at creation time via \`gh pr create --label full-sweep-enabled\` (or add it immediately after with \`gh pr edit <num> --add-label full-sweep-enabled\`). Do not skip this — downstream automation keys off the label."
+            echo ""
+            echo "**PR title / commit message formatting:** Multi-line titles and bodies MUST use a heredoc, not \`\\n\` escapes and not \`\$'...'\` ANSI-C quoting. A prior run produced commits literally starting with \`\$\` and containing \`\\n\\n\` as text because of mis-quoted ANSI-C strings. Use this pattern instead:"
             echo ""
             echo "\`\`\`bash"
             echo "git commit -m \"\$(cat <<'EOF'"
             echo "Update qwen3.5-bf16-b300-sglang-mtp SGLang image to v0.5.11-cu130"
             echo ""
-            echo "Ref #${ISSUE_NUMBER}"
+            echo "Ref #<this issue's number>"
             echo "EOF"
             echo ")\""
             echo ""
             echo "gh pr create --title \"Update qwen3.5-bf16-b300-sglang-mtp SGLang image to v0.5.11-cu130\" \\"
             echo "  --label full-sweep-enabled \\"
             echo "  --body \"\$(cat <<'EOF'"
-            echo "Updates the SGLang image tag for \\\`qwen3.5-bf16-b300-sglang-mtp\\\` to v0.5.11-cu130."
+            echo "Updates the SGLang image tag for \`qwen3.5-bf16-b300-sglang-mtp\` to v0.5.11-cu130."
             echo ""
-            echo "Ref #${ISSUE_NUMBER}"
+            echo "Ref #<this issue's number>"
             echo "EOF"
             echo ")\""
             echo "\`\`\`"
             echo ""
-            echo "PR titles must be a single line (no newlines). Bodies are multi-line and must contain real \\\\n, not the literal characters \`\\\\n\`. Never put \`\$\` in front of a quoted message string."
-            echo ""
-            echo "**Required PR label:** Every PR you open from this issue MUST carry the \`full-sweep-enabled\` label. Apply it at creation time via \`gh pr create --label full-sweep-enabled\` (or add it immediately after with \`gh pr edit <num> --add-label full-sweep-enabled\`). Do not skip this — downstream automation keys off the label."
+            echo "PR titles must be a single line (no newlines). Bodies should contain real newlines (use a heredoc), not the literal characters \`\\n\`. Never put \`\$\` in front of a quoted message string."
             echo ""
             echo "**Runner gating:** Only open PRs for config-keys whose runner SKU is in the allowed list (\`$ALLOWED_SKUS\`). The runner SKU is the hardware segment in the config-key (e.g. \`dsr1-fp4-b200-sglang\` → \`b200\`). For any config-key whose SKU is not in the allowed list, skip it and list the skipped keys plus the reason (not clear / all-offline / no idle capacity) in a single comment on this issue."
             echo ""
@@ -243,18 +251,7 @@ jobs:
             echo ""
             echo "**Exception — MTP pairs:** When a config-key and its \`-mtp\` sibling exist for the same model/precision/runner/framework (e.g. \`qwen3.5-fp4-b300-sglang\` and \`qwen3.5-fp4-b300-sglang-mtp\`), bundle both into one PR. Treat the pair as a single unit for the per-SKU cap (counts as 1, not 2) and the sequential e2e queue. If only one side of the pair is present in the updates, open a PR for just that one."
             echo ""
-            echo "For each eligible config-key, check if there are multiple CUDA/ROCm versions available and choose appropriately based on current usage patterns in the configs."
-            echo ""
-            echo "**Slack ping when done:** After all PRs have been opened, all e2e runs have reached a terminal state, and the wrap-up comment with any deferred config-keys has been posted, send a single summary message to Slack channel \`C09PULGMVNG\` via the Bash tool. The \`SLACK_BOT_TOKEN\` env var is available. Use:"
-            echo ""
-            echo "\`\`\`bash"
-            echo "curl -sS -X POST https://slack.com/api/chat.postMessage \\"
-            echo "  -H \"Authorization: Bearer \$SLACK_BOT_TOKEN\" \\"
-            echo "  -H \"Content-Type: application/json; charset=utf-8\" \\"
-            echo "  --data \"\$(jq -n --arg ch C09PULGMVNG --arg t \"<text>\" '{channel: \$ch, text: \$t}')\""
-            echo "\`\`\`"
-            echo ""
-            echo "Message text should include: this issue link, count of PRs opened (per SKU), count of e2e runs passed/failed, list of skipped or deferred config-keys, and link to this workflow run. Send exactly one Slack message — do not post per-SKU or per-PR."
+            echo "If Docker Hub lists multiple variants for the same base version (e.g. \`cu128\` vs \`cu130\`, \`rocm70\` vs \`rocm72\`), pick the variant whose suffix matches what the config-key's current image entry already uses — don't switch CUDA/ROCm minor versions in this update."
           } > "$BODY_FILE"
 
           rm -f "$RUNNERS_TABLE" "$ALLOWED_SKUS_FILE" /tmp/ci.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,33 @@
 # AGENT.md
 
-This file provides guidance for AI agents working with the InferenceX codebase.
+Guidance for AI agents working with InferenceX.
 
 ## Project Overview
 
-InferenceX is an open-source, automated benchmarking system that continuously tracks LLM inference performance across different hardware platforms (NVIDIA B200/H100/H200/GB200, AMD MI300X/MI325X/MI355X) and software stacks (vLLM, SGLang, TensorRT-LLM, ATOM). Results are published to https://inferencex.com/.
+InferenceX is an open-source automated benchmarking system that tracks LLM inference performance across hardware (NVIDIA B200/H100/H200/GB200, AMD MI300X/MI325X/MI355X) and software stacks (vLLM, SGLang, TensorRT-LLM, ATOM). Results published to https://inferencex.com/.
 
 ## Directory Structure
 
-Top-level layout (run `ls` for details):
+Run `ls` for details. Key paths:
 
-- `perf-changelog.yaml` — benchmark trigger log; append-only; preserve whitespace
-- `benchmarks/` — `benchmark_lib.sh` shared helpers; `single_node/` and `multi_node/` entrypoints (per model/precision/hardware/framework `.sh` scripts); `*_mtp.sh` for MTP/spec-decoding; `multi_node/srt-slurm-recipes/` checked-in external recipe YAMLs
-- `runners/` — hardware launcher scripts
-- `utils/matrix_logic/` — `generate_sweep_configs.py` CLI, `validation.py` Pydantic schemas, tests
-- `utils/bench_serving/` — `benchmark_serving.py` serving client and backends
-- `utils/evals/` — lm-eval task configs, thresholds, `validate_scores.py` (see `EVALS.md`)
-- `utils/` (top level) — `process_result.py`, `process_changelog.py` (incl. `trim_conc`), `summarize.py`, `collect_*.py`, `compare_results.py`
-- `experimental/` — non-core experiments
+- `perf-changelog.yaml` - benchmark trigger log; append-only; preserve whitespace.
+- `benchmarks/` - `benchmark_lib.sh` (shared helpers); `single_node/` and `multi_node/` entrypoints; `*_mtp.sh` for MTP/spec-decoding; `multi_node/srt-slurm-recipes/` checked-in external recipe YAMLs.
+- `runners/` - hardware launcher scripts.
+- `utils/matrix_logic/` - `generate_sweep_configs.py`, `validation.py` Pydantic schemas, tests.
+- `utils/bench_serving/` - `benchmark_serving.py` and backends.
+- `utils/evals/` - lm-eval task configs, thresholds, `validate_scores.py` (see `EVALS.md`).
+- `utils/` - `process_result.py`, `process_changelog.py` (incl. `trim_conc`), `summarize.py`, `collect_*.py`, `compare_results.py`.
+- `experimental/` - non-core experiments.
 
 ## Terminology
 
-- **STP (Single Token Prediction)**: Standard autoregressive decoding where one token is generated per forward pass. No speculative decoding or MTP (Multi-Token Prediction) is used. When a benchmark is labeled "STP only", it means vanilla decoding without any speculation.
-- **MTP (Multi-Token Prediction)**: A technique where the model predicts multiple tokens per forward pass, typically using speculative decoding methods like EAGLE or NEXTN.
+STP (Single Token Prediction): vanilla autoregressive decoding, one token per forward pass, no speculative decoding. MTP (Multi-Token Prediction): predicts multiple tokens per forward pass via speculative decoding (EAGLE, NEXTN, etc.).
 
 ## Development Workflow
 
-### Running Tests
+Tests: `python -m pytest utils/matrix_logic/ -v` (markers: `slow`, `integration`).
 
-```bash
-python -m pytest utils/matrix_logic/ -v
-```
-
-Markers: `slow`, `integration`.
-
-### Generating Benchmark Configs
+Generate configs:
 
 ```bash
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
@@ -45,76 +38,37 @@ python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   [--runner-type b200|h100|h200|gb200|...]
 ```
 
-### Processing Results
-
-```bash
-python utils/process_result.py
-python utils/summarize.py
-```
+Process results: `python utils/process_result.py && python utils/summarize.py`.
 
 ## Supported Configuration Values
 
-When working with benchmark configurations, use these valid values:
-
-**Frameworks**:
-- `sglang` - SGLang inference engine
-- `trt` - TensorRT-LLM
-- `vllm` - vLLM inference engine
-- `atom` - AMD ATOM framework
-- `dynamo-trt` - NVIDIA Dynamo with TensorRT-LLM backend
-- `dynamo-sglang` - NVIDIA Dynamo with SGLang backend
-- `sglang-disagg` - SGLang disaggregated inference
-
-**Sequence Lengths (ISL/OSL)**:
-- `1k1k` - 1024 input / 1024 output
-- `8k1k` - 8192 input / 1024 output
+Frameworks: `sglang`, `trt`, `vllm`, `atom`, `dynamo-trt`, `dynamo-sglang`, `sglang-disagg`.
+Sequence lengths (ISL/OSL): `1k1k` (1024/1024), `8k1k` (8192/1024).
 
 ## Code Conventions
 
-### Python
+Python: type hints (`list[str]`, `Optional[int]`), Pydantic with `extra='forbid'`, field aliases `Field(alias="model-prefix")`, docstrings on functions.
 
-- Use type hints: `list[str]`, `dict`, `Optional[int]`
-- Pydantic models for validation with `extra='forbid'`
-- Field aliases for YAML compatibility: `Field(alias="model-prefix")`
-- Docstrings for functions
+YAML: kebab-case field names (`model-prefix`, `conc-start`, `dp-attn`). Master configs define all benchmark configurations. `perf-changelog.yaml` triggers which configs to benchmark and is read chronologically (oldest at top, newest at bottom) - new entries MUST be appended to the END, never inserted in the middle or prepended.
 
-### YAML
+Bash: source shared utilities via `source benchmark_lib.sh` (`check_env_vars`, `wait_for_server_ready`, `run_benchmark_serving`, `run_eval`, `append_lm_eval_summary`); parameters passed via env vars. **MTP scripts MUST pass `--use-chat-template` to `run_benchmark_serving`** - EAGLE-style spec decoding is trained against chat-formatted inputs; benchmarking against raw prompts silently regresses acceptance rate. Applies to every `*_mtp.sh`.
 
-- Kebab-case for field names: `model-prefix`, `conc-start`, `dp-attn`
-- Master configs define all benchmark configurations
-- `perf-changelog.yaml` triggers which configs to benchmark
-  - **The file is read in chronological order: oldest at the top, newest at the bottom. New entries MUST be appended to the END of the file — never insert in the middle or prepend.**
-
-### Bash
-
-- Source shared utilities: `source benchmark_lib.sh`
-- Functions: `check_env_vars()`, `wait_for_server_ready()`, `run_benchmark_serving()`, `run_eval()`, `append_lm_eval_summary()`
-- Parameters passed via environment variables
-- **MTP scripts MUST pass `--use-chat-template` to `run_benchmark_serving` — no exceptions.** EAGLE-style speculative decoding is trained against chat-formatted inputs, so benchmarking against raw prompts silently regresses acceptance rate and produces misleading numbers. This applies to every `*_mtp.sh` script regardless of model, precision, or runner.
-
-### Git
-
-- Conventional commit messages
-- Use `[skip-sweep]` in commit message to skip benchmarks (push-to-main only)
-- Changes to `perf-changelog.yaml` trigger benchmark runs
+Git: conventional commit messages. `[skip-sweep]` in commit message skips benchmarks (push-to-main only). Changes to `perf-changelog.yaml` trigger benchmark runs.
 
 ### Pull Request Sweep Labels
 
-PRs do **not** run the sweep automatically — `run-sweep.yml` is gated on a label. Pick exactly one of the two; setting both is rejected by the workflow.
+PRs do not run the sweep automatically - `run-sweep.yml` is gated on a label. Pick exactly one; setting both is rejected by the workflow's `setup` job.
 
-`sweep-enabled` - Runs the sweep with `--trim-conc`: each parallelism config is reduced to its single highest configured concurrency point. Default for most PRs — validates the change runs end-to-end without consuming the full cluster.
-`full-sweep-enabled` - Runs the full intermediate concurrency sweep, identical to a push-to-main run. Use when intermediate concurrency points actually matter for the PR (e.g., a recipe change expected to shift the throughput/latency curve, not just its endpoints).
+- `sweep-enabled` - runs the sweep with `--trim-conc` (each parallelism config reduced to its single highest concurrency). Default for most PRs.
+- `full-sweep-enabled` - runs the full intermediate concurrency sweep, identical to push-to-main. Use when intermediate points matter (e.g. a recipe change shifts the throughput/latency curve, not just its endpoints).
 
-Notes:
-- The two labels are mutually exclusive — `run-sweep.yml`'s `setup` job fails fast with an explicit error if both are present.
-- Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message; the trim only applies to PR runs that opt in via `sweep-enabled`.
-- The trimming logic lives in `trim_conc()` in `utils/process_changelog.py` — single-node entries are grouped by every non-`conc` field and only the highest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[max(conc)]`.
+Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the highest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[max(conc)]`.
 
 ## Common Tasks
 
 ### Dispatching jobs
 
-Sweeps and one-off runs are dispatched against `.github/workflows/e2e-tests.yml` (the `workflow_dispatch` entrypoint). `run-sweep.yml` is push/PR-triggered and is not dispatchable.
+Sweeps and one-offs dispatch against `.github/workflows/e2e-tests.yml` (`workflow_dispatch`). `run-sweep.yml` is push/PR-triggered, not dispatchable.
 
 ```bash
 gh api -X POST \
@@ -126,139 +80,87 @@ gh api -X POST \
   -f 'inputs[duration-override]='
 ```
 
-Inputs:
+Inputs: top-level `ref` (required) is the workflow ref to dispatch from, almost always `main`. `inputs[ref]` is the repo ref under test (defaults to the dispatch ref's `github.sha`). `inputs[generate-cli-command]` (required) is passed verbatim to `generate_sweep_configs.py` - test locally first. `inputs[test-name]` is the display name in the Actions UI. `inputs[duration-override]` overrides per-config duration (seconds); empty = use matrix value.
 
-| Input | Required | Meaning |
-|---|---|---|
-| `ref` (top-level, no `inputs[...]`) | yes | Workflow ref to dispatch *from*. Almost always `main` unless you're testing a workflow change. |
-| `inputs[ref]` | no | Repo ref the matrix-generation job checks out (the branch/SHA under test). Defaults to `github.sha` of the dispatch ref. |
-| `inputs[generate-cli-command]` | yes | Args passed verbatim to `utils/matrix_logic/generate_sweep_configs.py`. Test locally first by running that command. |
-| `inputs[test-name]` | no | Display name in the Actions UI / `run-name`. |
-| `inputs[duration-override]` | no | Override per-config `duration` (seconds). Empty string = use matrix value. |
-
-The POST returns no body and no run ID. Find the run you just dispatched with the next section.
+The POST returns no body and no run ID - find the run with `gh run list` below.
 
 ### Monitoring jobs
 
 ```bash
-# 1. Find the run you just dispatched (most recent workflow_dispatch on e2e-tests.yml)
-gh run list --repo SemiAnalysisAI/InferenceX --workflow e2e-tests.yml \
-  --event workflow_dispatch --limit 5
-# Capture the ID of the run you just dispatched:
 RUN_ID=$(gh run list --repo SemiAnalysisAI/InferenceX --workflow e2e-tests.yml \
   --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')
-
-# 2. Block until it finishes (non-zero exit if the run fails)
-gh run watch "$RUN_ID" --repo SemiAnalysisAI/InferenceX --exit-status
-
-# 3. Inspect jobs / failed logs
-gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX
-gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX --log-failed
-
-# 4. Cancel if needed
-gh run cancel "$RUN_ID" --repo SemiAnalysisAI/InferenceX
+gh run watch "$RUN_ID" --repo SemiAnalysisAI/InferenceX --exit-status   # block, non-zero on failure
+gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX --log-failed     # inspect failures
+gh run cancel "$RUN_ID" --repo SemiAnalysisAI/InferenceX                # cancel
 ```
 
-For result artifacts after a successful run, see "Fetching GitHub Actions Benchmark Results" below.
+Artifacts: see "Fetching GitHub Actions Benchmark Results" below.
 
-### Adding a New Benchmark Configuration
+### Adding a benchmark configuration
 
-1. Add entry to `.github/configs/nvidia-master.yaml` or `amd-master.yaml`
-2. Add corresponding entry to `perf-changelog.yaml` to trigger benchmark
-3. Run validation: `python utils/matrix_logic/generate_sweep_configs.py full-sweep ...`
+Add entry to `.github/configs/nvidia-master.yaml` or `amd-master.yaml`, append to `perf-changelog.yaml`, validate with `generate_sweep_configs.py full-sweep`.
 
-### Adding a New Runner
+### Adding a runner
 
-1. Add runner to `.github/configs/runners.yaml`
-2. Create launcher script in `runners/` directory
-3. Update relevant master config with new runner type
+Add to `.github/configs/runners.yaml`, create launcher in `runners/`, add the runner type to the relevant master config.
 
-### Registering Recipes from srtslurm
+### Registering recipes from srtslurm
 
 For `dynamo-sglang` / `dynamo-trt` disaggregated multi-node configs, see `benchmarks/multi_node/srt-slurm-recipes/RECIPES.md` for the full mapping from srtslurm recipe YAML to `nvidia-master.yaml` entries.
 
-### Updating Docker Images
+Multi-node srt-slurm changes must edit the recipe yaml AND `nvidia-master.yaml` together. `srtctl` reads only the recipe (`model.container`, resources, prefill/decode workers); the sweep generator (`utils/matrix_logic/generate_sweep_configs.py`) reads `nvidia-master.yaml` for frontend labels - its prefill/decode numbers never reach `srtctl`. Recipe-only edits mislabel results, master-only edits don't take effect. For image bumps, `model.container` must equal `image:`, since the launcher uses the latter as the container-alias key.
 
-When upgrading Docker images in benchmark scripts and master configs .yaml:
+### Updating Docker images
 
-1. Update the image tag in the relevant `.github/configs/*-master.yaml` and/or `benchmarks/*.sh` script(s)
-2. Update any related environment variables or configuration parameters
-3. **MUST**: Add an entry to `perf-changelog.yaml`: for example:
-   ```yaml
-   - config-keys:
-       - dsr1-fp8-*-vllm  # Use wildcards to match multiple configs
-     description:
-       - "Update vLLM image from v0.11.2 to v0.13.0"
-       - "Add VLLM_MXFP4_USE_MARLIN=1 environment variable"
-     pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-   ```
-4. This triggers benchmarks for affected configs and tracks performance changes
+Update the image tag in the relevant `.github/configs/*-master.yaml` and/or `benchmarks/*.sh`, update any related env vars / config params, and append a `perf-changelog.yaml` entry (required - triggers benchmarks):
+
+```yaml
+- config-keys:
+    - dsr1-fp8-*-vllm  # wildcards match multiple configs
+  description:
+    - "Update vLLM image from v0.11.2 to v0.13.0"
+    - "Add VLLM_MXFP4_USE_MARLIN=1 environment variable"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+```
 
 ## Evals (Accuracy Validation)
 
-Optional accuracy checks that ensure inference optimizations do not degrade model outputs. See `utils/evals/EVALS.md` for the full reference.
+Optional accuracy checks ensuring inference optimizations do not degrade outputs. See `utils/evals/EVALS.md` for the full reference.
 
-Quick pointers:
-- Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals are marked by default on the 8k1k subset.
-- Eval workflow jobs run separately from throughput jobs in eval-only mode (`EVAL_ONLY=true`).
-- Flags on `generate_sweep_configs.py full-sweep`: `--no-evals` to skip, `--evals-only` for the eval subset only.
-- Aggregated eval output is produced by `utils/collect_eval_results.py`.
+Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals run by default on the 8k1k subset. Workflow jobs run separately from throughput jobs in `EVAL_ONLY=true` mode. Flags on `generate_sweep_configs.py full-sweep`: `--no-evals` to skip, `--evals-only` for the eval subset only. Aggregated output produced by `utils/collect_eval_results.py`.
 
-## Key Files to Understand
+## Key Files
 
-- `utils/matrix_logic/validation.py` - Defines all configuration schemas
-- `utils/matrix_logic/generate_sweep_configs.py` - Config generation logic
-- `utils/bench_serving/benchmark_serving.py` - Benchmark client for measuring serving performance
-- `.github/configs/nvidia-master.yaml` - NVIDIA benchmark definitions
-- `.github/workflows/run-sweep.yml` - Main CI/CD workflow
-- `.github/workflows/collect-evals.yml` - Eval results collection workflow
-- `benchmarks/benchmark_lib.sh` - Shared benchmark/eval utilities
-- `utils/evals/` - Eval task definitions (`gsm8k.yaml`, `gpqa_diamond.yaml`)
-- `utils/collect_eval_results.py` - Aggregates eval results into JSON/table
+`utils/matrix_logic/validation.py` (config schemas), `generate_sweep_configs.py` (config generation), `utils/bench_serving/benchmark_serving.py` (benchmark client), `.github/configs/nvidia-master.yaml` (NVIDIA benchmark definitions), `.github/workflows/run-sweep.yml` (main CI/CD), `.github/workflows/collect-evals.yml` (eval collection), `benchmarks/benchmark_lib.sh` (shared utilities), `utils/evals/` (eval task definitions), `utils/collect_eval_results.py` (aggregator).
 
 ## Important Notes
-1. Make sure no new directories are created in `/workspace` during the benchmark. Files are ok.
-2. **Never delete or modify whitespace in `perf-changelog.yaml`** — the CI pipeline depends on the exact whitespace (including trailing spaces on blank separator lines). Removing or altering whitespace will break CI and cause pipeline crashes.
+
+- No new directories in `/workspace` during a benchmark (files are fine).
+- **Never delete or modify whitespace in `perf-changelog.yaml`** - CI depends on exact whitespace (including trailing spaces on blank separator lines). Altering it breaks CI.
 
 ## Fetching GitHub Actions Benchmark Results
 
-When asked to analyze benchmark results from a GitHub Actions run:
 ```bash
-# List artifacts for a run
 gh api /repos/SemiAnalysisAI/InferenceX/actions/runs/<RUN_ID>/artifacts --jq '.artifacts[].name'
-
-# Download aggregated results
 gh run download <RUN_ID> --repo SemiAnalysisAI/InferenceX -n results_bmk -D ./results
 ```
-### Parsing Results (IMPORTANT: avoid dumping raw JSON)
 
-The results JSON is large with many decimals — never `cat` it raw. Use `jq` to extract and round:
+### Parsing results (don't dump raw JSON)
+
+`agg_bmk.json` is large with many decimals - never `cat` raw. Use `jq` to extract and round:
 
 ```bash
-# Summary table: hw, model, isl/osl, throughput (rounded)
 cat ./results/agg_bmk.json | jq -r '
   .[] | [.hw, .infmax_model_prefix, "\(.isl)/\(.osl)", (.tput_per_gpu | round)]
   | @tsv' | column -t
 
-# Filter to a specific model
 cat ./results/agg_bmk.json | jq '[.[] | select(.infmax_model_prefix == "gptoss")]'
 ```
 
-### Key Metrics
+### Key metrics
 
-| Field | Description |
-|-------|-------------|
-| `tput_per_gpu` | Total throughput per GPU (tokens/sec) |
-| `output_tput_per_gpu` | Output token throughput |
-| `mean_ttft` / `p99_ttft` | Time to first token |
-| `mean_tpot` | Time per output token |
-| `mean_e2el` | End-to-end latency |
+`tput_per_gpu` (total throughput per GPU, tok/s), `output_tput_per_gpu` (output token throughput), `mean_ttft` / `p99_ttft` (time to first token), `mean_tpot` (time per output token), `mean_e2el` (end-to-end latency).
 
-### Artifact Naming
+### Artifacts
 
-| Pattern | Contents |
-|---------|----------|
-| `results_bmk` | Aggregated benchmark results, `agg_bmk.json` |
-| `results_all` | All results aggregated , might not exist |
-| `eval_results_all` | Eval results, `agg_eval_all.json`, might not exist |
-| `run-stats` | `run_stats.json`, run stats, which nodes were ran and succeeded |
+`results_bmk` → `agg_bmk.json` (aggregated). `results_all` → all results aggregated (may not exist). `eval_results_all` → `agg_eval_all.json` (may not exist). `run-stats` → `run_stats.json` (which nodes ran and succeeded).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,117 +8,41 @@ InferenceX is an open-source, automated benchmarking system that continuously tr
 
 ## Directory Structure
 
-```
-.
-├─AGENTS.md                         # agent instructions
-├─perf-changelog.yaml               # benchmark trigger log; append-only; preserve whitespace
-├─benchmarks/
-│ ├─benchmark_lib.sh                # shared benchmark/eval/server helpers
-│ ├─single_node/                    # single-node benchmark entrypoints
-│ │ ├─agentic/                      # agentic benchmark scripts
-│ │ ├─chat_templates/               # model chat templates, e.g. DeepSeek-V4 thinking
-│ │ ├─*_mtp.sh                      # MTP/spec-decoding scripts
-│ │ └─*.sh                          # per model/precision/hardware/framework scripts
-│ └─multi_node/                     # multinode benchmark entrypoints
-│   ├─agentic_srt.sh
-│   ├─amd_utils/                    # AMD multinode Slurm/server/bench helpers
-│   │ ├─bench.sh
-│   │ ├─env.sh
-│   │ ├─job.slurm
-│   │ ├─models.yaml
-│   │ ├─server.sh
-│   │ ├─submit.sh
-│   │ └─sync.py
-│   ├─*_sglang-disagg.sh            # SGLang disaggregated multinode scripts
-│   ├─*_dynamo-trt.sh               # Dynamo/TensorRT multinode scripts
-│   └─srt-slurm-recipes/            # checked-in external recipe YAMLs
-│     ├─sglang/deepseek-v4/8k1k/
-│     └─vllm/deepseek-v4/8k1k/
-├─runners/                          # hardware launcher scripts
-├─utils/
-│ ├─matrix_logic/                   # benchmark matrix generation/validation/tests
-│ │ ├─generate_sweep_configs.py     # full-sweep/test-config CLI
-│ │ ├─validation.py                 # Pydantic schemas
-│ │ ├─test_generate_sweep_configs.py
-│ │ └─test_validation.py
-│ ├─bench_serving/                  # serving benchmark client
-│ │ ├─benchmark_serving.py
-│ │ ├─backend_request_func.py
-│ │ ├─benchmark_utils.py
-│ │ ├─encoding_dsv4.py
-│ │ └─KNOWN_LIMITATION.md
-│ ├─evals/                          # lm-eval task configs and score validation
-│ │ ├─EVALS.md
-│ │ ├─gsm8k.yaml
-│ │ ├─gpqa_diamond.yaml
-│ │ ├─thresholds.json
-│ │ ├─utils.py
-│ │ └─validate_scores.py
-│ ├─agentic-benchmark/              # agentic benchmark collection/analysis helpers
-│ ├─trace-replay/                   # trace replay utilities
-│ ├─constants.py
-│ ├─collect_results.py
-│ ├─collect_eval_results.py
-│ ├─compare_results.py
-│ ├─calc_success_rate.py
-│ ├─process_result.py               # benchmark aggregation/normalization
-│ ├─process_agentic_result.py
-│ ├─process_changelog.py            # perf-changelog parsing and trim_conc
-│ ├─summarize.py                    # markdown summary generation
-│ └─test_process_result.py
-└─experimental/                     # non-core experiments
-```
+Top-level layout (run `ls` for details):
+
+- `perf-changelog.yaml` — benchmark trigger log; append-only; preserve whitespace
+- `benchmarks/` — `benchmark_lib.sh` shared helpers; `single_node/` and `multi_node/` entrypoints (per model/precision/hardware/framework `.sh` scripts); `*_mtp.sh` for MTP/spec-decoding; `multi_node/srt-slurm-recipes/` checked-in external recipe YAMLs
+- `runners/` — hardware launcher scripts
+- `utils/matrix_logic/` — `generate_sweep_configs.py` CLI, `validation.py` Pydantic schemas, tests
+- `utils/bench_serving/` — `benchmark_serving.py` serving client and backends
+- `utils/evals/` — lm-eval task configs, thresholds, `validate_scores.py` (see `EVALS.md`)
+- `utils/` (top level) — `process_result.py`, `process_changelog.py` (incl. `trim_conc`), `summarize.py`, `collect_*.py`, `compare_results.py`
+- `experimental/` — non-core experiments
 
 ## Terminology
 
 - **STP (Single Token Prediction)**: Standard autoregressive decoding where one token is generated per forward pass. No speculative decoding or MTP (Multi-Token Prediction) is used. When a benchmark is labeled "STP only", it means vanilla decoding without any speculation.
 - **MTP (Multi-Token Prediction)**: A technique where the model predicts multiple tokens per forward pass, typically using speculative decoding methods like EAGLE or NEXTN.
 
-## Key Technologies
-
-- Python 3.13: Core automation and config generation
-- Pydantic Configuration validation (V2 with strict mode)
-- Bash**: Benchmark execution and infrastructure orchestration
-- YAML: Configuration files
-- GitHub Actions: CI/CD workflows
-- Evals: lm-eval validation of benchmark results
-- pytest: Testing framework
-
 ## Development Workflow
 
 ### Running Tests
 
 ```bash
-cd utils
-python -m pytest matrix_logic/ -v
+python -m pytest utils/matrix_logic/ -v
 ```
+
+Markers: `slow`, `integration`.
 
 ### Generating Benchmark Configs
 
 ```bash
-# Full sweep with all configs
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml
-
-# Filter by model prefix (dsr1 or gptoss)
 python utils/matrix_logic/generate_sweep_configs.py full-sweep \
   --config-files .github/configs/nvidia-master.yaml \
-  --model-prefix dsr1
-
-# Filter by framework (sglang, trt, vllm, atom, dynamo-trt, dynamo-sglang)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --framework sglang
-
-# Filter by precision (fp4, fp8)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --precision fp8
-
-# Filter by runner type (b200, h100, h200, gb200, mi300x, mi325x, mi355x)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --runner-type b200
+  [--model-prefix dsr1|gptoss|dsv4|...] \
+  [--framework sglang|trt|vllm|atom|dynamo-trt|dynamo-sglang] \
+  [--precision fp4|fp8|...] \
+  [--runner-type b200|h100|h200|gb200|...]
 ```
 
 ### Processing Results
@@ -190,23 +114,52 @@ Notes:
 
 ### Dispatching jobs
 
-When asked to do a run or a sweep,
-```
+Sweeps and one-off runs are dispatched against `.github/workflows/e2e-tests.yml` (the `workflow_dispatch` entrypoint). `run-sweep.yml` is push/PR-triggered and is not dispatchable.
+
+```bash
 gh api -X POST \
   /repos/SemiAnalysisAI/InferenceX/actions/workflows/e2e-tests.yml/dispatches \
-  -f ref='<ref>' \
-  -f 'inputs[ref]=<input ref>' \
-  -f 'inputs[test-name]=<name>' \
-  -f 'inputs[generate-cli-command]=command'
+  -f ref='main' \
+  -f 'inputs[ref]=my-feature-branch' \
+  -f 'inputs[test-name]=DSR1 fp8 H200 sglang smoke' \
+  -f 'inputs[generate-cli-command]=full-sweep --config-files .github/configs/nvidia-master.yaml --model-prefix dsr1 --framework sglang --runner-type h200 --min-conc 4 --max-conc 4 --seq-lens 1k1k' \
+  -f 'inputs[duration-override]='
 ```
-Input meanings:
 
-* ref: workflow ref to dispatch from; usually the branch containing the workflow.
-* inputs[ref]: checkout ref used by jobs and matrix generation.
-* inputs[test-name]: display name in GitHub Actions.
-* inputs[generate-cli-command]: arguments passed to utils/matrix_logic/generate_sweep_configs.py. Can be tested locally.
+Inputs:
 
-To monitor: `gh run watch <RUN_ID> --repo SemiAnalysisAI/InferenceX --exit-status`
+| Input | Required | Meaning |
+|---|---|---|
+| `ref` (top-level, no `inputs[...]`) | yes | Workflow ref to dispatch *from*. Almost always `main` unless you're testing a workflow change. |
+| `inputs[ref]` | no | Repo ref the matrix-generation job checks out (the branch/SHA under test). Defaults to `github.sha` of the dispatch ref. |
+| `inputs[generate-cli-command]` | yes | Args passed verbatim to `utils/matrix_logic/generate_sweep_configs.py`. Test locally first by running that command. |
+| `inputs[test-name]` | no | Display name in the Actions UI / `run-name`. |
+| `inputs[duration-override]` | no | Override per-config `duration` (seconds). Empty string = use matrix value. |
+
+The POST returns no body and no run ID. Find the run you just dispatched with the next section.
+
+### Monitoring jobs
+
+```bash
+# 1. Find the run you just dispatched (most recent workflow_dispatch on e2e-tests.yml)
+gh run list --repo SemiAnalysisAI/InferenceX --workflow e2e-tests.yml \
+  --event workflow_dispatch --limit 5
+# Capture the ID of the run you just dispatched:
+RUN_ID=$(gh run list --repo SemiAnalysisAI/InferenceX --workflow e2e-tests.yml \
+  --event workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# 2. Block until it finishes (non-zero exit if the run fails)
+gh run watch "$RUN_ID" --repo SemiAnalysisAI/InferenceX --exit-status
+
+# 3. Inspect jobs / failed logs
+gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX
+gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX --log-failed
+
+# 4. Cancel if needed
+gh run cancel "$RUN_ID" --repo SemiAnalysisAI/InferenceX
+```
+
+For result artifacts after a successful run, see "Fetching GitHub Actions Benchmark Results" below.
 
 ### Adding a New Benchmark Configuration
 
@@ -222,90 +175,7 @@ To monitor: `gh run watch <RUN_ID> --repo SemiAnalysisAI/InferenceX --exit-statu
 
 ### Registering Recipes from srtslurm
 
-For disaggregated multi-node configurations (dynamo-sglang, dynamo-trt), recipes are stored in the external [srtslurm](https://github.com/NVIDIA/srt-slurm) repository. To stage these recipes in InferenceX:
-
-**1. Locate source recipes in srtslurm:**
-```bash
-# Example: H200 sglang disagg recipes
-ls /path/to/srtslurm/recipes/h200/
-# 1k1k/  8k1k/
-```
-
-**2. Analyze recipe structure:**
-Each recipe YAML contains:
-- `name`: Recipe identifier
-- `model`: Model path/container info
-- `resources`: GPU type, prefill/decode node/worker counts
-- `backend.sglang_config`: Prefill and decode configuration (tp-size, dp-size, ep-size, dp-attention, etc.)
-- `benchmark`: ISL/OSL and concurrency settings
-
-**3. Add config to nvidia-master.yaml:**
-```yaml
-dsr1-fp8-h200-dynamo-sglang:
-  image: lmsysorg/sglang:v0.5.8-cu130-runtime
-  model: deepseek-ai/DeepSeek-R1-0528
-  model-prefix: dsr1
-  runner: h200-multinode-slurm
-  precision: fp8
-  framework: dynamo-sglang
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - conc-list: [1, 4, 16, 32, 64, 128, 256, 512]
-        prefill:
-        num-worker: 1
-        tp: 8
-        ep: 1
-        dp-attn: false
-        additional-settings:
-        - "CONFIG_FILE=recipes/h200/1k1k/bs128-agg-tp.yaml"
-      decode:
-        num-worker: 0
-        tp: 8
-        ep: 1
-        dp-attn: false
-```
-
-**4. Key mapping from srtslurm to nvidia-master.yaml:**
-
-| srtslurm field | nvidia-master.yaml field |
-|----------------|-------------------------|
-| `resources.prefill_workers` | `prefill.num-worker` |
-| `resources.decode_workers` | `decode.num-worker` |
-| `sglang_config.prefill.tp-size` | `prefill.tp` |
-| `sglang_config.prefill.ep-size` | `prefill.ep` |
-| `sglang_config.prefill.enable-dp-attention` | `prefill.dp-attn` |
-| `benchmark.concurrencies` (parsed) | `conc-list` |
-| Recipe file path | `additional-settings: CONFIG_FILE=...` |
-
-**5. Common patterns:**
-- **Aggregated (AGG)**: Single node, `num-worker: 1` for prefill, `num-worker: 0` for decode
-- **TEP (Tensor-Expert Parallel)**: `dp-attn: false`, `ep: 1`
-- **DEP (Data-Expert Parallel)**: `dp-attn: true`, `ep: 8` (typically)
-- **Low latency**: More decode workers (e.g., 9), lower concurrencies
-- **High throughput**: Fewer decode workers, higher concurrencies
-
-**6. Add perf-changelog entry:**
-```yaml
-- config-keys:
-    - dsr1-fp8-h200-dynamo-sglang
-  description:
-    - "Add DSR1 FP8 H200 Dynamo SGLang disaggregated multinode configuration"
-    - "Image: lmsysorg/sglang:v0.5.8-cu130-runtime"
-    - "Recipes sourced from srtslurm repo (recipes/h200/)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
-```
-
-**7. Validate configuration:**
-```bash
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --framework dynamo-sglang
-```
+For `dynamo-sglang` / `dynamo-trt` disaggregated multi-node configs, see `benchmarks/multi_node/srt-slurm-recipes/RECIPES.md` for the full mapping from srtslurm recipe YAML to `nvidia-master.yaml` entries.
 
 ### Updating Docker Images
 
@@ -324,40 +194,15 @@ When upgrading Docker images in benchmark scripts and master configs .yaml:
    ```
 4. This triggers benchmarks for affected configs and tracks performance changes
 
-### Debugging Benchmark Failures
-
-1. Check GitHub Actions logs for the failed job
-2. Look at environment variables passed to benchmark script
-3. Review benchmark script in `benchmarks/` directory
-4. Check `wait_for_server_ready()` logs for server startup issues
-
 ## Evals (Accuracy Validation)
 
-Evals are optional accuracy checks that ensure inference optimizations do not degrade model outputs. Keep detailed eval reference material in `utils/evals/EVALS.md`; this top-level file should only carry the essentials needed during routine agent runs.
+Optional accuracy checks that ensure inference optimizations do not degrade model outputs. See `utils/evals/EVALS.md` for the full reference.
 
 Quick pointers:
-- Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`.
+- Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals are marked by default on the 8k1k subset.
 - Eval workflow jobs run separately from throughput jobs in eval-only mode (`EVAL_ONLY=true`).
-- Generate normal configs with eval markings by default, skip evals with `--no-evals`, or generate only eval jobs with `--evals-only`.
-- Benchmark/eval helpers live in `benchmarks/benchmark_lib.sh`; aggregated eval output is produced by `utils/collect_eval_results.py`.
-
-### CLI
-
-```bash
-# Generate configs (evals marked by default on 8k1k subset)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml
-
-# Generate throughput-only configs (skip evals)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --no-evals
-
-# Generate only the eval subset (excludes non-eval configs)
-python utils/matrix_logic/generate_sweep_configs.py full-sweep \
-  --config-files .github/configs/nvidia-master.yaml \
-  --evals-only
-```
+- Flags on `generate_sweep_configs.py full-sweep`: `--no-evals` to skip, `--evals-only` for the eval subset only.
+- Aggregated eval output is produced by `utils/collect_eval_results.py`.
 
 ## Key Files to Understand
 
@@ -368,20 +213,8 @@ python utils/matrix_logic/generate_sweep_configs.py full-sweep \
 - `.github/workflows/run-sweep.yml` - Main CI/CD workflow
 - `.github/workflows/collect-evals.yml` - Eval results collection workflow
 - `benchmarks/benchmark_lib.sh` - Shared benchmark/eval utilities
-- `utils/evals/` - Eval task definitions (gsm8k.yaml, math500.yaml)
+- `utils/evals/` - Eval task definitions (`gsm8k.yaml`, `gpqa_diamond.yaml`)
 - `utils/collect_eval_results.py` - Aggregates eval results into JSON/table
-
-## Testing
-
-Tests are located in `utils/matrix_logic/`:
-
-- `test_validation.py` - Pydantic model validation tests
-- `test_generate_sweep_configs.py` - Config generation tests
-- `test_process_result.py` - Result processing tests
-
-Run with: `python -m pytest utils/matrix_logic/ -v`
-
-Markers available: `slow`, `integration`
 
 ## Important Notes
 1. Make sure no new directories are created in `/workspace` during the benchmark. Files are ok.
@@ -399,34 +232,16 @@ gh run download <RUN_ID> --repo SemiAnalysisAI/InferenceX -n results_bmk -D ./re
 ```
 ### Parsing Results (IMPORTANT: avoid dumping raw JSON)
 
-The results JSON can be large with multiple decimal places, so avoid dumping the raw JSON. Use `jq` to extract and round to see only what you need, for example:
+The results JSON is large with many decimals — never `cat` it raw. Use `jq` to extract and round:
+
 ```bash
-# Count total results
-cat ./results/results_bmk/*.json | jq 'length'
-
-# List unique hardware/framework combinations
-cat ./results/agg_bmk.json | jq -r '[.[] | "\(.hw)/\(.framework)"] | unique | .[]'
-
 # Summary table: hw, model, isl/osl, throughput (rounded)
 cat ./results/agg_bmk.json | jq -r '
-  .[] | [.hw, .infmax_model_prefix, "\(.isl)/\(.osl)", (.tput_per_gpu | round)] 
+  .[] | [.hw, .infmax_model_prefix, "\(.isl)/\(.osl)", (.tput_per_gpu | round)]
   | @tsv' | column -t
 
-# Filter to specific model
+# Filter to a specific model
 cat ./results/agg_bmk.json | jq '[.[] | select(.infmax_model_prefix == "gptoss")]'
-
-# Get single best result by throughput
-cat ./results/agg_bmk.json | jq 'max_by(.tput_per_gpu)'
-
-# Compact view with rounded values
-cat ./results/agg_bmk.json | jq '
-  .[] | {
-    hw, framework, model: .infmax_model_prefix, 
-    isl, osl, tp, ep, conc,
-    tput: (.tput_per_gpu | round),
-    ttft_p99: (.p99_ttft | .*100 | round | ./100),
-    e2e_mean: (.mean_e2el | .*100 | round | ./100)
-  }'
 ```
 
 ### Key Metrics

--- a/benchmarks/multi_node/srt-slurm-recipes/RECIPES.md
+++ b/benchmarks/multi_node/srt-slurm-recipes/RECIPES.md
@@ -1,0 +1,92 @@
+# Registering Recipes from srtslurm
+
+For disaggregated multi-node configurations (`dynamo-sglang`, `dynamo-trt`), recipes are stored in the external [srtslurm](https://github.com/NVIDIA/srt-slurm) repository. This doc covers staging those recipes in InferenceX.
+
+## 1. Locate source recipes in srtslurm
+
+```bash
+# Example: H200 sglang disagg recipes
+ls /path/to/srtslurm/recipes/h200/
+# 1k1k/  8k1k/
+```
+
+## 2. Recipe structure
+
+Each recipe YAML contains:
+- `name`: Recipe identifier
+- `model`: Model path/container info
+- `resources`: GPU type, prefill/decode node/worker counts
+- `backend.sglang_config`: Prefill and decode configuration (tp-size, dp-size, ep-size, dp-attention, etc.)
+- `benchmark`: ISL/OSL and concurrency settings
+
+## 3. Add config to nvidia-master.yaml
+
+```yaml
+dsr1-fp8-h200-dynamo-sglang:
+  image: lmsysorg/sglang:v0.5.8-cu130-runtime
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: h200-multinode-slurm
+  precision: fp8
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - conc-list: [1, 4, 16, 32, 64, 128, 256, 512]
+        prefill:
+        num-worker: 1
+        tp: 8
+        ep: 1
+        dp-attn: false
+        additional-settings:
+        - "CONFIG_FILE=recipes/h200/1k1k/bs128-agg-tp.yaml"
+      decode:
+        num-worker: 0
+        tp: 8
+        ep: 1
+        dp-attn: false
+```
+
+## 4. Field mapping (srtslurm → nvidia-master.yaml)
+
+| srtslurm field | nvidia-master.yaml field |
+|----------------|-------------------------|
+| `resources.prefill_workers` | `prefill.num-worker` |
+| `resources.decode_workers` | `decode.num-worker` |
+| `sglang_config.prefill.tp-size` | `prefill.tp` |
+| `sglang_config.prefill.ep-size` | `prefill.ep` |
+| `sglang_config.prefill.enable-dp-attention` | `prefill.dp-attn` |
+| `benchmark.concurrencies` (parsed) | `conc-list` |
+| Recipe file path | `additional-settings: CONFIG_FILE=...` |
+
+## 5. Common patterns
+
+- **Aggregated (AGG)**: Single node, `num-worker: 1` for prefill, `num-worker: 0` for decode
+- **TEP (Tensor-Expert Parallel)**: `dp-attn: false`, `ep: 1`
+- **DEP (Data-Expert Parallel)**: `dp-attn: true`, `ep: 8` (typically)
+- **Low latency**: More decode workers (e.g., 9), lower concurrencies
+- **High throughput**: Fewer decode workers, higher concurrencies
+
+## 6. Add perf-changelog entry
+
+```yaml
+- config-keys:
+    - dsr1-fp8-h200-dynamo-sglang
+  description:
+    - "Add DSR1 FP8 H200 Dynamo SGLang disaggregated multinode configuration"
+    - "Image: lmsysorg/sglang:v0.5.8-cu130-runtime"
+    - "Recipes sourced from srtslurm repo (recipes/h200/)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+```
+
+## 7. Validate
+
+```bash
+python utils/matrix_logic/generate_sweep_configs.py full-sweep \
+  --config-files .github/configs/nvidia-master.yaml \
+  --framework dynamo-sglang
+```

--- a/utils/merge_with_reuse.sh
+++ b/utils/merge_with_reuse.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Merge a PR while reusing its already-completed full sweep on push to main.
+#
+# Steps performed for the given PR:
+#   1. Post `/reuse-sweep-run` so the merge-to-main run authorizes reuse.
+#   2. Merge origin/main into the PR branch.  Any `perf-changelog.yaml`
+#      conflict is auto-resolved by accepting main's entries and re-appending
+#      the PR's entry at the bottom with `XXX` -> the PR number.
+#   3. Push the merge commit and cancel the sweep it triggers (the prior
+#      successful sweep is what the merge run will reuse).
+#   4. Squash-merge the PR to main (--admin).
+#
+# Usage: utils/merge_with_reuse.sh <pr-number>
+# Env:   REPO (default SemiAnalysisAI/InferenceX)
+
+set -euo pipefail
+
+REPO="${REPO:-SemiAnalysisAI/InferenceX}"
+CHANGELOG="perf-changelog.yaml"
+
+if [ $# -ne 1 ] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Usage: $0 <pr-number>" >&2
+    exit 2
+fi
+PR="$1"
+
+log() { printf '\033[1;36m→\033[0m %s\n' "$*"; }
+ok()  { printf '\033[1;32m✓\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+ORIGINAL_BRANCH="$(git symbolic-ref --quiet --short HEAD || git rev-parse HEAD)"
+cleanup() { git checkout --quiet "$ORIGINAL_BRANCH" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- preflight ---------------------------------------------------------------
+PR_INFO="$(gh pr view "$PR" --repo "$REPO" --json headRefName,state,labels)"
+PR_STATE="$(jq -r '.state' <<<"$PR_INFO")"
+[ "$PR_STATE" = "OPEN" ] || die "PR #${PR} is ${PR_STATE}, expected OPEN"
+
+HEAD_BRANCH="$(jq -r '.headRefName' <<<"$PR_INFO")"
+HAS_FULL_SWEEP="$(jq -r '[.labels[].name] | index("full-sweep-enabled") // ""' <<<"$PR_INFO")"
+[ -n "$HAS_FULL_SWEEP" ] || die "PR #${PR} is missing the 'full-sweep-enabled' label"
+
+# Warn early if no successful run exists on any current PR commit.
+PR_SHAS="$(gh api "repos/${REPO}/pulls/${PR}/commits" --paginate --jq '.[].sha')"
+SUCCESS_RUNS="$(gh api "repos/${REPO}/actions/workflows/run-sweep.yml/runs?event=pull_request&branch=${HEAD_BRANCH}&status=completed&per_page=100" \
+    --jq '.workflow_runs[] | select(.conclusion=="success") | .head_sha' || true)"
+if ! grep -qFxf <(echo "$SUCCESS_RUNS") <(echo "$PR_SHAS"); then
+    die "PR #${PR} has no successful run-sweep.yml run on any of its current commits"
+fi
+
+# --- step 1: comment ---------------------------------------------------------
+log "Posting /reuse-sweep-run on PR #${PR}"
+gh pr comment "$PR" --repo "$REPO" --body "/reuse-sweep-run" >/dev/null
+ok "Comment posted"
+
+# --- step 2: merge main into PR branch --------------------------------------
+LOCAL_BRANCH="pr-${PR}-reuse"
+log "Fetching PR branch ${HEAD_BRANCH}"
+git fetch origin "pull/${PR}/head:${LOCAL_BRANCH}" --force --quiet
+git checkout --quiet "$LOCAL_BRANCH"
+git fetch origin main --quiet
+
+PRE_MERGE="$(git rev-parse HEAD)"
+log "Merging origin/main"
+set +e
+git merge origin/main --no-ff --no-edit
+merge_status=$?
+set -e
+
+if [ "$merge_status" -ne 0 ]; then
+    unresolved="$(git diff --name-only --diff-filter=U)"
+    if [ "$unresolved" != "$CHANGELOG" ]; then
+        git merge --abort
+        die "Unexpected conflict(s) in: ${unresolved} — only ${CHANGELOG} is auto-resolved"
+    fi
+    log "Resolving ${CHANGELOG} conflict"
+    python3 - "$CHANGELOG" "$PR" <<'PY'
+import re
+import subprocess
+import sys
+
+import yaml
+
+path, pr = sys.argv[1], sys.argv[2]
+
+
+def read_stage(stage: int) -> str:
+    return subprocess.check_output(["git", "show", f":{stage}:{path}"]).decode()
+
+
+def split_entries(text: str) -> tuple[str, list[str]]:
+    """Split a perf-changelog.yaml into (preamble, [entry_text, ...])."""
+    parts = re.split(r"\n(?=- config-keys:)", text)
+    if not parts:
+        return "", []
+    if parts[0].startswith("- config-keys:"):
+        return "", [p.rstrip("\n") for p in parts]
+    return parts[0], [p.rstrip("\n") for p in parts[1:]]
+
+
+def entry_signature(entry: dict) -> tuple:
+    """Identity used to detect duplicates across sides.
+
+    Same config-keys + same description = same logical entry, even if pr-link
+    differs (which is exactly the case when a placeholder XXX entry on the PR
+    side collides with a real entry that landed on main from another PR)."""
+    keys = tuple(sorted(entry.get("config-keys") or []))
+    desc = tuple(entry.get("description") or [])
+    return (keys, desc)
+
+
+# Stage 2 = HEAD (PR before merge); Stage 3 = MERGE_HEAD (origin/main).
+pr_text = read_stage(2)
+main_text = read_stage(3)
+
+pr_preamble, pr_blocks = split_entries(pr_text)
+main_preamble, main_blocks = split_entries(main_text)
+
+pr_data = yaml.safe_load(pr_text) or []
+main_data = yaml.safe_load(main_text) or []
+
+if len(pr_data) != len(pr_blocks) or len(main_data) != len(main_blocks):
+    sys.exit(
+        f"Entry/text-block count mismatch — file uses an unsupported shape. "
+        f"pr_data={len(pr_data)} pr_blocks={len(pr_blocks)} "
+        f"main_data={len(main_data)} main_blocks={len(main_blocks)}"
+    )
+
+main_sigs = {entry_signature(e) for e in main_data}
+
+contribs: list[str] = []
+for entry, block in zip(pr_data, pr_blocks):
+    link = str(entry.get("pr-link") or "")
+    if "XXX" not in link and not link.endswith(f"/pull/{pr}"):
+        continue
+    if entry_signature(entry) in main_sigs:
+        continue  # Same logical entry already on main (e.g. XXX placeholder vs real pr-link).
+    contribs.append(block.replace("/pull/XXX", f"/pull/{pr}"))
+
+if not contribs:
+    sys.exit(
+        f"No PR contributions found in {path} "
+        f"(expected entry tagged with XXX or /pull/{pr} with new content)"
+    )
+
+sections: list[str] = []
+if main_preamble.strip():
+    sections.append(main_preamble.rstrip("\n"))
+sections.extend(main_blocks)
+sections.extend(contribs)
+
+result = "\n\n".join(s for s in sections if s) + "\n"
+open(path, "w").write(result)
+PY
+    python3 -c "
+import yaml
+entries = yaml.safe_load(open('$CHANGELOG'))
+last = entries[-1]
+assert last['pr-link'].endswith('/$PR'), f'last entry not for PR #$PR: {last}'
+print(f'  Last entry: {last[\"config-keys\"]} -> #$PR')
+"
+    [ -z "$(tail -c 1 "$CHANGELOG")" ] || die "${CHANGELOG} missing trailing newline"
+    git add "$CHANGELOG"
+    git commit --no-edit -m "Merge branch 'main' into ${HEAD_BRANCH}"
+fi
+
+POST_MERGE="$(git rev-parse HEAD)"
+
+# --- step 3: push and cancel triggered sweep --------------------------------
+if [ "$PRE_MERGE" = "$POST_MERGE" ]; then
+    log "PR already up to date with main; skipping push + cancel"
+else
+    log "Pushing merge commit ${POST_MERGE:0:8}"
+    git push origin "${LOCAL_BRANCH}:${HEAD_BRANCH}"
+
+    log "Waiting for triggered sweep run to register"
+    RUN_ID=""
+    for _ in 1 2 3 4 5; do
+        sleep 5
+        RUN_ID="$(gh run list --repo "$REPO" --branch "$HEAD_BRANCH" \
+            --workflow run-sweep.yml --limit 5 \
+            --json databaseId,headSha,status \
+            --jq ".[] | select(.headSha==\"${POST_MERGE}\" and (.status==\"queued\" or .status==\"in_progress\")) | .databaseId" | head -1)"
+        [ -n "$RUN_ID" ] && break
+    done
+    if [ -n "$RUN_ID" ]; then
+        log "Cancelling sweep run ${RUN_ID}"
+        gh run cancel "$RUN_ID" --repo "$REPO" >/dev/null
+        ok "Sweep cancelled"
+    else
+        echo "  No queued/in-progress sweep found after 25s — proceeding."
+    fi
+fi
+
+# --- step 4: squash-merge to main -------------------------------------------
+log "Squash-merging PR #${PR} into main"
+gh pr merge "$PR" --repo "$REPO" --squash --admin >/dev/null
+
+MERGE_SHA="$(gh pr view "$PR" --repo "$REPO" --json mergeCommit --jq '.mergeCommit.oid')"
+ok "PR #${PR} merged as ${MERGE_SHA:0:8} — the push-to-main run will reuse the prior successful sweep."


### PR DESCRIPTION
## What changed

**`.github/workflows/docker-tag-monitor.yml`**
The auto-generated update issue now embeds a snapshot of self-hosted runner availability fetched from `https://inferencex-ci-tracker.vercel.app/api/ci`, rendered as a markdown table (SKU / total / busy / idle / offline / pressure / available). The `@claude` prompt is gated on that snapshot — only opens PRs for config-keys whose runner SKU has `pressureLevel == "clear"` and idle capacity and is not all-offline. Per-SKU cap of 5 config-keys (alphabetical, deferred remainder posted as a comment), with sequential e2e dispatch within a SKU and parallel across SKUs. Single-node only; `multinode: true` entries are skipped. MTP exception: a config-key and its `-mtp` sibling bundle into one PR and count as 1 against the cap. The prompt now explicitly tells Claude to run `gh pr create` (not stop at git's "Create a pull request for …" hint), label every PR `full-sweep-enabled`, and use heredocs for multi-line commit/PR bodies (a prior run produced commits literally starting with `$` and containing `\n\n` from mis-quoted ANSI-C strings). Closing reminder is concrete about not switching CUDA/ROCm minor variants in a tag bump. A YAML comment at the top of the file documents the maintainer-only post-merge flow via `utils/merge_with_reuse.sh` — intentionally outside the prompt so Claude doesn't see it.

**`.github/workflows/claude.yml`**
Trimmed the inline `Updating perf-changelog.yaml` and STP/MTP terminology blocks; both now reference the corresponding sections in `AGENTS.md` so the canonical text lives in one place.

**`AGENTS.md`**
Reorganized and consolidated. Section anchors for `Terminology`, `Updating Docker Images`, and `Registering Recipes from srtslurm` match the cross-references from `claude.yml` and the new `RECIPES.md`.

**`utils/merge_with_reuse.sh`**
Maintainer helper for merging a PR while reusing its already-completed full sweep on the post-merge run. Given a PR number it: validates the PR is OPEN, carries `full-sweep-enabled`, and has a prior successful `run-sweep.yml` run on a current commit; posts `/reuse-sweep-run`; merges `origin/main` into the PR branch (only `perf-changelog.yaml` conflicts are auto-resolved — the resolver re-applies the PR's `XXX`-tagged entries on top of main's entries and dedupes by `(config-keys, description)`); pushes the merge commit and cancels the sweep it triggers; squash-merges with `--admin`.

**`benchmarks/multi_node/srt-slurm-recipes/RECIPES.md`**
New doc explaining how to register recipes from the external `srtslurm` repo for the disaggregated multi-node configs (`dynamo-sglang`, `dynamo-trt`).