### PR TITLE
dsr1-fp4-mi355x-sglang: bump ROCm 7.0->7.2 image + add TP4 search-space / 升级 ROCm 7.0 至 7.2 镜像并添加 TP4 搜索空间

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x
@@ -16,6 +16,7 @@ dsr1-fp4-mi355x-sglang:
     - isl: 8192
       osl: 1024
       search-space:
+      - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 64 }
     # Agentic-coding sweep commented out for this image-bump PR — the
     # 10-conc agentic matrix amplifies sweep cost and the bump validation
@@ -27,7 +28,7 @@ dsr1-fp4-mi355x-sglang:
     #   - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 32, 64, 128, 256] }
 
 dsr1-fp4-mi355x-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4
   model-prefix: dsr1
   runner: mi355x
@@ -39,10 +40,12 @@ dsr1-fp4-mi355x-sglang-mtp:
     - isl: 1024
       osl: 1024
       search-space:
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
 dsr1-fp4-mi355x-atom:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3395,3 +3395,12 @@
   description:
     - "Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP3 benchmark; image rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1627
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang
+    - dsr1-fp4-mi355x-sglang-mtp
+  description:
+    - "Image: lmsysorg/sglang:v0.5.12-rocm700-mi35x -> lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519 (ROCm 7.0 -> 7.2; same image already validated multi-node in PR #1566)"
+    - "Add tp:4 to search-space (8k1k for non-mtp; 1k1k+8k1k for mtp) to surface the TP4 throughput-per-GPU frontier"
+    - "Local MI355X bench (matched cfg: range-ratio 0.8 + ROCM_QUICK_REDUCE_QUANTIZATION=INT4): 8k1k decode TPOT 9-25% faster at every conc vs the rocm700 CI; c64 now leads both axes (TPOT 16.5 vs 18.1 ms, tput 2954 vs 2841 tok/s/gpu). TP4 c64 8k1k = 4254 tok/s/gpu (> TP8 2954)"
+  pr-link: PR_LINK_PENDING

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3403,4 +3403,4 @@
     - "Image: lmsysorg/sglang:v0.5.12-rocm700-mi35x -> lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519 (ROCm 7.0 -> 7.2; same image already validated multi-node in PR #1566)"
     - "Add tp:4 to search-space (8k1k for non-mtp; 1k1k+8k1k for mtp) to surface the TP4 throughput-per-GPU frontier"
     - "Local MI355X bench (matched cfg: range-ratio 0.8 + ROCM_QUICK_REDUCE_QUANTIZATION=INT4): 8k1k decode TPOT 9-25% faster at every conc vs the rocm700 CI; c64 now leads both axes (TPOT 16.5 vs 18.1 ms, tput 2954 vs 2841 tok/s/gpu). TP4 c64 8k1k = 4254 tok/s/gpu (> TP8 2954)"
-  pr-link: PR_LINK_PENDING
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1645


### PR DESCRIPTION
## What
Bump the **SGLang DSR1-FP4 MI355X** benchmark image from `lmsysorg/sglang:v0.5.12-rocm700-mi35x` (ROCm **7.0**) to `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519` (ROCm **7.2**), and add a `tp:4` search-space point. Applies to both `dsr1-fp4-mi355x-sglang` and `dsr1-fp4-mi355x-sglang-mtp`.

## Why
The SGLang DSR1-FP4 MI355X config is the last one still on ROCm 7.0 (the ATOM config is already on 7.2.3). Local MI355X benches with the **matched recipe** (range-ratio 0.8 + `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, MTP):
- **8k1k decode TPOT is 9-25% faster at every concurrency** vs the current rocm700 CI.
- At c64 the rocm720 build leads **both axes**: TPOT 16.5 vs 18.1 ms **and** tput 2954 vs 2841 tok/s/gpu.
- **TP4** at c64/8k1k reaches **4254 tok/s/gpu** (> TP8's 2954) — adds a throughput-per-GPU frontier point.

The target image is the **same one already validated multi-node in PR #1566**, so it's low-risk.

## Scope / safety
- Recipe `dsr1_fp4_mi355x_mtp.sh` is **unchanged** (already has QR-INT4 + range-ratio 0.8 + the MLA/MTP flags; handles `--tensor-parallel-size=4`).
- **fp8-mi355x configs are untouched** (still rocm700) — only the two fp4-sglang blocks change.
- Diff: 5 insertions / 2 deletions in `amd-master.yaml` + one `perf-changelog.yaml` trigger entry.

## Caveat
The ATOM config keeps 8k1k TP4 commented out (likely an OOM at high conc for that stack). For SGLang, TP4 (4 GPUs, ~90 GB MXFP4 weights) was benched cleanly at c4-64; if CI OOMs at tp4/8k1k, fall back to `conc-start: 32` like ATOM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only YAML and changelog changes; serving recipes are unchanged and the target image was already validated on related MI355X workloads.
> 
> **Overview**
> Updates **DeepSeek-R1 FP4 MI355X SGLang** benchmarks (`dsr1-fp4-mi355x-sglang` and `-mtp`) to move off the last ROCm **7.0** image onto **`lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519`** (ROCm **7.2**), matching the build already exercised on multi-node disagg in PR #1566.
> 
> The sweep matrix gains **`tp: 4`** alongside existing **`tp: 8`**—**8k1k** for both configs, plus **1k1k** for the MTP variant—to capture a better throughput-per-GPU point. **`agentic-coding`** on the non-MTP block is **commented out** for this validation PR to limit CI cost; **`perf-changelog.yaml`** records the image bump, TP4 addition, and local perf notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f52374a583ee523b477a94511c13867b6573c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## 中文说明
将 DeepSeek-R1 FP4 MI355X SGLang 基准测试镜像从 ROCm 7.0 升级到 ROCm 7.2（`lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519`），适用于 `dsr1-fp4-mi355x-sglang` 和 `dsr1-fp4-mi355x-sglang-mtp` 两个配置。新增 `tp:4` 搜索空间点。本地测试显示 8k1k 解码 TPOT 在各并发度下快 9-25%，TP4 在 c64/8k1k 达到 4254 tok/s/gpu（高于 TP8 的 2954）。目标镜像与 PR #1566 中已验证的多节点镜像一致，风险较低。
