### PR TITLE
Update gptoss-fp4-h200-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4308,7 +4308,7 @@ gptoss-fp4-h200-trt:
       - { tp: 8, ep: 8, dp-attn: false, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-h200-vllm:
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.21.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2493,3 +2493,9 @@
     - "Update image tag to vllm/vllm-openai:v0.20.2"
     - "Add DEP configs for B300 vLLM MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1271
+
+- config-keys:
+    - gptoss-fp4-h200-vllm
+  description:
+    - "Update vLLM image from v0.20.2 to v0.21.0"
+  pr-link: XXX


### PR DESCRIPTION
## Summary

- Updates the vLLM image tag for `gptoss-fp4-h200-vllm` from v0.20.2 to v0.21.0.

Ref #1154

Generated with [Claude Code](https://claude.ai/code)