### PR TITLE
[Klaud Cold] qwen3.5-fp8-mi355x-atom-mtp: enable --use-chat-template

### DIFF
--- a/benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh
@@ -71,7 +71,8 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
-    --trust-remote-code
+    --trust-remote-code \
+    --use-chat-template
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3089,3 +3089,9 @@
   description:
     - "Update SGLang image from v0.5.10.post1-cu130 / v0.5.11-cu130 (30d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1451
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-atom-mtp
+  description:
+    - "Add --use-chat-template to run_benchmark_serving so prompts are formatted with the Qwen chat template (matching the other Qwen MTP recipes)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1555


### PR DESCRIPTION
## Summary
- `benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh` (Qwen FP8 MTP on MI355X via ATOM) was not applying the chat template during `run_benchmark_serving`, while other Qwen MTP recipes (e.g. `qwen3.5_fp8_mi355x_mtp.sh`, `qwen3.5_fp8_mi325x_mtp.sh`, `qwen3.5_fp8_h200_mtp.sh`, etc.) pass `--use-chat-template`.
- Adds `--use-chat-template` to the `run_benchmark_serving` invocation so prompts are formatted with the model's chat template, matching the rest of the Qwen MTP recipes.

## Test plan
- [ ] Run the recipe on an MI355X node with the ATOM backend and confirm prompts are wrapped with the Qwen chat template.
- [ ] Confirm reported throughput / accept rate numbers are comparable to other Qwen MTP recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)