### PR TITLE
 gpt-oss-fp4-mi355x: switch to AITER-env-based recipe, work around v0.21 fuse_allreduce_rms regression

### DIFF
--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -18,27 +18,19 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-# If the machine runs a MEC FW older than 177, RCCL
-# cannot reclaim some memory.
-# Disable that features to avoid crashes.
-# This is related to the changes in the driver at:
-# https://rocm.docs.amd.com/en/docs-6.4.3/about/release-notes.html#amdgpu-driver-updates
-version=`rocm-smi --showfw | grep MEC | head -n 1 |  awk '{print $NF}'`
-if [[ "$version" == "" || $version -lt 177 ]]; then
-  export HSA_NO_SCRATCH_RECLAIM=1
-fi
-
 # Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
 if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
-export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_ROCM_USE_AITER_RMSNORM=1
+export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
+export VLLM_ROCM_USE_AITER_MHA=0
+export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
-FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
+export HSA_NO_SCRATCH_RECLAIM=1
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
@@ -51,13 +43,23 @@ fi
 start_gpu_monitor
 
 set -x
+# Disable fuse_allreduce_rms pass: enabled by default on ROCm in vllm 0.21+,
+# costs ~3% throughput on MI355x gpt-oss-fp4 with AITER (bisect: v021_compile_bisect_clean).
+# EXTRA_COMPILATION_CONFIG, if set, overrides this default.
+if [ -n "${EXTRA_COMPILATION_CONFIG:-}" ]; then
+  COMPILE_CFG_FLAGS=(--compilation-config "$EXTRA_COMPILATION_CONFIG")
+else
+  COMPILE_CFG_FLAGS=(--compilation-config '{"pass_config":{"fuse_allreduce_rms":false}}')
+fi
 vllm serve $MODEL --port $PORT \
-  $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
   --tensor-parallel-size=$TP \
+  --max-num-seqs 256 \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
-  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching \
+  --async-scheduling \
+  "${COMPILE_CFG_FLAGS[@]}" > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3043,3 +3043,10 @@
   description:
     - "Update SGLang image from v0.5.11-cu130 (5d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1475
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Switch to AITER-env-based recipe on v0.21: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
+    - "Pass --compilation-config to disable v0.21's new fuse_allreduce_rms pass (enabled by default on ROCm but costs ~4% on the AITER path). EXTRA_COMPILATION_CONFIG overrides the default"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
- Reworks gpt-oss-fp4-mi355x-vllm for v0.21. Enables the AITER kernel paths
  via env vars (MOE/RMSNorm/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM) and
  drops the old TRITON_ROPE, BUFFER_OPS, explicit --attention-backend, and
  fuse_rope_kvcache/use_inductor_graph_partition flags — none of them earn
  their keep on v0.21 anymore. Adds --max-num-seqs 256 and --async-scheduling.

-  The interesting bit is the --compilation-config flag that turns off
  fuse_allreduce_rms. vllm 0.21 enabled that pass by default on ROCm and it
  costs about 4% throughput on the AITER path for gpt-oss. I bisected this
  across the v0.19 → v0.20.0/.1/.2 → v0.21 docker images and confirmed with
  a swap-test (vllm 0.20.2 source on the v0.21.0 image), which narrowed the
  recoverable regression to this pass alone.

  Local numbers (single MI355x node, v0.21.0 image, 3 runs each, median):

  | ISL/OSL | conc | dashboard | this PR | Δ |
  |---|---|---|---|---|
  | 1k/1k | 4  | 2152  | 2478  | +15% |
  | 1k/1k | 8  | 3950  | 4547  | +15% |
  | 1k/1k | 16 | 6668  | 8682  | +30% |
  | 8k/1k | 4  | 7966  | 10208 | +28% |
  | 8k/1k | 8  | 14198 | 18159 | +28% |