### PR TITLE
Update dsr1-fp8-h200-sglang SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2634,7 +2634,7 @@ dsr1-fp8-b200-trt-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-h200-sglang:
-  image: lmsysorg/sglang:v0.5.11-cu130
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2548,3 +2548,9 @@
   description:
     - "Update vLLM image from v0.20.2 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1402
+
+- config-keys:
+    - dsr1-fp8-h200-sglang
+  description:
+    - "Update SGLang image from v0.5.11-cu130 to v0.5.12-cu130"
+  pr-link: XXX


### PR DESCRIPTION
Updates SGLang image for `dsr1-fp8-h200-sglang` from v0.5.11-cu130 to v0.5.12-cu130.
\nRef #1154

Generated with [Claude Code](https://claude.ai/code)