### PR TITLE
[Klaud Cold] runners(mi325x): exclude broken enroot node chi-mi325x-pod1-121

### DIFF
--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -9,7 +9,11 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+# Exclude known-broken mi325x nodes:
+#   chi-mi325x-pod1-121: enroot-aufs2ovlfs setcap fails on this node's NFS-backed
+#                        squash dir; container image import never completes
+#                        (root-caused via #1467/#1468/#1469 sweep failures).
+JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi325x-pod1-121.ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Summary
Adds `--exclude=chi-mi325x-pod1-121.ord.vultr.cpe.ice.amd.com` to the salloc in `runners/launch_mi325x-amds.sh`. Mirrors the mi300x infra-pin fix in #1462, but uses `--exclude` (since only one node is currently broken) so the launcher doesn't have to maintain an allow-list.

## Root cause (from #1467 / #1468 / #1469 failed sweeps)
All three open `[Klaud Cold]` mi325x `vllm/vllm-openai-rocm:v0.21.0` bumps failed identically — every failure landed on `chi-mi325x-pod1-121`, all hitting:
```
enroot-aufs2ovlfs: failed to set capabilities: Operation not permitted
```
during `enroot import` (`runners/launch_mi325x-amds.sh:27`). The squash file is never created, so the second srun then fails with `No such file or directory`. The bench script never even starts — so it's not OOM and not a recipe-level issue.

The same image (`vllm/vllm-openai-rocm:v0.21.0`) works cleanly on every other up node (017/018/019/020/027) — confirmed in the matching successful matrix runs (e.g. `tp=8` ran at `--gpu-memory-utilization=0.95` with 223 GiB KV-cache headroom).

PR-comment diagnoses:
- #1467: <https://github.com/SemiAnalysisAI/InferenceX/pull/1467#issuecomment-4473759071>
- #1468: <https://github.com/SemiAnalysisAI/InferenceX/pull/1468#issuecomment-4473761074>
- #1469: <https://github.com/SemiAnalysisAI/InferenceX/pull/1469#issuecomment-4473758191>

## Other actions taken
- `pod1-121` set `State=DRAIN` on the controller via `scontrol`, with a 10-second watchdog at `/home/gharunner/_audit/drain_pod1-121_watchdog.sh` re-applying the drain if SLURM auto-clears it (same pattern as KLAUD_DEBUG.md §5.6 for chi-mi300x-049). Holds until ops fix the underlying `setcap` regression on the node.
- After this PR merges, #1467/#1468/#1469 will be rebased to pick up the new launcher and re-trigger their sweep.

## Test plan
- [x] `bash -n runners/launch_mi325x-amds.sh` syntax-checks.
- [ ] After merge: rebased #1467/#1468/#1469 sweeps complete without landing on `pod1-121`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)