### PR TITLE
[WIP] kimik2.5-fp4-gb200-dynamo-vllm: bump vLLM image to v0.21.0

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8270,7 +8270,7 @@ kimik2.5-fp4-gb200-dynamo-trt:
           dp-attn: true
 
 kimik2.5-fp4-gb200-dynamo-vllm:
-  image: vllm/vllm-openai:v0.18.0-cu130
+  image: vllm/vllm-openai:v0.21.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: gb200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3192,3 +3192,10 @@
     - "Add GLM-5-FP8 models.yaml flags, setup_deps.sh (aiter gluon + transformers glm_moe_dsa), GLM-5 env tuning in env.sh"
     - "Add multinode launch script glm5_fp8_mi355x_sglang-disagg.sh; server.sh sources setup_deps.sh"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1572
+
+- config-keys:
+    - kimik2.5-fp4-gb200-dynamo-vllm
+  description:
+    - "Bump vLLM image from vllm/vllm-openai:v0.18.0-cu130 to vllm/vllm-openai:v0.21.0"
+  pr-link: TBD
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3197,5 +3197,5 @@
     - kimik2.5-fp4-gb200-dynamo-vllm
   description:
     - "Bump vLLM image from vllm/vllm-openai:v0.18.0-cu130 to vllm/vllm-openai:v0.21.0"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1582
 


### PR DESCRIPTION
## Summary
- Bump `kimik2.5-fp4-gb200-dynamo-vllm` image from `vllm/vllm-openai:v0.18.0-cu130` to `vllm/vllm-openai:v0.21.0`.
- Matches the v0.21.0 tag convention from PR #1461 (`dsv4-fp8-h200-vllm`) and the recent `kimik2.5-fp4-b200-vllm-agentic` bump.
- Appends a perf-changelog entry (`pr-link` will be patched in a follow-up commit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only container tag bump and changelog; no application or auth logic changes.
> 
> **Overview**
> Updates the **`kimik2.5-fp4-gb200-dynamo-vllm`** benchmark in `nvidia-master.yaml` to use **`vllm/vllm-openai:v0.21.0`** instead of **`v0.18.0-cu130`**, aligning with other recent vLLM v0.21.0 bumps in the repo.
> 
> Adds a matching **`perf-changelog.yaml`** entry for that config key documenting the image change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424a2946609cc64210c3812a7c758abf3e444af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->