### PR TITLE
[WIP] [NV] Add Kimi K2.5 FP4 B200/B300 EP sweep

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2661,12 +2661,16 @@ kimik2.5-fp4-b200-vllm:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -2714,12 +2718,16 @@ kimik2.5-fp4-b300-vllm:
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 64 }
 
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2648,7 +2648,7 @@ kimik2.5-int4-h200-vllm-agentic:
       - { tp: 8, offloading: cpu,  conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
 
 kimik2.5-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.22.1
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b200
@@ -2705,7 +2705,7 @@ kimik2.5-fp4-b200-vllm-agentic:
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.22.1
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b300

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b200.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -39,9 +40,15 @@ start_gpu_monitor
 # benchmarks/single_node/agentic/kimik2.5_fp4_b200.sh).
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
 set -x
 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
 --tensor-parallel-size=$TP \
+"${EP_ARGS[@]}" \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs $CONC \

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -9,6 +9,7 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+    EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -47,9 +48,15 @@ fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
 set -x
 vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
 --tensor-parallel-size $TP \
+"${EP_ARGS[@]}" \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs $CONC \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3430,3 +3430,10 @@
     - "Image: vllm/vllm-openai:v0.20.1"
     - "Same 1k/1k and 8k/1k search space as gb300, plus a new tp8-1p1d at low concurrencies for both ISLs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1652
+
+- config-keys:
+    - kimik2.5-fp4-b200-vllm
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Add expert-parallel sweep points for Kimi K2.5 FP4 B200/B300 vLLM aggregate benchmarks"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1658

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3537,5 +3537,4 @@
     - kimik2.5-fp4-b300-vllm
   description:
     - "Add expert-parallel sweep points for Kimi K2.5 FP4 B200/B300 vLLM aggregate benchmarks"
-    - "Use vLLM image v0.22.1 for B200/B300"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1658


### PR DESCRIPTION
Add expert-parallel sweep points for Kimi K2.5 FP4 B200/B300 vLLM aggregate benchmarks.

Conditionally enables vLLM expert parallelism when EP_SIZE > 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark config and launch-script changes only; no production serving or auth paths affected.
> 
> **Overview**
> Extends **Kimi K2.5 FP4** fixed-seq-len sweeps on **B200 and B300 vLLM** with expert-parallel (`ep: 8` at `tp: 8`, `ep: 4` at `tp: 4`) for both **1k1k** and **8k1k**, each with its own concurrency range.
> 
> The **B200/B300** benchmark scripts now require **`EP_SIZE`** and pass **`--enable-expert-parallel`** only when `EP_SIZE > 1`, matching the repo’s vLLM MoE pattern. The B200 script also documents/disables the CUDA-graph memory profiler via **`VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0`** so KV cache sizing stays consistent with `gpu-memory-utilization=0.90`.
> 
> **`perf-changelog.yaml`** records the new sweep for `kimik2.5-fp4-b200-vllm` and `kimik2.5-fp4-b300-vllm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4f369f16f208b0177a6ff122e8ef22b247d41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->