### PR TITLE
[AMD][ROCM] gptoss-fp4-mi355x-atom: Bump image to rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -945,7 +945,7 @@ gptoss-fp4-mi355x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-mi355x-atom:
-  image: rocm/atom-dev:nightly_202605111702
+  image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -945,7 +945,7 @@ gptoss-fp4-mi355x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-mi355x-atom:
-  image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post
+  image: rocm/atom-dev:nightly_202605111702
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2957,3 +2957,10 @@
     - "Following recipe from https://github.com/vllm-project/recipes/pull/433"
     - "Add DEP8 dp-attn=true validation probes at conc=64 for 1k1k and 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1374
+
+- config-keys:
+    - gptoss-fp4-mi355x-atom
+  description:
+    - "Bump ATOM image from rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post to rocm/atom-dev:nightly_202605111702"
+    - "ATOM upstream benchmark shows +8% to +20% throughput improvement vs InferenceX baselines (1 GPU, ISL=1024/8192, OSL=1024)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2961,6 +2961,6 @@
 - config-keys:
     - gptoss-fp4-mi355x-atom
   description:
-    - "Bump ATOM image from rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post to rocm/atom-dev:nightly_202605111702"
+    - "Bump ATOM image from rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post to rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511"
     - "ATOM upstream benchmark shows +8% to +20% throughput improvement vs InferenceX baselines (1 GPU, ISL=1024/8192, OSL=1024)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1412

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2963,4 +2963,4 @@
   description:
     - "Bump ATOM image from rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post to rocm/atom-dev:nightly_202605111702"
     - "ATOM upstream benchmark shows +8% to +20% throughput improvement vs InferenceX baselines (1 GPU, ISL=1024/8192, OSL=1024)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1412


### PR DESCRIPTION
## Summary

- Bump ATOM image from `rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post` to `rocm/atom-dev:nightly_202605111702`
- Add perf-changelog entry for `gptoss-fp4-mi355x-atom`

## Performance (ATOM Upstream vs InferenceX baseline, TP=1, 1 GPU, fp4, MI355X)

| ISL  | OSL  | Conc | InferenceX (tok/s) | ATOM Upstream (tok/s) | Diff % |
|------|------|------|--------------------|-----------------------|--------|
| 1024 | 1024 | 16   | 4808.49            | 5757.55               | +19.7% |
| 1024 | 1024 | 32   | 7537.19            | 8869.83               | +17.7% |
| 1024 | 1024 | 64   | 11737.08           | 13566.85              | +15.6% |
| 1024 | 1024 | 128  | 17577.22           | 19234.78              | +9.4%  |
| 8192 | 1024 | 4    | 7563.76            | 8183.21               | +8.2%  |
| 8192 | 1024 | 8    | 12188.56           | 13409.95              | +10.0% |
| 8192 | 1024 | 16   | 18128.47           | 20788.08              | +14.7% |
| 8192 | 1024 | 32   | 25815.80           | 29588.12              | +14.6% |
| 8192 | 1024 | 64   | 35913.41           | 40886.65              | +13.8% |
| 8192 | 1024 | 128  | 44999.29           | 50888.02              | +13.1% |

InferenceX baseline: `rocm/atom:rocm7.1.1-ubuntu24.04-pytorch2.9-atom0.1.1-MI350x` (2026-01-14)  
ATOM upstream run: https://github.com/ROCm/ATOM/actions/runs/25686894636 (2026-05-11)

## Test plan

- [ ] Verify benchmark runs with new image on mi355x runner
- [ ] Verify throughput improvement vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)