### PR TITLE
[Klaud Cold] Update dsv4-fp8-mi355x-sglang SGLang ROCm image to v0.5.12-rocm720-mi35x-20260517

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1707,7 +1707,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
       
 
 dsv4-fp8-mi355x-sglang:
-  image: rocm/sgl-dev:deepseek-v4-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: sgl-project/DeepSeek-V4-Pro-FP8
   model-prefix: dsv4
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2658,4 +2658,4 @@
     - dsv4-fp8-mi355x-sglang
   description:
     - "Update SGLang ROCm image from custom rocm/sgl-dev:deepseek-v4-mi35x (23d old) to v0.5.12-rocm720-mi35x-20260517"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1470

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,9 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - dsv4-fp8-mi355x-sglang
+  description:
+    - "Update SGLang ROCm image from custom rocm/sgl-dev:deepseek-v4-mi35x (23d old) to v0.5.12-rocm720-mi35x-20260517"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Update SGLang ROCm image from custom rocm/sgl-dev:deepseek-v4-mi35x (23d old) to v0.5.12-rocm720-mi35x-20260517

Recipes touched: \`dsv4-fp8-mi355x-sglang\`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)