### PR TITLE
[WIP] Update Dsv4 B300 configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -3000,7 +3000,7 @@ dsv4-fp8-h200-sglang-mtp:
   # layouts on 4 allocated GPUs.
 dsv4-fp4-b300-vllm:
   image: vllm/vllm-openai:v0.22.0
-  model: deepseek-ai/DeepSeek-V4-Pro
+  model: nvidia/DeepSeek-V4-Pro-NVFP4
   model-prefix: dsv4
   runner: b300
   precision: fp4

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_vllm.sh
@@ -53,9 +53,9 @@ if [ "${EP_SIZE:-1}" -gt 1 ]; then
 fi
 
 MOE_ARGS=()
-if [ "${DP_ATTENTION}" = "true" ]; then
-    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
-fi
+# if [ "${DP_ATTENTION}" = "true" ]; then
+#     MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
+# fi
 
 if [ "${DP_ATTENTION}" = "true" ]; then
     MAX_NUM_BATCHED_TOKENS=2048

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_vllm.sh
@@ -92,6 +92,7 @@ vllm serve "$MODEL_PATH" --served-model-name "$MODEL" --host 0.0.0.0 --port "$PO
     --tool-call-parser deepseek_v4 \
     --enable-auto-tool-choice \
     --reasoning-parser deepseek_v4 \
+    --gpu-memory-utilization 0.97 \
     --max-cudagraph-capture-size 2048 \
     --max-model-len "$SERVE_MAX_MODEL_LEN" \
     --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" > "$SERVER_LOG" 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3430,3 +3430,9 @@
     - "Image: vllm/vllm-openai:v0.20.1"
     - "Same 1k/1k and 8k/1k search space as gb300, plus a new tp8-1p1d at low concurrencies for both ISLs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652
+
+- config-keys:
+    - dsv4-fp4-b300-vllm
+  description:
+    - "Update B300 dsv4 image to nvfp4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3435,4 +3435,4 @@
     - dsv4-fp4-b300-vllm
   description:
     - "Update B300 dsv4 image to nvfp4"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1656

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -305,6 +305,7 @@ else
         DeepSeek-R1-0528-NVFP4-v2
         DeepSeek-V4-Flash
         DeepSeek-V4-Pro
+        DeepSeek-V4-Pro-NVFP4
         GLM-5-FP8
         GLM-5-NVFP4
         GLM-5.1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark and runner config only; no auth, serving API, or production inference path changes.
> 
> **Overview**
> Switches the **dsv4-fp4-b300-vllm** recipe to the **`nvidia/DeepSeek-V4-Pro-NVFP4`** checkpoint instead of the upstream **`deepseek-ai/DeepSeek-V4-Pro`** weights, and registers **`DeepSeek-V4-Pro-NVFP4`** in the B300 runner’s pre-staged model list so jobs can load from scratch without a fresh HF pull.
> 
> The single-node benchmark script no longer passes **`--moe-backend deep_gemm_mega_moe`** when data-parallel attention is enabled—that block is commented out, so DP layouts run with default MoE backend behavior for this NVFP4 setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41630f2f0fc16ae3387906d1c1902577bedb4bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->