### PR TITLE
[Klaud Cold] Update minimaxm2.5-fp8-b300-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4303,7 +4303,7 @@ minimaxm2.5-fp8-b200-vllm-agentic:
   # MiniMax-M2.5 FP8 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 minimaxm2.5-fp8-b300-vllm:
-  image: vllm/vllm-openai:v0.19.0-cu130
+  image: vllm/vllm-openai:v0.21.0
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2634,4 +2634,4 @@
     - minimaxm2.5-fp8-b300-vllm
   description:
     - "Update vLLM image from v0.19.0-cu130 (26d old) to v0.21.0"
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1454

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2629,3 +2629,9 @@
   description:
     - "Update vLLM ROCm image from v0.18.0 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1404
+
+- config-keys:
+    - minimaxm2.5-fp8-b300-vllm
+  description:
+    - "Update vLLM image from v0.19.0-cu130 (26d old) to v0.21.0"
+  pr-link: PLACEHOLDER


### PR DESCRIPTION
## Summary
- Bumps `minimaxm2.5-fp8-b300-vllm` from `vllm/vllm-openai:v0.19.0-cu130` (26d old) to `vllm/vllm-openai:v0.21.0`.

## Test plan
- [ ] Full sweep passes with `full-sweep-enabled` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)