### PR TITLE
Update minimaxm2.5-fp8-mi355x-vllm vLLM ROCm image to v0.21.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -568,7 +568,7 @@ kimik2.5-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 128 }
 
 minimaxm2.5-fp8-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.19.0
+  image: vllm/vllm-openai-rocm:v0.21.0
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2493,3 +2493,9 @@
     - "Update image tag to vllm/vllm-openai:v0.20.2"
     - "Add DEP configs for B300 vLLM MTP"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1271
+
+- config-keys:
+    - minimaxm2.5-fp8-mi355x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.19.0 to v0.21.0"
+  pr-link: XXX


### PR DESCRIPTION
## Summary

- Updates the vLLM ROCm image tag for `minimaxm2.5-fp8-mi355x-vllm` from v0.19.0 to v0.21.0.

Ref #1154

Generated with [Claude Code](https://claude.ai/code)