### PR TITLE
[Klaud Cold] Update minimaxm2.5-fp8-b200-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4251,7 +4251,7 @@ gptoss-fp4-b200-vllm-agentic:
       - { tp: 8, offloading: cpu,  conc-list: [64, 96, 128, 192, 256] }
 
 minimaxm2.5-fp8-b200-vllm:
-  image: vllm/vllm-openai:v0.19.0-cu130
+  image: vllm/vllm-openai:v0.21.0
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2634,4 +2634,4 @@
     - minimaxm2.5-fp8-b200-vllm
   description:
     - "Update vLLM image from v0.19.0-cu130 (25d old) to v0.21.0"
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1449

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2629,3 +2629,9 @@
   description:
     - "Update vLLM ROCm image from v0.18.0 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1404
+
+- config-keys:
+    - minimaxm2.5-fp8-b200-vllm
+  description:
+    - "Update vLLM image from v0.19.0-cu130 (25d old) to v0.21.0"
+  pr-link: PLACEHOLDER


### PR DESCRIPTION
## Summary
- Bumps `minimaxm2.5-fp8-b200-vllm` from `vllm/vllm-openai:v0.19.0-cu130` (25 days old) to `vllm/vllm-openai:v0.21.0`.

## Test plan
- [ ] Full sweep passes with `full-sweep-enabled` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)