### PR TITLE
[Handoff to @Oseltamivir Claude /loop] Update gptoss-fp4-mi300x-vllm vLLM ROCm image to v0.21.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -891,7 +891,7 @@ minimaxm2.5-fp8-mi325x-vllm-agentic:
       - { tp: 4, offloading: cpu,  conc-list: [16, 20, 24, 28, 32] }
 
 gptoss-fp4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.17.0
+  image: vllm/vllm-openai-rocm:v0.21.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi300x

--- a/benchmarks/single_node/gptoss_fp4_mi300x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi300x.sh
@@ -53,7 +53,7 @@ set -x
 vllm serve $MODEL --port $PORT \
   $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
   --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
+  --gpu-memory-utilization 0.90 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
   --no-enable-prefix-caching > $SERVER_LOG 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3050,3 +3050,9 @@
   description:
     - "Update SGLang image from v0.5.11-cu130 (5d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1475
+
+- config-keys:
+    - gptoss-fp4-mi300x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.17.0 to v0.21.0; lower --gpu-memory-utilization 0.95 -> 0.90 to avoid v0.21 CUDA-graph profiler OOM"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1403


### PR DESCRIPTION
## Summary

- Bumps the vLLM ROCm image tag for `gptoss-fp4-mi300x-vllm` from `v0.17.0` → `v0.21.0`.
- Lowers `--gpu-memory-utilization 0.95 → 0.90` in `benchmarks/single_node/gptoss_fp4_mi300x.sh` to dodge the v0.21 CUDA-graph profiler OOM (see `KLAUD_DEBUG.md`).
- Adds the corresponding `perf-changelog.yaml` entry.

Rebased onto current `main` (squash of prior tangled merge-commits history; previous content was `v0.20.2`, this is the intended `v0.21.0`).

Ref #1154

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>