### PR TITLE
[Klaud Cold] Add glm5-fp8-h200-sglang-mtp recipe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3140,6 +3140,25 @@ glm5-fp8-h200-sglang:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
+glm5-fp8-h200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: h200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 dsr1-fp8-h200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
   model: deepseek-ai/DeepSeek-R1-0528

--- a/benchmarks/single_node/glm5_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_h200_mtp.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# GLM-5 FP8 on H200 (Hopper) with EAGLE / MTP speculative decoding.
+# Mirrors glm5_fp8_h200.sh but adds the speculative-* flags. We keep the
+# server-arg shape from the non-MTP H200 recipe (sglang defaults — no
+# nsa/trtllm-mha) since those backends are Blackwell-specific and not
+# applicable to Hopper.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model-path "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp-size "$TP" \
+  --tool-call-parser glm47 \
+  --reasoning-parser glm45 \
+  --mem-fraction-static 0.85 \
+  --served-model-name glm-5-fp8 \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  $EVAL_CONTEXT_ARGS > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    export MODEL_NAME=glm-5-fp8
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2716,4 +2716,4 @@
     - glm5-fp8-h200-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for glm5-fp8-h200-sglang on lmsysorg/sglang:v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1480

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2711,3 +2711,9 @@
     - "Update vLLM image from v0.20.2 to v0.21.0"
     - "Add VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 to disable aggressive CUDA-graph memory profiler that OOMs the KV cache"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1395
+
+- config-keys:
+    - glm5-fp8-h200-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling for glm5-fp8-h200-sglang on lmsysorg/sglang:v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Adds the MTP/EAGLE speculative-decoding sibling of `glm5-fp8-h200-sglang`. TP=8, conc 4..64, ISL/OSL 1k1k + 8k1k — same search-space shape as the existing non-MTP H200 recipe.

### Changes
- `nvidia-master.yaml`: new `glm5-fp8-h200-sglang-mtp` entry (image `lmsysorg/sglang:v0.5.12-cu130`, model `zai-org/GLM-5-FP8`).
- `benchmarks/single_node/glm5_fp8_h200_mtp.sh`: new launch script — mirrors `glm5_fp8_h200.sh` and adds `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`, plus `--use-chat-template` on the bench client per AGENTS.md.
- `perf-changelog.yaml`: trigger entry.

### Why not copy the B300 MTP launch script verbatim?
`glm5_fp8_b300_mtp.sh` uses NSA + trtllm-mha attention/MoE backends that are Blackwell-specific. On Hopper (H200) we stick with the same args the existing non-MTP H200 recipe uses and just bolt on the EAGLE flags.

## Test plan
- [x] `bash -n` syntax-checks the launch script.
- [x] YAML loads cleanly + new recipe entry shape matches existing MTP siblings.
- [ ] `full-sweep-enabled` sweep finishes green on H200 across tp=8 / conc 4..64 / 1k1k + 8k1k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)