### PR TITLE
[Handoff to @Oseltamivir Claude /loop] [Klaud Cold] Add glm5.1-fp4-mi355x-sglang-mtp recipe

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1802,7 +1802,7 @@ dsv4-fp4-mi355x-atom:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
 
 glm5.1-fp4-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
+  image: lmsysorg/sglang:v0.5.12-rocm720-mi35x
   model: amd/GLM-5.1-MXFP4
   model-prefix: glm5.1
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1800,3 +1800,24 @@ dsv4-fp4-mi355x-atom:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
+
+glm5.1-fp4-mi355x-sglang-mtp:
+  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
+  model: amd/GLM-5.1-MXFP4
+  model-prefix: glm5.1
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 4, conc-end: 16,  spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 4, conc-end: 16,  spec-decoding: mtp }

--- a/benchmarks/single_node/glm5.1_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/glm5.1_fp4_mi355x_mtp.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -x
+
+# GLM-5.1 MXFP4 on MI355X with EAGLE / MTP speculative decoding.
+# Mirrors glm5.1_fp4_mi355x.sh; adds the speculative-* flags + SPEC_V2.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# ROCm / SGLang performance tuning for MI355X
+export SGLANG_ROCM_FUSED_DECODE_MLA=0
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export SAFETENSORS_FAST_GPU=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+CONTEXT_LENGTH=$((ISL + OSL + 32))
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+pip install -U transformers
+
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --cuda-graph-max-bs $CONC \
+    --context-length $CONTEXT_LENGTH \
+    --mem-fraction-static 0.85 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
+    --nsa-prefill-backend tilelang \
+    --nsa-decode-backend tilelang $EVAL_CONTEXT_ARGS  \
+    --kv-cache-dtype fp8_e4m3 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --tokenizer-worker-num $((TP*2)) \
+    --disable-radix-cache > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2728,4 +2728,4 @@
     - glm5.1-fp4-mi355x-sglang-mtp
   description:
     - "Add MTP/EAGLE sibling of glm5.1-fp4-mi355x-sglang (model amd/GLM-5.1-MXFP4)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1494

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2723,3 +2723,9 @@
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for glm5-fp8-h200-sglang on lmsysorg/sglang:v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1480
+
+- config-keys:
+    - glm5.1-fp4-mi355x-sglang-mtp
+  description:
+    - "Add MTP/EAGLE sibling of glm5.1-fp4-mi355x-sglang (model amd/GLM-5.1-MXFP4)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
MTP/EAGLE sibling of the existing `glm5.1-fp4-mi355x-sglang` recipe. Model `amd/GLM-5.1-MXFP4`, same TP=2 / TP=4 search-space, on the clean **`lmsysorg/sglang:v0.5.12-rocm720-mi35x`** stable tag (`lmsysorg/sglang` — not `lmsysorg/sglang-rocm`; the latter only ships dated nightlies).

### Why this PR vs reviving older attempts
- [#1091](https://github.com/SemiAnalysisAI/InferenceX/pull/1091) — closed (`[SGLang broken]`); sglang couldn't run MTP on this model when filed.
- [#1254](https://github.com/SemiAnalysisAI/InferenceX/pull/1254) — open but targets `lmsysorg/sglang-rocm:v0.5.10.post1-rocm700-mi35x-20260428` (stale rocm700 dated nightly on the deprecated `-rocm` repo).

This PR lands a fresh recipe on the current canonical v0.5.12 stable tag. [#1254](https://github.com/SemiAnalysisAI/InferenceX/pull/1254) can be closed.

### Launch script
`benchmarks/single_node/glm5.1_fp4_mi355x_mtp.sh` mirrors `glm5.1_fp4_mi355x.sh` (NSA/tilelang backends, ROCm tuning, `pip install -U transformers`) and adds:
- `export SGLANG_ENABLE_SPEC_V2=1`
- `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`
- `--use-chat-template` on the bench client per AGENTS.md

## Test plan
- [x] YAML loads; `bash -n` syntax passes on the launch script.
- [ ] full-sweep-enabled sweep finishes green on mi355x (TP=2 conc 4..256 + TP=4 conc 4..16, 1k1k + 8k1k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)