### PR TITLE
Update qwen3.5-fp8-h200-sglang-mtp SGLang image to v0.5.12

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2868,7 +2868,7 @@ qwen3.5-fp8-h200-sglang:
       - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-h200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.11
+  image: lmsysorg/sglang:v0.5.12
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2548,3 +2548,9 @@
   description:
     - "Update vLLM image from v0.20.2 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1402
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-mtp
+  description:
+    - "Update SGLang image from v0.5.11 to v0.5.12"
+  pr-link: XXX


### PR DESCRIPTION
Updates SGLang image for `qwen3.5-fp8-h200-sglang-mtp` from v0.5.11 to v0.5.12.
\nRef #1154

Generated with [Claude Code](https://claude.ai/code)