### PR TITLE
[Klaud Cold] klaud-pr-status-html: add queue-aware ETA + Almost Ready section

### DIFF
--- a/.claude/commands/klaud-pr-status-html.md
+++ b/.claude/commands/klaud-pr-status-html.md
@@ -32,6 +32,7 @@ State buckets:
 
 ```bash
 : > /tmp/klaud_pr_status.tsv
+: > /tmp/klaud_pr_jobs.tsv   # per-job (pr, pool, state) for queue-aware ETA
 while IFS=$'\t' read -r pr branch created title; do
   rollup=$(gh pr view "$pr" --repo SemiAnalysisAI/InferenceX --json statusCheckRollup,headRefOid)
   classification=$(printf '%s' "$rollup" | jq -r '
@@ -53,6 +54,18 @@ while IFS=$'\t' read -r pr branch created title; do
     [.statusCheckRollup[] | state] | group_by(.) | map("\(.[0])=\(length)") | join(" ")')
   head_sha=$(printf '%s' "$rollup" | jq -r '.headRefOid')
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$pr" "$classification" "$breakdown" "$branch" "$created" "$head_sha" "$title" >> /tmp/klaud_pr_status.tsv
+
+  # Per-job pool + state for queue-aware ETA (only Run Sweep jobs that are pending).
+  # Pool extracted from job name via regex; "unknown" if no match.
+  printf '%s' "$rollup" | jq -r --arg pr "$pr" '
+    def state: if (.conclusion // "") != "" then .conclusion else .status end;
+    .statusCheckRollup[]
+    | select(.workflowName == "Run Sweep")
+    | state as $s
+    | select($s == "QUEUED" or $s == "IN_PROGRESS")
+    | ((.name | capture("(?<p>b200|b300|h100|h200|mi300x|mi325x|mi355x)").p) // "unknown") as $pool
+    | "\($pr)\t\($pool)\t\($s)"
+  ' >> /tmp/klaud_pr_jobs.tsv
 done < /tmp/klaud_pr_candidates.tsv
 ```
 
@@ -65,10 +78,23 @@ If you have per-PR diagnoses to inject (e.g. after running `/fix-klaud-cron-prs`
 ```bash
 cat > /tmp/gen_klaud_pr_status_html.py <<'PYEOF'
 #!/usr/bin/env python3
-import html, json, datetime as dt
+"""Render the Claude/Klaud-Cold PR status HTML dashboard.
+
+Per-PR ETA is computed as a *pool drain time* — for each runner pool the PR has
+pending jobs in, ETA_pool = ceil(global_pool_pending / pool_runners) × per-job
+time. The PR's overall ETA is max(ETA_pool) across the pools it touches.
+
+This is an upper bound, not an SLA — GitHub Actions does not guarantee FIFO
+dispatch outside `concurrency:` groups and does not expose queue position
+(see docs.github.com/en/actions). Treat ETAs as ordering hints only.
+"""
+import html, json, math, re, datetime as dt
+from collections import defaultdict
 from pathlib import Path
 
 tsv = Path("/tmp/klaud_pr_status.tsv").read_text().strip().splitlines()
+jobs_tsv_path = Path("/tmp/klaud_pr_jobs.tsv")
+jobs_tsv = jobs_tsv_path.read_text().strip().splitlines() if jobs_tsv_path.exists() else []
 diag_path = Path("/tmp/klaud_pr_diag.json")
 diag = json.loads(diag_path.read_text()) if diag_path.exists() else {}
 
@@ -80,18 +106,82 @@ state_class = {
     "NO_SWEEP": "state-NOSWEEP", "NO_SUCCESS": "state-NOSWEEP",
 }
 
+# Active self-hosted runner counts per pool (from GHA registrations as of the
+# session this was last touched). If a pool isn't listed, falls back to 4 — a
+# conservative guess. To refresh:
+#   gh api --paginate repos/SemiAnalysisAI/InferenceX/actions/runners \
+#     --jq '.runners[] | select(.status == "online") | .labels[].name' \
+#     | grep -xE 'b200|b300|h200|h100|mi300x|mi325x|mi355x' | sort | uniq -c
+POOL_RUNNERS = {"b200": 12, "b300": 18, "h100": 19, "h200": 18,
+                "mi300x": 9, "mi325x": 9, "mi355x": 9}
+DEFAULT_POOL_RUNNERS = 4
+AVG_JOB_MIN = 7  # rough sweep-job median; eval+1k1k ~5min, 8k1k+agentic ~10-15min
+
+def parse_breakdown(breakdown):
+    counts = {}
+    for kv in breakdown.split():
+        m = re.match(r"^([A-Z_]+)=(\d+)$", kv)
+        if m: counts[m.group(1)] = int(m.group(2))
+    return counts
+
+# Aggregate per-pool global pending across all open Klaud-Cold/claude PRs +
+# per-PR per-pool pending (so we know which pools each PR's queue traffic hits).
+pool_global_pending = defaultdict(int)         # pool → total pending across all PRs
+pr_pool_pending = defaultdict(lambda: defaultdict(int))  # pr → pool → pending count
+for line in jobs_tsv:
+    parts = line.split("\t")
+    if len(parts) < 3: continue
+    pr, pool, state = parts[0], parts[1], parts[2]
+    pool_global_pending[pool] += 1
+    pr_pool_pending[pr][pool] += 1
+
+def eta_min_for_pr(pr):
+    """Per-pool pessimistic ETA: pool drain time = ceil(global_pending / runners) × avg_job_min.
+    PR's ETA is max across pools (pools run in parallel; slowest one bounds completion)."""
+    pools = pr_pool_pending.get(pr, {})
+    if not pools: return 0
+    eta_min = 0
+    for pool in pools:
+        runners = POOL_RUNNERS.get(pool, DEFAULT_POOL_RUNNERS)
+        drain = math.ceil(pool_global_pending[pool] / runners) * AVG_JOB_MIN
+        if drain > eta_min: eta_min = drain
+    return eta_min
+
+def eta_label_from_min(m):
+    if m == 0:   return ""
+    if m < 5:    return "&lt;5m"
+    if m <= 15:  return "5-15m"
+    if m <= 30:  return "15-30m"
+    if m <= 60:  return "30-60m"
+    if m <= 120: return "1-2h"
+    return "2h+"
+
+ALMOST_READY_THRESHOLD = 5  # RUNNING PRs with <= this many pending jobs are "almost ready"
+
 rows = []
+almost_ready = []  # (pending_total, pr, title, breakdown, eta_min, eta_label) — for RUNNING rows
 for line in tsv:
     parts = line.split("\t")
-    if len(parts) < 7:
-        continue
+    if len(parts) < 7: continue
     pr, state, breakdown, branch, created, sha, title = parts[0], parts[1], parts[2], parts[3], parts[4], parts[5], "\t".join(parts[6:])
     state_counts[state] = state_counts.get(state, 0) + 1
     d = diag.get(pr, {})
-    rows.append((state_order.get(state, 99), -int(pr), pr, state, breakdown, title, d.get("reason", ""), d.get("fix", "")))
+    bc = parse_breakdown(breakdown)
+    ip, q = bc.get("IN_PROGRESS", 0), bc.get("QUEUED", 0)
+    em = eta_min_for_pr(pr) if state == "RUNNING" else 0
+    eta = eta_label_from_min(em)
+    rows.append((state_order.get(state, 99), -int(pr), pr, state, breakdown, title, d.get("reason", ""), d.get("fix", ""), eta))
+    if state == "RUNNING" and 0 < (ip + q) <= ALMOST_READY_THRESHOLD:
+        almost_ready.append((em, ip + q, ip, q, pr, title, breakdown, eta))
 
 rows.sort()
+almost_ready.sort()  # primary by eta-min ascending → closest to ready first
 now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+total_global_pending = sum(pool_global_pending.values())
+pool_pressure_summary = " · ".join(
+    f"{pool}={cnt}/{POOL_RUNNERS.get(pool, DEFAULT_POOL_RUNNERS)}r"
+    for pool, cnt in sorted(pool_global_pending.items()) if cnt > 0
+)
 
 out = ['<!doctype html>',
 '<html lang="en"><head><meta charset="utf-8"><title>Claude / Klaud Cold PR status — InferenceX</title>',
@@ -111,6 +201,7 @@ out = ['<!doctype html>',
 '  .breakdown { font-family: ui-monospace, "SF Mono", Menlo, monospace; color:#444; white-space: nowrap; font-size:11px; }',
 '  .reason, .fix { font-size: 12px; max-width: 460px; }',
 '  .fix { color:#444; }',
+'  .eta { font-family: ui-monospace, "SF Mono", Menlo, monospace; color:#0a7; white-space: nowrap; font-size:11px; }',
 '  code { background:#f0f0f0; padding:1px 4px; border-radius:3px; font-size:11px; }',
 '  a { color:#06c; text-decoration: none; } a:hover { text-decoration: underline; }',
 '  .summary { display:flex; gap:10px; margin-bottom: 12px; flex-wrap:wrap; }',
@@ -119,28 +210,53 @@ out = ['<!doctype html>',
 '  .pill.running { background:#dfeeff; color:#06c; }',
 '  .pill.failed  { background:#fde0e0; color:#c33; }',
 '  .pill.noswp   { background:#fbe9c8; color:#a60; }',
+'  .pill.almost  { background:#e6f5e0; color:#3a3; }',
+'  .almost-section { background:#f5fbf2; border:1px solid #d6ebcc; border-radius:6px; padding:10px 14px; margin-bottom:16px; font-size:13px; }',
+'  .almost-section h2 { font-size:13px; margin:0 0 8px; color:#3a3; text-transform: uppercase; letter-spacing:0.04em; }',
+'  .almost-section ul { margin:0; padding-left:0; list-style:none; }',
+'  .almost-section li { padding: 3px 0; }',
+'  .almost-section .pen { display:inline-block; min-width:48px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size:11px; color:#666; }',
+'  .almost-section .eta { display:inline-block; min-width:56px; color:#3a3; font-weight:600; }',
 '</style></head><body>',
 '<h1>Claude / [Klaud Cold] PR status &mdash; InferenceX</h1>',
-f'<div class="meta">Generated {now}. Source: <code>gh pr view --json statusCheckRollup</code> for every <code>claude/*</code> or <code>[Klaud Cold]</code>-titled open PR. Diagnoses (if any) loaded from <code>/tmp/klaud_pr_diag.json</code>.</div>']
+f'<div class="meta">Generated {now}. Source: <code>gh pr view --json statusCheckRollup</code> for every <code>claude/*</code> or <code>[Klaud Cold]</code>-titled open PR. Diagnoses (if any) loaded from <code>/tmp/klaud_pr_diag.json</code>. <strong>ETA</strong> = pool-drain pessimistic estimate (<code>ceil(global_pool_pending / runners) × ~{AVG_JOB_MIN}m/job</code>); GHA dispatch isn\'t guaranteed FIFO and queue position isn\'t exposed (see <a href="https://docs.github.com/en/actions">docs.github.com/en/actions</a>) so this is an upper-bound ordering hint, not a SLA.</div>',
+f'<div class="meta">Global pending across all open Klaud/claude sweeps: <strong>{total_global_pending}</strong> jobs &mdash; per-pool: {html.escape(pool_pressure_summary) if pool_pressure_summary else "—"}</div>']
 
 pill_specs = [("READY", "ready"), ("RUNNING", "running"),
               ("FAILED", "failed"), ("FAILED+RUNNING", "failed"),
               ("NO_SWEEP", "noswp"), ("NO_SUCCESS", "noswp")]
 pills = [f'<span class="pill {cls}">{name}: {state_counts[name]}</span>'
          for name, cls in pill_specs if state_counts.get(name, 0)]
+if almost_ready:
+    pills.append(f'<span class="pill almost">ALMOST READY: {len(almost_ready)}</span>')
 out.append('<div class="summary">' + "".join(pills) + '</div>')
+
+# Almost-ready section (RUNNING PRs with <= 5 pending), sorted by pool-aware ETA asc
+if almost_ready:
+    out.append('<div class="almost-section"><h2>Almost ready (closest to mergeable — sorted by ETA)</h2><ul>')
+    for em, total, ip, q, pr, title, breakdown, eta in almost_ready:
+        pool_str = ", ".join(f"{p}:{c}" for p, c in pr_pool_pending.get(pr, {}).items())
+        out.append(
+            f'<li>'
+            f'<span class="pen">pending={total} (q={q} ip={ip}; pools={pool_str or "?"})</span> '
+            f'<span class="eta">ETA {eta or "—"}</span> '
+            f'<a href="https://github.com/SemiAnalysisAI/InferenceX/pull/{pr}" target="_blank">#{pr}</a> &mdash; {html.escape(title)}'
+            f'</li>'
+        )
+    out.append('</ul></div>')
 
 out.append('<table><thead><tr>'
            '<th>PR</th><th>State</th><th>Check breakdown</th>'
-           '<th>Reason</th><th>Suggested fix</th><th>Title</th>'
+           '<th>ETA</th><th>Reason</th><th>Suggested fix</th><th>Title</th>'
            '</tr></thead><tbody>')
 
-for _, _, pr, state, breakdown, title, reason, fix in rows:
+for _, _, pr, state, breakdown, title, reason, fix, eta in rows:
     cls = state_class.get(state, "state-RUNNING")
     out.append(
         f'<tr><td class="pr"><a href="https://github.com/SemiAnalysisAI/InferenceX/pull/{pr}" target="_blank">#{pr}</a></td>'
         f'<td class="{cls}">{state}</td>'
         f'<td class="breakdown">{html.escape(breakdown)}</td>'
+        f'<td class="eta">{eta or "&mdash;"}</td>'
         f'<td class="reason">{reason or "&mdash;"}</td>'
         f'<td class="fix">{fix or "&mdash;"}</td>'
         f'<td>{html.escape(title)}</td></tr>'
@@ -148,7 +264,7 @@ for _, _, pr, state, breakdown, title, reason, fix in rows:
 
 out.append('</tbody></table></body></html>')
 Path("/tmp/klaud_pr_status.html").write_text("\n".join(out))
-print(f"Wrote /tmp/klaud_pr_status.html — {len(rows)} rows, states: {state_counts}")
+print(f"Wrote /tmp/klaud_pr_status.html — {len(rows)} rows, states: {state_counts}, almost-ready: {len(almost_ready)}")
 PYEOF
 python3 /tmp/gen_klaud_pr_status_html.py
 open /tmp/klaud_pr_status.html 2>/dev/null || true


### PR DESCRIPTION
## Summary
Extends `.claude/commands/klaud-pr-status-html.md` with:

1. **Per-PR ETA column** in the main status table.
2. **"Almost ready" callout** at the top — now sorted by ETA (instead of raw pending count) so PRs stuck behind a heavily-contended pool stop falsely surfacing as "close to mergeable".
3. **Global pending context line** in the page header showing per-pool depth + runner counts.

## ETA model

```
ETA_pr = max over the pools the PR has pending jobs in of:
           ceil(global_pool_pending / pool_runners) × avg_per_job_min
```

i.e. pool-drain pessimistic estimate. Time for the most-contended pool the PR is queued on to fully drain, assuming serial per-runner processing. Upper bound, not SLA.

Bucketed labels: `<5m / 5-15m / 15-30m / 30-60m / 1-2h / 2h+`.

### Why not a position-precise SLA

Researched first (see commit body): GitHub Actions doesn't guarantee FIFO dispatch outside `concurrency:` groups, doesn't expose a `queued_at` job timestamp (only `created_at`), and doesn't expose queue position via any API. Pool-drain pessimistic is the strongest honest signal available without scheduling-internals access.

## Plumbing

- Step 2 now writes `/tmp/klaud_pr_jobs.tsv` (one row per pending Run Sweep job: `pr<TAB>pool<TAB>state`) in addition to the existing `/tmp/klaud_pr_status.tsv`. Pool extracted from job name via regex.
- Step 3 Python loads both, aggregates global per-pool pending, hard-codes runner counts, computes per-PR ETA.

Runner counts are hard-coded from current GHA registrar state (`b200=12, b300=18, h100=19, h200=18, mi300x/325x/355x=9`). Comment in the Python explains how to re-fetch.

No new external API calls — reuses existing rollup data with one more jq pass per PR.

## Test plan
- [x] Tested locally end-to-end on current dashboard state (385 jobs pending across 28 PRs); render verified in browser. Almost Ready section correctly re-sorted: PRs with 1-2 pending on mi355x (pool drain ~2h+) no longer surface above PRs with 3 pending on b300 (pool drain ~21m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)