### PR TITLE
[Klaud Cold] Update kimik2.5-int4-mi300x-vllm vLLM ROCm image to v0.22.0

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -782,7 +782,7 @@ kimik2.5-int4-mi325x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:v0.22.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3239,3 +3239,9 @@
     - "Add --compilation-config '{\"mode\":3,\"cudagraph_mode\":\"PIECEWISE\"}' to vllm serve, mirroring `model.base_args` from the upstream recipe. `pass_config.fuse_minimax_qk_norm` from the recipe is intentionally omitted — it triggers an upstream NameError on ROCm because vllm/compilation/passes/pass_manager.py imports MiniMaxQKNormPass under `is_cuda()` (NVIDIA-only) while using it unconditionally"
     - "Conditionally enable VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1 per (TP, EP, CONC) — on for shapes where the AITER ASM paged-attention kernel exists in the gfx942 heuristic table (TP=2 EP=1 CONC<=16, TP=8 EP=8 CONC<=64), off otherwise. Above the thresholds vllm/v1/attention/backends/rocm_aiter_fa.py routes decode through aiter pa_fwd_asm and crashes with `RuntimeError: get_heuristic_kernel: cannot get heuristic kernel!` for MiniMax-M2.5's attention shape (gqa=6 block_size=32 qTile=0); below them the ASM auto-dispatch is the perf win the recipe wants. Thresholds confirmed across 17 bench cells + 3 eval cells in PR #1594 sweep run 26692603804. Mirrors the per-shape toggle pattern in benchmarks/single_node/minimaxm2.5_fp8_mi355x.sh; can collapse to unconditional SHUFFLE=1 once AITER registers the missing kernel on gfx942"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1594
+
+- config-keys:
+    - kimik2.5-int4-mi300x-vllm
+  description:
+    - "Update vLLM ROCm image from v0.21.0 to v0.22.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1615


### PR DESCRIPTION
## Summary
Update vLLM ROCm image from v0.21.0 to v0.22.0

Recipes touched: `kimik2.5-int4-mi300x-vllm`

## Test plan
- [ ] full-sweep-enabled sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-recipe container tag bump with no serving-flag or search-space edits; risk is limited to v0.22.0 runtime compatibility or perf shifts on MI300X for Kimi K2.5 INT4.
> 
> **Overview**
> Bumps the **Kimi K2.5 INT4** MI300X vLLM benchmark container from `vllm/vllm-openai-rocm:v0.21.0` to **`v0.22.0`** in `.github/configs/amd-master.yaml` for `kimik2.5-int4-mi300x-vllm`. Model, TP=8 fixed-seq-len sweeps, and other recipe fields are unchanged.
> 
> Adds a matching **`perf-changelog.yaml`** entry for config-key `kimik2.5-int4-mi300x-vllm` (PR #1615).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51636bf845aefb4f75ceca35eda98c9161ebdf00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->