### PR TITLE
Update DSV4 GB300 8k1k MTP disagg configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9116,21 +9116,6 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
           tp: 4
           ep: 1
           dp-attn: false
-      # Mid curve 1p1d-dep4-dep8. 3 nodes.
-      - spec-decoding: "mtp"
-        conc-list: [256]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-1p1d-dep4-dep8-mtp.yaml"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
       # Mid curve 1p1d-dep4-dep16. 5 nodes.
       - spec-decoding: "mtp"
         conc-list: [256]
@@ -9146,7 +9131,7 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
           tp: 16
           ep: 16
           dp-attn: true
-      # Mid curve 2p1d-dep4-dep8. 4 nodes.
+      # Mid curve 2p1d-dep4-dep16. 6 nodes.
       - spec-decoding: "mtp"
         conc-list: [512]
         prefill:
@@ -9155,13 +9140,13 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
           ep: 4
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-2p1d-dep4-dep8-mtp.yaml"
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-2p1d-dep4-dep16-mtp.yaml"
         decode:
           num-worker: 1
-          tp: 8
-          ep: 8
+          tp: 16
+          ep: 16
           dp-attn: true
-      # Mid curve 4p1d-dep4-dep8. 6 nodes.
+      # Mid curve 4p1d-dep4-dep16. 8 nodes.
       - spec-decoding: "mtp"
         conc-list: [1024]
         prefill:
@@ -9170,11 +9155,41 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
           ep: 4
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-4p1d-dep4-dep8-mtp.yaml"
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-4p1d-dep4-dep16-mtp.yaml"
         decode:
           num-worker: 1
-          tp: 8
-          ep: 8
+          tp: 16
+          ep: 16
+          dp-attn: true
+      # Mid curve 8p1d-dep4-dep16. 12 nodes.
+      - spec-decoding: "mtp"
+        conc-list: [1024]
+        prefill:
+          num-worker: 8
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-8p1d-dep4-dep16-mtp.yaml"
+        decode:
+          num-worker: 1
+          tp: 16
+          ep: 16
+          dp-attn: true
+      # Mid curve 12p1d-dep4-dep12. 15 nodes.
+      - spec-decoding: "mtp"
+        conc-list: [6144]
+        prefill:
+          num-worker: 12
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-12p1d-dep4-dep12-mtp.yaml"
+        decode:
+          num-worker: 1
+          tp: 12
+          ep: 12
           dp-attn: true
 
 kimik2.5-int4-h100-vllm:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-12p1d-dep4-dep12-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-12p1d-dep4-dep12-mtp.yaml
@@ -1,4 +1,4 @@
-name: "dsv4-pro-gb300-disagg-8k1k-low-latency-1p6d-dep4-tp4-mtp"
+name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-12p1d-dep4-dep12-mtp"
 
 frontend:
   type: dynamo
@@ -6,7 +6,7 @@ frontend:
   num_additional_frontends: 8
 
 dynamo:
-  hash: "9d3c913d300eb368cda28b3f98a23a5762621e0d"
+  hash: "34d55a596fb8d3d44daefe425ec1e303131f4d2c"
   install: true
 
 model:
@@ -21,10 +21,12 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 1
-  prefill_workers: 1
-  decode_nodes: 6
-  decode_workers: 6
+  prefill_nodes: 12
+  prefill_workers: 12
+  gpus_per_prefill: 4
+  decode_nodes: 3
+  decode_workers: 1
+  gpus_per_decode: 12
 
 backend:
   type: sglang
@@ -68,6 +70,16 @@ backend:
     SGLANG_OPT_USE_JIT_NORM: "1"
     SGLANG_OPT_USE_JIT_INDEXER_METADATA: "1"
     SGLANG_OPT_USE_TOPK_V2: "1"
+
+    SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN: "1"
+    SGLANG_OPT_USE_FAST_MASK_EP: "1"
+    SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE: "1"
+    SGLANG_OPT_FIX_HASH_MEGA_MOE: "1"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "4096"
+    SGLANG_OPT_FIX_MEGA_MOE_MEMORY: "1"
+    SGLANG_OPT_FIX_NEXTN_MEGA_MOE: "1"
+    SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
+
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
     SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
@@ -75,8 +87,7 @@ backend:
     SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
     SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW: "1"
-    # SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 intentionally NOT set: CAR_V2
-    # is single-node only and corrupts results in 2-node decode setups.
+    SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2: "0"  # CAR_V2 is single-node only.
 
   sglang_config:
     prefill:
@@ -99,9 +110,10 @@ backend:
       deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
 
       mem-fraction-static: 0.9
-      max-running-requests: 128
-      cuda-graph-max-bs: 128
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
       chunked-prefill-size: 32768
+      stream-interval: 60
 
     decode:
       served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
@@ -112,12 +124,15 @@ backend:
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
 
-      tensor-parallel-size: 4
-      data-parallel-size: 1
-      expert-parallel-size: 1
+      tensor-parallel-size: 12
+      data-parallel-size: 12
+      expert-parallel-size: 12
 
-      moe-runner-backend: "flashinfer_mxfp4"
-      disable-flashinfer-autotune: true
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+
+      moe-a2a-backend: "deepep"
+      deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
 
       speculative-algo: "EAGLE"
       speculative-num-steps: 3
@@ -125,17 +140,18 @@ backend:
       speculative-num-draft-tokens: 4
 
       mem-fraction-static: 0.9
-      max-running-requests: 128
-      cuda-graph-max-bs: 128
-      swa-full-tokens-ratio: 0.1
+      max-running-requests: 6144
+      cuda-graph-max-bs: 1024
+      swa-full-tokens-ratio: 0.15
       context-length: 16384
+      stream-interval: 60
 
 benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
   random_range_ratio: 0.8
-  concurrencies: "8x32x64"
+  concurrencies: "6144"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-2p1d-dep4-dep16-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-2p1d-dep4-dep16-mtp.yaml
@@ -1,4 +1,4 @@
-name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-1p1d-dep4-dep8-mtp"
+name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-2p1d-dep4-dep16-mtp"
 
 frontend:
   type: dynamo
@@ -21,12 +21,12 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 1
-  prefill_workers: 1
+  prefill_nodes: 2
+  prefill_workers: 2
   gpus_per_prefill: 4
-  decode_nodes: 2
+  decode_nodes: 4
   decode_workers: 1
-  gpus_per_decode: 8
+  gpus_per_decode: 16
 
 backend:
   type: sglang
@@ -75,7 +75,7 @@ backend:
     SGLANG_OPT_USE_FAST_MASK_EP: "1"
     SGLANG_OPT_USE_DEEPGEMM_MEGA_MOE: "1"
     SGLANG_OPT_FIX_HASH_MEGA_MOE: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "2048"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "4096"
     SGLANG_OPT_FIX_MEGA_MOE_MEMORY: "1"
     SGLANG_OPT_FIX_NEXTN_MEGA_MOE: "1"
     SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "0"
@@ -110,8 +110,8 @@ backend:
       deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
 
       mem-fraction-static: 0.9
-      max-running-requests: 256
-      cuda-graph-max-bs: 256
+      max-running-requests: 512
+      cuda-graph-max-bs: 512
       chunked-prefill-size: 32768
       stream-interval: 60
 
@@ -124,9 +124,9 @@ backend:
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
 
-      tensor-parallel-size: 8
-      data-parallel-size: 8
-      expert-parallel-size: 8
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
 
       enable-dp-attention: true
       enable-dp-lm-head: true
@@ -139,9 +139,9 @@ backend:
       speculative-eagle-topk: 1
       speculative-num-draft-tokens: 4
 
-      mem-fraction-static: 0.94
+      mem-fraction-static: 0.9
       max-running-requests: 3072
-      cuda-graph-max-bs: 256
+      cuda-graph-max-bs: 512
       swa-full-tokens-ratio: 0.15
       context-length: 16384
       stream-interval: 60
@@ -151,7 +151,7 @@ benchmark:
   isl: 8192
   osl: 1024
   random_range_ratio: 0.8
-  concurrencies: "256"
+  concurrencies: "512"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-4p1d-dep4-dep16-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-4p1d-dep4-dep16-mtp.yaml
@@ -1,4 +1,4 @@
-name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-4p1d-dep4-dep8-mtp"
+name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-4p1d-dep4-dep16-mtp"
 
 frontend:
   type: dynamo
@@ -24,9 +24,9 @@ resources:
   prefill_nodes: 4
   prefill_workers: 4
   gpus_per_prefill: 4
-  decode_nodes: 2
+  decode_nodes: 4
   decode_workers: 1
-  gpus_per_decode: 8
+  gpus_per_decode: 16
 
 backend:
   type: sglang
@@ -124,9 +124,9 @@ backend:
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
 
-      tensor-parallel-size: 8
-      data-parallel-size: 8
-      expert-parallel-size: 8
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
 
       enable-dp-attention: true
       enable-dp-lm-head: true

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-8p1d-dep4-dep16-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-mid-curve-8p1d-dep4-dep16-mtp.yaml
@@ -1,4 +1,4 @@
-name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-2p1d-dep4-dep8-mtp"
+name: "dsv4-pro-gb300-disagg-8k1k-mid-curve-8p1d-dep4-dep16-mtp"
 
 frontend:
   type: dynamo
@@ -21,12 +21,12 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 2
-  prefill_workers: 2
+  prefill_nodes: 8
+  prefill_workers: 8
   gpus_per_prefill: 4
-  decode_nodes: 2
+  decode_nodes: 4
   decode_workers: 1
-  gpus_per_decode: 8
+  gpus_per_decode: 16
 
 backend:
   type: sglang
@@ -110,8 +110,8 @@ backend:
       deepep-config: '{"normal_dispatch":{"num_sms":96},"normal_combine":{"num_sms":96}}'
 
       mem-fraction-static: 0.9
-      max-running-requests: 512
-      cuda-graph-max-bs: 512
+      max-running-requests: 1024
+      cuda-graph-max-bs: 1024
       chunked-prefill-size: 32768
       stream-interval: 60
 
@@ -124,9 +124,9 @@ backend:
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
 
-      tensor-parallel-size: 8
-      data-parallel-size: 8
-      expert-parallel-size: 8
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
 
       enable-dp-attention: true
       enable-dp-lm-head: true
@@ -141,7 +141,7 @@ backend:
 
       mem-fraction-static: 0.9
       max-running-requests: 3072
-      cuda-graph-max-bs: 512
+      cuda-graph-max-bs: 1024
       swa-full-tokens-ratio: 0.15
       context-length: 16384
       stream-interval: 60
@@ -151,7 +151,7 @@ benchmark:
   isl: 8192
   osl: 1024
   random_range_ratio: 0.8
-  concurrencies: "512"
+  concurrencies: "3072"
   req_rate: "inf"
   use_chat_template: true
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3089,3 +3089,11 @@
   description:
     - "Update SGLang image from v0.5.10.post1-cu130 / v0.5.11-cu130 (30d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1451
+
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-sglang-mtp
+  description:
+    - "Add dep16 mid-curve configs (2p1d, 4p1d, 8p1d) and 12p1d-dep4-dep12"
+    - "Update 1p6d low-latency dynamo hash"
+    - "Remove dep8 mid-curve configs (replaced by dep16)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1529


### PR DESCRIPTION
## Summary
- Add dep16 mid-curve configs: 2p1d, 4p1d, 8p1d
- Add 12p1d-dep4-dep12 mid-curve config
- Update 1p6d low-latency dynamo hash
- Remove dep8 mid-curve configs (replaced by dep16)

Reference: https://github.com/elvischenv/srt-slurm/tree/dsv4-gb300-disagg-8k1k-mtp-2/recipes/dsv4-pro/sglang/gb300-fp4/8k1k/disagg/mtp