### PR TITLE
[Klaud Cold] mi300x runner: switch --nodelist pin to --exclude -049

### DIFF
--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -9,10 +9,9 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 
 set -x
 
-# Pin to the known-good mi300x nodes; others are unavailable:
-#   chi-mi300x-033, chi-mi300x-037: down (Not responding)
-#   chi-mi300x-049:                  drained (persistent /nvme_home disk-full)
-JOB_ID=$(salloc --partition=$PARTITION --nodelist=chi-mi300x-[034-036,054,057-058].ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+# Exclude known-bad nodes; let Slurm pick from anything else:
+#   chi-mi300x-049: drained (persistent /nvme_home disk-full)
+JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049.ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Summary
- Removes the hardcoded `--nodelist=chi-mi300x-[034-036,054,057-058]...` pin in `runners/launch_mi300x-amds.sh` and replaces it with `--exclude=chi-mi300x-049.ord.vultr.cpe.ice.amd.com`.
- Lets Slurm allocate on any healthy mi300x node (-033/-035/-037 are currently `down*` but can come back at any time). Only -049 is permanently banned (persistent `/nvme_home` disk-full).
- No infra changes required; effective on next sweep run.

## Test plan
- [ ] Run any mi300x sweep against this branch (e.g. retrigger #1486) and confirm `salloc` succeeds on a node outside the old pin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)