### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-b200-sglang (+mtp) SGLang image to v0.5.12-cu130

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2106,7 +2106,7 @@ qwen3.5-bf16-b200-sglang-agentic:
       - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
 
 qwen3.5-fp8-b200-sglang:
-  image: lmsysorg/sglang:nightly-dev-20260422-de962f32
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: b200
@@ -2374,7 +2374,7 @@ glm5-fp4-b300-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-b200-sglang-mtp:
-  image: lmsysorg/sglang:nightly-dev-20260422-de962f32
+  image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2653,3 +2653,10 @@
   description:
     - "Update SGLang image from v0.5.9-cu129-amd64 (74d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1458
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang
+    - qwen3.5-fp8-b200-sglang-mtp
+  description:
+    - "Update SGLang image from nightly-dev-20260422-de962f32 (18d/12d old) to v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2659,4 +2659,4 @@
     - qwen3.5-fp8-b200-sglang-mtp
   description:
     - "Update SGLang image from nightly-dev-20260422-de962f32 (18d/12d old) to v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1473


### PR DESCRIPTION
## Summary
Update SGLang image from nightly-dev-20260422-de962f32 (18d/12d old) to v0.5.12-cu130

Recipes touched: \`qwen3.5-fp8-b200-sglang\`, `qwen3.5-fp8-b200-sglang-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)