### PR TITLE
[Klaud Cold] Add qwen3.5-bf16-h200-sglang (off + mtp) recipes

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3083,6 +3083,44 @@ dsv4-fp4-b300-vllm-mtp:
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
 
+qwen3.5-bf16-h200-sglang:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: Qwen/Qwen3.5-397B-A17B
+  model-prefix: qwen3.5
+  runner: h200
+  precision: bf16
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
+
+qwen3.5-bf16-h200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: Qwen/Qwen3.5-397B-A17B
+  model-prefix: qwen3.5
+  runner: h200
+  precision: bf16
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 qwen3.5-fp8-h200-sglang:
   image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/benchmarks/single_node/qwen3.5_bf16_h200.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_h200.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Qwen-3.5-397B-A17B BF16 on H200 via sglang. Mirrors qwen3.5_fp8_h200.sh but
+# drops the FP8-quant / FP8-KV-cache flags since the model is bf16.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+MAX_SEQ_LEN=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_SEQ_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp "$TP" \
+  --expert-parallel-size "$EP_SIZE" \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --enable-flashinfer-allreduce-fusion \
+  --max-running-requests 128 \
+  --chunked-prefill-size 16384 \
+  --decode-log-interval 1 \
+  --mem-fraction-static 0.8 \
+  --cuda-graph-max-bs "$CONC" \
+  --context-length "$MAX_SEQ_LEN" \
+  --attention-backend flashinfer \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --mamba-ssm-dtype bfloat16 \
+  --disable-radix-cache \
+  --trust-remote-code \
+  > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/qwen3.5_bf16_h200_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_bf16_h200_mtp.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Qwen-3.5-397B-A17B BF16 on H200 with EAGLE / MTP speculative decoding.
+# Mirrors qwen3.5_bf16_h200.sh; adds the speculative-* flags + SGLANG_ENABLE_SPEC_V2=1
+# and passes --use-chat-template per AGENTS.md (EAGLE is trained against chat inputs).
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+MAX_SEQ_LEN=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_SEQ_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp "$TP" \
+  --expert-parallel-size "$EP_SIZE" \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --enable-flashinfer-allreduce-fusion \
+  --max-running-requests 128 \
+  --chunked-prefill-size 16384 \
+  --decode-log-interval 1 \
+  --mem-fraction-static 0.8 \
+  --cuda-graph-max-bs "$CONC" \
+  --context-length "$MAX_SEQ_LEN" \
+  --attention-backend flashinfer \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --mamba-ssm-dtype bfloat16 \
+  --disable-radix-cache \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2834,3 +2834,10 @@
     - "Update SGLang image from v0.5.11-cu130 to v0.5.12-cu130"
     - "Add --mm-attention-backend triton_attn to bypass flash-attn cute sm_103 assertion (see sgl-project/sglang#25564)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1422
+
+- config-keys:
+    - qwen3.5-bf16-h200-sglang
+    - qwen3.5-bf16-h200-sglang-mtp
+  description:
+    - "Add Qwen-3.5-397B-A17B BF16 sglang recipes (off + MTP/EAGLE) for H200 on lmsysorg/sglang:v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2840,4 +2840,4 @@
     - qwen3.5-bf16-h200-sglang-mtp
   description:
     - "Add Qwen-3.5-397B-A17B BF16 sglang recipes (off + MTP/EAGLE) for H200 on lmsysorg/sglang:v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1508


### PR DESCRIPTION
## Summary
Closes the H200 qwen3.5 BF16 gap. Existing H200 recipes only covered qwen3.5-fp8 (off + mtp) and glm5-fp8 (off + mtp); the bf16 sibling for qwen3.5 was missing despite H200 having the headroom for it.

### Recipes
- `qwen3.5-bf16-h200-sglang`
- `qwen3.5-bf16-h200-sglang-mtp`

Image: `lmsysorg/sglang:v0.5.12-cu130` (matches the fp8 sibling). Model: `Qwen/Qwen3.5-397B-A17B`. TP=8, EP=8, conc 4..64, 1k1k + 8k1k — same shape as the fp8 sibling on H200.

### Launch scripts
Both mirror `qwen3.5_fp8_h200.sh`; the FP8-quant + FP8-KV-cache flags are dropped since the model is bf16. MTP variant adds `SGLANG_ENABLE_SPEC_V2=1`, the standard EAGLE knobs, and `--use-chat-template` on the bench client per AGENTS.md.

## Test plan
- [x] YAML loads; `bash -n` syntax passes on both launch scripts.
- [ ] full-sweep-enabled sweep finishes green for both off + mtp matrices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)