### PR TITLE
[Throwaway] gsm8k eval for DSR1 DEP8+MTP3 mid-pareto disagg (do not merge)

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1986,67 +1986,13 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
     - isl: 8192
       osl: 1024
       search-space:
-      # MTP configurations
-      # 1P1D pure TP8
+      # THROWAWAY one-off (not for merge): narrowed to ONLY the DEP8 + MTP3
+      # mid-pareto entry (conc 64-640) so mark_eval_entries emits exactly one
+      # gsm8k eval for it. Normally this entry shares the (dp=true) eval group
+      # with the higher-conc DEP8 MTP1 entry and is dropped from evals.
+      # 1*DEP8 + 1*DEP8, MTP3
       - spec-decoding: "mtp"
-        conc-list: [ 1, 2, 4, 8 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=3"
-
-      # 1P2D TP8
-      - spec-decoding: "mtp"
-        conc-list: [ 2, 4, 8, 16, 32 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 2
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=2"
-          - "DECODE_MTP_SIZE=3"
-
-      # 1P2D TP8
-      - spec-decoding: "mtp"
-        conc-list: [ 32, 64 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 2
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=2"
-          - "DECODE_MTP_SIZE=3"
-
-      # 1*DEP8 + 1*DEP8
-      - spec-decoding: "mtp"
-        conc-list: [ 640, 512 ]
+        conc-list: [ 64, 128, 256, 512, 640 ]
         prefill:
           num-worker: 1
           tp: 8
@@ -2062,83 +2008,6 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
           additional-settings:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=3"
-
-      # 1*DEP8 + 1*DEP8
-      - spec-decoding: "mtp"
-        conc-list: [ 256 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=3"
-
-
-      # 1*DEP8 + 1*DEP8
-      - spec-decoding: "mtp"
-        conc-list: [ 128 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=3"
-
-      # 1*DEP8 + 1*DEP8
-      - spec-decoding: "mtp"
-        conc-list: [ 64 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=3"
-
-      # 2*DEP8 + 1*DEP8
-      - spec-decoding: "mtp"
-        conc-list: [ 1024, 2048, 4096 ]
-        prefill:
-          num-worker: 2
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=2"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=1"
 
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3395,3 +3395,10 @@
   description:
     - "Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark; image rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1627
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp
+  description:
+    - "One-off (throwaway, not for merge): gsm8k eval for the DEP8 + MTP3 mid-pareto disagg config (conc 64-640) that mark_eval_entries skips because it shares the (dp=true) eval group with the higher-conc DEP8 MTP1 entry. Config search-space temporarily narrowed to just this entry so exactly one eval runs."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING
+  evals-only: true


### PR DESCRIPTION
## Purpose (throwaway — not for merge)

Trigger a one-off `gsm8k` eval on the **DEP8 + MTP3** mid-pareto disagg config (conc 64–640) of `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` (`amd/DeepSeek-R1-0528-MXFP4-v2`, FP4, MI355X, SGLang disagg).

In sweep [run 26714221123](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26714221123/job/78773470778) this config was benchmarked but **never accuracy-validated** — only low-latency TP8 MTP3 (conc 64) and high-tput DEP8 MTP1 (conc 2048) got evals.

## Root cause

`mark_eval_entries()` groups multi-node entries by `(model, runner, framework, precision, spec-decoding, prefill-dp, decode-dp)` and keeps only the highest-max-conc entry per group. The `dp=true` group holds both DEP8 **MTP3** (conc 64–640, `DECODE_MTP_SIZE=3`) and DEP8 **MTP1** (conc 1024–4096, `DECODE_MTP_SIZE=1`); they share a key, so MTP1 (max conc 4096) wins and DEP8 MTP3 is dropped from evals.

## What this PR does

- Temporarily narrows the config's search-space to **only** the DEP8 MTP3 entry so the selector emits exactly one eval (verified locally: 1 `multinode_evals` entry, `eval-conc 256`).
- Adds an `evals-only` changelog entry to trigger `sweep-multi-node-evals`.

**This branch will not be merged** — it exists solely to run the eval. Apply `non-canary-full-sweep-enabled` to start it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark YAML and eval-only changelog only; explicitly throwaway and not for merge, with no production code path changes.
> 
> **Overview**
> **Throwaway branch** (not intended to merge): it forces a single **gsm8k** multinode eval for `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` on the **DEP8 + MTP3** mid-pareto point that normal sweeps benchmark but **`mark_eval_entries` drops** because it shares a `(dp=true)` eval group with the higher-concurrency DEP8 MTP1 row.
> 
> In **`.github/configs/amd-master.yaml`**, the 8k/1k MTP disagg `search-space` is stripped down to one entry: **1×DEP8 prefill + 1×DEP8 decode**, `DECODE_MTP_SIZE=3`, **`conc-list` [64, 128, 256, 512, 640]** (was a single conc=64 among many TP8/1P2D/DEP8 layouts).
> 
> **`perf-changelog.yaml`** adds an **`evals-only: true`** changelog for `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` so **`sweep-multi-node-evals`** runs on this branch only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd85f979d5d52bd14f33dec3ed736217ddfeda8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->