### PR TITLE
[Klaud Cold] AGENTS: note sweep doesn't trigger while a PR has merge conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ PRs do not run the sweep automatically - `run-sweep.yml` is gated on a label. Pi
 - `sweep-enabled` - runs the sweep with `--trim-conc` (each parallelism config reduced to its single highest concurrency). Default for most PRs.
 - `full-sweep-enabled` - runs the full intermediate concurrency sweep, identical to push-to-main. Use when intermediate points matter (e.g. a recipe change shifts the throughput/latency curve, not just its endpoints).
 
+**The sweep does not trigger while the PR has merge conflicts.** Even with `sweep-enabled` / `full-sweep-enabled` applied, the `run-sweep.yml` workflow will not start until the PR cleanly merges into main — a stale claude/* or update-* branch with a `perf-changelog.yaml` conflict (the common case) will sit in NO_SWEEP / NO_SUCCESS until rebased. Resolution recipe is documented in `KLAUD_DEBUG.md §1.1`: `git merge origin/main`, then `git checkout origin/main -- perf-changelog.yaml`, then re-append the PR's own changelog entry at the tail. Don't 3-way merge `perf-changelog.yaml`; whitespace edits silently re-trigger the deletion check.
+
 Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the highest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[max(conc)]`.
 
 ## Common Tasks


### PR DESCRIPTION
## Summary
Single-paragraph doc edit in `AGENTS.md` under "Pull Request Sweep Labels": calls out that a PR sitting on a stale branch with a `perf-changelog.yaml` conflict will land in NO_SWEEP / NO_SUCCESS even when `sweep-enabled` / `full-sweep-enabled` is applied — the `run-sweep.yml` workflow needs the PR to be cleanly mergeable into main first.

Surfaced this repeatedly today (#1422, #1451) — the dashboard would show `NO_SWEEP` and it wasn't obvious that "no sweep" meant "rebase your branch" rather than "the label dropped" or "something is broken upstream". Points readers at the existing canonical resolution recipe in `KLAUD_DEBUG.md §1.1`.

## Test plan
- [x] Doc-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)