### PR TITLE
[Klaud Cold] Add dsr1-fp4-mi355x-sglang-mtp single-node MTP recipe

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -26,6 +26,25 @@ dsr1-fp4-mi355x-sglang:
     #   search-space:
     #   - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 32, 64, 128, 256] }
 
+dsr1-fp4-mi355x-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-rocm700-mi35x
+  model: amd/DeepSeek-R1-0528-MXFP4
+  model-prefix: dsr1
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 dsr1-fp4-mi355x-atom:
   image: rocm/atom:rocm7.1.1-ubuntu24.04-pytorch2.9-atom0.1.1-MI350x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview

--- a/benchmarks/single_node/dsr1_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_mi355x_mtp.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# DeepSeek-R1-0528 MXFP4 on MI355X with EAGLE/MTP speculative decoding.
+# Mirrors dsr1_fp4_mi355x.sh and adds the speculative-* flags.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+export SGLANG_USE_AITER=1
+export SGLANG_AITER_MLA_PERSIST=1
+export SGLANG_ENABLE_SPEC_V2=1
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+PREFILL_SIZE=196608
+if [[ "$ISL" == "8192" && "$OSL" == "1024" ]]; then
+	if [[ "$CONC" -gt "32" ]]; then
+		PREFILL_SIZE=32768
+	fi
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
+--host=0.0.0.0 --port=$PORT \
+--tensor-parallel-size=$TP \
+--ep-size $EP_SIZE \
+--chunked-prefill-size=$PREFILL_SIZE \
+--mem-fraction-static=0.8 \
+--disable-radix-cache \
+--num-continuous-decode-steps=4 \
+--max-prefill-tokens=$PREFILL_SIZE \
+--cuda-graph-max-bs=128 \
+--attention-backend aiter \
+--kv-cache-dtype fp8_e4m3 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 4 \
+$EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2969,4 +2969,4 @@
     - dsr1-fp4-mi355x-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-mi355x-sglang (model: amd/DeepSeek-R1-0528-MXFP4) on lmsysorg/sglang:v0.5.12-rocm700-mi35x"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1520

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2964,3 +2964,9 @@
     - "Update SGLang image from glm5-hopper to v0.5.10.post1-cu130"
     - "Add --enable-flashinfer-allreduce-fusion to server launch"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1033
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-mi355x-sglang (model: amd/DeepSeek-R1-0528-MXFP4) on lmsysorg/sglang:v0.5.12-rocm700-mi35x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
Add the single-node MTP/EAGLE speculative-decoding sibling for the existing `dsr1-fp4-mi355x-sglang` recipe.

| Field | Value |
| --- | --- |
| Recipe key | `dsr1-fp4-mi355x-sglang-mtp` |
| Model | `amd/DeepSeek-R1-0528-MXFP4` (MTP-ready non-Preview fp4 build, matching `dsr1-fp4-mi355x-atom-mtp`) |
| Image | `lmsysorg/sglang:v0.5.12-rocm700-mi35x` (same as the off sibling) |
| Search space | `tp=8 ep=1 conc 4..64 spec-decoding=mtp` on 1k1k + 8k1k |

### Launch script
`benchmarks/single_node/dsr1_fp4_mi355x_mtp.sh` clones the off variant (`dsr1_fp4_mi355x.sh`) and adds, modeled on the production `dsr1_fp8_mi325x_mtp.sh` template:

- `--ep-size $EP_SIZE`
- `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`
- Env vars: `SGLANG_AITER_MLA_PERSIST=1`, `SGLANG_ENABLE_SPEC_V2=1`
- `--use-chat-template` on the bench client

## Test plan
- [x] YAML loads; `bash -n` syntax passes on the new launch script.
- [ ] full-sweep-enabled sweep finishes green on mi355x for tp=8 ep=1 conc 4..64 spec-decoding=mtp / 1k1k + 8k1k.