### PR TITLE
[AMD][MI35X] 0521 DSV4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1774,7 +1774,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
 # image tag, so bumping sglang is just an image tag bump here. Sweeps
 # DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:rocm720-mi35x-b19052c-20260518-DSv4
+  image: rocm/sgl-dev:rocm720-mi35x-8c3b5aa-20260521-DSv4
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1786,13 +1786,13 @@ dsv4-fp4-mi355x-sglang:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, dp-attn: true, conc-start: 32, conc-end: 1024 }
-      - { tp: 8, dp-attn: false, conc-start: 1 , conc-end: 64 }
+      - { tp: 8, dp-attn: true, conc-start: 64, conc-end: 1024 }
+      - { tp: 8, dp-attn: false, conc-start: 1 , conc-end: 32 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, dp-attn: true, conc-start: 32, conc-end: 512 }
-      - { tp: 8, dp-attn: false, conc-start: 1, conc-end: 64 }
+      - { tp: 8, dp-attn: true, conc-start: 64, conc-end: 512 }
+      - { tp: 8, dp-attn: false, conc-start: 1, conc-end: 32 }
 
 # DSv4 on MI355X via vLLM, using the official vllm/vllm-openai-rocm
 # nightly image. DSv4 base ROCm support (vllm-project/vllm#40871) merged

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3062,3 +3062,9 @@
   description:
     - "Bump vLLM ROCm image from nightly-b50646e5effd7cb5884cd96fdff4c53c18521198 to nightly-4f940896a32c9e2a0eba7f50d521bf5f6b4de458"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1546
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "Bump image to rocm/sgl-dev:rocm720-mi35x-8c3b5aa-20260521-DSv4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1548


### PR DESCRIPTION
Bump docker image to rocm/sgl-dev:rocm720-mi35x-8c3b5aa-20260521-DSv4.
No server args change. 

Succecuss run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26211414795
Chart: https://inferencex.semianalysis.com/inference?unofficialRun=26211414795