### PR TITLE
[Klaud Cold] Update dsv4-fp4-b300-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2963,7 +2963,7 @@ dsv4-fp8-h200-sglang-mtp:
   # field, so dp-attn=true is used as the existing vLLM script switch for DP4
   # layouts on 4 allocated GPUs.
 dsv4-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.20.0-cu130
+  image: vllm/vllm-openai:v0.21.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2629,3 +2629,9 @@
   description:
     - "Update vLLM ROCm image from v0.18.0 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1404
+
+- config-keys:
+    - dsv4-fp4-b300-vllm
+  description:
+    - "Update vLLM image from v0.20.0-cu130 (18d old) to v0.21.0"
+  pr-link: PLACEHOLDER

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2634,4 +2634,4 @@
     - dsv4-fp4-b300-vllm
   description:
     - "Update vLLM image from v0.20.0-cu130 (18d old) to v0.21.0"
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1456


### PR DESCRIPTION
## Summary
- Bumps `dsv4-fp4-b300-vllm` from `vllm/vllm-openai:v0.20.0-cu130` (18d old) to `vllm/vllm-openai:v0.21.0`.

## Test plan
- [ ] Full sweep passes with `full-sweep-enabled` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)