### PR TITLE
[Klaud Cold] Update glm5-fp8-h200-sglang SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3121,7 +3121,7 @@ qwen3.5-fp8-h200-sglang-mtp:
       - { tp: 8, ep: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
 
 glm5-fp8-h200-sglang:
-  image: lmsysorg/sglang:glm5-hopper
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2629,3 +2629,9 @@
   description:
     - "Update vLLM ROCm image from v0.18.0 to v0.21.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1404
+
+- config-keys:
+    - glm5-fp8-h200-sglang
+  description:
+    - "Update SGLang image from custom glm5-hopper tag (59d old) to v0.5.12-cu130"
+  pr-link: PLACEHOLDER

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2634,4 +2634,4 @@
     - glm5-fp8-h200-sglang
   description:
     - "Update SGLang image from custom glm5-hopper tag (59d old) to v0.5.12-cu130"
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1459


### PR DESCRIPTION
## Summary
- Bumps `glm5-fp8-h200-sglang` from custom `lmsysorg/sglang:glm5-hopper` tag (59d old) to `lmsysorg/sglang:v0.5.12-cu130` (standard release tag matching other h200 sglang recipes on main).
- ⚠️ Note: `glm5-hopper` was a custom build; the generic v0.5.12-cu130 may or may not retain GLM-5-specific kernel paths. Sweep results will surface any incompat.

## Test plan
- [ ] Full sweep passes with `full-sweep-enabled` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)