### PR TITLE
[Handoff to @Oseltamivir Claude /loop] [Klaud Cold] Test sgl-deep-gemm==0.0.1 pin for sgl#25551 (glm5-fp8-b300 DeepGemm regression)

### DIFF
--- a/benchmarks/single_node/glm5_fp8_b300.sh
+++ b/benchmarks/single_node/glm5_fp8_b300.sh
@@ -23,14 +23,16 @@ nvidia-smi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+pip install --break-system-packages --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
 # Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
 # downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
 # whether the deepgemm version jump is what causes the B300 TMA-descriptor
 # CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
 # downgraded version actually runs.
-pip install --no-deps "sgl-deep-gemm==0.0.1"
+# --break-system-packages required: the container's Python is PEP-668 externally-managed,
+# so the previous attempt silently failed and left the bundled 0.1.0 in place.
+pip install --break-system-packages --no-deps "sgl-deep-gemm==0.0.1"
 export SGL_ENABLE_JIT_DEEPGEMM=1
 
 SERVER_LOG=/workspace/server.log

--- a/benchmarks/single_node/glm5_fp8_b300.sh
+++ b/benchmarks/single_node/glm5_fp8_b300.sh
@@ -25,11 +25,13 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
 pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
-# Workaround for sgl-project/sglang#25551: v0.5.12 DeepGemm TMA-descriptor
-# regression on B300 (sm_120) crashes CUDA graph capture with
-# CUDA_ERROR_ILLEGAL_ADDRESS. Disabling JIT DeepGemm bypasses the affected
-# kernel path. Restore to =1 once the upstream regression is fixed.
-export SGL_ENABLE_JIT_DEEPGEMM=0
+# Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
+# downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
+# whether the deepgemm version jump is what causes the B300 TMA-descriptor
+# CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
+# downgraded version actually runs.
+pip install --no-deps "sgl-deep-gemm==0.0.1"
+export SGL_ENABLE_JIT_DEEPGEMM=1
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}

--- a/benchmarks/single_node/glm5_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_b300_mtp.sh
@@ -23,14 +23,16 @@ nvidia-smi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+pip install --break-system-packages --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
 # Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
 # downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
 # whether the deepgemm version jump is what causes the B300 TMA-descriptor
 # CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
 # downgraded version actually runs.
-pip install --no-deps "sgl-deep-gemm==0.0.1"
+# --break-system-packages required: the container's Python is PEP-668 externally-managed,
+# so the previous attempt silently failed and left the bundled 0.1.0 in place.
+pip install --break-system-packages --no-deps "sgl-deep-gemm==0.0.1"
 export SGL_ENABLE_JIT_DEEPGEMM=1
 export SGLANG_ENABLE_SPEC_V2=1
 

--- a/benchmarks/single_node/glm5_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_b300_mtp.sh
@@ -25,11 +25,13 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
 pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
-# Workaround for sgl-project/sglang#25551: v0.5.12 DeepGemm TMA-descriptor
-# regression on B300 (sm_120) crashes CUDA graph capture with
-# CUDA_ERROR_ILLEGAL_ADDRESS. Disabling JIT DeepGemm bypasses the affected
-# kernel path. Restore to =1 once the upstream regression is fixed.
-export SGL_ENABLE_JIT_DEEPGEMM=0
+# Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
+# downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
+# whether the deepgemm version jump is what causes the B300 TMA-descriptor
+# CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
+# downgraded version actually runs.
+pip install --no-deps "sgl-deep-gemm==0.0.1"
+export SGL_ENABLE_JIT_DEEPGEMM=1
 export SGLANG_ENABLE_SPEC_V2=1
 
 SERVER_LOG=/workspace/server.log

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3043,3 +3043,10 @@
   description:
     - "Update SGLang image from v0.5.11-cu130 (5d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1475
+
+- config-keys:
+    - glm5-fp8-b300-sglang
+    - glm5-fp8-b300-sglang-mtp
+  description:
+    - "Test @trevor-m's suggestion in sgl-project/sglang#25551: pin sgl-deep-gemm==0.0.1 inside v0.5.12 container to isolate whether the deep-gemm 0.0.1→0.1.0 upgrade is the source of the B300 CUDA_ERROR_ILLEGAL_ADDRESS regression."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1512


### PR DESCRIPTION
## Summary

Testing @trevor-m's suggestion in [sgl-project/sglang#25551 (comment)](https://github.com/sgl-project/sglang/issues/25551#issuecomment-4481466979): inside the `lmsysorg/sglang:v0.5.12-cu130` container, downgrade `sgl-deep-gemm` from `0.1.0` → `0.0.1` and re-enable JIT DeepGemm to see whether the deep-gemm version jump is what triggers the B300 `CUDA_ERROR_ILLEGAL_ADDRESS` TMA-descriptor regression.

Previously, both `glm5_fp8_b300.sh` and `glm5_fp8_b300_mtp.sh` worked around the bug by setting `SGL_ENABLE_JIT_DEEPGEMM=0`, which avoids the broken kernel path entirely. This PR replaces that workaround with a targeted version pin so we can attribute the regression.

## Outcome interpretation
- **Sweep green** → the deep-gemm 0.0.1 → 0.1.0 upgrade is the source of the regression; we should file an upstream issue against sgl-deep-gemm with a standalone repro.
- **Sweep red** → the regression is elsewhere in sglang's v0.5.12 changes (not in deep-gemm), and bisecting per Trevor's second experiment is the next step.

## Not for merge
This PR is **for upstream debugging only** — once the result is known, either revert (if 0.0.1 doesn't fix it) or convert into a real fix (if it does). Do not merge as-is; we don't want to silently pin an older deep-gemm in production.

## Test plan
- [ ] Sweep runs to completion on both `glm5-fp8-b300-sglang` and `glm5-fp8-b300-sglang-mtp`
- [ ] Capture result on sgl-project/sglang#25551
- [ ] Decide next step based on green/red

🤖 AI-generated via Claude Code `/loop`.
