### PR TITLE
Update glm5.1-fp4-mi355x-sglang-agentic SGLang ROCm image to v0.5.12-rocm720-mi35x-20260517

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -471,9 +471,9 @@ glm5.1-fp4-mi355x-sglang:
 # Diverged from glm5.1-fp4-mi355x-sglang (agentic-coding sibling). Reasons below;
 # the original glm5.1-fp4-mi355x-sglang entry is left identical to origin/main so
 # its fixed-seq-len sweep is unaffected.
-#   - image: 'lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415' -> 'lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517'
+#   - image: 'lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415' -> 'lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x'
 glm5.1-fp4-mi355x-sglang-agentic:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x
   model: amd/GLM-5.1-MXFP4
   model-prefix: glm5.1
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -474,7 +474,7 @@ glm5.1-fp4-mi355x-sglang:
 # (either main had none or had a different conc/offload sweep).
 # The original glm5.1-fp4-mi355x-sglang entry stays byte-identical to origin/main.
 glm5.1-fp4-mi355x-sglang-agentic:
-  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: amd/GLM-5.1-MXFP4
   model-prefix: glm5.1
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -468,11 +468,10 @@ glm5.1-fp4-mi355x-sglang:
       - { tp: 2, conc-start: 4, conc-end: 256 }
       - { tp: 4, conc-start: 4, conc-end: 16 }
 
-# Diverged from glm5.1-fp4-mi355x-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's glm5.1-fp4-mi355x-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original glm5.1-fp4-mi355x-sglang entry stays byte-identical to origin/main.
+# Diverged from glm5.1-fp4-mi355x-sglang (agentic-coding sibling). Reasons below;
+# the original glm5.1-fp4-mi355x-sglang entry is left identical to origin/main so
+# its fixed-seq-len sweep is unaffected.
+#   - image: 'lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415' -> 'lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517'
 glm5.1-fp4-mi355x-sglang-agentic:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: amd/GLM-5.1-MXFP4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2627,5 +2627,5 @@
 - config-keys:
     - glm5.1-fp4-mi355x-sglang-agentic
   description:
-    - "Update SGLang ROCm image from v0.5.10rc0-rocm720-mi35x-20260415 to v0.5.12-rocm720-mi35x-20260517"
+    - "Update SGLang ROCm image from v0.5.10rc0-rocm720-mi35x-20260415 to v0.5.12-rocm720-mi35x"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1442

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2623,3 +2623,9 @@
   description:
     - "Update vLLM image from v0.15.1 to v0.20.2"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1394
+
+- config-keys:
+    - glm5.1-fp4-mi355x-sglang-agentic
+  description:
+    - "Update SGLang ROCm image from v0.5.10rc0-rocm720-mi35x-20260415 to v0.5.12-rocm720-mi35x-20260517"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2628,4 +2628,4 @@
     - glm5.1-fp4-mi355x-sglang-agentic
   description:
     - "Update SGLang ROCm image from v0.5.10rc0-rocm720-mi35x-20260415 to v0.5.12-rocm720-mi35x-20260517"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1442


### PR DESCRIPTION
## Summary

- Update `glm5.1-fp4-mi355x-sglang-agentic` image from `lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415` to `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517`

Ref #1154

Generated with [Claude Code](https://claude.ai/code)

