### PR TITLE
[Klaud Cold] Update dsr1-fp8-b200-trt (+mtp) TRT-LLM image to v1.3.0rc14

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2776,7 +2776,7 @@ kimik2.5-fp4-b300-vllm-agentic:
       - { tp: 8, ep: 1, offloading: cpu,  conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
 
 dsr1-fp8-b200-trt:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b200
@@ -2799,7 +2799,7 @@ dsr1-fp8-b200-trt:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 8 }
 
 dsr1-fp8-b200-trt-mtp:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2723,4 +2723,4 @@
     - dsr1-fp8-b200-trt-mtp
   description:
     - "Update TensorRT-LLM image (off: v1.2.0rc6.post2 109d / mtp: v1.2.0rc6.post3 102d) to v1.3.0rc14 (latest pre-release)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1488

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2717,3 +2717,10 @@
   description:
     - "Update SGLang image from v0.5.10-rocm720-mi30x to v0.5.12-rocm720-mi30x"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1426
+
+- config-keys:
+    - dsr1-fp8-b200-trt
+    - dsr1-fp8-b200-trt-mtp
+  description:
+    - "Update TensorRT-LLM image (off: v1.2.0rc6.post2 109d / mtp: v1.2.0rc6.post3 102d) to v1.3.0rc14 (latest pre-release)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Update TensorRT-LLM image (off: v1.2.0rc6.post2 109d / mtp: v1.2.0rc6.post3 102d) to v1.3.0rc14 (latest pre-release)

- `dsr1-fp8-b200-trt`: `nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post2` → `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14`
- `dsr1-fp8-b200-trt-mtp`: `nvcr.io#nvidia/tensorrt-llm/release:1.2.0rc6.post3` → `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)