### PR TITLE
Fix /find-mergeable-claude-prs empty-conclusion bypass

### DIFF
--- a/.claude/commands/find-mergeable-claude-prs.md
+++ b/.claude/commands/find-mergeable-claude-prs.md
@@ -23,14 +23,17 @@ For each candidate, fetch the full rollup with `gh pr view`. A PR qualifies only
 - No check has status `QUEUED`, `IN_PROGRESS`, or `PENDING` (sweep finished, not still running)
 - At least one `Run Sweep` check has conclusion `SUCCESS` (sweep actually ran — not all skipped)
 
+Note: `gh` returns `conclusion: ""` (empty string, not `null`) for in-flight checks, so jq's `//` operator does **not** fall through to `.status`. Each check's effective state must be computed as `if conclusion is non-empty then conclusion else status`.
+
 ```bash
 : > /tmp/claude_prs_green.txt
 while read -r pr; do
   is_green=$(gh pr view "$pr" --repo SemiAnalysisAI/InferenceX --json statusCheckRollup --jq '
+    def state: if (.conclusion // "") != "" then .conclusion else .status end;
     . as $p
-    | ([$p.statusCheckRollup[] | (.conclusion // .status)]) as $s
+    | ([$p.statusCheckRollup[] | state]) as $s
     | ($s | any(. == "FAILURE" or . == "CANCELLED" or . == "TIMED_OUT" or . == "QUEUED" or . == "IN_PROGRESS" or . == "PENDING")) as $bad
-    | ([$p.statusCheckRollup[] | select(.workflowName == "Run Sweep" and (.conclusion // .status) == "SUCCESS")] | length > 0) as $swept
+    | ([$p.statusCheckRollup[] | select(.workflowName == "Run Sweep" and (state) == "SUCCESS")] | length > 0) as $swept
     | (($bad | not) and $swept)')
   if [ "$is_green" = "true" ]; then
     title=$(gh pr view "$pr" --repo SemiAnalysisAI/InferenceX --json title --jq '.title')


### PR DESCRIPTION
## Summary
- `gh` returns `conclusion: ""` (empty string, not `null`) for QUEUED / IN_PROGRESS checks, so jq's `//` operator did **not** fall through to `.status` — the filter saw `""` and never matched the pending-status guard.
- Net effect: PRs with sweeps still running were silently reported as all-green. Observed today on PR #1422 (48 still-running sweep jobs falsely passing the filter).
- Fix: define a `state` jq helper that treats empty conclusion as missing and falls back to `.status`, and apply it wherever the effective check state is consulted.

## Test plan
- [ ] Run `/find-mergeable-claude-prs` and confirm PRs with QUEUED/IN_PROGRESS sweep jobs are excluded.
- [ ] Spot-check a PR that is genuinely all-green to confirm it's still included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)