### PR TITLE
[Klaud Cold] Revert #1512 "Fix glm5-fp8-b300 DeepGemm regression" (experimental-only PR)

### DIFF
--- a/benchmarks/single_node/glm5_fp8_b300.sh
+++ b/benchmarks/single_node/glm5_fp8_b300.sh
@@ -23,17 +23,13 @@ nvidia-smi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-pip install --break-system-packages --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
-# Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
-# downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
-# whether the deepgemm version jump is what causes the B300 TMA-descriptor
-# CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
-# downgraded version actually runs.
-# --break-system-packages required: the container's Python is PEP-668 externally-managed,
-# so the previous attempt silently failed and left the bundled 0.1.0 in place.
-pip install --break-system-packages --no-deps "sgl-deep-gemm==0.0.1"
-export SGL_ENABLE_JIT_DEEPGEMM=1
+# Workaround for sgl-project/sglang#25551: v0.5.12 DeepGemm TMA-descriptor
+# regression on B300 (sm_120) crashes CUDA graph capture with
+# CUDA_ERROR_ILLEGAL_ADDRESS. Disabling JIT DeepGemm bypasses the affected
+# kernel path. Restore to =1 once the upstream regression is fixed.
+export SGL_ENABLE_JIT_DEEPGEMM=0
 
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}

--- a/benchmarks/single_node/glm5_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/glm5_fp8_b300_mtp.sh
@@ -23,17 +23,13 @@ nvidia-smi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-pip install --break-system-packages --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
+pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
 
-# Testing @trevor-m's suggestion in sgl-project/sglang#25551 (comment 4481466979):
-# downgrade sgl-deep-gemm 0.1.0 → 0.0.1 inside the v0.5.12 container to check
-# whether the deepgemm version jump is what causes the B300 TMA-descriptor
-# CUDA_ERROR_ILLEGAL_ADDRESS regression. Re-enabling JIT DeepGemm so the
-# downgraded version actually runs.
-# --break-system-packages required: the container's Python is PEP-668 externally-managed,
-# so the previous attempt silently failed and left the bundled 0.1.0 in place.
-pip install --break-system-packages --no-deps "sgl-deep-gemm==0.0.1"
-export SGL_ENABLE_JIT_DEEPGEMM=1
+# Workaround for sgl-project/sglang#25551: v0.5.12 DeepGemm TMA-descriptor
+# regression on B300 (sm_120) crashes CUDA graph capture with
+# CUDA_ERROR_ILLEGAL_ADDRESS. Disabling JIT DeepGemm bypasses the affected
+# kernel path. Restore to =1 once the upstream regression is fixed.
+export SGL_ENABLE_JIT_DEEPGEMM=0
 export SGLANG_ENABLE_SPEC_V2=1
 
 SERVER_LOG=/workspace/server.log

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3050,10 +3050,3 @@
   description:
     - "Update SGLang image from v0.5.11-cu130 (5d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1475
-
-- config-keys:
-    - glm5-fp8-b300-sglang
-    - glm5-fp8-b300-sglang-mtp
-  description:
-    - "Test @trevor-m's suggestion in sgl-project/sglang#25551: pin sgl-deep-gemm==0.0.1 inside v0.5.12 container to isolate whether the deep-gemm 0.0.1→0.1.0 upgrade is the source of the B300 CUDA_ERROR_ILLEGAL_ADDRESS regression."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1512


### PR DESCRIPTION
## Summary
Reverts commit `12fb33ea` ([#1512](https://github.com/SemiAnalysisAI/InferenceX/pull/1512)) which was explicitly marked **"Not for merge"** — it was an upstream-debugging experiment for [sgl-project/sglang#25551](https://github.com/sgl-project/sglang/issues/25551), pinning `sgl-deep-gemm==0.0.1` and re-enabling JIT DeepGemm in the `glm5-fp8-b300` launch scripts.

Result reported upstream ([sglang#25551 comment](https://github.com/sgl-project/sglang/issues/25551#issuecomment-4502502796)): the pin fixes conc 4..64 but **still crashes at conc=128** with the same `runtime_utils.hpp:143` signature. Since the sweep matrix runs conc=128 (and #1512 is now in main), production `glm5-fp8-b300{,-mtp}` sweeps would regress.

This restores the prior `SGL_ENABLE_JIT_DEEPGEMM=0` workaround so production sweeps stay green at all conc levels while the upstream investigation continues with [Trevor's experiment #2](https://github.com/sgl-project/sglang/issues/25551#issuecomment-4481466979).

## Test plan
- [ ] glm5-fp8-b300-sglang + glm5-fp8-b300-sglang-mtp sweeps complete green at all conc tiers (including 128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)