### PR TITLE
Update B200 Dsv4 configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1756,7 +1756,7 @@ dsv4-fp4-b200-sglang:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 dsv4-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.22.0
+  image: vllm/vllm-openai:nightly-3f0a91bb96f8d72e0498b95c166e817deae14d62
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200-dsv4

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
@@ -49,10 +49,6 @@ if [ "${DP_ATTENTION}" = "true" ]; then
     EPLB_ARGS=(--enable-eplb --eplb-config '{"communicator":"torch_nccl", "use_async": false}')
 fi
 
-# needed for NIXL EPLB
-export NCCL_NET_PLUGIN=none
-export UCX_TLS=self,tcp,cuda_ipc,cuda_copy
-
 if [ "${ISL}" -eq 8192 ] && [ "${CONC}" -le 128 ]; then
     MAX_NUM_BATCHED_TOKENS=${ISL}
 else

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
@@ -46,7 +46,7 @@ MOE_ARGS=()
 EPLB_ARGS=()
 if [ "${DP_ATTENTION}" = "true" ]; then
     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
-    EPLB_ARGS=(--enable-eplb)
+    EPLB_ARGS=(--enable-eplb --eplb-config '{"communicator":"torch_nccl", "use_async": false}')
 fi
 
 # needed for NIXL EPLB

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
@@ -49,6 +49,10 @@ if [ "${DP_ATTENTION}" = "true" ]; then
     EPLB_ARGS=(--enable-eplb)
 fi
 
+# needed for NIXL EPLB
+export NCCL_NET_PLUGIN=none
+export UCX_TLS=self,tcp,cuda_ipc,cuda_copy
+
 if [ "${ISL}" -eq 8192 ] && [ "${CONC}" -le 128 ]; then
     MAX_NUM_BATCHED_TOKENS=${ISL}
 else

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_vllm.sh
@@ -43,8 +43,10 @@ fi
 
 GMU_ARGS=()
 MOE_ARGS=()
+EPLB_ARGS=()
 if [ "${DP_ATTENTION}" = "true" ]; then
     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
+    EPLB_ARGS=(--enable-eplb)
 fi
 
 if [ "${ISL}" -eq 8192 ] && [ "${CONC}" -le 128 ]; then
@@ -78,6 +80,7 @@ vllm serve "$MODEL" --host 0.0.0.0 --port "$PORT" \
     "${EP_ARGS[@]}" \
     "${GMU_ARGS[@]}" \
     "${MOE_ARGS[@]}" \
+    "${EPLB_ARGS[@]}" \
     --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
     --attention_config.use_fp4_indexer_cache=True \
     --tokenizer-mode deepseek_v4 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3430,3 +3430,9 @@
     - "Image: vllm/vllm-openai:v0.20.1"
     - "Same 1k/1k and 8k/1k search space as gb300, plus a new tp8-1p1d at low concurrencies for both ISLs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652
+
+- config-keys:
+    - dsv4-fp4-b200-vllm
+  description:
+    - "Enable EPLB for DEP configs"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1655


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark-only image and vLLM serve-flag changes; no production auth or application logic.
> 
> **Overview**
> Updates **DeepSeek-V4 FP4 B200 vLLM** fixed-seq-len benchmarks to a pinned **vLLM nightly** image and turns on **expert-parallel load balancing (EPLB)** whenever **DP attention** (DEP) is active.
> 
> For `DP_ATTENTION=true`, `dsv4_fp4_b200_vllm.sh` now passes `--enable-eplb` with an NCCL communicator config alongside the existing `deep_gemm_mega_moe` MoE backend. `perf-changelog.yaml` documents this under `dsv4-fp4-b200-vllm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b075023091f192ed2cfbcf547ba072a3951d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->