### PR TITLE
[Klaud Cold] Update gptoss-fp4-h200-trt TRT-LLM image to v1.3.0rc14

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4636,7 +4636,7 @@ dsr1-fp8-h100-dynamo-sglang:
           dp-attn: true
 
 gptoss-fp4-h200-trt:
-  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc11
+  image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2722,4 +2722,4 @@
     - gptoss-fp4-h200-trt
   description:
     - "Update TensorRT-LLM image from v1.3.0rc11 (34d old) to v1.3.0rc14 (latest pre-release)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1491

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2717,3 +2717,9 @@
   description:
     - "Update SGLang image from v0.5.10-rocm720-mi30x to v0.5.12-rocm720-mi30x"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1426
+
+- config-keys:
+    - gptoss-fp4-h200-trt
+  description:
+    - "Update TensorRT-LLM image from v1.3.0rc11 (34d old) to v1.3.0rc14 (latest pre-release)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Update TensorRT-LLM image from v1.3.0rc11 (34d old) to v1.3.0rc14 (latest pre-release)

- `gptoss-fp4-h200-trt`: `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc11` → `nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)