### PR TITLE
glm5-fp4-gb300-dynamo-sglang: extend 8k1k low-lat sweep with 1p17d topology

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9295,7 +9295,7 @@ glm5-fp4-gb300-dynamo-sglang:
       osl: 1024
       search-space:
       # 1p3d. 4 nodes (1P + 3 D workers @ 1 node each).
-      - conc-list: [1024]
+      - conc-list: [128]
         prefill:
           num-worker: 1
           tp: 4
@@ -9309,7 +9309,7 @@ glm5-fp4-gb300-dynamo-sglang:
           ep: 1
           dp-attn: false
       # 1p5d. 6 nodes.
-      - conc-list: [1024]
+      - conc-list: [64]
         prefill:
           num-worker: 1
           tp: 4
@@ -9323,7 +9323,7 @@ glm5-fp4-gb300-dynamo-sglang:
           ep: 1
           dp-attn: false
       # 1p9d. 10 nodes.
-      - conc-list: [1024]
+      - conc-list: [32]
         prefill:
           num-worker: 1
           tp: 4
@@ -9337,7 +9337,7 @@ glm5-fp4-gb300-dynamo-sglang:
           ep: 1
           dp-attn: false
       # 1p15d. 16 nodes.
-      - conc-list: [1024]
+      - conc-list: [16]
         prefill:
           num-worker: 1
           tp: 4
@@ -9347,6 +9347,20 @@ glm5-fp4-gb300-dynamo-sglang:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_3.yaml"
         decode:
           num-worker: 15
+          tp: 4
+          ep: 1
+          dp-attn: false
+      # 1p17d. 18 nodes.
+      - conc-list: [12]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_4.yaml"
+        decode:
+          num-worker: 17
           tp: 4
           ep: 1
           dp-attn: false

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_0.yaml
@@ -158,8 +158,8 @@ backend:
       enable-flashinfer-allreduce-fusion: true
 
       moe-runner-backend: "flashinfer_trtllm"
-      max-running-requests: 4096
-      cuda-graph-max-bs:    4096
+      max-running-requests: 128
+      cuda-graph-max-bs:    128
 
 
 
@@ -171,5 +171,5 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1024"
+  concurrencies: "128"
   req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_1.yaml
@@ -158,8 +158,8 @@ backend:
       enable-flashinfer-allreduce-fusion: true
 
       moe-runner-backend: "flashinfer_trtllm"
-      max-running-requests: 4096
-      cuda-graph-max-bs:    4096
+      max-running-requests: 64
+      cuda-graph-max-bs:    64
 
 
 
@@ -171,5 +171,5 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1024"
+  concurrencies: "64"
   req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_3.yaml
@@ -158,8 +158,8 @@ backend:
       enable-flashinfer-allreduce-fusion: true
 
       moe-runner-backend: "flashinfer_trtllm"
-      max-running-requests: 4096
-      cuda-graph-max-bs:    4096
+      max-running-requests: 16
+      cuda-graph-max-bs:    16
 
 
 
@@ -171,5 +171,5 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1024"
+  concurrencies: "16"
   req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_4.yaml
@@ -1,4 +1,4 @@
-name: "gb300-fp4-glm5_8k1k_lowlat_2"
+name: "gb300-fp4-glm5_8k1k_lowlat_4"
 
 # Ported from upstream srt-slurm recipes/gb300-fp4/glm5.yaml (PR #152).
 # Upstream uses a single combined file with `zip_override_*` arrays
@@ -37,8 +37,8 @@ resources:
   prefill_nodes: 1
   prefill_workers: 1
   gpus_per_prefill: 4
-  decode_nodes: 9
-  decode_workers: 9
+  decode_nodes: 17
+  decode_workers: 17
   gpus_per_decode: 4
 
 frontend:
@@ -158,8 +158,8 @@ backend:
       enable-flashinfer-allreduce-fusion: true
 
       moe-runner-backend: "flashinfer_trtllm"
-      max-running-requests: 32
-      cuda-graph-max-bs:    32
+      max-running-requests: 1
+      cuda-graph-max-bs:    1
 
 
 
@@ -171,5 +171,5 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "32"
+  concurrencies: "12"
   req_rate: "inf"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3205,5 +3205,5 @@
     - glm5-fp4-gb300-dynamo-sglang
   description:
     - "Update GB300 FP4 GLM-5 8k1k low-latency sweep to mirror NVIDIA/srt-slurm#175: add a 5th 1p17d topology (decode_nodes/workers=17), and lower decode max-running-requests / cuda-graph-max-bs / benchmark concurrency per-zip-index from a flat 4096/1024 to 128/64/32/16/1 (mrr & cuda-graph) and 128/64/32/16/12 (concurrency)"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1583
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3200,3 +3200,10 @@
     - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523, 1P1D TP8/EP1, dp-attn false, conc [8..512]"
     - "MoRI conn.py overlay (48e459bd) via job.slurm; launcher qwen3.5_fp4_mi355x_sglang-disagg.sh"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1579
+
+- config-keys:
+    - glm5-fp4-gb300-dynamo-sglang
+  description:
+    - "Update GB300 FP4 GLM-5 8k1k low-latency sweep to mirror NVIDIA/srt-slurm#175: add a 5th 1p17d topology (decode_nodes/workers=17), and lower decode max-running-requests / cuda-graph-max-bs / benchmark concurrency per-zip-index from a flat 4096/1024 to 128/64/32/16/1 (mrr & cuda-graph) and 128/64/32/16/12 (concurrency)"
+  pr-link: TBD
+


### PR DESCRIPTION
## Summary
Mirrors [NVIDIA/srt-slurm#175](https://github.com/NVIDIA/srt-slurm/pull/175) (zip_override_8k1k_lowlat update for `recipes/gb300-fp4/glm5.yaml`):
- Adds a 5th low-lat topology `8k1k_stp_lowlat_4.yaml` with `decode_nodes` / `decode_workers = 17` (1p17d, 18 nodes total).
- Lowers per-zip-index decode `max-running-requests` and `cuda-graph-max-bs` from a flat `4096` to `128 / 64 / 32 / 16 / 1` across `lowlat_0..4`.
- Drops the per-recipe `benchmark.concurrencies` from `"1024"` to `"128" / "64" / "32" / "16" / "12"` to match.
- Keeps `nvidia-master.yaml` in sync: each `glm5-fp4-gb300-dynamo-sglang` 8k1k lowlat entry's `conc-list` now matches its recipe; a new `conc-list: [12]` / `decode.num-worker: 17` entry is appended for the 1p17d topology.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and Slurm recipe tuning only; no runtime application or auth changes.
> 
> **Overview**
> Aligns **GB300 FP4 GLM-5** 8k1k **disaggregated low-latency** STP coverage with NVIDIA/srt-slurm#175: per-topology concurrency and decode batch limits instead of a flat 1024/4096 sweep.
> 
> For the four existing **1p3d → 1p15d** recipes (`8k1k_stp_lowlat_0`–`3`), **`conc-list`** in `nvidia-master.yaml` drops from **1024** to **128 / 64 / 32 / 16**, and each recipe’s decode **`max-running-requests`**, **`cuda-graph-max-bs`**, and **`benchmark.concurrencies`** are lowered to the same values (from 4096/1024).
> 
> A **fifth topology (1p17d, 18 nodes)** is added via new **`8k1k_stp_lowlat_4.yaml`** (17 decode workers) with concurrency **12** and decode limits **1**, plus a matching master search-space entry pointing at **`8k1k_stp_lowlat_4.yaml`**. **`perf-changelog.yaml`** documents the change under **`glm5-fp4-gb300-dynamo-sglang`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdafe2936e96de8ae937d41c224c2da59c63c6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->