### PR TITLE
[NV] Update H100 Qwen3.5 SGLang agg config

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9238,13 +9238,13 @@ qwen3.5-fp8-h100-sglang:
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
       - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
       - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
 
 qwen3.5-fp8-h100-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9237,14 +9237,12 @@ qwen3.5-fp8-h100-sglang:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
-      - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 16, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
-      - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 16, conc-end: 256 }
 
 qwen3.5-fp8-h100-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9236,11 +9236,15 @@ qwen3.5-fp8-h100-sglang:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
+      - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 8, conc-start: 4, conc-end: 32 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 8 }
+      - { tp: 8, ep: 8, conc-start: 16, conc-end: 64 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
 
 qwen3.5-fp8-h100-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
@@ -8,7 +8,6 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
-    DP_ATTENTION \
     CONC \
     ISL \
     OSL \
@@ -37,42 +36,37 @@ if [ "${EP_SIZE}" -gt 1 ]; then
 fi
 
 SCHEDULER_RECV_INTERVAL=
-if [ "${DP_ATTENTION}" != "true" ]; then
-    case "$CONC" in
-      1|2|4)
-        SCHEDULER_RECV_INTERVAL=2
-        ;;
-      8)
-        SCHEDULER_RECV_INTERVAL=60
-        ;;
-      16)
-        SCHEDULER_RECV_INTERVAL=30
-        ;;
-      32)
-        SCHEDULER_RECV_INTERVAL=1200
-        ;;
-      64)
-        SCHEDULER_RECV_INTERVAL=600
-        ;;
-      128|256)
-        SCHEDULER_RECV_INTERVAL=1920
-        ;;
-      *)
-        echo "Unsupported CONC=$CONC for qwen3.5 FP8 H100 SGLang recipe" >&2
-        exit 1
-        ;;
-    esac
-fi
+case "$CONC" in
+  1|2|4)
+    SCHEDULER_RECV_INTERVAL=2
+    ;;
+  8)
+    SCHEDULER_RECV_INTERVAL=60
+    ;;
+  16)
+    SCHEDULER_RECV_INTERVAL=30
+    ;;
+  32)
+    SCHEDULER_RECV_INTERVAL=1200
+    ;;
+  64)
+    SCHEDULER_RECV_INTERVAL=600
+    ;;
+  128|256)
+    SCHEDULER_RECV_INTERVAL=1920
+    ;;
+  *)
+    echo "Unsupported CONC=$CONC for qwen3.5 FP8 H100 SGLang recipe" >&2
+    exit 1
+    ;;
+esac
 
 SCHEDULER_ARGS=()
 if [ -n "$SCHEDULER_RECV_INTERVAL" ]; then
     SCHEDULER_ARGS=(--scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL")
 fi
-if [ "${DP_ATTENTION}" = "true" ]; then
-    PARALLEL_ARGS+=(--dp-size "$TP" --enable-dp-attention)
-fi
 
-echo "TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+echo "TP: $TP, EP_SIZE: $EP_SIZE, CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
 echo "SCHEDULER_RECV_INTERVAL: ${SCHEDULER_RECV_INTERVAL:-none}"
 echo "SCHEDULER_ARGS: ${SCHEDULER_ARGS[*]}"
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Qwen-3.5-397B-A17B FP8 on H100 via sglang.
-# Uses TP8/EP1 at conc 1-8, TP8/EP8 at conc 16-64,
-# and TP8/EP8 with DP attention at conc 128-256.
+# Uses TP8/EP1 at conc 1-8 and TP8/EP8 at conc 16-256.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -54,6 +53,9 @@ if [ "${DP_ATTENTION}" != "true" ]; then
         ;;
       64)
         SCHEDULER_RECV_INTERVAL=600
+        ;;
+      128|256)
+        SCHEDULER_RECV_INTERVAL=1920
         ;;
       *)
         echo "Unsupported CONC=$CONC for qwen3.5 FP8 H100 SGLang recipe" >&2

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_h100.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 
 # Qwen-3.5-397B-A17B FP8 on H100 via sglang.
-# Mirrors qwen3.5_fp8_h200.sh but with tighter memory accommodations:
-# H100 has 80GB HBM3 vs H200's 141GB HBM3e, so weights + KV cache fit
-# more snugly. Mem-fraction-static lowered from 0.8 → 0.75 and
-# chunked-prefill-size from 16384 → 8192 to leave more headroom.
-# Sweep tops out at conc=32 instead of 64 for the same reason.
+# Uses TP8/EP1 at conc 1-8, TP8/EP8 at conc 16-64,
+# and TP8/EP8 with DP attention at conc 128-256.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \
     TP \
+    DP_ATTENTION \
     CONC \
     ISL \
     OSL \
@@ -34,7 +32,47 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     MAX_SEQ_LEN="$EVAL_MAX_MODEL_LEN"
 fi
 
-echo "CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+PARALLEL_ARGS=(--tp "$TP")
+if [ "${EP_SIZE}" -gt 1 ]; then
+    PARALLEL_ARGS+=(--expert-parallel-size "$EP_SIZE")
+fi
+
+SCHEDULER_RECV_INTERVAL=
+if [ "${DP_ATTENTION}" != "true" ]; then
+    case "$CONC" in
+      1|2|4)
+        SCHEDULER_RECV_INTERVAL=2
+        ;;
+      8)
+        SCHEDULER_RECV_INTERVAL=60
+        ;;
+      16)
+        SCHEDULER_RECV_INTERVAL=30
+        ;;
+      32)
+        SCHEDULER_RECV_INTERVAL=1200
+        ;;
+      64)
+        SCHEDULER_RECV_INTERVAL=600
+        ;;
+      *)
+        echo "Unsupported CONC=$CONC for qwen3.5 FP8 H100 SGLang recipe" >&2
+        exit 1
+        ;;
+    esac
+fi
+
+SCHEDULER_ARGS=()
+if [ -n "$SCHEDULER_RECV_INTERVAL" ]; then
+    SCHEDULER_ARGS=(--scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL")
+fi
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS+=(--dp-size "$TP" --enable-dp-attention)
+fi
+
+echo "TP: $TP, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION, CONC: $CONC, ISL: $ISL, OSL: $OSL, MAX_SEQ_LEN: $MAX_SEQ_LEN"
+echo "SCHEDULER_RECV_INTERVAL: ${SCHEDULER_RECV_INTERVAL:-none}"
+echo "SCHEDULER_ARGS: ${SCHEDULER_ARGS[*]}"
 
 start_gpu_monitor
 
@@ -43,15 +81,14 @@ python3 -m sglang.launch_server \
   --model "$MODEL" \
   --host 0.0.0.0 \
   --port "$PORT" \
-  --tp "$TP" \
-  --expert-parallel-size "$EP_SIZE" \
+  "${PARALLEL_ARGS[@]}" \
   --reasoning-parser qwen3 \
   --tool-call-parser qwen3_coder \
   --enable-flashinfer-allreduce-fusion \
-  --max-running-requests 64 \
-  --chunked-prefill-size 8192 \
+  --max-running-requests 256 \
+  --chunked-prefill-size 16384 \
   --decode-log-interval 1 \
-  --mem-fraction-static 0.75 \
+  --mem-fraction-static 0.8 \
   --cuda-graph-max-bs "$CONC" \
   --context-length "$MAX_SEQ_LEN" \
   --kv-cache-dtype fp8_e4m3 \
@@ -61,7 +98,9 @@ python3 -m sglang.launch_server \
   --tokenizer-worker-num 6 \
   --mamba-ssm-dtype bfloat16 \
   --disable-radix-cache \
+  --enable-symm-mem \
   --trust-remote-code \
+  "${SCHEDULER_ARGS[@]}" \
   > "$SERVER_LOG" 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3451,3 +3451,12 @@
     - "Add MiniMax-M2.5 FP8 GB300 disaggregated multinode vLLM benchmarks via Dynamo"
     - "Add 1k1k/8k1k FP8 recipe set under benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1647
+
+- config-keys:
+    - qwen3.5-fp8-h100-sglang
+  description:
+    - "Tune Qwen3.5-397B-A17B-FP8 H100 SGLang aggregate recipe for 1k/1k and 8k/1k sweeps"
+    - "Use TP8/EP1 for conc 1-8, TP8/EP8 for conc 16-64, and TP8/EP8 DP-attention for conc 128-256"
+    - "Use scheduler-recv-interval values 2/60/30/1200/600 for non-DP conc 1-4/8/16/32/64"
+    - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3456,7 +3456,7 @@
     - qwen3.5-fp8-h100-sglang
   description:
     - "Tune Qwen3.5-397B-A17B-FP8 H100 SGLang aggregate recipe for 1k/1k and 8k/1k sweeps"
-    - "Use TP8/EP1 for conc 1-8, TP8/EP8 for conc 16-64, and TP8/EP8 DP-attention for conc 128-256"
-    - "Use scheduler-recv-interval values 2/60/30/1200/600 for non-DP conc 1-4/8/16/32/64"
+    - "Use TP8/EP1 for conc 1-8 and TP8/EP8 for conc 16-256"
+    - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544


### PR DESCRIPTION
Updates Qwen3.5-397B-A17B-FP8 H100 SGLang agg recipes with tuned configs for 1k/1k and 8k/1k.

<!-- QWEN35_H100_PERF_TABLE_START -->
## Performance comparison

Source rows: `results_bmk` artifacts from [baseline 2026-05-18 CI run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26055185038) vs [updated 2026-06-04 CI run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26918589379). `tok/s/user` is `median_intvty`.

Apples-to-apples note: deltas compare non-MTP Qwen3.5 FP8 H100 SGLang rows only. The May artifact has non-MTP TP8/EP8 rows at conc 4, 8, 16, and 32 for both workloads; new-only concurrencies are marked `n/a` on the May side.

| ISL/OSL | Conc | May non-MTP tok/s/gpu | New non-MTP tok/s/gpu | Delta tok/s/gpu | May non-MTP tok/s/user | New non-MTP tok/s/user | Delta tok/s/user |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1k/1k | 1 | n/a | 38.9 | n/a | n/a | 165.7 | n/a |
| 1k/1k | 2 | n/a | 68.3 | n/a | n/a | 144.7 | n/a |
| 1k/1k | 4 | 100.3 | 113.0 | +12.6% | 106.3 | 119.9 | +12.7% |
| 1k/1k | 8 | 159.4 | 200.0 | +25.5% | 83.0 | 108.1 | +30.3% |
| 1k/1k | 16 | 245.2 | 255.8 | +4.4% | 62.7 | 66.5 | +6.0% |
| 1k/1k | 32 | 352.3 | 453.4 | +28.7% | 44.9 | 64.6 | +43.8% |
| 1k/1k | 64 | n/a | 734.4 | n/a | n/a | 52.2 | n/a |
| 1k/1k | 128 | n/a | 1055.5 | n/a | n/a | 39.2 | n/a |
| 1k/1k | 256 | n/a | 1316.4 | n/a | n/a | 28.3 | n/a |
| 8k/1k | 1 | n/a | 170.2 | n/a | n/a | 163.2 | n/a |
| 8k/1k | 2 | n/a | 297.5 | n/a | n/a | 142.1 | n/a |
| 8k/1k | 4 | 440.2 | 484.5 | +10.1% | 104.2 | 114.7 | +10.1% |
| 8k/1k | 8 | 676.7 | 737.5 | +9.0% | 80.6 | 89.4 | +10.9% |
| 8k/1k | 16 | 978.7 | 1030.5 | +5.3% | 56.5 | 60.4 | +6.9% |
| 8k/1k | 32 | 1338.6 | 1526.3 | +14.0% | 38.6 | 54.9 | +42.1% |
| 8k/1k | 64 | n/a | 2065.1 | n/a | n/a | 38.7 | n/a |
| 8k/1k | 128 | n/a | 2338.1 | n/a | n/a | 23.6 | n/a |
| 8k/1k | 256 | n/a | 2506.1 | n/a | n/a | 10.5 | n/a |

1k/1k matched geomean: +17.4% tok/s/gpu, +22.3% tok/s/user; 8k/1k matched geomean: +9.5% tok/s/gpu, +16.7% tok/s/user.
<!-- QWEN35_H100_PERF_TABLE_END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI YAML tuning only; no production serving, auth, or application runtime paths.
> 
> **Overview**
> Retunes the **Qwen3.5-397B-A17B-FP8** aggregate **SGLang on H100** benchmark for **1k/1k** and **8k/1k** fixed-seq sweeps.
> 
> **CI/config** (`qwen3.5-fp8-h100-sglang`): replaces a single **TP8/EP8, conc 4–32** grid with **TP8/EP1, conc 1–8** and **TP8/EP8, conc 16–256** for both scenarios.
> 
> **Launch recipe** (`qwen3.5_fp8_h100.sh`): drops H100-vs-H200 memory caveats; applies **expert parallel only when `EP_SIZE` > 1**; maps **conc** to **`--scheduler-recv-interval`** (with hard fail on unsupported conc); raises **`max-running-requests`** (64→256), **`chunked-prefill-size`** (8192→16384), **`mem-fraction-static`** (0.75→0.8); adds **`--enable-symm-mem`** and passes scheduler args into `sglang.launch_server`.
> 
> Documents the change in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50bf385ef8db25330f33641d510aacd33a67e803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->