### PR TITLE
[AMD][MI355X] update model for gpt-oss 

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1134,7 +1134,7 @@ gptoss-fp4-mi325x-vllm:
 
 gptoss-fp4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.22.0
-  model: amd/gpt-oss-120b-w-mxfp4-a-fp8
+  model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x
   precision: fp4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,9 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Update GPT-OSS model for MI355X vLLM from amd/gpt-oss-120b-w-mxfp4-a-fp8 to openai/gpt-oss-120b"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1638


### PR DESCRIPTION
Switch moe backend to CK to leverage the benefits from this PR. 
https://github.com/vllm-project/vllm/pull/42098

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which weights the MI355X GPT-OSS sweep loads and serves; throughput and eval numbers may shift versus the prior AMD checkpoint even though sweep geometry is unchanged.
> 
> **Overview**
> **Switches the MI355X GPT-OSS FP4 vLLM benchmark** (`gptoss-fp4-mi355x-vllm`) from the AMD MXFP4 checkpoint **`amd/gpt-oss-120b-w-mxfp4-a-fp8`** to the upstream Hugging Face weights **`openai/gpt-oss-120b`**, while keeping the same image (`vllm/vllm-openai-rocm:v0.22.0`), runner, precision label, and fixed-seq-len TP/concurrency sweep.
> 
> **Documents the change** in `perf-changelog.yaml` for config key `gptoss-fp4-mi355x-vllm` (PR #1638). The PR description ties this to using the **CK MoE backend** in vLLM (vllm#42098); that behavior is not altered in this diff—only the configured `model` id and changelog entry change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30921f45ed2180433923a66f654d3d37d7d9c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->