### PR TITLE
glm5 update launch B200/B300 FP8/FP4 agg

### DIFF
--- a/benchmarks/single_node/glm5_fp4_b200.sh
+++ b/benchmarks/single_node/glm5_fp4_b200.sh
@@ -52,6 +52,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --stream-interval 30 \
 --scheduler-recv-interval 10 \
 --tokenizer-worker-num 6 \
+--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000 \
 --tokenizer-path $MODEL $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/glm5_fp4_b300.sh
+++ b/benchmarks/single_node/glm5_fp4_b300.sh
@@ -56,6 +56,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --stream-interval 30 \
 --scheduler-recv-interval 10 \
 --tokenizer-worker-num 6 \
+--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000 \
 --tokenizer-path $MODEL $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/glm5_fp8_b200.sh
+++ b/benchmarks/single_node/glm5_fp8_b200.sh
@@ -54,6 +54,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --chunked-prefill-size 32768 --max-prefill-tokens 32768 \
 --enable-flashinfer-allreduce-fusion --disable-radix-cache \
 --stream-interval 30 \
+--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000 \
 --model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/glm5_fp8_b300.sh
+++ b/benchmarks/single_node/glm5_fp8_b300.sh
@@ -61,6 +61,7 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --chunked-prefill-size 32768 --max-prefill-tokens 32768 \
 --enable-flashinfer-allreduce-fusion --disable-radix-cache \
 --stream-interval 30 \
+--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000 \
 --model-loader-extra-config '{"enable_multithread_load": true}' $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3036,4 +3036,4 @@
     - glm5-fp4-b300-sglang
   description:
     - "Enable SGLang prefill-delayer on GLM-5 B200/B300 FP8/FP4 agg server launch: `--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000`"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1525

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3028,3 +3028,12 @@
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-b200-sglang (model: nvidia/DeepSeek-R1-0528-FP4-V2) on lmsysorg/sglang:v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1522
+
+- config-keys:
+    - glm5-fp8-b200-sglang
+    - glm5-fp8-b300-sglang
+    - glm5-fp4-b200-sglang
+    - glm5-fp4-b300-sglang
+  description:
+    - "Enable SGLang prefill-delayer on GLM-5 B200/B300 FP8/FP4 agg server launch: `--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000`"
+  pr-link: TBD


### PR DESCRIPTION
## Summary
- Adds `--enable-prefill-delayer --prefill-delayer-queue-min-ratio 0.1 --prefill-delayer-max-delay-ms 5000` to the `sglang.launch_server` command for the four GLM-5 single-node agg configs: `glm5-fp8-b200-sglang`, `glm5-fp8-b300-sglang`, `glm5-fp4-b200-sglang`, `glm5-fp4-b300-sglang`.
- Appends a perf-changelog entry for these four config-keys (`pr-link` placeholder will be replaced in a follow-up commit).