### PR TITLE
Update kimik2.5-int4-h200-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2481,7 +2481,7 @@ kimik2.5-int4-b300-vllm:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-h200-vllm:
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.21.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2493,3 +2493,9 @@
     - "Update image tag to vllm/vllm-openai:v0.20.2"
     - "Add DEP configs for B300 vLLM MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1271
+
+- config-keys:
+    - kimik2.5-int4-h200-vllm
+  description:
+    - "Update vLLM image from v0.20.2 to v0.21.0"
+  pr-link: XXX


### PR DESCRIPTION
## Summary

- Updates the vLLM image tag for `kimik2.5-int4-h200-vllm` from v0.20.2 to v0.21.0.

Ref #1154

Generated with [Claude Code](https://claude.ai/code)