### PR TITLE
[AMD] Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2259,6 +2259,25 @@ dsv4-fp4-mi355x-atom:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 64 }
       - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 512 }
 
+dsv4-fp4-mi355x-atom-mtp:
+  image: rocm/atom-dev:nightly_202605301523
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: mi355x
+  precision: fp4
+  framework: atom
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+
 qwen3.5-bf16-mi325x-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2260,7 +2260,7 @@ dsv4-fp4-mi355x-atom:
       - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 512 }
 
 dsv4-fp4-mi355x-atom-mtp:
-  image: rocm/atom-dev:nightly_202605301523
+  image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -2272,11 +2272,11 @@ dsv4-fp4-mi355x-atom-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 1024, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 1024, spec-decoding: mtp }
 
 qwen3.5-bf16-mi325x-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-rocm720-mi30x

--- a/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
@@ -62,6 +62,12 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
+# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
+# <bos><User>...<Assistant><think> framing DeepSeek-V4-Pro expects. The DSv4-Pro
+# tokenizer ships without a jinja chat_template, so plain --use-chat-template
+# would crash; --dsv4 sidesteps that and satisfies the AGENTS.md rule that all
+# MTP scripts must benchmark against chat-formatted inputs (EAGLE acceptance
+# silently regresses on raw random tokens).
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
@@ -72,8 +78,7 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/ \
-    --use-chat-template 
+    --result-dir /workspace/
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
@@ -78,7 +78,8 @@ run_benchmark_serving \
     --num-prompts "$((CONC * 10))" \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
-    --result-dir /workspace/
+    --result-dir /workspace/ \
+    --use-chat-template 
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
@@ -62,12 +62,6 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
-# <bos><User>...<Assistant><think> framing DeepSeek-V4-Pro expects. The DSv4-Pro
-# tokenizer ships without a jinja chat_template, so plain --use-chat-template
-# would crash; --dsv4 sidesteps that and satisfies the AGENTS.md rule that all
-# MTP scripts must benchmark against chat-formatted inputs (EAGLE acceptance
-# silently regresses on raw random tokens).
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \

--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
@@ -54,6 +54,12 @@ SERVER_PID=$!
 # Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
+# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
+# <bos><User>...<Assistant><think> framing DeepSeek-V4-Pro expects. The DSv4-Pro
+# tokenizer ships without a jinja chat_template, so plain --use-chat-template
+# would crash; --dsv4 sidesteps that and satisfies the AGENTS.md rule that all
+# MTP scripts must benchmark against chat-formatted inputs (EAGLE acceptance
+# silently regresses on raw random tokens).
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
@@ -65,7 +71,6 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
-    --dsv4 \
     --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true

--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
@@ -22,11 +22,16 @@ echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTIO
 SERVER_LOG=/workspace/server.log
 PORT=${PORT:-8888}
 
-if [ "$EP_SIZE" -gt 1 ]; then
-  EP=" --enable-expert-parallel"
-else
-  EP=" "
-fi
+PARALLEL_ARGS=(-tp "$TP") #TP
+if [ "$DP_ATTENTION" = "true" ]; then
+    if [ "$EP_SIZE" -gt 1 ]; then #DP+EP
+        PARALLEL_ARGS=(-tp "$TP" --enable-expert-parallel --enable-dp-attention )
+    else #DP+TP
+        PARALLEL_ARGS=(-tp "$TP" --enable-dp-attention )
+    fi
+fi 
+
+SPEC_ARGS=(--method mtp --num-speculative-tokens 3 )
 
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -38,10 +43,9 @@ export ATOM_MOE_GU_ITLV=1
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
     --server-port $PORT \
-    -tp $TP \
-    --kv_cache_dtype fp8 $EP \
-    --method mtp \
-    --num-speculative-tokens 3 \
+    "${PARALLEL_ARGS[@]}" \
+    "${SPEC_ARGS[@]}" \
+    --kv_cache_dtype fp8 \
     --trust-remote-code \
     > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME \
+    EP_SIZE \
+    DP_ATTENTION
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL, EP_SIZE: $EP_SIZE, DP_ATTENTION: $DP_ATTENTION"
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+if [ "$EP_SIZE" -gt 1 ]; then
+  EP=" --enable-expert-parallel"
+else
+  EP=" "
+fi
+
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+export ATOM_DISABLE_MMAP=true
+export AITER_BF16_FP8_MOE_BOUND=0
+export ATOM_MOE_GU_ITLV=1
+python3 -m atom.entrypoints.openai_server \
+    --model $MODEL \
+    --server-port $PORT \
+    -tp $TP \
+    --kv_cache_dtype fp8 $EP \
+    --method mtp \
+    --num-speculative-tokens 3 \
+    --trust-remote-code \
+    > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
@@ -65,7 +65,7 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
-    --use-chat-template \
+    --dsv4 \
     --trust-remote-code
 
 # After throughput, run evaluation only if RUN_EVAL is true

--- a/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh
@@ -71,7 +71,8 @@ run_benchmark_serving \
     --max-concurrency "$CONC" \
     --result-filename "$RESULT_FILENAME" \
     --result-dir /workspace/ \
-    --trust-remote-code
+    --trust-remote-code \
+    --dsv4
 
 # After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3348,9 +3348,15 @@
   description:
     - "Add DeepSeek-V4-Pro FP4 MI355X ATOM DP-attention benchmark; image rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1626
-  
+
 - config-keys:
     - dsv4-fp4-mi355x-vllm-mtp
   description:
     - "Add MTP speculative-decoding sibling for dsv4-fp4-mi355x-vllm (model: deepseek-ai/DeepSeek-V4-Pro) on vllm/vllm-openai-rocm:v0.22.0, per vllm-project/vllm#43385"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1630
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-mtp
+  description:
+    - "Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark; image rocm/atom-dev:nightly_202605301523, concurrency 4-256"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1627

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3358,5 +3358,5 @@
 - config-keys:
     - dsv4-fp4-mi355x-atom-mtp
   description:
-    - "Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark; image rocm/atom-dev:nightly_202605301523, concurrency 4-256"
+    - "Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark; image rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1627


### PR DESCRIPTION
## Summary

- Add new benchmark config `dsv4-fp4-mi355x-atom-mtp` for DeepSeek-V4-Pro with MTP3 speculative decoding on MI355X using ATOM
- Add new script `benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh` with `--method mtp --num-speculative-tokens 3`
- Image: `rocm/atom-dev:nightly_202605301523` (ATOM upstream run [26690241645](https://github.com/ROCm/ATOM/actions/runs/26690241645), 2026-05-30)
- Concurrency range: 4–256 for both ISL 1024 and 8192

## Performance vs current InferenceX (dsv4-fp4-mi355x-atom, nightly_202605130853) - removed as this is without chat templates..
## Test plan

- [ ] Verify `dsv4_fp4_mi355x_atom_mtp.sh` starts atom server with `--method mtp --num-speculative-tokens 3`
- [ ] Confirm `--use-chat-template` is passed to the benchmark client
- [ ] Confirm `dsv4-fp4-mi355x-atom-mtp` config picks up the new script via `spec-decoding: mtp`
- [ ] Run benchmark at conc=32 to confirm throughput matches upstream numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only changes (YAML config, shell script, changelog); no production serving or auth paths touched.
> 
> **Overview**
> Adds **DeepSeek-V4-Pro FP4 MI355X ATOM MTP3** benchmark coverage alongside the existing non-MTP `dsv4-fp4-mi355x-atom` entry.
> 
> A new matrix key **`dsv4-fp4-mi355x-atom-mtp`** in `.github/configs/amd-master.yaml` points at `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3`, **TP=8**, **conc 1–1024** for **1k/1k** and **8k/1k**, with **`spec-decoding: mtp`** routing to the new script.
> 
> **`benchmarks/single_node/dsv4_fp4_mi355x_atom_mtp.sh`** starts the ATOM OpenAI server with **`--method mtp --num-speculative-tokens 3`**, optional DP-attention/EP parallel flags, FP8 KV cache, and runs serving benchmarks with **`--dsv4`** (DSv4 chat framing instead of `--use-chat-template`, which the model tokenizer lacks).
> 
> **`perf-changelog.yaml`** records the new config key and image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7522717667e553cef659b19be2755c25e2fbf74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->