### PR TITLE
[Klaud Cold] Add glm5-fp4-mi355x-sglang (off + mtp) recipes

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1800,3 +1800,45 @@ dsv4-fp4-mi355x-atom:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
+
+glm5-fp4-mi355x-sglang:
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  model: amd/GLM-5-MXFP4
+  model-prefix: glm5
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 8 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 8 }
+
+glm5-fp4-mi355x-sglang-mtp:
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  model: amd/GLM-5-MXFP4
+  model-prefix: glm5
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 8, conc-start: 4, conc-end: 8, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 8, conc-start: 4, conc-end: 8, spec-decoding: mtp }

--- a/benchmarks/single_node/glm5_fp4_mi355x.sh
+++ b/benchmarks/single_node/glm5_fp4_mi355x.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -x
+
+# GLM-5 MXFP4 on MI355X (sglang, no spec decoding).
+# Mirrors glm5_fp8_mi355x.sh; the FP4 model uses the same NSA/tilelang
+# backend stack since the recipe is also a DeepSeek-V3-style MoE.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# ROCm / SGLang performance tuning for MI355X
+export SGLANG_ROCM_FUSED_DECODE_MLA=0
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export SAFETENSORS_FAST_GPU=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 32))
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --cuda-graph-max-bs $CONC \
+    --context-length $CONTEXT_LENGTH \
+    --mem-fraction-static 0.85 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
+    --nsa-prefill-backend tilelang \
+    --nsa-decode-backend tilelang $EVAL_CONTEXT_ARGS  \
+    --kv-cache-dtype fp8_e4m3 \
+    --tokenizer-worker-num $((TP*2)) \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/glm5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/glm5_fp4_mi355x_mtp.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -x
+
+# GLM-5 MXFP4 on MI355X with EAGLE / MTP speculative decoding.
+# Mirrors glm5_fp8_mi355x_mtp.sh — same NSA/tilelang backend stack, same EAGLE knobs.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# ROCm / SGLang performance tuning for MI355X
+export SGLANG_ROCM_FUSED_DECODE_MLA=0
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export SAFETENSORS_FAST_GPU=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 32))
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --cuda-graph-max-bs $CONC \
+    --context-length $CONTEXT_LENGTH \
+    --mem-fraction-static 0.85 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
+    --nsa-prefill-backend tilelang \
+    --nsa-decode-backend tilelang $EVAL_CONTEXT_ARGS  \
+    --kv-cache-dtype fp8_e4m3 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --tokenizer-worker-num $((TP*2)) \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2729,4 +2729,4 @@
     - glm5-fp4-mi355x-sglang-mtp
   description:
     - "Add GLM-5 MXFP4 SGLang ROCm recipes (off + MTP/EAGLE) for MI355X on lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 (model amd/GLM-5-MXFP4)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1493

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2723,3 +2723,10 @@
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for glm5-fp8-h200-sglang on lmsysorg/sglang:v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1480
+
+- config-keys:
+    - glm5-fp4-mi355x-sglang
+    - glm5-fp4-mi355x-sglang-mtp
+  description:
+    - "Add GLM-5 MXFP4 SGLang ROCm recipes (off + MTP/EAGLE) for MI355X on lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 (model amd/GLM-5-MXFP4)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Adds a new GLM-5 MXFP4 SGLang ROCm recipe family for MI355X, both **off** and **MTP/EAGLE** variants in one PR (grouped per project convention).

### Recipes
- `glm5-fp4-mi355x-sglang`
- `glm5-fp4-mi355x-sglang-mtp`

### Model / image
- Model: `amd/GLM-5-MXFP4` (same model the abandoned [#1254](https://github.com/SemiAnalysisAI/InferenceX/pull/1254) attempt was targeting).
- Image: `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517` (the canonical mi35x v0.5.12 dated-nightly tag — same tag used by the merged mi355x bump PRs #1440/#1441/#1443/#1444).

### Search-space
TP=4 / conc 4..128 and TP=8 / conc 4..8, on both 1k1k and 8k1k — mirrors the shape of `glm5-fp8-mi355x-sglang-mtp` that's already on main.

### Launch scripts
Mirror `glm5_fp8_mi355x.sh` / `glm5_fp8_mi355x_mtp.sh` (same NSA/tilelang backend stack, ROCm fused-decode-mla disabled, quick-reduce INT4 quantization). MTP variant additionally sets `SGLANG_ENABLE_SPEC_V2=1` and the standard EAGLE knobs (`--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`) plus `--use-chat-template` per AGENTS.md.

### Why a new PR vs reviving #1254
[#1254](https://github.com/SemiAnalysisAI/InferenceX/pull/1254) targeted an older image (`v0.5.10.post1-rocm700-mi35x-20260428`) on rocm700 base; that tag is now stale. Cleaner to land fresh on the current canonical v0.5.12-rocm720 image used by all other live mi355x recipes — and [#1254](https://github.com/SemiAnalysisAI/InferenceX/pull/1254) can be closed without losing work since the model name + recipe shape carry over.

## Test plan
- [x] YAML loads; `bash -n` syntax passes on both launch scripts.
- [ ] full-sweep-enabled sweep finishes green for both off + mtp matrices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)