### PR TITLE
bench_serving: fallback when vLLM get_tokenizer hits removed API

### DIFF
--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -95,10 +95,44 @@ class BenchmarkMetrics:
 _worker_tokenizer = None
 
 
+def _load_tokenizer(tokenizer_id, tokenizer_mode, trust_remote_code):
+    """Load tokenizer for random-prompt generation.
+
+    vLLM's get_tokenizer can raise AttributeError when transformers removes
+    LlamaTokenizer.all_special_tokens_extended (e.g. Qwen3.5 with newer
+    transformers). Prefer backend_request_func.get_tokenizer on fallback so
+    client tokenization stays aligned with the sglang server (#1381, #1428).
+    """
+    try:
+        return get_tokenizer(
+            tokenizer_id,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=trust_remote_code,
+        )
+    except AttributeError as exc:
+        if "all_special_tokens_extended" not in str(exc):
+            raise
+        try:
+            from backend_request_func import get_tokenizer as _backend_get_tokenizer
+            return _backend_get_tokenizer(
+                tokenizer_id,
+                tokenizer_mode=tokenizer_mode,
+                trust_remote_code=trust_remote_code,
+            )
+        except ImportError:
+            from transformers import AutoTokenizer
+            use_fast = tokenizer_mode != "slow"
+            return AutoTokenizer.from_pretrained(
+                tokenizer_id,
+                trust_remote_code=trust_remote_code,
+                use_fast=use_fast,
+            )
+
+
 def _init_tokenizer_worker(tokenizer_id, tokenizer_mode, trust_remote_code):
     """Initialize tokenizer once per worker process."""
     global _worker_tokenizer
-    _worker_tokenizer = get_tokenizer(
+    _worker_tokenizer = _load_tokenizer(
         tokenizer_id,
         tokenizer_mode=tokenizer_mode,
         trust_remote_code=trust_remote_code,
@@ -787,9 +821,11 @@ def main(args: argparse.Namespace):
         api_url = f"http://{args.host}:{args.port}{args.endpoint}"
         base_url = f"http://{args.host}:{args.port}"
 
-    tokenizer = get_tokenizer(tokenizer_id,
-                              tokenizer_mode=tokenizer_mode,
-                              trust_remote_code=args.trust_remote_code)
+    tokenizer = _load_tokenizer(
+        tokenizer_id,
+        tokenizer_mode=tokenizer_mode,
+        trust_remote_code=args.trust_remote_code,
+    )
 
 
     if args.dataset_name == "random":


### PR DESCRIPTION
## Summary

- Add `_load_tokenizer()` in `utils/bench_serving/benchmark_serving.py` for random-prompt generation (`main()` and multiprocessing workers).
- When vLLM's `get_tokenizer` raises `AttributeError` on `all_special_tokens_extended` (removed in newer `transformers`, seen with Qwen3.5), fall back to `backend_request_func.get_tokenizer` so the client keeps the sglang v5 tokenizer alignment from #1381.
- Keeps #1428 import order (`backend_request_func` first, vLLM only on `ImportError`); this handles environments that still resolve vLLM's wrapper or hit the error on the vLLM fallback path.

Unblocks Qwen3.5 FP8 MI355X SGLang disagg smoke / bench runs that use `--use-chat-template` without changing inference server code.

## Test plan

- [ ] `python utils/bench_serving/benchmark_serving.py --help` (import sanity)
- [ ] Load tokenizer for a Qwen3.5 model id with `random` dataset + `--use-chat-template` (no server required for prompt generation path)
- [ ] Qwen3.5 disagg CI smoke after #1570 lands (or locally with matching container)

## Related

- #1428 — prefer `backend_request_func.get_tokenizer` over vLLM
- #1381 — v5 tokenizer client/server alignment in `backend_request_func`
- #1570 — Qwen3.5 FP8 MI355X SGLang disagg (CI; excludes this fix intentionally)

## Out of scope

- SGLang runtime / server tokenizer changes
- Benchmark config or image bumps


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only benchmark prompt-generation path; no auth, serving, or inference changes.
> 
> **Overview**
> Adds **`_load_tokenizer()`** in `benchmark_serving.py` and routes tokenizer loading through it in **`main()`** and multiprocessing **`_init_tokenizer_worker`**, instead of calling vLLM’s `get_tokenizer` directly.
> 
> When vLLM’s wrapper fails with **`AttributeError`** on removed **`all_special_tokens_extended`** (e.g. Qwen3.5 + newer `transformers`), the helper retries **`backend_request_func.get_tokenizer`** so bench client tokenization stays aligned with the SGLang server; if that import fails, it falls back to **`AutoTokenizer.from_pretrained`**.
> 
> This unblocks random-dataset / **`--use-chat-template`** benchmark runs that previously crashed during prompt generation, without changing inference server code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74f133a97cec90f886dd03c44fd86a5afa51f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->