### PR TITLE
[Klaud Cold] Update kimik2.5-int4-mi325x-vllm vLLM ROCm image to v0.21.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -527,7 +527,7 @@ kimik2.5-int4-mi355x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.18.0
+  image: vllm/vllm-openai-rocm:v0.21.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2658,4 +2658,4 @@
     - kimik2.5-int4-mi325x-vllm
   description:
     - "Update vLLM ROCm image from v0.18.0 (52d old) to v0.21.0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1468

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,9 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - kimik2.5-int4-mi325x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.18.0 (52d old) to v0.21.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Update vLLM ROCm image from v0.18.0 (52d old) to v0.21.0

Recipes touched: \`kimik2.5-int4-mi325x-vllm\`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)