### PR TITLE
[DO NOT MERGE][WIP][NV] update- qwen3.5-fp8-b200-sglang-mtp

### DIFF
--- a/benchmarks/single_node/qwen3.5_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_b200_mtp.sh
@@ -36,7 +36,6 @@ set -x
 SGLANG_ENABLE_SPEC_V2=1 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 --expert-parallel-size=$EP_SIZE \
---enable-symm-mem \
 --disable-radix-cache \
 --quantization fp8 \
 --kv-cache-dtype fp8_e4m3 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2841,3 +2841,9 @@
   description:
     - "Add Qwen-3.5-397B-A17B FP8 sglang recipes (off + MTP/EAGLE) for H100 on lmsysorg/sglang:v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1509
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang-mtp
+  description:
+    - "Drop --enable-symm-mem from qwen3.5 FP8 B200 sglang MTP server launch"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2846,4 +2846,4 @@
     - qwen3.5-fp8-b200-sglang-mtp
   description:
     - "Drop --enable-symm-mem from qwen3.5 FP8 B200 sglang MTP server launch"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1513


### PR DESCRIPTION
## Summary

Remove `--enable-symm-mem` flag from the Qwen 3.5 FP8 B200 SGLang MTP benchmark recipe (`benchmarks/single_node/qwen3.5_fp8_b200_mtp.sh`).

## Changes

- **`benchmarks/single_node/qwen3.5_fp8_b200_mtp.sh`**: Drop `--enable-symm-mem` from the SGLang server launch args
- **`perf-changelog.yaml`**: Add changelog entry for the `qwen3.5-fp8-b200-sglang-mtp` config to trigger a sweep re-run with the updated launch args

## Motivation

Disable symmetric memory allreduce for the Qwen 3.5 FP8 B200 MTP recipe to evaluate performance without this flag.