### PR TITLE
[Klaud Cold] Update gptoss-fp4-b200-vllm vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4205,7 +4205,7 @@ gptoss-fp4-b200-trt:
       - { tp: 8, conc-start:   4, conc-end:   4}
 
 gptoss-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.21.0
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2658,4 +2658,4 @@
     - gptoss-fp4-b200-vllm
   description:
     - "Update vLLM image from v0.20.2 (1d old) to v0.21.0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1466

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,9 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - gptoss-fp4-b200-vllm
+  description:
+    - "Update vLLM image from v0.20.2 (1d old) to v0.21.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Bumps the `gptoss-fp4-b200-vllm` recipe image from `vllm/vllm-openai:v0.20.2` (1d stale) to `vllm/vllm-openai:v0.21.0`.

The agentic sibling `gptoss-fp4-b200-vllm-agentic` stays pinned to `v0.19.1` (independent diverged track) — only the main recipe is bumped here.

## Test plan
- [ ] `full-sweep-enabled` sweep passes on B200 (TP 1 / 2 / 4 / 8 across 1k1k and 8k1k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)