### PR TITLE
[blocked by NATIVE sglang not supporting this model yet] [AMD] Add DeepSeek-R1-0528 FP4 MI355X ATOM MTP3 benchmark, TP4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -67,12 +67,11 @@ dsr1-fp4-mi355x-atom:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
 
 dsr1-fp4-mi355x-atom-mtp:
-  image: rocm/atom-dev:nightly_202605301523
+  image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3
   model: amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4
   model-prefix: dsr1
   runner: mi355x
   precision: fp4
-  # WIP framework (no customers yet)
   framework: atom
   multinode: false
   scenarios:
@@ -80,11 +79,11 @@ dsr1-fp4-mi355x-atom-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 4, conc-end: 1024, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 4, conc-end: 1024, spec-decoding: mtp }
 
 dsr1-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.12-rocm700-mi30x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -67,8 +67,8 @@ dsr1-fp4-mi355x-atom:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
 
 dsr1-fp4-mi355x-atom-mtp:
-  image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
-  model: amd/DeepSeek-R1-0528-MXFP4
+  image: rocm/atom-dev:nightly_202605301523
+  model: amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4
   model-prefix: dsr1
   runner: mi355x
   precision: fp4
@@ -81,12 +81,10 @@ dsr1-fp4-mi355x-atom-mtp:
       osl: 1024
       search-space:
       - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      #- { tp: 4, conc-start: 32, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-mi300x-sglang:
   image: lmsysorg/sglang:v0.5.12-rocm700-mi30x

--- a/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/dsr1_fp4_mi355x_atom_mtp.sh
@@ -24,23 +24,22 @@ PORT=${PORT:-8888}
 
 export OMP_NUM_THREADS=1
 
-# Calculate max-model-len based on ISL and OSL
-if [ "$ISL" = "1024" ] && [ "$OSL" = "1024" ]; then
-    CALCULATED_MAX_MODEL_LEN=""
-else
-    CALCULATED_MAX_MODEL_LEN=" --max-model-len 10240 "
-fi
-
+CALCULATED_MAX_MODEL_LEN=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     CALCULATED_MAX_MODEL_LEN=" --max-model-len $EVAL_MAX_MODEL_LEN "
 fi
 
-if [ "$EP_SIZE" -gt 1 ]; then
-  EP=" --enable-expert-parallel"
-else
-  EP=" "
-fi
+PARALLEL_ARGS=(-tp "$TP") #TP
+if [ "$DP_ATTENTION" = "true" ]; then
+    if [ "$EP_SIZE" -gt 1 ]; then #DP+EP
+        PARALLEL_ARGS=(-tp "$TP" --enable-expert-parallel --enable-dp-attention )
+    else #DP+TP
+        PARALLEL_ARGS=(-tp "$TP" --enable-dp-attention )
+    fi
+fi 
+
+SPEC_ARGS=(--method mtp --num-speculative-tokens 3 )
 
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -52,9 +51,9 @@ export AMDGCN_USE_BUFFER_OPS=1
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
     --server-port $PORT \
-    -tp $TP \
-    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN $EP \
-    --method mtp \
+    "${PARALLEL_ARGS[@]}" \
+    "${SPEC_ARGS[@]}" \
+    --kv_cache_dtype fp8 $CALCULATED_MAX_MODEL_LEN \
     > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3338,7 +3338,7 @@
     - "Switch to TP=4 only (drop TP=8 search-space); enable isl=8192 TP=4 sweep"
     - "isl=1024/osl=1024 TP=4: +5.7% to +16.6% improvement at conc 4-64 vs prior InferenceX numbers"
     - "isl=1024/osl=1024 TP=4: -0.6% to -1.9% at high concurrency (conc 128-256)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1629
 
 - config-keys:
     - kimik2.5-fp4-mi355x-vllm

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3331,6 +3331,16 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1624
 
 - config-keys:
+    - dsr1-fp4-mi355x-atom-mtp
+  description:
+    - "Update ATOM image from rocm7.2.3_..._atom20260511 to nightly_202605301523"
+    - "Update model from amd/DeepSeek-R1-0528-MXFP4 to amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4"
+    - "Switch to TP=4 only (drop TP=8 search-space); enable isl=8192 TP=4 sweep"
+    - "isl=1024/osl=1024 TP=4: +5.7% to +16.6% improvement at conc 4-64 vs prior InferenceX numbers"
+    - "isl=1024/osl=1024 TP=4: -0.6% to -1.9% at high concurrency (conc 128-256)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+
+- config-keys:
     - kimik2.5-fp4-mi355x-vllm
   description:
     - "Update vLLM ROCm image from v0.21.0 to v0.22.0"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3333,7 +3333,7 @@
 - config-keys:
     - dsr1-fp4-mi355x-atom-mtp
   description:
-    - "Update ATOM image from rocm7.2.3_..._atom20260511 to nightly_202605301523"
+    - "Update ATOM image to rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3"
     - "Update model from amd/DeepSeek-R1-0528-MXFP4 to amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4"
     - "Switch to TP=4 only (drop TP=8 search-space); enable isl=8192 TP=4 sweep"
     - "isl=1024/osl=1024 TP=4: +5.7% to +16.6% improvement at conc 4-64 vs prior InferenceX numbers"


### PR DESCRIPTION
## Summary

- Update `dsr1-fp4-mi355x-atom-mtp` image: `rocm/atom:rocm7.2.3_..._atom20260511` → `rocm/atom-dev:nightly_202605301523`
- Update model: `amd/DeepSeek-R1-0528-MXFP4` → `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4`
- Switch to TP=4 only (drop TP=8 search-space rows); enable previously-commented isl=8192 TP=4 sweep
- Source: [ATOM upstream benchmark run #26690241645](https://github.com/ROCm/ATOM/actions/runs/26690241645) (all jobs passed)

## Performance vs current InferenceX numbers (DeepSeek-R1-0528 fp4, spec_method=mtp, TP=4, 4×MI355X)

### isl=1024, osl=1024

| Conc | InferenceX tput/GPU | ATOM tput/GPU | Delta |
|------|--------------------:|-------------:|------:|
| 4    | 285.71              | 313.73        | +9.8%   |
| 8    | 443.18              | 516.84        | +16.6%  |
| 16   | 714.89              | 755.43        | +5.7%   |
| 32   | 1059.71             | 1167.40       | +10.2%  |
| 64   | 1560.14             | 1747.02       | +12.0%  |
| 128  | 2374.74             | 2359.81       | -0.6%   |
| 256  | 3174.40             | 3112.98       | -1.9%   |

### isl=8192, osl=1024 (new — previously disabled in config)

| Conc | ATOM tput/GPU |
|------|-------------:|
| 4    | 1210.53       |
| 8    | 1769.24       |
| 16   | 2503.06       |
| 32   | 3285.07       |
| 64   | 4294.76       |
| 128  | 4962.98       |
| 256  | 5406.06       |

## Test plan
- [ ] Verify server starts with `rocm/atom-dev:nightly_202605301523` and model `amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4`
- [ ] Confirm TP=4 benchmark numbers match expected tput/GPU values above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI config/script changes only; no production app logic, auth, or data-path changes.
> 
> **Overview**
> Updates the **DeepSeek-R1 FP4 MI355X ATOM MTP** benchmark to a newer **ATOM** image (`rocm7.2.4` / `atom0.1.3`) and model **`amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4`**.
> 
> **`dsr1-fp4-mi355x-atom-mtp` in `amd-master.yaml`:** drops **TP=8** sweeps, keeps **TP=4** with **MTP** for **1k/1k** and **8k/1k**, and extends concurrency to **1024** (including the previously disabled **isl=8192** row).
> 
> **`dsr1_fp4_mi355x_atom_mtp.sh`:** builds server args via **`PARALLEL_ARGS`** (optional **DP attention** + **expert parallel**) and **`SPEC_ARGS`** (`--method mtp`, **3** speculative tokens); drops the old ISL-based **`--max-model-len`** logic except in eval mode.
> 
> Documents the change and expected throughput deltas in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14da3ee6d85bcf81eb6d262b86a09b7e25eddbbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->