### PR TITLE
[Klaud Cold] Add qwen3.5-fp8-h100-sglang (off + mtp) recipes

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8945,3 +8945,41 @@ kimik2.5-int4-h100-vllm:
       search-space:
       - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 20] }
       - { tp: 8, offloading: cpu,  conc-list: [1, 2, 4, 8, 12, 16, 20] }
+
+qwen3.5-fp8-h100-sglang:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: h100
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32 }
+
+qwen3.5-fp8-h100-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: h100
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32, spec-decoding: mtp }

--- a/benchmarks/single_node/qwen3.5_fp8_h100.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_h100.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Qwen-3.5-397B-A17B FP8 on H100 via sglang.
+# Mirrors qwen3.5_fp8_h200.sh but with tighter memory accommodations:
+# H100 has 80GB HBM3 vs H200's 141GB HBM3e, so weights + KV cache fit
+# more snugly. Mem-fraction-static lowered from 0.8 → 0.75 and
+# chunked-prefill-size from 16384 → 8192 to leave more headroom.
+# Sweep tops out at conc=32 instead of 64 for the same reason.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+MAX_SEQ_LEN=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_SEQ_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp "$TP" \
+  --expert-parallel-size "$EP_SIZE" \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --enable-flashinfer-allreduce-fusion \
+  --max-running-requests 64 \
+  --chunked-prefill-size 8192 \
+  --decode-log-interval 1 \
+  --mem-fraction-static 0.75 \
+  --cuda-graph-max-bs "$CONC" \
+  --context-length "$MAX_SEQ_LEN" \
+  --kv-cache-dtype fp8_e4m3 \
+  --quantization fp8 \
+  --attention-backend flashinfer \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --mamba-ssm-dtype bfloat16 \
+  --disable-radix-cache \
+  --trust-remote-code \
+  > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/qwen3.5_fp8_h100_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_h100_mtp.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Qwen-3.5-397B-A17B FP8 on H100 with EAGLE / MTP speculative decoding.
+# Mirrors qwen3.5_fp8_h100.sh; adds the speculative-* flags + SGLANG_ENABLE_SPEC_V2=1
+# and passes --use-chat-template per AGENTS.md.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+MAX_SEQ_LEN=$((ISL + OSL + 20))
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_SEQ_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+  --model "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tp "$TP" \
+  --expert-parallel-size "$EP_SIZE" \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --enable-flashinfer-allreduce-fusion \
+  --max-running-requests 64 \
+  --chunked-prefill-size 8192 \
+  --decode-log-interval 1 \
+  --mem-fraction-static 0.75 \
+  --cuda-graph-max-bs "$CONC" \
+  --context-length "$MAX_SEQ_LEN" \
+  --kv-cache-dtype fp8_e4m3 \
+  --quantization fp8 \
+  --attention-backend flashinfer \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --mamba-ssm-dtype bfloat16 \
+  --disable-radix-cache \
+  --trust-remote-code \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2834,3 +2834,10 @@
     - "Update SGLang image from v0.5.11-cu130 to v0.5.12-cu130"
     - "Add --mm-attention-backend triton_attn to bypass flash-attn cute sm_103 assertion (see sgl-project/sglang#25564)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1422
+
+- config-keys:
+    - qwen3.5-fp8-h100-sglang
+    - qwen3.5-fp8-h100-sglang-mtp
+  description:
+    - "Add Qwen-3.5-397B-A17B FP8 sglang recipes (off + MTP/EAGLE) for H100 on lmsysorg/sglang:v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2840,4 +2840,4 @@
     - qwen3.5-fp8-h100-sglang-mtp
   description:
     - "Add Qwen-3.5-397B-A17B FP8 sglang recipes (off + MTP/EAGLE) for H100 on lmsysorg/sglang:v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1509


### PR DESCRIPTION
## Summary
H100 had no qwen3.5 sglang recipes at all. Adds FP8 (off + MTP) on `lmsysorg/sglang:v0.5.12-cu130`. BF16 intentionally skipped — Qwen3.5-397B-A17B BF16 doesn't fit in H100's 80GB HBM3 at TP=8 (~100GB/GPU just for weights).

### Recipes
- `qwen3.5-fp8-h100-sglang`
- `qwen3.5-fp8-h100-sglang-mtp`

TP=8, EP=8, conc 4..32, 1k1k + 8k1k.

### Launch scripts
Mirror `qwen3.5_fp8_h200.sh` but with tighter memory accommodations for H100 (80GB vs H200's 141GB):

| Knob | H200 | H100 (this PR) |
|---|---|---|
| `--mem-fraction-static` | 0.80 | 0.75 |
| `--chunked-prefill-size` | 16384 | 8192 |
| `--max-running-requests` | 128 | 64 |
| Sweep conc cap | 64 | 32 |

MTP variant adds `SGLANG_ENABLE_SPEC_V2=1`, the standard EAGLE knobs, and `--use-chat-template`.

If the conservative settings leave throughput on the table once the first sweep lands, we can iterate upward.

## Test plan
- [x] YAML loads; `bash -n` syntax passes.
- [ ] full-sweep-enabled sweep finishes green for both off + mtp matrices on H100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)