### PR TITLE
Update qwen3.5-fp8-mi325x-sglang SGLang image to v0.5.12-rocm720-mi30x

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -200,7 +200,7 @@ qwen3.5-bf16-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2548,3 +2548,9 @@
   description:
     - "Update vLLM image from v0.20.2 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1402
+
+- config-keys:
+    - qwen3.5-fp8-mi325x-sglang
+  description:
+    - "Update SGLang image from v0.5.10-rocm720-mi30x to v0.5.12-rocm720-mi30x"
+  pr-link: XXX


### PR DESCRIPTION
Updates SGLang image for `qwen3.5-fp8-mi325x-sglang` from v0.5.10-rocm720-mi30x to v0.5.12-rocm720-mi30x.
\nRef #1154

Generated with [Claude Code](https://claude.ai/code)