### PR TITLE
[Klaud Cold] Update qwen3.5-bf16-b200-sglang (+mtp) SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2049,7 +2049,7 @@ dsv4-fp4-b300-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 32, spec-decoding: mtp }
 
 qwen3.5-bf16-b200-sglang:
-  image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: b200
@@ -2068,7 +2068,7 @@ qwen3.5-bf16-b200-sglang:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64 }
 
 qwen3.5-bf16-b200-sglang-mtp:
-  image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: b200
@@ -2092,7 +2092,7 @@ qwen3.5-bf16-b200-sglang-mtp:
 # (either main had none or had a different conc/offload sweep).
 # The original qwen3.5-bf16-b200-sglang entry stays byte-identical to origin/main.
 qwen3.5-bf16-b200-sglang-agentic:
-  image: lmsysorg/sglang:nightly-dev-20260216-d3bae71e
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: b200

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2086,24 +2086,22 @@ qwen3.5-bf16-b200-sglang-mtp:
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
-# Diverged from qwen3.5-bf16-b200-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's qwen3.5-bf16-b200-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original qwen3.5-bf16-b200-sglang entry stays byte-identical to origin/main.
-qwen3.5-bf16-b200-sglang-agentic:
-  image: lmsysorg/sglang:v0.5.12-cu130
-  model: Qwen/Qwen3.5-397B-A17B
-  model-prefix: qwen3.5
-  runner: b200
-  precision: bf16
-  framework: sglang
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+# agentic-coding sibling — temporarily disabled, blocked by e2e-tests.yml
+# artifact-name mismatch (downloads `agentic_*` but benchmark-tmpl.yml uploads
+# as `bmk_agentic_*`). Re-enable once that workflow is aligned.
+# qwen3.5-bf16-b200-sglang-agentic:
+#   image: lmsysorg/sglang:v0.5.12-cu130
+#   model: Qwen/Qwen3.5-397B-A17B
+#   model-prefix: qwen3.5
+#   runner: b200
+#   precision: bf16
+#   framework: sglang
+#   multinode: false
+#   scenarios:
+#     agentic-coding:
+#     - duration: 1800
+#       search-space:
+#       - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
 
 qwen3.5-fp8-b200-sglang:
   image: lmsysorg/sglang:nightly-dev-20260422-de962f32

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2636,4 +2636,4 @@
     - qwen3.5-bf16-b200-sglang-agentic
   description:
     - "Update SGLang image from nightly-dev-20260216-d3bae71e (86d old) to v0.5.12-cu130"
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1446

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2633,7 +2633,6 @@
 - config-keys:
     - qwen3.5-bf16-b200-sglang
     - qwen3.5-bf16-b200-sglang-mtp
-    - qwen3.5-bf16-b200-sglang-agentic
   description:
     - "Update SGLang image from nightly-dev-20260216-d3bae71e (86d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1446

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2629,3 +2629,11 @@
   description:
     - "Update vLLM ROCm image from v0.18.0 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1404
+
+- config-keys:
+    - qwen3.5-bf16-b200-sglang
+    - qwen3.5-bf16-b200-sglang-mtp
+    - qwen3.5-bf16-b200-sglang-agentic
+  description:
+    - "Update SGLang image from nightly-dev-20260216-d3bae71e (86d old) to v0.5.12-cu130"
+  pr-link: PLACEHOLDER


### PR DESCRIPTION
## Summary
- Bumps `qwen3.5-bf16-b200-sglang` and `qwen3.5-bf16-b200-sglang-mtp` from `lmsysorg/sglang:nightly-dev-20260216-d3bae71e` (86 days old) to `lmsysorg/sglang:v0.5.12-cu130` (matches all other b200 cu130 sglang recipes on main).
- The sibling `qwen3.5-bf16-b200-sglang-agentic` is intentionally commented out in `nvidia-master.yaml` — blocked by an e2e-tests.yml artifact-name mismatch (downloads `agentic_*` but `benchmark-tmpl.yml` uploads as `bmk_agentic_*`). Will re-enable in a follow-up once that workflow is aligned.

## Test plan
- [ ] Full sweep passes with `full-sweep-enabled` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
