### PR TITLE
[Klaud Cold] runners(mi355x): exclude broken nodes mia1-p01-g09 + mia1-p01-g11

### DIFF
--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -187,7 +187,11 @@ else
     LOCK_FILE="${SQUASH_FILE}.lock"
 
     set -x
-    salloc --partition=$PARTITION --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=500 --no-shell --job-name="$RUNNER_NAME"
+    # Exclude known-bad mi355x compute nodes (KLAUD_DEBUG §5.1 / §5.2):
+    #   mia1-p01-g09: pyxis broken (persistently fails to create container filesystem)
+    #   mia1-p01-g11: docker.sock permissions denied (cluster-cleanup step fails)
+    # Both have been root-caused via #1431/#1432/#1440/#1441/#1443 sweep failures.
+    salloc --partition=$PARTITION --exclude=mia1-p01-g09,mia1-p01-g11 --gres=gpu:$TP --exclusive --cpus-per-task=128 --time=500 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -h -o %A | head -n1)
 
     srun --jobid=$JOB_ID bash -c "docker stop \$(docker ps -a -q)"


### PR DESCRIPTION
## Summary
Adds `--exclude=mia1-p01-g09,mia1-p01-g11` to the salloc in `runners/launch_mi355x-amds.sh`. Mirrors the same pattern as #1462 (mi300x, `--nodelist=`) and #1477 (mi325x, `--exclude=chi-mi325x-pod1-121`).

## Root cause (from sweeps on #1431/#1432/#1440/#1441/#1443)
Every failure landed on one of two broken nodes:

| Node | Error |
|---|---|
| `mia1-p01-g09` | `pyxis: failed to create container filesystem` — extended attributes not supported on the destination filesystem; pyxis can't mount the squashfs |
| `mia1-p01-g11` | `permission denied while trying to connect to docker.sock` — cluster-cleanup `docker stop` step fails, cascading into pyxis init |

Both are already documented as known-bad in `KLAUD_DEBUG.md §5.1` (g09: "persistently drained — pyxis broken") and `§5.2` (g11: "docker socket perms"), but the launcher wasn't excluding them. Failures were 100% deterministic — the same image works cleanly on every other mi355x node (e.g. `g16`, `g08`, etc.).

## Other actions taken
After this PR merges, the 5 affected mi355x PRs (#1431/#1432/#1440/#1441/#1443) will be rebased to pick up the launcher fix and re-trigger their sweeps on healthy nodes only.

## Test plan
- [x] `bash -n runners/launch_mi355x-amds.sh` syntax-checks.
- [ ] After merge: rebased #1431/#1432/#1440/#1441/#1443 sweeps complete without landing on g09/g11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)