### PR TITLE
fix: correct Qwen3.5 MI355X MTP benchmark setup

### DIFF
--- a/benchmarks/single_node/qwen3.5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp4_mi355x_mtp.sh
@@ -60,7 +60,8 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir /workspace/ \
+    --use-chat-template
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh
@@ -31,6 +31,11 @@ else
     CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
 fi
 
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    CALCULATED_MAX_MODEL_LEN=" --max-model-len $EVAL_MAX_MODEL_LEN "
+fi
+
 if [ "$EP_SIZE" -gt 1 ]; then
   EP=" --enable-expert-parallel"
 else
@@ -71,6 +76,7 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
+    --use-chat-template \
     --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3089,3 +3089,11 @@
   description:
     - "Update SGLang image from v0.5.10.post1-cu130 / v0.5.11-cu130 (30d old) to v0.5.12-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1451
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang-mtp
+    - qwen3.5-fp8-mi355x-atom-mtp
+  description:
+    - "Pass --use-chat-template in Qwen3.5 MI355X MTP benchmark clients"
+    - "Apply eval-only max-model-len sizing for Qwen3.5 FP8 MI355X ATOM MTP"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1556


### PR DESCRIPTION
## Summary

- pass `--use-chat-template` for the Qwen3.5 FP4 SGLang and FP8 ATOM MI355X MTP benchmarks
- apply eval-only context sizing before launching the Qwen3.5 FP8 ATOM MTP server
- append a `perf-changelog.yaml` entry to benchmark the two corrected configurations

## Root Cause

The two MTP launchers invoked the benchmark client without the chat template required for speculative-decoding inputs. The ATOM MTP launcher also omitted the eval-only context override already used by the equivalent ATOM MTP path.

## Validation

- `bash -n benchmarks/single_node/qwen3.5_fp4_mi355x_mtp.sh benchmarks/single_node/qwen3.5_fp8_mi355x_atom_mtp.sh`
- `git diff --check`
- parsed `perf-changelog.yaml` and confirmed the new entry is the final stanza
- generated both referenced AMD benchmark configurations with `utils/matrix_logic/generate_sweep_configs.py test-config`
