### PR TITLE
feat: Kimi-K2.5-MXFP4 LMCache MP offloading for MI355X agentic benchmarks

### DIFF
--- a/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
@@ -442,8 +442,16 @@ def _apply_patch():
 
     def _patched_get_finished(self, scheduler_output):
         result = _orig_get_finished(self, scheduler_output)
-        # Clean up chunk state for finished requests
-        for req in getattr(scheduler_output, "finished_req_ids", []):
+        # Clean up chunk state for finished requests.
+        # vLLM passes scheduler_output as a set of request-ID strings
+        # (not a SchedulerOutput object), so iterate directly when it
+        # is a set/frozenset; fall back to the attribute path for
+        # forward compatibility.
+        if isinstance(scheduler_output, (set, frozenset)):
+            finished = scheduler_output
+        else:
+            finished = getattr(scheduler_output, "finished_req_ids", [])
+        for req in finished:
             _chunk_state.pop(req, None)
         return result
 

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
@@ -336,6 +336,230 @@ if os.environ.get("LMCACHE_ROCM_MP_BLOCK_FALLBACK") == "1":
                         raise ValueError(f"Unsupported transfer direction: {direction}")
 
         lmc.multi_layer_block_kv_transfer = multi_layer_block_kv_transfer
+
+# ---- Chunked KV loading (prevents GPU block exhaustion at high concurrency) ----
+if os.environ.get("CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD", "0") != "0":
+    import chunked_connector_patch  # noqa: F401
+
+# ---- vLLM scheduler assertion fix (stale KV transfer notifications) ----
+import scheduler_assertion_patch  # noqa: F401
+PY
+}
+
+write_chunked_connector_patch() {
+    local patch_dir="$1"
+    mkdir -p "$patch_dir"
+    cat > "$patch_dir/chunked_connector_patch.py" <<'PY'
+"""
+Monkey-patch for LMCacheMPConnector to add chunked KV loading.
+
+Fixes GPU block exhaustion deadlock at high concurrency by capping
+the number of external tokens reported AND retrieved per scheduling step.
+
+Usage: set CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD=<tokens> and import this
+module from sitecustomize.py before LMCache is loaded.
+"""
+
+import logging
+import os
+import sys
+import builtins
+
+logger = logging.getLogger("chunked_lmcache_patch")
+
+_MAX_TOKENS = int(os.environ.get("CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD", "32768"))
+
+# Per-request chunk tracking (module-level, survives across calls)
+_chunk_state: dict[str, dict] = {}
+
+
+def _apply_patch():
+    """Patch LMCacheMPConnector in-place."""
+    mod = sys.modules.get("lmcache.integration.vllm.lmcache_mp_connector")
+    if mod is None:
+        return
+    cls = getattr(mod, "LMCacheMPConnector", None)
+    if cls is None or getattr(cls, "_chunked_patch_applied", False):
+        return
+
+    LMCacheMPRequestState = getattr(mod, "LMCacheMPRequestState", None)
+    _orig_get_matched = cls.get_num_new_matched_tokens
+    _orig_get_finished = cls.get_finished
+
+    def _get_blocks_per_chunk(self):
+        block_size = getattr(self, "block_size", 1)
+        return max(1, _MAX_TOKENS // block_size)
+
+    def _patched_get_num_new_matched_tokens(self, request, num_computed_tokens):
+        full_match = _orig_get_matched(self, request, num_computed_tokens)
+        if full_match <= 0 or _MAX_TOKENS <= 0:
+            return full_match
+
+        req_id = request.request_id
+        block_size = getattr(self, "block_size", 1)
+        blocks_per_chunk = _get_blocks_per_chunk(self)
+        full_match_blocks = full_match // block_size
+
+        state = _chunk_state.get(req_id)
+        if state is None or state.get("num_computed_at_start") != num_computed_tokens:
+            state = {
+                "full_match_blocks": full_match_blocks,
+                "chunk_end_blocks": 0,
+                "num_computed_at_start": num_computed_tokens,
+                "lookup_done": False,
+            }
+            _chunk_state[req_id] = state
+
+        if state["lookup_done"]:
+            return 0
+
+        remaining = state["full_match_blocks"] - state["chunk_end_blocks"]
+        if remaining <= 0:
+            state["lookup_done"] = True
+            return 0
+
+        this_chunk = min(remaining, blocks_per_chunk)
+        state["chunk_end_blocks"] += this_chunk
+        if state["chunk_end_blocks"] >= state["full_match_blocks"]:
+            state["lookup_done"] = True
+
+        capped = this_chunk * block_size
+        if capped < full_match:
+            logger.debug(
+                "Chunked LMCache: req %s capped %d -> %d tokens "
+                "(chunk %d/%d blocks)",
+                req_id, full_match, capped, this_chunk, full_match_blocks,
+            )
+
+        # Cap the tracker's hit blocks to match what we report
+        tracker = getattr(request, "kv_transfer_params", None)
+        if tracker is not None:
+            orig_hits = getattr(tracker, "num_lmcache_hit_blocks", 0)
+            if orig_hits > this_chunk:
+                tracker.num_lmcache_hit_blocks = this_chunk
+
+        return capped
+
+    def _patched_get_finished(self, scheduler_output):
+        result = _orig_get_finished(self, scheduler_output)
+        # Clean up chunk state for finished requests
+        for req in getattr(scheduler_output, "finished_req_ids", []):
+            _chunk_state.pop(req, None)
+        return result
+
+    cls.get_num_new_matched_tokens = _patched_get_num_new_matched_tokens
+    cls.get_finished = _patched_get_finished
+    cls._chunked_patch_applied = True
+    logger.info(
+        "Chunked LMCache connector patch applied "
+        "(max_tokens_per_load=%d)", _MAX_TOKENS,
+    )
+
+
+_orig_import = builtins.__import__
+
+
+def _patching_import(name, *args, **kwargs):
+    module = _orig_import(name, *args, **kwargs)
+    if (
+        name == "lmcache.integration.vllm.lmcache_mp_connector"
+        or (
+            name.startswith("lmcache")
+            and "lmcache.integration.vllm.lmcache_mp_connector" in sys.modules
+        )
+    ):
+        _apply_patch()
+    return module
+
+
+builtins.__import__ = _patching_import
+_apply_patch()
+PY
+}
+
+write_scheduler_assertion_patch() {
+    local patch_dir="$1"
+    mkdir -p "$patch_dir"
+    cat > "$patch_dir/scheduler_assertion_patch.py" <<'PY'
+"""
+Patch vLLM scheduler to handle stale finished_recving gracefully.
+
+The assertion at scheduler.py crashes when a KV transfer reports
+"finished recving" but the request is already in RUNNING state.
+This happens when transfers complete asynchronously and the scheduler
+has already moved the request forward.
+
+Fix: Instead of asserting, log a warning and skip.
+"""
+
+import logging
+import sys
+import builtins
+
+logger = logging.getLogger("scheduler_assertion_patch")
+
+
+def _apply_patch():
+    """Patch vLLM scheduler's _update_from_kv_xfer_finished."""
+    sched_mod = sys.modules.get("vllm.v1.core.sched.scheduler")
+    if sched_mod is None:
+        return
+    req_mod = sys.modules.get("vllm.v1.request")
+    if req_mod is None:
+        return
+    Scheduler = getattr(sched_mod, "Scheduler", None)
+    RequestStatus = getattr(req_mod, "RequestStatus", None)
+    if Scheduler is None or RequestStatus is None:
+        return
+    if getattr(Scheduler, "_kv_xfer_patch_applied", False):
+        return
+
+    _orig_update = Scheduler._update_from_kv_xfer_finished
+
+    def _patched_update(self, kv_connector_output):
+        if self.connector is not None:
+            self.connector.update_connector_output(kv_connector_output)
+        for req_id in kv_connector_output.finished_recving or ():
+            if req_id not in self.requests:
+                continue
+            req = self.requests[req_id]
+            if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(self.requests[req_id])
+            else:
+                logger.warning(
+                    "Stale finished_recving for req %s in status %s; skipping.",
+                    req_id, req.status.name,
+                )
+        for req_id in kv_connector_output.finished_sending or ():
+            if req_id not in self.requests:
+                continue
+            self._free_blocks(self.requests[req_id])
+
+    Scheduler._update_from_kv_xfer_finished = _patched_update
+    Scheduler._kv_xfer_patch_applied = True
+    logger.info("Scheduler KV transfer assertion patch applied")
+
+
+_orig_import = builtins.__import__
+
+
+def _patching_import(name, *args, **kwargs):
+    module = _orig_import(name, *args, **kwargs)
+    if (
+        name == "vllm.v1.core.sched.scheduler"
+        or (
+            name.startswith("vllm")
+            and "vllm.v1.core.sched.scheduler" in sys.modules
+        )
+    ):
+        _apply_patch()
+    return module
+
+
+builtins.__import__ = _patching_import
+_apply_patch()
 PY
 }
 
@@ -481,9 +705,16 @@ if not getattr(cupy_runtime, "is_hip", False):
 PY
         LMCACHE_ROCM_PATCH_DIR="$RESULT_DIR/lmcache_rocm_patch"
         write_lmcache_rocm_mp_patch "$LMCACHE_ROCM_PATCH_DIR"
+        write_chunked_connector_patch "$LMCACHE_ROCM_PATCH_DIR"
+        write_scheduler_assertion_patch "$LMCACHE_ROCM_PATCH_DIR"
         export LMCACHE_ROCM_MP_BLOCK_FALLBACK=1
         export LMCACHE_ROCM_MP_BLOCK_FALLBACK_DTYPE=bfloat16
         export LMCACHE_ROCM_DEMAND_PINNED_ALLOCATOR=1
+        # Cap external KV tokens loaded per scheduling step to prevent GPU
+        # block exhaustion deadlock at high concurrency (c>=32).  Default
+        # 32768 keeps peak block demand within the GPU KV pool.  Set to 0 to
+        # disable chunking (only safe at low concurrency).
+        export CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD="${CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD:-32768}"
         export PYTHONPATH="$LMCACHE_ROCM_PATCH_DIR${PYTHONPATH:+:$PYTHONPATH}"
         python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 


### PR DESCRIPTION
## Summary

Adds chunked KV loading and vLLM scheduler assertion patches to the Kimi-K2.5-MXFP4 LMCache MP offloading pipeline for MI355X agentic benchmarks. These patches are required for stable, high-concurrency operation (c≥32) on ROCm.

### What is LMCache MP?

LMCache MP (Multi-Process) uses an external LMCache server process that owns a large CPU DRAM pool (2.5 TB) for semantic KV caching. Unlike vLLM's built-in `SimpleCPUOffloadConnector` which evicts/restores KV blocks reactively, LMCache MP:
- **Caches KV at the semantic level** — prefix-matched KV blocks are stored once and shared across requests
- **Decouples CPU memory management** from vLLM's scheduler via ZMQ IPC
- **Achieves 3× throughput** at high concurrency where native offloading collapses

### Changes in this PR

Two new ROCm-specific runtime patches added to `sitecustomize.py`:

1. **Chunked connector patch** (`chunked_connector_patch.py`): Caps external KV tokens loaded per scheduling step via `CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD` (default 32768). Without this, at c≥32, LMCache attempts to restore more KV blocks than the GPU pool can hold simultaneously, causing a deadlock where no request can make progress.

2. **Scheduler assertion patch** (`scheduler_assertion_patch.py`): Handles stale KV transfer `finished_recving` notifications gracefully. Under high concurrency, asynchronous H2D transfers can complete after the scheduler has already moved a request past `WAITING_FOR_REMOTE_KVS` → `RUNNING`, triggering an assertion crash.

### Benchmark Results (19-config sweep on MI355X)

**Environment:** vLLM 0.21.0, ROCm 7.2.2, 8× MI355X (288 GB VRAM each), mia1-p02-g17  
**Model:** amd/Kimi-K2.5-MXFP4 (MoE, 262K context)  
**Benchmark:** AgentX v0.3 agentic trace replay, 1800s duration, 375 conversations

#### TP=8: No Offloading vs LMCache

| Conc | none Reqs | lmc Reqs | Δ Reqs | none ITL p50 | lmc ITL p50 | none Out tok/s | lmc Out tok/s | Δ Throughput |
|:----:|:---------:|:--------:|:------:|:------------:|:-----------:|:--------------:|:-------------:|:------------:|
| 16 | 789 | 721 | −8.6% | 44ms | 48ms | 214.7 | 204.6 | −4.7% |
| 24 | 563 | 607 | +7.8% | 76ms | 76ms | 159.3 | 176.2 | **+10.6%** |
| **32** | **168** | **257** | **+53%** | **493ms** | **68ms** | **32.8** | **97.0** | **+196%** |
| 40 | 174 | 135 | −22% | 511ms | 67ms | 33.5 | 41.2 | +23% |
| 48 | 175 | 75 | −57% | 511ms | 90ms | 34.9 | 32.5 | −6.9% |

**Key findings:**
- **LMCache crossover at c=24** — below this, GPU KV cache is sufficient and LMCache adds overhead
- **Sweet spot at c=32** — 3× output throughput (97 vs 33 tok/s), 7.3× lower ITL (68ms vs 493ms)
- **Diminishing returns past c=40** — PCIe transfer overhead dominates at extreme saturation

#### TP=4: LMCache extends usable range

| Conc | none Out tok/s | lmc Out tok/s | Δ |
|:----:|:--------------:|:-------------:|:-:|
| 16 | 90.4 | 98.2 | +8.6% |
| 24 | 21.9 | 35.7 | +63% |
| 32 | 19.8 | 26.5 | +34% |
| 40 | 20.5 | 31.5 | +54% |

### ROCm-Specific Patches (full stack)

| Patch | Purpose | Env Var |
|-------|---------|---------|
| Demand-pinned memory | Lazy-expand LMCache's 2.5 TB pinned pool on ROCm (avoids 10-min startup stall) | `LMCACHE_ROCM_DEMAND_PINNED_ALLOCATOR=1` |
| MP block transfer fallback | Python fallback for `multi_layer_block_kv_transfer` (no CUDA kernel on ROCm) | `LMCACHE_ROCM_MP_BLOCK_FALLBACK=1` |
| **Chunked KV loading** *(new)* | Cap tokens per scheduling step to prevent GPU block exhaustion deadlock | `CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD=32768` |
| **Scheduler assertion fix** *(new)* | Handle stale KV transfer notifications gracefully | *(always active)* |

### How to Run

```bash
export OFFLOADING=lmcache
export TP=8
export CONC=32
# Optional: tune chunk size (default 32768, set 0 to disable)
export CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD=32768
```

### Related

- Upstream LMCache PR for chunked loading: https://github.com/LMCache/LMCache/pull/3382
- Existing MiniMax-M2.5 LMCache PR: #1262

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Monkey-patches LMCache connector and vLLM scheduler scheduling/KV-transfer behavior at runtime; incorrect caps or stale-notification handling could affect correctness or throughput under load, though scope is limited to the benchmark ROCm patch path.
> 
> **Overview**
> Extends the MI355X Kimi LMCache MP benchmark bootstrap with **two runtime monkey-patches** dropped into the existing ROCm `sitecustomize` patch directory and loaded via `PYTHONPATH`.
> 
> **Chunked KV loading** (`CHUNKED_LMCACHE_MAX_TOKENS_PER_LOAD`, default **32768**): patches `LMCacheMPConnector` so each scheduling step only reports/loads a capped slice of external matched tokens (with per-request chunk state and cleanup on finish). This avoids GPU KV block exhaustion deadlocks at high concurrency (e.g. c≥32). Set **0** to disable chunking.
> 
> **Scheduler KV transfer fix**: replaces vLLM’s `_update_from_kv_xfer_finished` handling so stale `finished_recving` notifications (request already past `WAITING_FOR_REMOTE_KVS`) log a warning instead of asserting, while still honoring normal receive/send completion paths.
> 
> The `lmcache` offload path now writes both patch modules alongside the existing ROCm patches and exports the chunk env var by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5bd4d827de0dadb9b0352c5eac607c98ebbf78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->