### PR TITLE
Add SPEED-Bench reference synthetic AL values for DeepSeek-V4-Pro MTP 1-8

### DIFF
--- a/benchmarks/speedbench-reference-al.yaml
+++ b/benchmarks/speedbench-reference-al.yaml
@@ -1,0 +1,13 @@
+# Acceptance Length (AL) reference values measured with SPEED-Bench
+# dataset: coding | temperature: 1.0 | thinking: true
+# key = num_speculative_tokens (MTP level), value = golden AL
+
+deepseek-v4-pro:
+  1: 1.90
+  2: 2.60
+  3: 2.97
+  4: 3.04
+  5: 3.13
+  6: 3.08
+  7: 3.13
+  8: 3.12

--- a/benchmarks/speedbench-reference-al.yaml
+++ b/benchmarks/speedbench-reference-al.yaml
@@ -1,13 +1,29 @@
-# Acceptance Length (AL) reference values measured with SPEED-Bench
-# dataset: coding | temperature: 1.0 | thinking: true
-# key = num_speculative_tokens (MTP level), value = golden AL
-
+# Acceptance Length (AL) reference values measured with SPEED-Bench.
+# dataset: coding | temperature: 1.0 | output_len: 4096
+# Measured on DeepSeek-V4-Pro (B300, vLLM MTP), per num_speculative_tokens.
+#
+# Two modes are reported:
+#   thinking_on  - reasoning enabled; this is the PRODUCTION configuration and
+#                  the golden reference used for synthetic-acceptance modeling.
+#   thinking_off - reasoning disabled; provided for comparison only.
+#
+# key = num_speculative_tokens (MTP level); value = golden AL
 deepseek-v4-pro:
-  1: 1.90
-  2: 2.60
-  3: 2.97
-  4: 3.04
-  5: 3.13
-  6: 3.08
-  7: 3.13
-  8: 3.12
+  thinking_on:
+    1: 1.79
+    2: 2.27
+    3: 2.47
+    4: 2.54
+    5: 2.52
+    6: 2.54
+    7: 2.54
+    8: 2.56
+  thinking_off:
+    1: 1.92
+    2: 2.60
+    3: 2.97
+    4: 3.04
+    5: 3.13
+    6: 3.08
+    7: 3.13
+    8: 3.12


### PR DESCRIPTION
Measured with SPEED-Bench coding dataset, temperature=1.0, thinking=true. Values used for synthetic acceptance rate configuration in MTP benchmarks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only benchmark reference data with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`benchmarks/speedbench-reference-al.yaml`**, a new SPEED-Bench reference for **acceptance length (AL)** on **DeepSeek-V4-Pro** with vLLM MTP for **`num_speculative_tokens` 1–8** (coding dataset, temperature 1.0, output_len 4096).
> 
> The file documents **two AL curves**: **`thinking_on`** (marked as the **production** golden reference for synthetic-acceptance modeling) and **`thinking_off`** (comparison only). The numeric tables differ from the PR description’s single table, which aligns with the **`thinking_off`** values rather than production **`thinking_on`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0d9dda71581253339727a5a36b476c214b419f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->