### PR TITLE
[Klaud Cold] Add glm5-fp8-mi325x-sglang (off + mtp) recipes

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1876,3 +1876,41 @@ qwen3.5-fp8-mi325x-sglang-mtp:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
+glm5-fp8-mi325x-sglang:
+  image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: mi325x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+
+glm5-fp8-mi325x-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
+  model: zai-org/GLM-5-FP8
+  model-prefix: glm5
+  runner: mi325x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }

--- a/benchmarks/single_node/glm5_fp8_mi325x.sh
+++ b/benchmarks/single_node/glm5_fp8_mi325x.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
+fi
+
+start_gpu_monitor
+
+# Follows the qwen3.5-fp8-mi325x recipe (AMD Andy's LinkedIn-recommended
+# args for sglang ROCm on mi325x) with GLM-5-specific parsers.
+python3 -m sglang.launch_server \
+    --attention-backend aiter \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --data-parallel-size 1 \
+    --trust-remote-code \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/glm5_fp8_mi325x.sh
+++ b/benchmarks/single_node/glm5_fp8_mi325x.sh
@@ -31,10 +31,9 @@ fi
 
 start_gpu_monitor
 
-# Follows the qwen3.5-fp8-mi325x recipe (AMD Andy's LinkedIn-recommended
-# args for sglang ROCm on mi325x) with GLM-5-specific parsers.
+# Launch args follow sglang issue #25672 comment 4485916205:
+# tilelang NSA backends + fp8_e4m3 KV cache + multithread model load.
 python3 -m sglang.launch_server \
-    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -44,12 +43,16 @@ python3 -m sglang.launch_server \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --tokenizer-worker-num 6 \
-    --enable-aiter-allreduce-fusion \
     --cuda-graph-max-bs $CONC \
     --disable-radix-cache \
     --max-prefill-tokens $MAX_PREFILL_TOKENS \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.75 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.80 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
+    --nsa-prefill-backend tilelang \
+    --nsa-decode-backend tilelang \
+    --kv-cache-dtype fp8_e4m3 \
+    $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/glm5_fp8_mi325x_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_mi325x_mtp.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# GLM-5 FP8 on MI325X with EAGLE / MTP speculative decoding.
+# Mirrors glm5_fp8_mi325x.sh and adds the speculative-* flags.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
+fi
+
+start_gpu_monitor
+
+python3 -m sglang.launch_server \
+    --attention-backend aiter \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --ep-size $EP_SIZE \
+    --trust-remote-code \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --tokenizer-worker-num 6 \
+    --enable-aiter-allreduce-fusion \
+    --cuda-graph-max-bs $CONC \
+    --disable-radix-cache \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --scheduler-recv-interval 30 \
+    --mem-fraction-static 0.75 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/glm5_fp8_mi325x_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_mi325x_mtp.sh
@@ -35,8 +35,10 @@ fi
 
 start_gpu_monitor
 
+# Launch args follow sglang issue #25672 comment 4485916205:
+# tilelang NSA backends + fp8_e4m3 KV cache + multithread model load,
+# plus EAGLE/MTP speculative decoding.
 python3 -m sglang.launch_server \
-    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -46,12 +48,15 @@ python3 -m sglang.launch_server \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --tokenizer-worker-num 6 \
-    --enable-aiter-allreduce-fusion \
     --cuda-graph-max-bs $CONC \
     --disable-radix-cache \
     --max-prefill-tokens $MAX_PREFILL_TOKENS \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.75 \
+    --mem-fraction-static 0.80 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
+    --nsa-prefill-backend tilelang \
+    --nsa-decode-backend tilelang \
+    --kv-cache-dtype fp8_e4m3 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 3 \
     --speculative-eagle-topk 1 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2957,3 +2957,10 @@
     - "Following recipe from https://github.com/vllm-project/recipes/pull/433"
     - "Add DEP8 dp-attn=true validation probes at conc=64 for 1k1k and 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1374
+
+- config-keys:
+    - glm5-fp8-mi325x-sglang
+    - glm5-fp8-mi325x-sglang-mtp
+  description:
+    - "Add GLM-5 FP8 SGLang ROCm recipes (off + MTP/EAGLE) for MI325X on lmsysorg/sglang:v0.5.12-rocm720-mi30x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2963,4 +2963,4 @@
     - glm5-fp8-mi325x-sglang-mtp
   description:
     - "Add GLM-5 FP8 SGLang ROCm recipes (off + MTP/EAGLE) for MI325X on lmsysorg/sglang:v0.5.12-rocm720-mi30x"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1485


### PR DESCRIPTION
## Summary
Adds a new GLM-5 FP8 SGLang ROCm recipe family for MI325X, both the **off** and **MTP/EAGLE** variants in one PR (grouped per the project convention of pairing MTP with its non-MTP sibling).

### Recipes
- `glm5-fp8-mi325x-sglang`
- `glm5-fp8-mi325x-sglang-mtp`

### Image
`lmsysorg/sglang:v0.5.12-rocm720-mi30x` (same tag as the existing `qwen3.5-*-mi325x-sglang` recipes; mi30x suffix is shared between mi300x and mi325x).

### Launch scripts
Launch args follow [sglang issue #25672 comment 4485916205](https://github.com/sgl-project/sglang/issues/25672#issuecomment-4485916205): tilelang NSA backends, fp8_e4m3 KV cache, multithread model loader, and a bumped `--mem-fraction-static 0.80`:

```
--mem-fraction-static 0.80
--model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
--nsa-prefill-backend tilelang --nsa-decode-backend tilelang --disable-radix-cache
--kv-cache-dtype fp8_e4m3
```

GLM-5 parsers: `--tool-call-parser glm47`, `--reasoning-parser glm45`. The MTP variant adds `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4` and `--use-chat-template` on the bench client.

## Test plan
- [x] YAML loads; `bash -n` syntax passes on both launch scripts.
- [ ] full-sweep-enabled sweep finishes green on mi325x for tp=8 / conc 4..64 / 1k1k + 8k1k (both off + mtp matrices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)