### PR TITLE
[Klaud Cold] Update dsv4-fp8-mi355x-vllm vLLM ROCm image to v0.21.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1757,7 +1757,7 @@ dsv4-fp4-mi355x-sglang:
 # pinned SHA. Once both PRs merge into a release, switch to a vLLM ROCm
 # MI355X image and remove the build step.
 dsv4-fp8-mi355x-vllm:
-  image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post
+  image: vllm/vllm-openai-rocm:v0.21.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,9 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - dsv4-fp8-mi355x-vllm
+  description:
+    - "Update vLLM image from custom rocm/atom (20d old) to vllm/vllm-openai-rocm:v0.21.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2658,4 +2658,4 @@
     - dsv4-fp8-mi355x-vllm
   description:
     - "Update vLLM image from custom rocm/atom (20d old) to vllm/vllm-openai-rocm:v0.21.0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1472


### PR DESCRIPTION
## Summary
Update vLLM image from custom rocm/atom (20d old) to vllm/vllm-openai-rocm:v0.21.0

Recipes touched: \`dsv4-fp8-mi355x-vllm\`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)