### PR TITLE
fix(process_result): fail loudly on zero-throughput disagg runs (no more masked ZeroDivisionError)

### DIFF
--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -42,6 +42,23 @@ image = base_env['IMAGE']
 with open(f'{result_filename}.json') as f:
     bmk_result = json.load(f)
 
+# A failed/degenerate benchmark (server never came up, disagg warmup deadlock,
+# MoRI/KV-transport failure, etc.) still writes a result JSON, but with zeroed
+# throughput and latency metrics. Detect that here and fail with the real,
+# actionable reason. Otherwise the tpot reciprocal below (1000.0 / tpot) raises
+# an opaque "ZeroDivisionError: float division by zero" that masks the true
+# server-side cause and makes every such failure look identical.
+_output_tput = float(bmk_result.get('output_throughput', 0) or 0)
+_total_tput = float(bmk_result.get('total_token_throughput', 0) or 0)
+if _output_tput <= 0 or _total_tput <= 0:
+    raise SystemExit(
+        "FAIL: benchmark produced no decode throughput "
+        f"(output_throughput={_output_tput}, total_token_throughput={_total_tput}) "
+        f"in {result_filename}.json — the server almost certainly failed to serve "
+        "(disagg warmup deadlock / MoRI transport failure / server never reached "
+        "ready). Check the multinode_server_logs artifact for the real error."
+    )
+
 data = {
     'hw': hw,
     'conc': int(bmk_result['max_concurrency']),


### PR DESCRIPTION
## What

When a disagg benchmark fails server-side (warmup deadlock, MoRI/KV-transport failure, server never reaching ready), the harness still writes a result JSON — but with **zeroed throughput/latency**. `utils/process_result.py` then computes the tpot→interactivity reciprocal `1000.0 / float(tpot)` with `tpot == 0`, raising:

```
ZeroDivisionError: float division by zero  (utils/process_result.py:132)
```

This opaque error is the dominant red signature on `mi355x-disagg` sweeps (e.g. #1584's DEP8/MTP jobs). It **masks the real cause** and makes every server-side failure look identical, so triage always requires hand-pulling slurm logs.

## Fix

Guard up front, right after the result JSON is loaded: if `output_throughput` or `total_token_throughput` is 0, exit with a clear, actionable message pointing at the `multinode_server_logs` artifact — instead of letting the reciprocal raise.

A legitimately successful run always has positive throughput, so this never triggers on healthy results.

## Why this matters

This doesn't *fix* the underlying MoRI warmup deadlock (that's upstream / #1585), but it converts "mystery ZeroDivisionError" into the real story on every future disagg run — the prerequisite for actually debugging AMD multinode. It would, for example, have immediately distinguished #1584 (real disagg failure) from #1581 (deterministic model-not-found, fails before any result is written).

Vendor-agnostic; affects both NVIDIA and AMD disagg result processing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard on result ingestion only; successful runs with positive throughput are unchanged.
> 
> **Overview**
> Adds an early check in `utils/process_result.py` right after the benchmark result JSON is loaded: if **`output_throughput`** or **`total_token_throughput`** is zero or missing, the script **`SystemExit`s** with an explicit failure message (including the metric values and a pointer to **`multinode_server_logs`**) instead of continuing into downstream math.
> 
> That prevents the later **`1000.0 / tpot`** interactivity conversion from raising a **`ZeroDivisionError`** when failed/disagg runs still write a result file with zeroed throughput and latency—so server-side failures (warmup deadlock, transport issues, server not ready) surface as one actionable error rather than an identical division-by-zero on every bad run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd405c142bc9d1c7d8eb4877e8a82ff35bc60852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->