### PR TITLE
Update dsr1-fp8-b300-sglang and -mtp SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1936,7 +1936,7 @@ dsr1-fp8-b200-sglang:
   # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP8
   # B200 SGLang recipe as-is until B300-specific tuning is available.
 dsr1-fp8-b300-sglang:
-  image: lmsysorg/sglang:v0.5.11-cu130
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b300
@@ -2568,7 +2568,7 @@ dsr1-fp8-b200-sglang-mtp:
   # B200 SGLang MTP recipe as-is until B300-specific tuning is available. Image bumped
   # to v0.5.10.post1-cu130 to match the standard B300 SGLang image used by other B300 configs.
 dsr1-fp8-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.10.post1-cu130
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2548,3 +2548,10 @@
   description:
     - "Update vLLM image from v0.20.2 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1402
+
+- config-keys:
+    - dsr1-fp8-b300-sglang
+    - dsr1-fp8-b300-sglang-mtp
+  description:
+    - "Update SGLang image from v0.5.11-cu130 to v0.5.12-cu130"
+  pr-link: XXX


### PR DESCRIPTION
Updates SGLang image for `dsr1-fp8-b300-sglang` (from v0.5.11-cu130) and `dsr1-fp8-b300-sglang-mtp` (from v0.5.10.post1-cu130) to v0.5.12-cu130.
\nRef #1154

Generated with [Claude Code](https://claude.ai/code)