### PR TITLE
Add DSR1 FP4 B300 vLLM TokenSpeed benchmark

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1891,6 +1891,29 @@ dsr1-fp4-b300-sglang:
       - { tp: 4, ep: 4, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 16 }
 
+# vLLM v0.21.0 includes TokenSpeed MLA for DeepSeek-R1-shaped MLA on
+# Blackwell with FP8 KV cache; the launcher installs its optional fastokens dependency.
+dsr1-fp4-b300-vllm:
+  image: vllm/vllm-openai:v0.21.0
+  model: nvidia/DeepSeek-R1-0528-FP4-V2
+  model-prefix: dsr1
+  runner: b300
+  precision: fp4
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 4, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 128 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 4, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 16 }
+
 dsr1-fp4-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: nvidia/DeepSeek-R1-0528-FP4-V2

--- a/benchmarks/single_node/dsr1_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/dsr1_fp4_b300_vllm.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# DeepSeek-R1 FP4 B300 vLLM run for the TokenSpeed MLA and fastokens paths
+# introduced in vLLM v0.21.0. TokenSpeed MLA requires Blackwell and FP8 KV.
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+# Model loading can exceed the default timeout for the 394B FP4 checkpoint.
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+BENCHMARK_MAX_MODEL_LEN="$MAX_MODEL_LEN"
+if [ "${EVAL_ONLY}" = "true" ]; then
+    EVAL_MAX_MODEL_LEN=$(compute_eval_context_length "$MODEL" "$BENCHMARK_MAX_MODEL_LEN")
+    export EVAL_MAX_MODEL_LEN
+    SERVE_MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+else
+    SERVE_MAX_MODEL_LEN="$BENCHMARK_MAX_MODEL_LEN"
+fi
+
+MAX_NUM_BATCHED_TOKENS=$(( ISL * 2 ))
+
+# vLLM v0.21.0 integrates the pre-v0.2 fastokens patching API as an optional package.
+pip install -q 'fastokens>=0.1.1,<0.2.0' datasets pandas
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
+    --tensor-parallel-size "$TP" \
+    --pipeline-parallel-size 1 \
+    --kv-cache-dtype fp8 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    "${EP_ARGS[@]}" \
+    --attention-backend TOKENSPEED_MLA \
+    --attention-config.mla_prefill_backend TOKENSPEED_MLA \
+    --tokenizer-mode fastokens \
+    --max-model-len "$SERVE_MAX_MODEL_LEN" \
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3136,3 +3136,9 @@
   description:
     - "Add --use-chat-template to run_benchmark_serving so prompts are formatted with the Qwen chat template (matching the other Qwen MTP recipes)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1555
+
+- config-keys:
+    - dsr1-fp4-b300-vllm
+  description:
+    - "Add DeepSeek-R1 FP4 B300 vLLM benchmark on vllm/vllm-openai:v0.21.0 with TOKENSPEED_MLA prefill/decode and fastokens tokenization"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1562


### PR DESCRIPTION
## Summary

- add `dsr1-fp4-b300-vllm` on `vllm/vllm-openai:v0.21.0`, mirroring the existing B300 DSR1 FP4 sweep coverage
- select `TOKENSPEED_MLA` for both MLA decode and prefill with the required FP8 KV cache
- install the vLLM v0.21-compatible `fastokens` package and enable `--tokenizer-mode fastokens`

## Validation

- `bash -n benchmarks/single_node/dsr1_fp4_b300_vllm.sh`
- `python utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/nvidia-master.yaml --model-prefix dsr1 --framework vllm --precision fp4 --runner-type b300 --no-evals`
- `python -m pytest utils/matrix_logic/ -v` (`151 passed`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI matrix config only; no production serving or auth paths changed.
> 
> **Overview**
> Adds a **DeepSeek-R1 FP4 on B300** vLLM benchmark path so the matrix can sweep the same fixed-seq-len scenarios as the existing B300 SGLang recipe.
> 
> New config key `dsr1-fp4-b300-vllm` pins `vllm/vllm-openai:v0.21.0` and the `nvidia/DeepSeek-R1-0528-FP4-V2` model with TP/EP search spaces at 1k/1k and 8k/1k. The launcher script installs `fastokens`, serves with **FP8 KV**, **TOKENSPEED_MLA** for MLA prefill/decode, and **fastokens** tokenization, then runs the standard serving benchmark (and optional eval). `perf-changelog.yaml` documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895c106d42e805d6da613d1cc54f29e6826f5b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->