### PR TITLE
[AMD][MI355X] add the kimik2.5_int4_mi355x_vllm-disagg support for AMD GPU.

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1577,6 +1577,60 @@ kimik2.5-fp4-mi355x-vllm-disagg:
           additional-settings:
           - "DECODE_NODES=2"
 
+kimik2.5-int4-mi355x-vllm-disagg:
+  image: vllm/vllm-openai-rocm:v0.21.0
+  model: moonshotai/Kimi-K2.5-INT4
+  model-prefix: kimik2.5
+  runner: mi355x-disagg
+  precision: int4
+  framework: vllm-disagg
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      # 1P2D: 1 prefill node (co-located with proxy) + 2 decode nodes = 3 nodes total
+      - spec-decoding: "none"
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "VLLM_MORIIO_CONNECTOR_READ_MODE=1"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=2"
+
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - spec-decoding: "none"
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "VLLM_MORIIO_CONNECTOR_READ_MODE=1"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=2"
+
 minimaxm2.5-fp8-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-a6682d1d259cca69a9ae737ea5608fbbe7520031
   model: MiniMaxAI/MiniMax-M2.5

--- a/benchmarks/multi_node/amd_utils/models_vllm.yaml
+++ b/benchmarks/multi_node/amd_utils/models_vllm.yaml
@@ -30,6 +30,12 @@ Kimi-K2.5-MXFP4:
   env: "VLLM_USE_V1=1 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_PAGED_ATTN=0 VLLM_ROCM_USE_AITER_RMSNORM=1 VLLM_USE_AITER_TRITON_SILU_MUL=0 VLLM_ENGINE_READY_TIMEOUT_S=3600"
   hf_dir: "models--amd--Kimi-K2.5-MXFP4"
 
+Kimi-K2.5-INT4:
+  prefill_flags: "--tensor-parallel-size 8 --compilation-config '{\"cudagraph_mode\":\"PIECEWISE\"}' --no-enable-prefix-caching --gpu-memory-utilization 0.9 --mm-encoder-tp-mode data --trust-remote-code"
+  decode_flags: "--tensor-parallel-size 8 --all2all-backend mori --compilation-config '{\"cudagraph_mode\":\"PIECEWISE\"}' --no-enable-prefix-caching --gpu-memory-utilization 0.9 --mm-encoder-tp-mode data --trust-remote-code"
+  env: "VLLM_ROCM_USE_AITER=1 VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 VLLM_ROCM_USE_AITER_RMSNORM=0 VLLM_USE_V2_MODEL_RUNNER=1 VLLM_ENGINE_READY_TIMEOUT_S=3600"
+  hf_dir: "models--moonshotai--Kimi-K2.5"
+
 MiniMax-M2.5:
   # AITER fused-MoE kernel fmoe_bf16_blockscaleFp8_g1u1_vs_silu_32x384 for gfx950 writes OOB when run with MiniMax's shapes at M=8K(=num batched tokens), crashing vllm during AITER warmup.
   # Set token budget to 4k to avoid using that shape, instead of disabling AITER_MOE.

--- a/benchmarks/multi_node/kimik2.5_int4_mi355x_vllm-disagg.sh
+++ b/benchmarks/multi_node/kimik2.5_int4_mi355x_vllm-disagg.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    CONC_LIST \
+    ISL \
+    OSL \
+    IMAGE \
+    SPEC_DECODING \
+    MODEL_PATH \
+    PREFILL_NUM_WORKERS \
+    PREFILL_TP \
+    PREFILL_EP \
+    PREFILL_DP_ATTN \
+    DECODE_NUM_WORKERS \
+    DECODE_TP \
+    DECODE_EP \
+    DECODE_DP_ATTN \
+    PREFILL_NODES \
+    DECODE_NODES \
+    RANDOM_RANGE_RATIO \
+    FRAMEWORK
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+set -x
+
+cd "$GITHUB_WORKSPACE/benchmarks/multi_node/amd_utils" || exit 1
+
+export TIME_LIMIT="08:00:00"
+export MODEL_PATH=$MODEL_PATH
+export MODEL_NAME=$MODEL_NAME
+export CONTAINER_IMAGE=$IMAGE
+
+if [[ "${PREFILL_EP:-1}" -eq 1 ]]; then
+    export PREFILL_ENABLE_EP=false
+else
+    export PREFILL_ENABLE_EP=true
+fi
+
+if [[ "$PREFILL_DP_ATTN" == "true" ]]; then
+    export PREFILL_ENABLE_DP=true
+else
+    export PREFILL_ENABLE_DP=false
+fi
+
+if [[ "${DECODE_EP:-1}" -eq 1 ]]; then
+    export DECODE_ENABLE_EP=false
+else
+    export DECODE_ENABLE_EP=true
+fi
+
+if [[ "$DECODE_DP_ATTN" == "true" ]]; then
+    export DECODE_ENABLE_DP=true
+else
+    export DECODE_ENABLE_DP=false
+fi
+
+JOB_ID=$(bash ./submit.sh $PREFILL_NODES \
+    $PREFILL_NUM_WORKERS \
+    $DECODE_NODES \
+    $DECODE_NUM_WORKERS \
+    $ISL $OSL "${CONC_LIST// /x}" inf \
+    ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
+    ${PREFILL_TP} ${DECODE_TP} \
+    ${RANDOM_RANGE_RATIO} \
+    "${NODELIST:-}")
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to submit job" >&2
+    exit 1
+fi
+
+echo "$JOB_ID"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3200,3 +3200,12 @@
     - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523, 1P1D TP8/EP1, dp-attn false, conc [8..512]"
     - "MoRI conn.py overlay (48e459bd) via job.slurm; launcher qwen3.5_fp4_mi355x_sglang-disagg.sh"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1579
+
+- config-keys:
+    - kimik2.5-int4-mi355x-vllm-disagg
+  description:
+    - "Add Kimi-K2.5 INT4 MI355X vLLM disaggregated prefill-decode benchmark"
+    - "Image: vllm/vllm-openai-rocm:v0.21.0"
+    - "1P+2D TP8 topology for 1k1k and 8k1k (conc 8-512), matching the Kimi-K2.5 MXFP4 vLLM-disagg workflow"
+    - "Add models_vllm.yaml server flags and multinode launch script kimik2.5_int4_mi355x_vllm-disagg.sh"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1581


### PR DESCRIPTION
## Summary
- Add Kimi-K2.5 INT4 to the MI355X vLLM disaggregated multi-node model registry.
- Add a matching MI355X vLLM-disagg multi-node config and launcher following the Kimi-K2.5 INT4 topology.
-Add Kimi-K2.5-INT4 disagg inference configs (1P2D)
-Consolidate amd_utils to support both sglang and vllm disagg engines


## Test plan
- Parsed edited YAML files with python3/yaml.
- Generated the new multi-node matrix config with generate_sweep_configs.py.
-Verify CI passes on amd-master config with vllm-disagg entries
 -Validate multi-node sglang benchmarks still work (no regressions from amd_utils refactor)
 -Run vllm-disagg multi-node benchmark on MI355X cluster
 -Confirm Kimi-K2.5 INT4 disagg recipes launch correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI matrix wiring only; no runtime application or auth paths change.
> 
> **Overview**
> Adds **Kimi-K2.5 INT4** disaggregated prefill–decode benchmarking on **MI355X** with **vLLM** (`vllm/vllm-openai-rocm:v0.21.0`), aligned with the existing Kimi MXFP4 vLLM-disagg **1P+2D** layout.
> 
> Registers `kimik2.5-int4-mi355x-vllm-disagg` in `amd-master.yaml` for **1k1k** and **8k1k** (conc **8–512**): one prefill worker (TP8, EP1) plus two decode workers (TP8, EP8), with `PREFILL_NODES`/`DECODE_NODES` and `VLLM_MORIIO_CONNECTOR_READ_MODE=1`.
> 
> Adds **`Kimi-K2.5-INT4`** in `models_vllm.yaml` (prefill/decode CLI flags, MoRI on decode, INT4 quick-reduce / V2 model-runner env, `models--moonshotai--Kimi-K2.5` cache dir) and a new multinode launcher **`kimik2.5_int4_mi355x_vllm-disagg.sh`** that maps matrix EP/DP settings and submits via `amd_utils/submit.sh`. Documents the change in `perf-changelog.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aceaf2622ce8fb0df7da6503a345ffb93889c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->