### PR TITLE
[Klaud Cold] runners(mi300x): pin salloc to known-good nodes

### DIFF
--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -9,7 +9,10 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+# Pin to the known-good mi300x nodes; others are unavailable:
+#   chi-mi300x-033, chi-mi300x-037: down (Not responding)
+#   chi-mi300x-049:                  drained (persistent /nvme_home disk-full)
+JOB_ID=$(salloc --partition=$PARTITION --nodelist=chi-mi300x-[034-036,054,057-058].ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Summary
- Adds an explicit `--nodelist=chi-mi300x-[034-036,054,057-058].ord.vultr.cpe.ice.amd.com` to the mi300x salloc, mirroring the pattern already used in `runners/launch_b300-nv.sh:336`.
- Three of the nine mi300x nodes are currently unusable:
  - `chi-mi300x-033`, `chi-mi300x-037` — `down` (Not responding)
  - `chi-mi300x-049` — drained for persistent `/nvme_home` disk-full (kept down by a watchdog re-applying `State=DOWN` every 10s)
- Symptom this fixes: PRs land on a doomed node and fail at pyxis extraction (`No space left on device`) or `srun: Node failure`. See #1426 and #1403 for current examples.

## Test plan
- [ ] Subsequent mi300x sweeps land only on the 6 healthy nodes.
- [ ] No `Node failure` / `pyxis ... No space left on device` errors after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)