### PR TITLE
Add /merge-prs Claude slash command

### DIFF
--- a/.claude/commands/merge-prs.md
+++ b/.claude/commands/merge-prs.md
@@ -1,0 +1,14 @@
+---
+description: Sequentially run utils/merge_with_reuse.sh for each PR number
+argument-hint: <pr-number> [<pr-number>...]
+---
+
+First, ensure local main is up to date:
+
+```bash
+git checkout main && git pull origin main
+```
+
+Then run `utils/merge_with_reuse.sh <pr>` once for each PR number in: $ARGUMENTS
+
+Run them strictly sequentially — the script does git checkouts, so they cannot run in parallel. Stop on the first failure and report which PRs were merged (with merge SHA) and which one failed.


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/merge-prs.md`, a Claude Code slash command that takes a list of PR numbers and runs `utils/merge_with_reuse.sh` sequentially for each.
- The script does git checkouts, so PRs are processed one at a time. The command stops on the first failure and reports which PRs were merged.

## Usage
```
/merge-prs 1397 1396 1402
```

## Test plan
- [ ] `/merge-prs <pr>` runs the existing script unchanged and merges a single PR.
- [ ] `/merge-prs <pr1> <pr2>` processes both sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)