### PR TITLE
[Klaud Cold] Update dsr1-fp8-h200-trt (+mtp) TRT-LLM image to v1.3.0rc14

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3141,7 +3141,7 @@ glm5-fp8-h200-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-h200-trt:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200
@@ -3164,7 +3164,7 @@ dsr1-fp8-h200-trt:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 64 }
 
 dsr1-fp8-h200-trt-mtp:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2717,3 +2717,10 @@
   description:
     - "Update SGLang image from v0.5.10-rocm720-mi30x to v0.5.12-rocm720-mi30x"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1426
+
+- config-keys:
+    - dsr1-fp8-h200-trt
+    - dsr1-fp8-h200-trt-mtp
+  description:
+    - "Update TensorRT-LLM image from v1.1.0rc2.post2 (154d/124d old) to v1.3.0rc14 (latest pre-release)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2723,4 +2723,4 @@
     - dsr1-fp8-h200-trt-mtp
   description:
     - "Update TensorRT-LLM image from v1.1.0rc2.post2 (154d/124d old) to v1.3.0rc14 (latest pre-release)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1487


### PR DESCRIPTION
## Summary
Update TensorRT-LLM image from v1.1.0rc2.post2 (154d/124d old) to v1.3.0rc14 (latest pre-release)

- `dsr1-fp8-h200-trt`: `nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2` → `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14`
- `dsr1-fp8-h200-trt-mtp`: `nvcr.io#nvidia/tensorrt-llm/release:1.1.0rc2.post2` → `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)