### PR TITLE
Trim sweep-enabled concurrency to min instead of max

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -88,7 +88,7 @@ jobs:
                   contains(github.event.pull_request.labels.*.name, 'sweep-enabled') &&
                   contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled')
               run: |
-                  echo "::error::PR has both 'sweep-enabled' and 'full-sweep-enabled' labels. Remove one — 'full-sweep-enabled' runs the full intermediate concurrency sweep; 'sweep-enabled' trims to max(conc) per parallelism config."
+                  echo "::error::PR has both 'sweep-enabled' and 'full-sweep-enabled' labels. Remove one — 'full-sweep-enabled' runs the full intermediate concurrency sweep; 'sweep-enabled' trims to min(conc) per parallelism config."
                   exit 1
 
             - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,12 +61,12 @@ Git: conventional commit messages. `[skip-sweep]` in commit message skips benchm
 
 PRs do not run the sweep automatically - `run-sweep.yml` is gated on a label. Pick exactly one; setting both is rejected by the workflow's `setup` job.
 
-- `sweep-enabled` - runs the sweep with `--trim-conc` (each parallelism config reduced to its single highest concurrency). Default for most PRs.
+- `sweep-enabled` - runs the sweep with `--trim-conc` (each parallelism config reduced to its single lowest concurrency). Default for most PRs.
 - `full-sweep-enabled` - runs the full intermediate concurrency sweep, identical to push-to-main. Use when intermediate points matter (e.g. a recipe change shifts the throughput/latency curve, not just its endpoints).
 
 **The sweep does not trigger while the PR has merge conflicts.** Even with `sweep-enabled` / `full-sweep-enabled` applied, the `run-sweep.yml` workflow will not start until the PR cleanly merges into main — a stale claude/* or update-* branch with a `perf-changelog.yaml` conflict (the common case) will sit in NO_SWEEP / NO_SUCCESS until rebased. Resolution recipe is documented in `KLAUD_DEBUG.md §1.1`: `git merge origin/main`, then `git checkout origin/main -- perf-changelog.yaml`, then re-append the PR's own changelog entry at the tail. Don't 3-way merge `perf-changelog.yaml`; whitespace edits silently re-trigger the deletion check.
 
-Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the highest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[max(conc)]`.
+Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the lowest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[min(conc)]`.
 
 ## Common Tasks
 

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -42,13 +42,13 @@ def get_added_lines(base_ref: str, head_ref: str, filepath: str) -> str:
 
 
 def trim_conc(entries: list[dict]) -> list[dict]:
-    """Trim each parallelism config's concurrency sweep to its highest point.
+    """Trim each parallelism config's concurrency sweep to its lowest point.
 
     Non-full-sweep PRs only need a single concurrency point per parallelism
     config to validate a change runs end-to-end, so the shared cluster stays
     clear. Push-to-main and ``full-sweep-enabled`` PRs skip this reduction.
 
-    The retained value is the maximum configured concurrency — independent of
+    The retained value is the minimum configured concurrency — independent of
     the source ordering of ``conc-list`` / ``conc-start``.
 
     Input comes from ``json.loads(subprocess.stdout)`` so ``conc`` is always
@@ -56,8 +56,8 @@ def trim_conc(entries: list[dict]) -> list[dict]:
     are hashable scalars.
 
     - Single-node entries: group by every other field and keep only the entry
-      with the highest ``conc`` per group.
-    - Multi-node entries: trim the ``conc`` list in place to ``[max(conc)]``.
+      with the lowest ``conc`` per group.
+    - Multi-node entries: trim the ``conc`` list in place to ``[min(conc)]``.
     """
     groups: dict[tuple, list[int]] = {}
     out: list[dict] = []
@@ -66,7 +66,7 @@ def trim_conc(entries: list[dict]) -> list[dict]:
         if entry.get("prefill") is not None:
             conc = entry.get("conc")
             if isinstance(conc, list) and len(conc) > 1:
-                entry = {**entry, "conc": [max(conc)]}
+                entry = {**entry, "conc": [min(conc)]}
             out.append(entry)
             continue
 
@@ -77,7 +77,7 @@ def trim_conc(entries: list[dict]) -> list[dict]:
     drop: set[int] = set()
     for idxs in groups.values():
         if len(idxs) > 1:
-            keep = max(idxs, key=lambda i: out[i]["conc"])
+            keep = min(idxs, key=lambda i: out[i]["conc"])
             drop.update(i for i in idxs if i != keep)
     return [e for i, e in enumerate(out) if i not in drop]
 


### PR DESCRIPTION
## Summary

- `trim_conc()` in `utils/process_changelog.py` now keeps the lowest concurrency point per parallelism config (was: highest). Single-node entries collapse to the min-`conc` entry per group; multi-node `conc-list`s collapse to `[min(conc)]`.
- Updated the conflicting-labels error in `.github/workflows/run-sweep.yml` and the trim-behavior paragraphs in `AGENTS.md` to match.

Behavior only changes for PRs with the `sweep-enabled` label (the `--trim-conc` path). `full-sweep-enabled` and push-to-main runs are unaffected — they continue to run the full untrimmed sweep.

## Test plan

- [ ] Dispatch e2e-tests against this branch with a H100 gptoss config to confirm the matrix/benchmark pipeline still runs end-to-end.
- [ ] Optionally label this PR `sweep-enabled` to confirm the trimmed configs land on min(conc) per parallelism row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which benchmark points run on labeled PR sweeps (lower load, different latency/throughput signal); full sweeps and main pushes are unaffected.
> 
> **Overview**
> For PRs labeled **`sweep-enabled`**, the `--trim-conc` path now keeps the **lowest** concurrency per parallelism config instead of the highest.
> 
> **`trim_conc()`** in `utils/process_changelog.py` uses `min` for single-node grouping and collapses multi-node `conc` lists to `[min(conc)]`. Docs in **`AGENTS.md`** and the conflicting-labels message in **`run-sweep.yml`** were updated to match. **`full-sweep-enabled`** and push-to-main sweeps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6342f9ecdad689d17b20a2a363d2f09ad76611ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->