### PR TITLE
[Klaud Cold] Add dsr1-fp8-h200-sglang-mtp single-node MTP recipe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2841,6 +2841,25 @@ dsr1-fp8-h200-sglang:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
+dsr1-fp8-h200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.12-cu130
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  runner: h200
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 # DeepSeek-V4-Pro H200 recipe from https://vllm.ai/blog/deepseek-v4
 # Uses the cu129 image. H200 has no FP4 path, so the FP4 indexer cache
 # flag is omitted. Max-model-len is pinned at 800k per the recipe.

--- a/benchmarks/single_node/dsr1_fp8_h200_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp8_h200_mtp.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# DeepSeek-R1-0528 FP8 on H200 with EAGLE/MTP speculative decoding.
+# Mirrors dsr1_fp8_h200.sh and adds the speculative-* flags from
+# dsr1_fp8_b200_mtp.sh (the production sglang MTP template).
+# Keeps the H200's flashinfer attention backend (no trtllm_mla path on
+# H200 for this image).
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+pip3 install --user --break-system-packages sentencepiece
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# MTP only supports TP=8 for now (matching dsr1_fp8_b200_mtp.sh)
+if [[ $TP -ne 8 ]]; then
+  echo "MTP only supports TP=8, got TP=$TP!"
+  exit 1
+fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# MTP (Multi-Token Prediction) Config - EAGLE speculative decoding
+SPECULATIVE_NUM_STEPS=2
+SPECULATIVE_DRAFT_TOKENS=3
+SPECULATIVE_EAGLE_TOPK=1
+
+export SGLANG_ENABLE_SPEC_V2=1
+export TORCH_CUDA_ARCH_LIST="9.0"
+
+start_gpu_monitor
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+set -x
+if [[ $ISL -eq 1024 && $OSL -eq 1024 ]]; then
+    MAX_RUNNING_REQUESTS=512
+    CUDA_GRAPH_MAX_BS=512
+else
+    MAX_RUNNING_REQUESTS=256
+    CUDA_GRAPH_MAX_BS=256
+fi
+
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL \
+--host 0.0.0.0 --port $PORT --trust-remote-code \
+--tensor-parallel-size=$TP --data-parallel-size=1 \
+--ep-size $EP_SIZE \
+--disable-radix-cache \
+--max-running-requests $MAX_RUNNING_REQUESTS \
+--cuda-graph-max-bs $CUDA_GRAPH_MAX_BS \
+--chunked-prefill-size 32768 --max-prefill-tokens 32768 --mem-fraction-static 0.82 \
+--attention-backend flashinfer --stream-interval 10 \
+--decode-log-interval 1 \
+--speculative-algorithm EAGLE \
+--speculative-num-steps $SPECULATIVE_NUM_STEPS \
+--speculative-num-draft-tokens $SPECULATIVE_DRAFT_TOKENS \
+--speculative-eagle-topk $SPECULATIVE_EAGLE_TOPK \
+$EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $(( $CONC * 10 )) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2975,5 +2975,5 @@
 - config-keys:
     - dsr1-fp8-h200-sglang-mtp
   description:
-    - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp8-h200-sglang (model: deepseek-ai/DeepSeek-R1-0528) on lmsysorg/sglang:v0.5.12-cu130"
+    - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp8-h200-sglang (model: deepseek-ai/DeepSeek-R1-0528) on lmsysorg/sglang:v0.5.12-cu130 — TP=8, EP=1, search-space conc 4..64 on 1k1k + 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1523

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2971,3 +2971,9 @@
   description:
     - "Update Atom ROCm image (off: rocm7.1.1-...-atom0.1.1-MI350x 125d / mtp: rocm7.2.0-...-atom0.1.1 83d) to rocm7.2.3_..._atom20260511"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1518
+
+- config-keys:
+    - dsr1-fp8-h200-sglang-mtp
+  description:
+    - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp8-h200-sglang (model: deepseek-ai/DeepSeek-R1-0528) on lmsysorg/sglang:v0.5.12-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2976,4 +2976,4 @@
     - dsr1-fp8-h200-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp8-h200-sglang (model: deepseek-ai/DeepSeek-R1-0528) on lmsysorg/sglang:v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1523


### PR DESCRIPTION
## Summary
Add the single-node MTP/EAGLE speculative-decoding sibling for the existing `dsr1-fp8-h200-sglang` recipe.

| Field | Value |
| --- | --- |
| Recipe key | `dsr1-fp8-h200-sglang-mtp` |
| Model | `deepseek-ai/DeepSeek-R1-0528` (same as the off sibling) |
| Image | `lmsysorg/sglang:v0.5.12-cu130` (same as the off sibling) |
| Search space | `tp=8 ep=1 conc 4..64 spec-decoding=mtp` on 1k1k + 8k1k |

### Launch script
`benchmarks/single_node/dsr1_fp8_h200_mtp.sh` clones the off variant (`dsr1_fp8_h200.sh`) and overlays MTP bits from the production sglang MTP template (`dsr1_fp8_b200_mtp.sh`):

- TP=8 enforcement check
- `--ep-size $EP_SIZE`
- `--speculative-algorithm EAGLE --speculative-num-steps 2 --speculative-num-draft-tokens 3 --speculative-eagle-topk 1`
- Env: `SGLANG_ENABLE_SPEC_V2=1`
- `--use-chat-template` on the bench client

Keeps H200-specific bits intact (`flashinfer` attention backend — no `trtllm_mla` path on H200 for this image, the 1k1k-vs-8k1k batch-size branch from the off variant, `TORCH_CUDA_ARCH_LIST=9.0`).

## Test plan
- [x] YAML loads; `bash -n` syntax passes on the new launch script.
- [ ] full-sweep-enabled sweep finishes green on h200 for tp=8 ep=1 conc 4..64 spec-decoding=mtp / 1k1k + 8k1k.