### PR TITLE
AMD - gpt-oss vllm mxfp4: AITER tuning + n-gram spec decode + server …

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/gptoss_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/gptoss_fp4_mi355x.sh
@@ -33,12 +33,28 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
-export AMDGCN_USE_BUFFER_OPS=0
+# --- AITER backend optimizations (env-var tuning) ---
 export VLLM_ROCM_USE_AITER=1
+export VLLM_USE_ROCM_AITER_MXFP4=1
+export VLLM_ROCM_USE_AITER_PAGED_ATTN=1
+export VLLM_ROCM_USE_AITER_LINEAR=1
 export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
+export VLLM_ROCM_USE_AITER_FP4_ASM_GEMM=1
+export VLLM_ROCM_USE_AITER_TRITON_GEMM=0
+export VLLM_ROCM_MOE_PADDING=0
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export AITER_BF16_FP8_BOUND=0
+export AITER_USE_OPUS_MOE_SORTING=1
+export AITER_USE_NT=0
+export AMDGCN_USE_BUFFER_OPS=1
+export CK_MXFP4_MOE_DIM_ALIGNMENT=64
+export GPU_MAX_HW_QUEUES=4
+
 ATTN_BACKEND="--attention-backend ROCM_AITER_UNIFIED_ATTN"
 FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache=True -cc.use_inductor_graph_partition=True"
+
+# --- Speculative decoding (06/02 — n-gram prompt lookup, lossless) ---
+SPEC_DECODE="--speculative-config {\"method\":\"ngram\",\"num_speculative_tokens\":3,\"prompt_lookup_min\":2,\"prompt_lookup_max\":64}"
 
 SERVER_LOG=/workspace/server.log
 
@@ -53,10 +69,13 @@ set -x
 vllm serve $MODEL --port $PORT \
   $ATTN_BACKEND $FUSE_ROPE_KVCACHE \
   --tensor-parallel-size=$TP \
-  --gpu-memory-utilization 0.95 \
+  --gpu-memory-utilization 0.97 \
   --max-model-len $MAX_MODEL_LEN \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 16384 \
   --block-size=64 \
-  --no-enable-prefix-caching > $SERVER_LOG 2>&1 &
+  --no-enable-prefix-caching \
+  $SPEC_DECODE > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3430,3 +3430,11 @@
     - "Image: vllm/vllm-openai:v0.20.1"
     - "Same 1k/1k and 8k/1k search space as gb300, plus a new tp8-1p1d at low concurrencies for both ISLs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Enable n-gram speculative decoding (prompt-lookup, num_speculative_tokens=3) for 3.26x decode throughput improvement"
+    - "Add full AITER env-var tuning: MXFP4, FP4 ASM GEMM, unified paged attention, inductor graph partition, opus MoE sorting"
+    - "Set gpu-memory-utilization=0.97, max-num-seqs=256, max-num-batched-tokens=16384, GPU_MAX_HW_QUEUES=4"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1657


### PR DESCRIPTION
## Summary

- Enable n-gram speculative decoding (prompt-lookup, 3 draft tokens) — 3.26x decode throughput at low concurrency
- Add full AITER env-var tuning (MXFP4, FP4 ASM GEMM, unified paged attention, inductor graph partition, fused RoPE+KV cache, opus MoE sorting)
- Tune server params: gpu-memory-utilization=0.97, max-num-seqs=256, max-num-batched-tokens=16384, GPU_MAX_HW_QUEUES=4

## Files changed

| File | Change |
|------|--------|
| benchmarks/single_node/fixed_seq_len/gptoss_fp4_mi355x.sh | Env vars + spec decode + server tuning |
| perf-changelog.yaml | New entry documenting the uplift |

## Dependencies

- AITER kernel patches submitted separately to nehaprakriya/aiter (MoE GEMM num_stages + split_k fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only script and changelog changes; no production serving or auth paths.
> 
> **Overview**
> Tunes the **GPT-OSS FP4 MI355X vLLM** benchmark launch path for higher throughput on ROCm.
> 
> **`benchmarks/single_node/fixed_seq_len/gptoss_fp4_mi355x.sh`** expands **AITER** env tuning (MXFP4, unified paged attention, linear layers, FP4 ASM GEMM with Triton GEMM off, opus MoE sorting, `AMDGCN_USE_BUFFER_OPS=1`, `GPU_MAX_HW_QUEUES=4`, etc.) and keeps **ROCM_AITER_UNIFIED_ATTN** plus **fuse RoPE+KV cache** / inductor graph partition. It adds **lossless n-gram prompt-lookup** speculative decoding (`num_speculative_tokens=3`) via `--speculative-config`, raises **`--gpu-memory-utilization`** to **0.97**, and sets **`--max-num-seqs 256`** and **`--max-num-batched-tokens 16384`**.
> 
> **`perf-changelog.yaml`** records the **`gptoss-fp4-mi355x-vllm`** uplift (~3.26× decode throughput at low concurrency, per changelog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286dc1ae7d78a3514286e192c50ebf35f6a47296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->