### PR TITLE
Add DSV4 GB300 wide-EP sweep configs (EP=12/16/24/32/40)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8781,34 +8781,6 @@ dsv4-fp4-gb300-dynamo-sglang:
           tp: 16
           ep: 16
           dp-attn: true
-      # WideEP TP=16 decode: 4p1d-dep4-dep16. 8 nodes.
-      - conc-list: [1024]
-        prefill:
-          num-worker: 4
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-4p1d-dep4-dep16-8-c1024.yaml"
-        decode:
-          num-worker: 1
-          tp: 16
-          ep: 16
-          dp-attn: true
-      # WideEP TP=16 decode: 8p1d-dep4-dep16. 12 nodes.
-      - conc-list: [4096]
-        prefill:
-          num-worker: 8
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-8p1d-dep4-dep16-12-c4096.yaml"
-        decode:
-          num-worker: 1
-          tp: 16
-          ep: 16
-          dp-attn: true
       # Low concurrency: 1p1d-tp4-tp4. 2 nodes.
       - conc-list: [1]
         prefill:
@@ -8823,33 +8795,76 @@ dsv4-fp4-gb300-dynamo-sglang:
           tp: 4
           ep: 1
           dp-attn: false
-      # Mid concurrency: 10p1d-dep4-dep16. 14 nodes.
-      - conc-list: [8192]
+      # --- Weiliang wide-EP sweep (srt-slurm PR#173), 18 nodes total ---
+      # EP=12: 15P+3D, conc=12000.
+      - conc-list: [12000]
         prefill:
-          num-worker: 10
+          num-worker: 15
           tp: 4
           ep: 4
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-10p1d-dep4-dep16-14-c8192.yaml"
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-15p1d-dep4-dep12-18-c12000.yaml"
+        decode:
+          num-worker: 1
+          tp: 12
+          ep: 12
+          dp-attn: true
+      # EP=16: 14P+4D, conc=8192.
+      - conc-list: [8192]
+        prefill:
+          num-worker: 14
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-14p1d-dep4-dep16-18-c8192.yaml"
         decode:
           num-worker: 1
           tp: 16
           ep: 16
           dp-attn: true
-      # Max concurrency: 12p1d-dep4-dep12. 15 nodes.
-      - conc-list: [21504]
+      # EP=24: 12P+6D, conc=3000.
+      - conc-list: [3000]
         prefill:
           num-worker: 12
           tp: 4
           ep: 4
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-12p1d-dep4-dep12-15-c21504.yaml"
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-12p1d-dep4-dep24-18-c3000.yaml"
         decode:
           num-worker: 1
-          tp: 12
-          ep: 12
+          tp: 24
+          ep: 24
+          dp-attn: true
+      # EP=32: 10P+8D, conc=2500.
+      - conc-list: [2500]
+        prefill:
+          num-worker: 10
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-10p1d-dep4-dep32-18-c2500.yaml"
+        decode:
+          num-worker: 1
+          tp: 32
+          ep: 32
+          dp-attn: true
+      # EP=40: 8P+10D, conc=2048.
+      - conc-list: [2048]
+        prefill:
+          num-worker: 8
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/deepseek-v4/8k1k/disagg-gb300-8p1d-dep4-dep40-18-c2048.yaml"
+        decode:
+          num-worker: 1
+          tp: 40
+          ep: 40
           dp-attn: true
 
 glm5-fp8-b200-dynamo-sglang:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-10p1d-dep4-dep32-18-c2500.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-10p1d-dep4-dep32-18-c2500.yaml
@@ -1,35 +1,8 @@
-name: "disagg-gb300-8p1d-dep4-dep16-12-c4096"
+name: "disagg-gb300-10p1d-dep4-dep32-18-c2500"
 
-# 8k/1k high-throughput topology for the wideep DSV4-Pro setup.
-#
-# Schema/values come from PR #1213 (513cbef) — that PR introduced the
-# `dsv4-pro-gb300-fp4` upstream-style recipe with two `zip_override`
-# variants (wideep [0] / narrow_ep [1]) and `backend.benchmark`. Our
-# pinned srtctl (NVIDIA/srt-slurm @ sa-submission-q2-2026) doesn't
-# support either: `zip_override_*_hightpt` rejects with `Unknown field`
-# and `benchmark` only validates at top level. So this file inlines the
-# wideep [0] override and lifts `benchmark` back out — same operational
-# values, schema the pinned srtctl will accept.
-#
-# Other adjustments back to the InferenceX cluster shape: container &
-# model.path restored to the aliases mapped in launch_gb300.sh's
-# srtslurm.yaml (`lmsysorg/sglang:deepseek-v4-grace-blackwell` and
-# `deepseek-v4-pro`); `dynamo.install: true` added so the container
-# (which has no dynamo baked in) installs from the pinned hash.
-#
-# Cluster-specific items NOT inlined (require InferenceX-side equivalents):
-#   - slurm.partition (yangminl's gb300-cw uses `hpc-mid`)
-#   - frontend.nginx_container (yangminl's `nginx-1.27.4.sqsh` path)
-#   - extra_mount: yangminl/sglang-patched/sglang. Earlier diff analysis
-#     showed only `expert_location_dispatch.py` topk_ids int32 cast is an
-#     active runtime diff vs container sglang; other patched files are
-#     env-gated dead code under the same SGLANG_OPT_* flags this yaml
-#     already sets.
-#
-# DG-related env intentionally diverged (DG cache path is host-specific):
-#   - SGLANG_DG_CACHE_DIR=/configs/deepgemm_cache (yangminl host)
-#   - SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 (yangminl uses prebuilt cache)
-#   This yaml uses SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1 instead.
+# Weiliang wide-EP sweep point: EP=32, 10P+8D = 18 nodes, conc=2500.
+# Matches srt-slurm PR#173 zip_override EP=32 topology.
+# Env vars and sglang_config from InferenceX main (not Weiliang's 0510 image).
 
 model:
   path: "deepseek-v4-pro"
@@ -50,18 +23,19 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 8
-  prefill_workers: 8
+  prefill_nodes: 10
+  prefill_workers: 10
   gpus_per_prefill: 4
-  decode_nodes: 4
+  decode_nodes: 8
   decode_workers: 1
-  gpus_per_decode: 16
+  gpus_per_decode: 32
 
 frontend:
   type: dynamo
-  enable_multiple_frontends: false
+  enable_multiple_frontends: true
+  num_additional_frontends: 8
   env:
-    DYN_ROUTER_LOAD_BLOCK_SIZE: "1" 
+    DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
   args:
     router-mode: "kv"
     router-kv-overlap-score-weight: 0
@@ -120,7 +94,6 @@ backend:
     SGLANG_LOG_FORWARD_ITERS: "1"
     SGLANG_LOG_MS: "1"
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
-    # is single-node only and corrupts results in 2-node decode setups.
 
   sglang_config:
     prefill:
@@ -141,9 +114,11 @@ backend:
 
       disaggregation-mode: "prefill"
       disaggregation-transfer-backend: mooncake
+      enable-dp-lm-head: true
 
       mem-fraction-static: 0.90
       max-running-requests: 512
+      cuda-graph-max-bs: 512
       chunked-prefill-size: 32768
 
     decode:
@@ -153,22 +128,23 @@ backend:
       skip-tokenizer-init: true
       stream-interval: 60
 
-      load-balance-method: "total_requests"
       moe-a2a-backend: "megamoe"
+
+      moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
       disaggregation-decode-polling-interval: 8
 
       mem-fraction-static: 0.94
-      swa-full-tokens-ratio: 0.056
+      swa-full-tokens-ratio: 0.20
       context-length: 9216
-      tensor-parallel-size: 16
-      data-parallel-size: 16
-      expert-parallel-size: 16
+      tensor-parallel-size: 32
+      data-parallel-size: 32
+      expert-parallel-size: 32
       enable-dp-attention: true
       enable-dp-lm-head: true
-      max-running-requests: 21504
+      max-running-requests: 18432
       cuda-graph-max-bs: 1280
 
 
@@ -176,7 +152,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "4096"
+  concurrencies: "2500"
   req_rate: "inf"
   use_chat_template: false
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-12p1d-dep4-dep24-18-c3000.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-12p1d-dep4-dep24-18-c3000.yaml
@@ -1,35 +1,8 @@
-name: "disagg-gb300-12p1d-dep4-dep12-15-c21504"
+name: "disagg-gb300-12p1d-dep4-dep24-18-c3000"
 
-# 8k/1k high-throughput topology for the wideep DSV4-Pro setup.
-#
-# Schema/values come from PR #1213 (513cbef) — that PR introduced the
-# `dsv4-pro-gb300-fp4` upstream-style recipe with two `zip_override`
-# variants (wideep [0] / narrow_ep [1]) and `backend.benchmark`. Our
-# pinned srtctl (NVIDIA/srt-slurm @ sa-submission-q2-2026) doesn't
-# support either: `zip_override_*_hightpt` rejects with `Unknown field`
-# and `benchmark` only validates at top level. So this file inlines the
-# wideep [0] override and lifts `benchmark` back out — same operational
-# values, schema the pinned srtctl will accept.
-#
-# Other adjustments back to the InferenceX cluster shape: container &
-# model.path restored to the aliases mapped in launch_gb300.sh's
-# srtslurm.yaml (`lmsysorg/sglang:deepseek-v4-grace-blackwell` and
-# `deepseek-v4-pro`); `dynamo.install: true` added so the container
-# (which has no dynamo baked in) installs from the pinned hash.
-#
-# Cluster-specific items NOT inlined (require InferenceX-side equivalents):
-#   - slurm.partition (yangminl's gb300-cw uses `hpc-mid`)
-#   - frontend.nginx_container (yangminl's `nginx-1.27.4.sqsh` path)
-#   - extra_mount: yangminl/sglang-patched/sglang. Earlier diff analysis
-#     showed only `expert_location_dispatch.py` topk_ids int32 cast is an
-#     active runtime diff vs container sglang; other patched files are
-#     env-gated dead code under the same SGLANG_OPT_* flags this yaml
-#     already sets.
-#
-# DG-related env intentionally diverged (DG cache path is host-specific):
-#   - SGLANG_DG_CACHE_DIR=/configs/deepgemm_cache (yangminl host)
-#   - SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 (yangminl uses prebuilt cache)
-#   This yaml uses SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1 instead.
+# Weiliang wide-EP sweep point: EP=24, 12P+6D = 18 nodes, conc=3000.
+# Matches srt-slurm PR#173 zip_override EP=24 topology.
+# Env vars and sglang_config from InferenceX main (not Weiliang's 0510 image).
 
 model:
   path: "deepseek-v4-pro"
@@ -53,15 +26,16 @@ resources:
   prefill_nodes: 12
   prefill_workers: 12
   gpus_per_prefill: 4
-  decode_nodes: 3
+  decode_nodes: 6
   decode_workers: 1
-  gpus_per_decode: 12
+  gpus_per_decode: 24
 
 frontend:
   type: dynamo
-  enable_multiple_frontends: false
+  enable_multiple_frontends: true
+  num_additional_frontends: 8
   env:
-    DYN_ROUTER_LOAD_BLOCK_SIZE: "1" 
+    DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
   args:
     router-mode: "kv"
     router-kv-overlap-score-weight: 0
@@ -120,7 +94,6 @@ backend:
     SGLANG_LOG_FORWARD_ITERS: "1"
     SGLANG_LOG_MS: "1"
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
-    # is single-node only and corrupts results in 2-node decode setups.
 
   sglang_config:
     prefill:
@@ -141,9 +114,11 @@ backend:
 
       disaggregation-mode: "prefill"
       disaggregation-transfer-backend: mooncake
+      enable-dp-lm-head: true
 
       mem-fraction-static: 0.90
       max-running-requests: 512
+      cuda-graph-max-bs: 512
       chunked-prefill-size: 32768
 
     decode:
@@ -153,22 +128,23 @@ backend:
       skip-tokenizer-init: true
       stream-interval: 60
 
-      load-balance-method: "total_requests"
       moe-a2a-backend: "megamoe"
+
+      moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
       disaggregation-decode-polling-interval: 8
 
       mem-fraction-static: 0.94
-      swa-full-tokens-ratio: 0.056
+      swa-full-tokens-ratio: 0.20
       context-length: 9216
-      tensor-parallel-size: 12
-      data-parallel-size: 12
-      expert-parallel-size: 12
+      tensor-parallel-size: 24
+      data-parallel-size: 24
+      expert-parallel-size: 24
       enable-dp-attention: true
       enable-dp-lm-head: true
-      max-running-requests: 21504
+      max-running-requests: 18432
       cuda-graph-max-bs: 1280
 
 
@@ -176,7 +152,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "21504"
+  concurrencies: "3000"
   req_rate: "inf"
   use_chat_template: false
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-14p1d-dep4-dep16-18-c8192.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-14p1d-dep4-dep16-18-c8192.yaml
@@ -1,0 +1,158 @@
+name: "disagg-gb300-14p1d-dep4-dep16-18-c8192"
+
+# Weiliang wide-EP sweep point: EP=16, 14P+4D = 18 nodes, conc=8192.
+# Matches srt-slurm PR#173 zip_override EP=16 topology.
+# Env vars and sglang_config from InferenceX main (not Weiliang's 0510 image).
+
+model:
+  path: "deepseek-v4-pro"
+  container: "lmsysorg/sglang:nightly-dev-cu13-20260520-425dffbd"
+  precision: "fp4"
+
+dynamo:
+  hash: "81d0555ee23519cea80a42b4fe824e30368b7300"
+  install: true
+
+slurm:
+  time_limit: "03:00:00"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  prefill_nodes: 14
+  prefill_workers: 14
+  gpus_per_prefill: 4
+  decode_nodes: 4
+  decode_workers: 1
+  gpus_per_decode: 16
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: true
+  num_additional_frontends: 8
+  env:
+    DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
+  args:
+    router-mode: "kv"
+    router-kv-overlap-score-weight: 0
+    router-queue-threshold: 64
+    router-temperature: 0.5
+    no-kv-events: true
+
+backend:
+  type: sglang
+
+  prefill_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_RADIX_FORCE_MISS: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DEFAULT_THINKING: "1"
+    SGLANG_DSV4_REASONING_EFFORT: "max"
+    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
+    SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN: "1"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
+    SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    MC_FORCE_MNNVL: "1"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_LOG_FORWARD_ITERS: "1"
+    SGLANG_LOG_MS: "1"
+    SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
+
+  decode_environment:
+    PYTHONUNBUFFERED: "1"
+    SGLANG_RADIX_FORCE_MISS: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DEFAULT_THINKING: "1"
+    SGLANG_DSV4_REASONING_EFFORT: "max"
+    SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
+    SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN: "1"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "1280"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
+    SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION: "8"
+    MC_FORCE_MNNVL: "1"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+    SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW: "1"
+    DYN_SKIP_SGLANG_LOG_FORMATTING: "1"
+    SGLANG_LOG_FORWARD_ITERS: "1"
+    SGLANG_LOG_MS: "1"
+    SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
+
+  sglang_config:
+    prefill:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      trust-remote-code: true
+      watchdog-timeout: 86400
+      skip-tokenizer-init: true
+      stream-interval: 60
+
+      tensor-parallel-size: 4
+      data-parallel-size: 4
+      expert-parallel-size: 4
+
+      enable-dp-attention: true
+      moe-a2a-backend: "megamoe"
+      deepep-config: '{"normal_dispatch":{"num_sms":88,"num_max_nvl_chunked_send_tokens":28,"num_max_nvl_chunked_recv_tokens":512},"normal_combine": {"num_sms":88,"num_max_nvl_chunked_send_tokens":16,"num_max_nvl_chunked_recv_tokens":512}}'
+      moe-dense-tp-size: 1
+
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: mooncake
+      enable-dp-lm-head: true
+
+      mem-fraction-static: 0.90
+      max-running-requests: 512
+      cuda-graph-max-bs: 512
+      chunked-prefill-size: 32768
+
+    decode:
+      served-model-name: "deepseek-ai/DeepSeek-V4-Pro"
+      trust-remote-code: true
+      watchdog-timeout: 86400
+      skip-tokenizer-init: true
+      stream-interval: 60
+
+      moe-a2a-backend: "megamoe"
+
+      moe-dense-tp-size: 1
+
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: mooncake
+      disaggregation-decode-polling-interval: 8
+
+      mem-fraction-static: 0.94
+      swa-full-tokens-ratio: 0.20
+      context-length: 9216
+      tensor-parallel-size: 16
+      data-parallel-size: 16
+      expert-parallel-size: 16
+      enable-dp-attention: true
+      enable-dp-lm-head: true
+      max-running-requests: 18432
+      cuda-graph-max-bs: 1280
+
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "8192"
+  req_rate: "inf"
+  use_chat_template: false
+  custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-15p1d-dep4-dep12-18-c12000.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-15p1d-dep4-dep12-18-c12000.yaml
@@ -1,35 +1,8 @@
-name: "disagg-gb300-10p1d-dep4-dep16-14-c8192"
+name: "disagg-gb300-15p1d-dep4-dep12-18-c12000"
 
-# 8k/1k high-throughput topology for the wideep DSV4-Pro setup.
-#
-# Schema/values come from PR #1213 (513cbef) — that PR introduced the
-# `dsv4-pro-gb300-fp4` upstream-style recipe with two `zip_override`
-# variants (wideep [0] / narrow_ep [1]) and `backend.benchmark`. Our
-# pinned srtctl (NVIDIA/srt-slurm @ sa-submission-q2-2026) doesn't
-# support either: `zip_override_*_hightpt` rejects with `Unknown field`
-# and `benchmark` only validates at top level. So this file inlines the
-# wideep [0] override and lifts `benchmark` back out — same operational
-# values, schema the pinned srtctl will accept.
-#
-# Other adjustments back to the InferenceX cluster shape: container &
-# model.path restored to the aliases mapped in launch_gb300.sh's
-# srtslurm.yaml (`lmsysorg/sglang:deepseek-v4-grace-blackwell` and
-# `deepseek-v4-pro`); `dynamo.install: true` added so the container
-# (which has no dynamo baked in) installs from the pinned hash.
-#
-# Cluster-specific items NOT inlined (require InferenceX-side equivalents):
-#   - slurm.partition (yangminl's gb300-cw uses `hpc-mid`)
-#   - frontend.nginx_container (yangminl's `nginx-1.27.4.sqsh` path)
-#   - extra_mount: yangminl/sglang-patched/sglang. Earlier diff analysis
-#     showed only `expert_location_dispatch.py` topk_ids int32 cast is an
-#     active runtime diff vs container sglang; other patched files are
-#     env-gated dead code under the same SGLANG_OPT_* flags this yaml
-#     already sets.
-#
-# DG-related env intentionally diverged (DG cache path is host-specific):
-#   - SGLANG_DG_CACHE_DIR=/configs/deepgemm_cache (yangminl host)
-#   - SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 (yangminl uses prebuilt cache)
-#   This yaml uses SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1 instead.
+# Weiliang wide-EP sweep point: EP=12, 15P+3D = 18 nodes, conc=12000.
+# Matches srt-slurm PR#173 zip_override EP=12 topology.
+# Env vars and sglang_config from InferenceX main (not Weiliang's 0510 image).
 
 model:
   path: "deepseek-v4-pro"
@@ -50,18 +23,19 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 10
-  prefill_workers: 10
+  prefill_nodes: 15
+  prefill_workers: 15
   gpus_per_prefill: 4
-  decode_nodes: 4
+  decode_nodes: 3
   decode_workers: 1
-  gpus_per_decode: 16
+  gpus_per_decode: 12
 
 frontend:
   type: dynamo
-  enable_multiple_frontends: false
+  enable_multiple_frontends: true
+  num_additional_frontends: 8
   env:
-    DYN_ROUTER_LOAD_BLOCK_SIZE: "1" 
+    DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
   args:
     router-mode: "kv"
     router-kv-overlap-score-weight: 0
@@ -120,7 +94,6 @@ backend:
     SGLANG_LOG_FORWARD_ITERS: "1"
     SGLANG_LOG_MS: "1"
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
-    # is single-node only and corrupts results in 2-node decode setups.
 
   sglang_config:
     prefill:
@@ -141,9 +114,11 @@ backend:
 
       disaggregation-mode: "prefill"
       disaggregation-transfer-backend: mooncake
+      enable-dp-lm-head: true
 
       mem-fraction-static: 0.90
       max-running-requests: 512
+      cuda-graph-max-bs: 512
       chunked-prefill-size: 32768
 
     decode:
@@ -153,22 +128,23 @@ backend:
       skip-tokenizer-init: true
       stream-interval: 60
 
-      load-balance-method: "total_requests"
       moe-a2a-backend: "megamoe"
+
+      moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
       disaggregation-decode-polling-interval: 8
 
       mem-fraction-static: 0.94
-      swa-full-tokens-ratio: 0.056
+      swa-full-tokens-ratio: 0.20
       context-length: 9216
-      tensor-parallel-size: 16
-      data-parallel-size: 16
-      expert-parallel-size: 16
+      tensor-parallel-size: 12
+      data-parallel-size: 12
+      expert-parallel-size: 12
       enable-dp-attention: true
       enable-dp-lm-head: true
-      max-running-requests: 21504
+      max-running-requests: 18432
       cuda-graph-max-bs: 1280
 
 
@@ -176,7 +152,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "8192"
+  concurrencies: "12000"
   req_rate: "inf"
   use_chat_template: false
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-8p1d-dep4-dep40-18-c2048.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-gb300-8p1d-dep4-dep40-18-c2048.yaml
@@ -1,35 +1,8 @@
-name: "disagg-gb300-4p1d-dep4-dep16-8-c1024"
+name: "disagg-gb300-8p1d-dep4-dep40-18-c2048"
 
-# 8k/1k high-throughput topology for the wideep DSV4-Pro setup.
-#
-# Schema/values come from PR #1213 (513cbef) — that PR introduced the
-# `dsv4-pro-gb300-fp4` upstream-style recipe with two `zip_override`
-# variants (wideep [0] / narrow_ep [1]) and `backend.benchmark`. Our
-# pinned srtctl (NVIDIA/srt-slurm @ sa-submission-q2-2026) doesn't
-# support either: `zip_override_*_hightpt` rejects with `Unknown field`
-# and `benchmark` only validates at top level. So this file inlines the
-# wideep [0] override and lifts `benchmark` back out — same operational
-# values, schema the pinned srtctl will accept.
-#
-# Other adjustments back to the InferenceX cluster shape: container &
-# model.path restored to the aliases mapped in launch_gb300.sh's
-# srtslurm.yaml (`lmsysorg/sglang:deepseek-v4-grace-blackwell` and
-# `deepseek-v4-pro`); `dynamo.install: true` added so the container
-# (which has no dynamo baked in) installs from the pinned hash.
-#
-# Cluster-specific items NOT inlined (require InferenceX-side equivalents):
-#   - slurm.partition (yangminl's gb300-cw uses `hpc-mid`)
-#   - frontend.nginx_container (yangminl's `nginx-1.27.4.sqsh` path)
-#   - extra_mount: yangminl/sglang-patched/sglang. Earlier diff analysis
-#     showed only `expert_location_dispatch.py` topk_ids int32 cast is an
-#     active runtime diff vs container sglang; other patched files are
-#     env-gated dead code under the same SGLANG_OPT_* flags this yaml
-#     already sets.
-#
-# DG-related env intentionally diverged (DG cache path is host-specific):
-#   - SGLANG_DG_CACHE_DIR=/configs/deepgemm_cache (yangminl host)
-#   - SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 (yangminl uses prebuilt cache)
-#   This yaml uses SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1 instead.
+# Weiliang wide-EP sweep point: EP=40, 8P+10D = 18 nodes, conc=2048.
+# Matches srt-slurm PR#173 zip_override EP=40 topology.
+# Env vars and sglang_config from InferenceX main (not Weiliang's 0510 image).
 
 model:
   path: "deepseek-v4-pro"
@@ -50,18 +23,19 @@ sbatch_directives:
 resources:
   gpu_type: "gb300"
   gpus_per_node: 4
-  prefill_nodes: 4
-  prefill_workers: 4
+  prefill_nodes: 8
+  prefill_workers: 8
   gpus_per_prefill: 4
-  decode_nodes: 4
+  decode_nodes: 10
   decode_workers: 1
-  gpus_per_decode: 16
+  gpus_per_decode: 40
 
 frontend:
   type: dynamo
-  enable_multiple_frontends: false
+  enable_multiple_frontends: true
+  num_additional_frontends: 8
   env:
-    DYN_ROUTER_LOAD_BLOCK_SIZE: "1" 
+    DYN_ROUTER_LOAD_BLOCK_SIZE: "1"
   args:
     router-mode: "kv"
     router-kv-overlap-score-weight: 0
@@ -120,7 +94,6 @@ backend:
     SGLANG_LOG_FORWARD_ITERS: "1"
     SGLANG_LOG_MS: "1"
     SGLANG_REQUEST_STATE_WAIT_TIMEOUT: "60"
-    # is single-node only and corrupts results in 2-node decode setups.
 
   sglang_config:
     prefill:
@@ -141,9 +114,11 @@ backend:
 
       disaggregation-mode: "prefill"
       disaggregation-transfer-backend: mooncake
+      enable-dp-lm-head: true
 
       mem-fraction-static: 0.90
       max-running-requests: 512
+      cuda-graph-max-bs: 512
       chunked-prefill-size: 32768
 
     decode:
@@ -153,22 +128,24 @@ backend:
       skip-tokenizer-init: true
       stream-interval: 60
 
-      load-balance-method: "total_requests"
       moe-a2a-backend: "megamoe"
+
+      moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"
       disaggregation-transfer-backend: mooncake
       disaggregation-decode-polling-interval: 8
 
       mem-fraction-static: 0.94
-      swa-full-tokens-ratio: 0.056
+      swa-full-tokens-ratio: 0.20
       context-length: 9216
-      tensor-parallel-size: 16
-      data-parallel-size: 16
-      expert-parallel-size: 16
+      tensor-parallel-size: 40
+      data-parallel-size: 40
+      expert-parallel-size: 40
+      ep-num-redundant-experts: 16
       enable-dp-attention: true
       enable-dp-lm-head: true
-      max-running-requests: 21504
+      max-running-requests: 18400
       cuda-graph-max-bs: 1280
 
 
@@ -176,7 +153,7 @@ benchmark:
   type: "sa-bench"
   isl: 8192
   osl: 1024
-  concurrencies: "1024"
+  concurrencies: "2048"
   req_rate: "inf"
   use_chat_template: false
   custom_tokenizer: "sa_bench_tokenizers.sglang_deepseek_v4.SGLangDeepseekV4Tokenizer"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3514,3 +3514,12 @@
   description:
     - "Expand concurrency sweep for the 1k/1k and 8k/1k cells: TP4/EP1 conc 4-64 -> 1-128, TP8/EP1 conc-start 4 -> 1 (conc-end 4 unchanged)."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1677
+
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-sglang
+  description:
+    - "Add wide-EP sweep configs (EP=12/16/24/32/40) matching srt-slurm PR#173 topology (18 nodes total)"
+    - "EP=12 15P+3D conc=12000, EP=16 14P+4D conc=8192, EP=24 12P+6D conc=3000, EP=32 10P+8D conc=2500, EP=40 8P+10D conc=2048"
+    - "Aligned decode params with Weiliang config: swa-full-tokens-ratio=0.20, max-running-requests=18432, moe-dense-tp-size=1; added prefill enable-dp-lm-head and cuda-graph-max-bs=512"
+    - "Remove 4 dominated old configs (4p-dep16-8n, 8p-dep16-12n, 10p-dep16-14n, 12p-dep12-15n) superseded by wide-EP frontier"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1586


### PR DESCRIPTION
## Summary
- Add 5 new search-space entries and recipe files for DSV4 GB300 non-MTP wide-EP sweep, matching srt-slurm PR#173 topology (18 nodes total).
- EP sizes: 12/16/24/32/40, decode nodes: 3/4/6/8/10, concurrencies: 12000/8192/3000/2500/2048.
- Uses InferenceX env vars and sglang_config (megamoe, W4A4, nightly-20260520 image), with Weiliang's tuned decode params (swa-full-tokens-ratio=0.20, max-running-requests=18432).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and Slurm recipe YAML only; no application or inference runtime code paths change.
> 
> **Overview**
> Replaces several **GB300 DeepSeek-V4 disaggregated SGLang** benchmark scenarios in `nvidia-master.yaml` with a **wide expert-parallel sweep** (srt-slurm PR#173): five 18-node points at decode **EP 12/16/24/32/40**, each with its own prefill/decode worker counts, decode TP/EP, and concurrency (12000 down to 2048). The low-concurrency **1p1d tp4** case is kept and reordered; older wide-EP entries (e.g. 4p/8p dep16, 12p dep12 at 21504 conc) are dropped from the search space.
> 
> Matching **srt-slurm recipe** files are renamed/retargeted (and one new `12p1d` / EP24 recipe added): cluster topology, `CONFIG_FILE` paths, benchmark concurrency, **multi-frontend** Dynamo routing, nightly container image, and decode **TP/DP/EP** (up to 40 with redundant experts on EP40). Shared tuning shifts include **swa-full-tokens-ratio 0.20**, **max-running-requests ~18432**, prefill **enable-dp-lm-head** and **cuda-graph-max-bs=512**, and removal of decode **load-balance-method**.
> 
> `perf-changelog.yaml` documents the new `dsv4-fp4-gb300-dynamo-sglang` sweep and retired configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b54022dc0a683e0ea3e45a6464116c2f7ced0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->