### PR TITLE
[Klaud Cold] runners(h100-dgxc-slurm): flock the enroot import to fix concurrent-sweep race

### DIFF
--- a/runners/launch_h100-dgxc-slurm.sh
+++ b/runners/launch_h100-dgxc-slurm.sh
@@ -281,16 +281,28 @@ else
 
     HF_HUB_CACHE_MOUNT="/mnt/nfs/sa-shared/gharunners/hf-hub-cache/"
     SQUASH_FILE="/mnt/nfs/lustre/containers/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    LOCK_FILE="${SQUASH_FILE}.lock"
 
     salloc --exclude="$SLURM_EXCLUDED_NODELIST" --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
-    srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
-    if ! srun --jobid=$JOB_ID bash -c "unsquashfs -l $SQUASH_FILE > /dev/null"; then
-        echo "unsquashfs failed, removing $SQUASH_FILE and re-importing..."
-        srun --jobid=$JOB_ID bash -c "rm -f $SQUASH_FILE"
-        srun --jobid=$JOB_ID bash -c "enroot import -o $SQUASH_FILE docker://$IMAGE"
-    fi
+    # flock-serialize the enroot import so concurrent sweep jobs on the same
+    # shared NFS path don't race each other into 'File already exists' (race
+    # observed on PR #1509: 13/30 jobs failed, all on the dgxc-slurm runners
+    # hitting the same /mnt/nfs/lustre/containers/<image>.sqsh path). Matches
+    # the canonical pattern already used in launch_h100-cw.sh + the mi3xx
+    # launchers. The skip-if-valid check avoids re-downloading when the file
+    # was successfully created by an earlier job.
+    srun --jobid=$JOB_ID bash -c "
+        exec 9>\"$LOCK_FILE\"
+        flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
+        if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
+            echo 'Squash file already exists and is valid, skipping import'
+        else
+            rm -f \"$SQUASH_FILE\"
+            enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
+        fi
+    "
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \


### PR DESCRIPTION
## Summary
Adds the canonical `flock + unsquashfs-l skip-if-valid + enroot import` pattern to `runners/launch_h100-dgxc-slurm.sh`. Matches what `launch_h100-cw.sh` and the mi3xx launchers (#1462/#1477/#1498) already do.

## Why
PR [#1509](https://github.com/SemiAnalysisAI/InferenceX/pull/1509) (qwen3.5-fp8-h100-sglang new recipe) failed 13/30 matrix jobs on the dgxc-slurm runners. All 13 hit:

```
[ERROR] File already exists: /mnt/nfs/lustre/containers/lmsysorg_sglang_v0.5.12-cu130.sqsh
srun: error: hpc-gpu-1-12: task 0: Exited with exit code 1
```

…then sglang followed with `OSError: [Errno 116] Stale file handle` from the partial sqsh once the next jobs tried to mount it.

Root cause: concurrent matrix jobs all `srun enroot import -o <shared NFS path>` without a lock. First one wins; the rest crash. The shared NFS storage (`/mnt/nfs/lustre/containers/`) makes the race deterministic at high sweep concurrency. The other h100 launcher variant (`launch_h100-cw.sh`) had this fix already; the dgxc-slurm variant didn't.

## Diff
Wraps the import in:
```bash
exec 9>"$LOCK_FILE"
flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
if unsquashfs -l "$SQUASH_FILE" > /dev/null 2>&1; then
    echo 'Squash file already exists and is valid, skipping import'
else
    rm -f "$SQUASH_FILE"
    enroot import -o "$SQUASH_FILE" docker://$IMAGE
fi
```

No other behavior change. The `--exclude=$SLURM_EXCLUDED_NODELIST`, salloc args, and downstream srun stay the same.

## Test plan
- [x] `bash -n runners/launch_h100-dgxc-slurm.sh` syntax-checks.
- [ ] After merge: rebased #1509 sweep re-runs without the import race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)