### PR TITLE
[Klaud Cold] Add dsr1-fp4-b200-sglang-mtp single-node MTP recipe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1698,6 +1698,25 @@ dsr1-fp4-b200-sglang:
     #   - { tp: 4, ep: 4, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 24, 32, 48, 64, 128, 256] }
     #   - { tp: 8, ep: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 32, 64, 128, 256, 512] }
 
+dsr1-fp4-b200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: nvidia/DeepSeek-R1-0528-FP4-V2
+  model-prefix: dsr1
+  runner: b200
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
+
 dsv4-fp4-b200-sglang:
   image: lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/benchmarks/single_node/dsr1_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_b200_mtp.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# DeepSeek-R1-0528 FP4 on B200 with EAGLE/MTP speculative decoding.
+# Mirrors dsr1_fp4_b200.sh and adds the speculative-* flags from
+# dsr1_fp8_b200_mtp.sh (the production B200 sglang MTP template).
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+nvidia-smi
+
+# MTP only supports TP=8 for now (matching dsr1_fp8_b200_mtp.sh)
+if [[ $TP -ne 8 ]]; then
+  echo "MTP only supports TP=8, got TP=$TP!"
+  exit 1
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+if [[ $CONC -ge 16 ]]; then
+  SCHEDULER_RECV_INTERVAL=30
+else
+  SCHEDULER_RECV_INTERVAL=10
+fi
+echo "SCHEDULER_RECV_INTERVAL: $SCHEDULER_RECV_INTERVAL, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+# MTP (Multi-Token Prediction) Config - EAGLE speculative decoding
+SPECULATIVE_NUM_STEPS=2
+SPECULATIVE_DRAFT_TOKENS=3
+SPECULATIVE_EAGLE_TOPK=1
+
+export SGLANG_ENABLE_SPEC_V2=1
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL --host 0.0.0.0 --port $PORT --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--cuda-graph-max-bs 512 --max-running-requests 512 --mem-fraction-static 0.82 --kv-cache-dtype fp8_e4m3 \
+--chunked-prefill-size 16384 --max-prefill-tokens 16384 \
+--ep-size $EP_SIZE --quantization modelopt_fp4 --enable-flashinfer-allreduce-fusion --scheduler-recv-interval $SCHEDULER_RECV_INTERVAL \
+--enable-symm-mem --disable-radix-cache --attention-backend trtllm_mla --moe-runner-backend flashinfer_trtllm --stream-interval 30 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps $SPECULATIVE_NUM_STEPS \
+--speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS \
+--speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK \
+$EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $((CONC * 10)) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2971,3 +2971,9 @@
   description:
     - "Update Atom ROCm image (off: rocm7.1.1-...-atom0.1.1-MI350x 125d / mtp: rocm7.2.0-...-atom0.1.1 83d) to rocm7.2.3_..._atom20260511"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1518
+
+- config-keys:
+    - dsr1-fp4-b200-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-b200-sglang (model: nvidia/DeepSeek-R1-0528-FP4-V2) on lmsysorg/sglang:v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2976,4 +2976,4 @@
     - dsr1-fp4-b200-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-b200-sglang (model: nvidia/DeepSeek-R1-0528-FP4-V2) on lmsysorg/sglang:v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1522


### PR DESCRIPTION
## Summary
Add the single-node MTP/EAGLE speculative-decoding sibling for the existing `dsr1-fp4-b200-sglang` recipe.

| Field | Value |
| --- | --- |
| Recipe key | `dsr1-fp4-b200-sglang-mtp` |
| Model | `nvidia/DeepSeek-R1-0528-FP4-V2` (same as the off sibling) |
| Image | `lmsysorg/sglang:v0.5.12-cu130` (same as the off sibling) |
| Search space | `tp=8 ep=1 conc 4..512 spec-decoding=mtp` on 1k1k + 8k1k (matches dsr1-fp8-b200-sglang-mtp) |

### Launch script
`benchmarks/single_node/dsr1_fp4_b200_mtp.sh` clones the off variant (`dsr1_fp4_b200.sh`) and overlays MTP bits from the production B200 sglang MTP template (`dsr1_fp8_b200_mtp.sh`):

- TP=8 enforcement check
- `--cuda-graph-max-bs 512` / `--max-running-requests 512` (up from 256 in the off variant)
- `--speculative-algorithm EAGLE --speculative-num-steps 2 --speculative-num-draft-tokens 3 --speculative-eagle-topk 1`
- Env: `SGLANG_ENABLE_SPEC_V2=1`
- `--use-chat-template` on the bench client

Keeps fp4-specific bits intact: `--quantization modelopt_fp4`, `--moe-runner-backend flashinfer_trtllm`, `--attention-backend trtllm_mla`.

## Test plan
- [x] YAML loads; `bash -n` syntax passes on the new launch script.
- [ ] full-sweep-enabled sweep finishes green on b200 for tp=8 ep=1 conc 4..512 spec-decoding=mtp / 1k1k + 8k1k.