### PR TITLE
[AMD] Add Kimi-K2.5 MXFP4 SGLang single-node benchmark for MI355X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -821,6 +821,27 @@ kimik2.5-fp4-mi355x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 64 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
 
+kimik2.5-fp4-mi355x-sglang:
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260602
+  model: amd/Kimi-K2.5-MXFP4
+  model-prefix: kimik2.5
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+
 # Diverged from kimik2.5-fp4-mi355x-vllm (agentic-coding sibling). Reasons below;
 # the original kimik2.5-fp4-mi355x-vllm entry is left identical to origin/main so
 # its fixed-seq-len sweep is unaffected.

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x_sglang.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# Kimi-K2.5 MXFP4 on MI355X via SGLang. Mirrors the AMD-published recipe for
+# amd/Kimi-K2.5-MXFP4 on SGLang/ROCm: aiter attention + aiter all-reduce
+# fusion, fp8_e4m3 KV cache, chunked-prefill 16k, kimi_k2 tool/reasoning
+# parsers. PORT/host wiring follows the rest of the InferenceX SGLang
+# single-node recipes (host=0.0.0.0; PORT comes from the launcher).
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# Per AMD's published Kimi-K2.5-MXFP4 SGLang recipe: prefer hipBLASLt for the
+# matmul backend on MI355X.
+export TORCH_BLAS_PREFER_HIPBLASLT=1
+export SGLANG_USE_AITER=1
+
+# Disable AITER RMSNorm for TP < 8 due to known accuracy issues (matches the
+# vLLM Kimi MXFP4 recipe in this repo).
+if [ "${TP}" -lt 8 ]; then
+  export SGLANG_USE_AITER_RMSNORM=0
+fi
+
+SERVER_LOG=/workspace/server.log
+CONTEXT_LENGTH=$((ISL + OSL + 32))
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else
+    EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
+fi
+
+start_gpu_monitor
+
+set -x
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --trust-remote-code \
+    --mem-fraction-static 0.765 \
+    --disable-radix-cache \
+    --attention-backend aiter \
+    --kv-cache-dtype fp8_e4m3 \
+    --chunked-prefill-size 16384 \
+    --max-prefill-tokens 16384 \
+    --max-running-requests $CONC \
+    --cuda-graph-max-bs $CONC \
+    --tool-call-parser kimi_k2 \
+    --reasoning-parser kimi_k2 \
+    --enable-aiter-allreduce-fusion \
+    $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x_sglang.sh
@@ -28,12 +28,6 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 export TORCH_BLAS_PREFER_HIPBLASLT=1
 export SGLANG_USE_AITER=1
 
-# Disable AITER RMSNorm for TP < 8 due to known accuracy issues (matches the
-# vLLM Kimi MXFP4 recipe in this repo).
-if [ "${TP}" -lt 8 ]; then
-  export SGLANG_USE_AITER_RMSNORM=0
-fi
-
 SERVER_LOG=/workspace/server.log
 CONTEXT_LENGTH=$((ISL + OSL + 32))
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3465,3 +3465,4 @@
     - "Add Kimi-K2.5 MXFP4 SGLang single-node benchmark for MI355X"
     - "Image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260602; model: amd/Kimi-K2.5-MXFP4"
     - "Server flags: --attention-backend aiter, --kv-cache-dtype fp8_e4m3, --chunked-prefill-size 16384, --max-prefill-tokens 16384, --tool-call-parser kimi_k2, --reasoning-parser kimi_k2, --enable-aiter-allreduce-fusion, --mem-fraction-static 0.765, --disable-radix-cache; TORCH_BLAS_PREFER_HIPBLASLT=1"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1661

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3458,3 +3458,10 @@
     - "Add MiniMax-M2.5 FP8 GB200 disaggregated multinode vLLM benchmarks via Dynamo"
     - "Add 1k1k/8k1k FP8 recipe set under benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-gb200-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1648
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-sglang
+  description:
+    - "Add Kimi-K2.5 MXFP4 SGLang single-node benchmark for MI355X"
+    - "Image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260602; model: amd/Kimi-K2.5-MXFP4"
+    - "Server flags: --attention-backend aiter, --kv-cache-dtype fp8_e4m3, --chunked-prefill-size 16384, --max-prefill-tokens 16384, --tool-call-parser kimi_k2, --reasoning-parser kimi_k2, --enable-aiter-allreduce-fusion, --mem-fraction-static 0.765, --disable-radix-cache; TORCH_BLAS_PREFER_HIPBLASLT=1"


### PR DESCRIPTION
Add kimik2.5-fp4-mi355x-sglang config and recipe for amd/Kimi-K2.5-MXFP4 on SGLang/ROCm.
 - aiter attention
 - all-reduce fusion
 - fp8_e4m3 KV cache
 - chunked-prefill 16k


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only additions (CI config, shell recipe, changelog) with no changes to auth, data paths, or production serving code.
> 
> **Overview**
> Adds a new **Kimi-K2.5 MXFP4** single-node benchmark on **MI355X** using **SGLang/ROCm**, alongside the existing vLLM entry.
> 
> Registers `kimik2.5-fp4-mi355x-sglang` in `.github/configs/amd-master.yaml` with image `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260602`, model `amd/Kimi-K2.5-MXFP4`, and **fixed-seq-len** sweeps at 1k/1k and 8k/1k for **TP 4 and 8** (concurrency 4–64). Documents the new config in `perf-changelog.yaml`.
> 
> Introduces `benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x_sglang.sh`, which launches `sglang.launch_server` with the AMD-aligned stack (**aiter** attention, **fp8_e4m3** KV cache, 16k chunked prefill, **kimi_k2** tool/reasoning parsers, **aiter all-reduce fusion**, radix cache off, `mem-fraction-static` 0.765) and env `TORCH_BLAS_PREFER_HIPBLASLT` / `SGLANG_USE_AITER`, then runs the standard serving benchmark (and optional lm-eval).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48b0788b889a4d303c7464224de81b8ad6965a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->