### PR TITLE
[Klaud Cold] Add qwen3.5-bf16-mi300x-sglang-mtp recipe

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1800,3 +1800,22 @@ dsv4-fp4-mi355x-atom:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
+
+qwen3.5-bf16-mi300x-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.10-rocm720-mi30x
+  model: Qwen/Qwen3.5-397B-A17B
+  model-prefix: qwen3.5
+  runner: mi300x
+  precision: bf16
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }

--- a/benchmarks/single_node/qwen3.5_bf16_mi300x_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_mi300x_mtp.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+    EP_SIZE \
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+# following Andy Luo linkedin's recipe https://www.linkedin.com/feed/update/urn:li:activity:7429203734389280768/
+python3 -m sglang.launch_server \
+    --attention-backend aiter \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --trust-remote-code \
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    EP_SIZE \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2711,3 +2711,9 @@
     - "Update vLLM image from v0.20.2 to v0.21.0"
     - "Add VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 to disable aggressive CUDA-graph memory profiler that OOMs the KV cache"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1395
+
+- config-keys:
+    - qwen3.5-bf16-mi300x-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling of qwen3.5-bf16-mi300x-sglang"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2716,4 +2716,4 @@
     - qwen3.5-bf16-mi300x-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling of qwen3.5-bf16-mi300x-sglang"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1481


### PR DESCRIPTION
## Summary
Adds the qwen3.5-bf16-mi300x-sglang-mtp recipe (yaml + launch script(s) + perf-changelog entry).

## Test plan
- [x] YAML loads; `bash -n` syntax passes on launch script(s).
- [ ] full-sweep-enabled sweep finishes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)