### PR TITLE
Update glm5-fp4-b200-sglang and -mtp SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2207,7 +2207,7 @@ glm5-fp8-b300-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 glm5-fp4-b200-sglang:
-  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b200
@@ -2228,7 +2228,7 @@ glm5-fp4-b200-sglang:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 glm5-fp4-b200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.11-cu130
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2548,3 +2548,10 @@
   description:
     - "Update vLLM image from v0.20.2 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1402
+
+- config-keys:
+    - glm5-fp4-b200-sglang
+    - glm5-fp4-b200-sglang-mtp
+  description:
+    - "Update SGLang image from v0.5.10.post1-cu130 to v0.5.12-cu130"
+  pr-link: XXX


### PR DESCRIPTION
Updates SGLang image for `glm5-fp4-b200-sglang` (from v0.5.10.post1-cu130) and `glm5-fp4-b200-sglang-mtp` (from v0.5.11-cu130) to v0.5.12-cu130.
\nRef #1154

Generated with [Claude Code](https://claude.ai/code)