### PR TITLE
[Handoff to @Oseltamivir Claude /loop] [Klaud Cold] Add dsr1-fp8-mi300x-sglang-mtp recipe

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1933,3 +1933,22 @@ glm5-fp8-mi325x-sglang-mtp:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
+dsr1-fp8-mi300x-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-rocm700-mi30x
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: mi300x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }

--- a/benchmarks/single_node/dsr1_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp8_mi300x_mtp.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# DeepSeek-R1-0528 FP8 on MI300X with EAGLE/MTP speculative decoding.
+# Mirrors dsr1_fp8_mi300x.sh and adds the speculative-* flags.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# If the machine runs a MEC FW older than 177, RCCL
+# cannot reclaim some memory. Disable to avoid crashes.
+version=`rocm-smi --showfw | grep MEC | head -n 1 |  awk '{print $NF}'`
+if [[ "$version" == "" || $version -lt 177 ]]; then
+  export HSA_NO_SCRATCH_RECLAIM=1
+fi
+
+export SGLANG_USE_AITER=1
+export SGLANG_AITER_MLA_PERSIST=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+--model-path=$MODEL --host=0.0.0.0 --port=$PORT --trust-remote-code \
+--tensor-parallel-size=$TP \
+--ep-size $EP_SIZE \
+--mem-fraction-static=0.8 \
+--cuda-graph-max-bs=128 \
+--chunked-prefill-size=131072 \
+--num-continuous-decode-steps=4 \
+--max-prefill-tokens=131072 \
+--kv-cache-dtype fp8_e4m3 \
+--attention-backend aiter \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+--disable-radix-cache $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( $CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3055,4 +3055,4 @@
     - dsr1-fp8-mi300x-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling of dsr1-fp8-mi300x-sglang on lmsysorg/sglang:v0.5.12-rocm700-mi30x"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1499

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3050,3 +3050,9 @@
   description:
     - "Update SGLang image from v0.5.11-cu130 (5d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1475
+
+- config-keys:
+    - dsr1-fp8-mi300x-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling of dsr1-fp8-mi300x-sglang on lmsysorg/sglang:v0.5.12-rocm700-mi30x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
MTP/EAGLE sibling of the existing `dsr1-fp8-mi300x-sglang` recipe (DeepSeek-R1-0528). Same image (`lmsysorg/sglang:v0.5.12-rocm700-mi30x`, just merged via #1425), same model (`deepseek-ai/DeepSeek-R1-0528`), same TP=8 search-space (conc 4..64, 1k1k + 8k1k).

### Launch script
`benchmarks/single_node/dsr1_fp8_mi300x_mtp.sh` mirrors `dsr1_fp8_mi300x.sh` (aiter attention, MLA-persist, MEC-FW gate for `HSA_NO_SCRATCH_RECLAIM`) and adds:
- `export SGLANG_ENABLE_SPEC_V2=1`
- `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`
- `--use-chat-template` on the bench client per AGENTS.md

## Test plan
- [x] YAML loads; `bash -n` syntax passes on the launch script.
- [ ] full-sweep-enabled sweep finishes green on mi300x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)