### PR TITLE
 gpt-oss-fp4-mi355x: pin to v0.19 + switch to AITER-env-based recipe

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -960,7 +960,7 @@ gptoss-fp4-mi325x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 16 }
 
 gptoss-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:v0.19.0
   model: amd/gpt-oss-120b-w-mxfp4-a-fp8
   model-prefix: gptoss
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -973,13 +973,15 @@ gptoss-fp4-mi355x-vllm:
       osl: 1024
       search-space:
       - { tp: 1, conc-start: 4, conc-end: 128 }
-      - { tp: 4, conc-start: 4, conc-end: 8 }
+      - { tp: 2, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 16 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 1, conc-start: 4, conc-end: 128 }
-      - { tp: 4, conc-start: 4, conc-end: 4 }
+      - { tp: 2, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 8 }
 
 gptoss-fp4-mi355x-atom:

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -18,27 +18,19 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-# If the machine runs a MEC FW older than 177, RCCL
-# cannot reclaim some memory.
-# Disable that features to avoid crashes.
-# This is related to the changes in the driver at:
-# https://rocm.docs.amd.com/en/docs-6.4.3/about/release-notes.html#amdgpu-driver-updates
-version=`rocm-smi --showfw | grep MEC | head -n 1 |  awk '{print $NF}'`
-if [[ "$version" == "" || $version -lt 177 ]]; then
-  export HSA_NO_SCRATCH_RECLAIM=1
-fi
-
 # Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
 if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
-export AMDGCN_USE_BUFFER_OPS=0
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_ROCM_USE_AITER_RMSNORM=1
+export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
+export VLLM_ROCM_USE_AITER_MHA=0
+export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
-FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
+export HSA_NO_SCRATCH_RECLAIM=1
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
@@ -52,12 +44,13 @@ start_gpu_monitor
 
 set -x
 vllm serve $MODEL --port $PORT \
-  $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
   --tensor-parallel-size=$TP \
+  --max-num-seqs 256 \
   --gpu-memory-utilization 0.95 \
   --max-model-len $MAX_MODEL_LEN \
   --block-size=64 \
-  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching \
+  --async-scheduling > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -57,24 +57,6 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-# Pre-flight warmup at the benchmark shape (5 rounds of CONC parallel prompts)
-# so the actual measurement below starts at steady-state. Without this, AITER's
-# per-shape Triton JIT autotune and torch.compile cache misses bias the first
-# ~20-40s of the real benchmark window low (CI cold-cache measurements showed
-# a ~10% under-report). vllm bench's built-in --num-warmups defaults to 16
-# serial prompts, which doesn't exercise the full-concurrency kernel variants.
-run_benchmark_serving \
-    --model "$MODEL" \
-    --port "$PORT" \
-    --backend vllm \
-    --input-len "$ISL" \
-    --output-len "$OSL" \
-    --random-range-ratio "$RANDOM_RANGE_RATIO" \
-    --num-prompts "$((CONC * 5))" \
-    --max-concurrency "$CONC" \
-    --result-filename "warmup_$RESULT_FILENAME" \
-    --result-dir /tmp/ > /dev/null 2>&1 || true
-
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \

--- a/benchmarks/single_node/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/gptoss_fp4_mi355x.sh
@@ -57,6 +57,24 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
+# Pre-flight warmup at the benchmark shape (5 rounds of CONC parallel prompts)
+# so the actual measurement below starts at steady-state. Without this, AITER's
+# per-shape Triton JIT autotune and torch.compile cache misses bias the first
+# ~20-40s of the real benchmark window low (CI cold-cache measurements showed
+# a ~10% under-report). vllm bench's built-in --num-warmups defaults to 16
+# serial prompts, which doesn't exercise the full-concurrency kernel variants.
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 5))" \
+    --max-concurrency "$CONC" \
+    --result-filename "warmup_$RESULT_FILENAME" \
+    --result-dir /tmp/ > /dev/null 2>&1 || true
+
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3088,7 +3088,7 @@
   description:
     - "Pin image back to vllm/vllm-openai-rocm:v0.19.0 while we work through a v0.21 perf regression on MI355x AITER paths (image was bumped to v0.21.0 in #1406)"
     - "Switch to AITER-env-based recipe: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1531
 
 - config-keys:
     - dsv4-fp4-mi355x-sglang

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3084,6 +3084,13 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1546
 
 - config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Pin image back to vllm/vllm-openai-rocm:v0.19.0 while we work through a v0.21 perf regression on MI355x AITER paths (image was bumped to v0.21.0 in #1406)"
+    - "Switch to AITER-env-based recipe: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+
+- config-keys:
     - dsv4-fp4-mi355x-sglang
   description:
     - "Bump image to rocm/sgl-dev:rocm720-mi35x-8c3b5aa-20260521-DSv4"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3088,6 +3088,7 @@
   description:
     - "Pin image back to vllm/vllm-openai-rocm:v0.19.0 while we work through a v0.21 perf regression on MI355x AITER paths (image was bumped to v0.21.0 in #1406)"
     - "Switch to AITER-env-based recipe: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
+    - "Add a 5-round pre-flight warmup pass at the benchmark shape (CONC*5 prompts at CONC concurrency, result discarded) before the measured benchmark. AITER's per-shape Triton JIT autotune doesn't finish within vllm bench's built-in 16-prompt warmup, biasing single-shot CI measurements low by ~10%"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1531
 
 - config-keys:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3084,14 +3084,6 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1546
 
 - config-keys:
-    - gptoss-fp4-mi355x-vllm
-  description:
-    - "Pin image back to vllm/vllm-openai-rocm:v0.19.0 while we work through a v0.21 perf regression on MI355x AITER paths (image was bumped to v0.21.0 in #1406)"
-    - "Switch to AITER-env-based recipe: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
-    - "Add a 5-round pre-flight warmup pass at the benchmark shape (CONC*5 prompts at CONC concurrency, result discarded) before the measured benchmark. AITER's per-shape Triton JIT autotune doesn't finish within vllm bench's built-in 16-prompt warmup, biasing single-shot CI measurements low by ~10%"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1531
-
-- config-keys:
     - dsv4-fp4-mi355x-sglang
   description:
     - "Bump image to rocm/sgl-dev:rocm720-mi35x-8c3b5aa-20260521-DSv4"
@@ -3144,3 +3136,11 @@
   description:
     - "Add --use-chat-template to run_benchmark_serving so prompts are formatted with the Qwen chat template (matching the other Qwen MTP recipes)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1555
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Pin image back to vllm/vllm-openai-rocm:v0.19.0 while we work through a v0.21 perf regression on MI355x AITER paths (image was bumped to v0.21.0 in #1406)"
+    - "Switch to AITER-env-based recipe: enable AITER MOE/RMSNORM/UnifiedAttn/A16W4 + HSA_NO_SCRATCH_RECLAIM, drop legacy TRITON_ROPE/BUFFER_OPS/--attention-backend/fuse_rope_kvcache, add --max-num-seqs 256 + --async-scheduling"
+    - "Add a 5-round pre-flight warmup pass at the benchmark shape (CONC*5 prompts at CONC concurrency, result discarded) before the measured benchmark. AITER's per-shape Triton JIT autotune doesn't finish within vllm bench's built-in 16-prompt warmup, biasing single-shot CI measurements low by ~10%"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1531


### PR DESCRIPTION
- Pinning back to vllm 0.19.0 (was bumped to 0.21.0 in #1406). vllm 0.21 hits
  a ~10% regression on MI355x gpt-oss-fp4 — bisected to ~4% from the new ROCm
  `fuse_allreduce_rms` pass (recoverable via `--compilation-config`) and ~6%
  from the ROCm 7.0201 → 7.0202 patch in the v0.21 image (not launcher-fixable).
  Staying on 0.19 while we sort both. Heads-up: Klaud Cold will try to re-bump
  on its next cron.

 -  Also reworked the launcher: dropped `AMDGCN_USE_BUFFER_OPS`,
  `VLLM_ROCM_USE_AITER_TRITON_ROPE`, the explicit `--attention-backend`,
  `fuse_rope_kvcache`, and `use_inductor_graph_partition`. Added the AITER env
  vars (`VLLM_ROCM_USE_AITER_MOE/RMSNORM/UNIFIED_ATTENTION/FUSED_MOE_A16W4` +
  `HSA_NO_SCRATCH_RECLAIM=1`), plus `--max-num-seqs 256` and `--async-scheduling`.

  Local numbers (single MI355x, v0.19.0 image, 3 runs each, median):

  | TP | ISL/OSL | conc | dashboard | this PR | Δ |
  |---|---|---|---|---|---|
  | 1 | 1k/1k | 4    | 1653  | 1662  | +0.5% |
  | 1 | 1k/1k | 8    | 2668  | 2787  | +4.5% |
  | 1 | 1k/1k | 16   | 4189  | 4549  | +8.6% |
  | 1 | 1k/1k | 32   | 6275  | 6785  | +8.1% |
  | 1 | 1k/1k | 64   | 8812  | 10573 | +20.0% |
  | 1 | 1k/1k | 128  | 13186 | 16067 | +21.8% |
  | 4 | 1k/1k | 4    | 1203  | 2498  | **+107.6%** |
  | 4 | 1k/1k | 8    | 2100  | 4253  | **+102.5%** |
  | 8 | 1k/1k | 4    | 2152  | 2505  | +16.4% |
  | 8 | 1k/1k | 8    | 3950  | 4678  | +18.4% |
  | 8 | 1k/1k | 16   | 6668  | 8571  | +28.5% |
  | 1 | 8k/1k | 4    | 5974  | 7222  | +20.9% |
  | 1 | 8k/1k | 8    | 9210  | 11154 | +21.1% |
  | 1 | 8k/1k | 16   | 14499 | 16663 | +14.9% |
  | 1 | 8k/1k | 32   | 20528 | 23445 | +14.2% |
  | 1 | 8k/1k | 64   | 29448 | 32071 | +8.9% |
  | 1 | 8k/1k | 128  | 38532 | 39333 | +2.1% |
  | 4 | 8k/1k | 4    | 4826  | 10520 | **+118.0%** |
  | 8 | 8k/1k | 4    | 7966  | 10602 | +33.1% |
  | 8 | 8k/1k | 8    | 14198 | 19205 | +35.3% |

  Avg +30.3% across all 20 combos vs the 2026-03-09 dashboard. TP=4 sees the
  biggest wins (~100%+). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only image, env, sweep, and launcher changes for one MI355X vLLM config; no production app or security surface.
> 
> **Overview**
> Pins **gptoss-fp4-mi355x-vllm** back to `vllm/vllm-openai-rocm:v0.19.0` (reverting the v0.21.0 bump) and widens the fixed-seq-len sweep with **TP=2** and higher **TP=4** concurrency ranges on 1k/1k and 8k/1k.
> 
> The MI355X launcher (`gptoss_fp4_mi355x.sh`) moves to an **AITER env-var** recipe (MOE, RMSNorm, unified attention, fused MoE A16W4, `HSA_NO_SCRATCH_RECLAIM`), drops the old MEC-firmware gate, buffer-ops, explicit attention backend, and `fuse_rope_kvcache` compile flags, and adds **`--max-num-seqs 256`** and **`--async-scheduling`**.
> 
> A **discarded pre-flight warmup** (`CONC×5` prompts at full concurrency) runs before the measured benchmark so AITER Triton autotune does not under-report cold-cache CI throughput. **perf-changelog.yaml** documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e658541befe4901d87f224ed02ee7dc4b528f2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->