### PR TITLE
[Klaud Cold] Update dsv4-fp4-mi355x-sglang SGLang ROCm image to v0.5.12-rocm720-mi35x-20260517

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1730,7 +1730,7 @@ dsv4-fp8-mi355x-sglang:
 # image tag, so bumping sglang is just an image tag bump here. Sweeps
 # DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,9 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "Update SGLang ROCm image from custom rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4 (8d old) to v0.5.12-rocm720-mi35x-20260517"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2658,4 +2658,4 @@
     - dsv4-fp4-mi355x-sglang
   description:
     - "Update SGLang ROCm image from custom rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4 (8d old) to v0.5.12-rocm720-mi35x-20260517"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1471


### PR DESCRIPTION
## Summary
Update SGLang ROCm image from custom rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4 (8d old) to v0.5.12-rocm720-mi35x-20260517

Recipes touched: \`dsv4-fp4-mi355x-sglang\`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)