### PR TITLE
Revert "[Handoff to @Oseltamivir Claude /loop] Update glm5-fp4-b300-sglang and -mtp SGLang image to v0.5.12-cu130"

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2352,7 +2352,7 @@ glm5-fp4-b200-sglang-mtp:
   # does not have a B300-specific recipe, so this config reuses the existing
   # GLM-5 FP4 B200 SGLang recipe as-is until B300-specific tuning is available.
 glm5-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.11-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b300
@@ -2373,7 +2373,7 @@ glm5-fp4-b300-sglang:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 glm5-fp4-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.11-cu130
   model: nvidia/GLM-5-NVFP4
   model-prefix: glm5
   runner: b300

--- a/benchmarks/single_node/glm5_fp4_b300.sh
+++ b/benchmarks/single_node/glm5_fp4_b300.sh
@@ -24,13 +24,6 @@ nvidia-smi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-# Downgrade flashinfer to the version pinned in sglang v0.5.11 to test the
-# trtllm batched-GEMM regression suspicion from sgl-project/sglang#25563
-# (suggested by @trevor-m). sglang v0.5.12's pyproject.toml moved from
-# flashinfer_python==0.6.8.post1 → 0.6.11.post1, and the trtllm GEMM crash
-# at bs=128 + EAGLE on B300 appeared in the same image bump.
-pip install --no-deps "flashinfer_python==0.6.8.post1" "flashinfer_cubin==0.6.8.post1"
-
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 

--- a/benchmarks/single_node/glm5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/glm5_fp4_b300_mtp.sh
@@ -24,12 +24,6 @@ nvidia-smi
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
 pip install --no-deps "transformers==5.2.0" "huggingface-hub==1.4.1"
-# Downgrade flashinfer to the version pinned in sglang v0.5.11 to test the
-# trtllm batched-GEMM regression suspicion from sgl-project/sglang#25563
-# (suggested by @trevor-m). sglang v0.5.12's pyproject.toml moved from
-# flashinfer_python==0.6.8.post1 → 0.6.11.post1, and the trtllm GEMM crash
-# at bs=128 + EAGLE on B300 appeared in the same image bump.
-pip install --no-deps "flashinfer_python==0.6.8.post1" "flashinfer_cubin==0.6.8.post1"
 
 export SGL_ENABLE_JIT_DEEPGEMM=1
 export SGLANG_ENABLE_SPEC_V2=1

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3044,13 +3044,6 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1492
 
 - config-keys:
-    - glm5-fp4-b300-sglang
-    - glm5-fp4-b300-sglang-mtp
-  description:
-    - "Update SGLang image from v0.5.11-cu130 to v0.5.12-cu130"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1420
-
-- config-keys:
     - dsr1-fp4-b200-sglang-mtp
   description:
     - "Add MTP/EAGLE speculative-decoding sibling for dsr1-fp4-b200-sglang (model: nvidia/DeepSeek-R1-0528-FP4-V2) on lmsysorg/sglang:v0.5.12-cu130"


### PR DESCRIPTION
Reverts SemiAnalysisAI/InferenceX#1420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and benchmark-script rollback only; no auth, data, or core app logic changes.
> 
> **Overview**
> Reverts PR #1420 for **GLM-5 FP4 B300** SGLang benchmarks: `glm5-fp4-b300-sglang` and `glm5-fp4-b300-sglang-mtp` again use **`lmsysorg/sglang:v0.5.11-cu130`** instead of v0.5.12.
> 
> The single-node launch scripts **`glm5_fp4_b300.sh`** and **`glm5_fp4_b300_mtp.sh`** drop the temporary **`flashinfer_python` / `flashinfer_cubin` 0.6.8.post1** pins that were added to work around a suspected trtllm batched-GEMM issue on the newer image.
> 
> **`perf-changelog.yaml`** no longer records the v0.5.11 → v0.5.12 image bump for those config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe38a10ce5fb80ff61809fb062a2dd1d2f0bba4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->