### PR TITLE
[NV] Add MiniMax-M2.5 FP8 B300 Dynamo vLLM recipes

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11055,6 +11055,219 @@ minimaxm2.5-fp4-b300-dynamo-vllm:
           ep: 8
           dp-attn: true
 
+minimaxm2.5-fp8-b300-dynamo-vllm:
+  image: vllm/vllm-openai:v0.20.1
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: b300
+  precision: fp8
+  framework: dynamo-vllm
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - conc-list: [8, 16, 32, 64, 128]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-1p1d-tp4.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - conc-list: [32, 64, 128, 256, 512]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-1p2d-tp4.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - conc-list: [256, 512, 1024]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 4
+          dp-attn: false
+      - conc-list: [256, 512, 1024]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-2p1d-dep8.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+      - conc-list: [512, 1024, 2048]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-2p2d-dep4.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 4
+          dp-attn: true
+      - conc-list: [4096, 8192]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 4
+          dp-attn: true
+      - conc-list: [1024]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/1k1k/disagg-b300-2p3d-dep2.yaml"
+        decode:
+          num-worker: 3
+          tp: 2
+          ep: 2
+          dp-attn: true
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - conc-list: [16, 64, 128]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: false
+      - conc-list: [256, 512]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: false
+      - conc-list: [32]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-2p1d-tp2.yaml"
+        decode:
+          num-worker: 1
+          tp: 2
+          ep: 1
+          dp-attn: false
+      - conc-list: [64, 128, 256, 512]
+        prefill:
+          num-worker: 2
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: false
+      - conc-list: [64]
+        prefill:
+          num-worker: 3
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-3p1d-tp4.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - conc-list: [256, 512]
+        prefill:
+          num-worker: 3
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-3p1d-dep4.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+      - conc-list: [1024, 2048]
+        prefill:
+          num-worker: 3
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+      - conc-list: [512, 1024, 2048]
+        prefill:
+          num-worker: 5
+          tp: 1
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m2.5-fp8/8k1k/disagg-b300-5p2d-dep4.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 4
+          dp-attn: true
+
 minimaxm2.5-fp8-gb300-dynamo-vllm:
   image: vllm/vllm-openai:v0.20.1
   model: MiniMaxAI/MiniMax-M2.5

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
@@ -1,0 +1,65 @@
+name: "minimax-m2.5-vllm-disagg-b300-1p1d-tp4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "8x16x32x64x128"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p1d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4.yaml
@@ -1,0 +1,65 @@
+name: "minimax-m2.5-vllm-disagg-b300-1p2d-tp4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 2
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "32x64x128x256x512"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
@@ -1,0 +1,67 @@
+name: "minimax-m2.5-vllm-disagg-b300-1p2d-tp4ep"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 2
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "256x512x1024"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-1p2d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
@@ -1,0 +1,69 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p1d-dep8"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 8
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "256x512x1024"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p1d-dep8.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4-hi-conc.yaml
@@ -1,0 +1,69 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p2d-dep4-hi-conc"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 2
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 128
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "4096x8192"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
@@ -1,0 +1,69 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p2d-dep4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 2
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "512x1024x2048"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p2d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/1k1k/disagg-b300-2p3d-dep2.yaml
@@ -1,0 +1,69 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p3d-dep2"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 3
+  gpus_per_prefill: 1
+  gpus_per_decode: 2
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 2
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 1024
+  osl: 1024
+  concurrencies: "1024"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
@@ -1,0 +1,67 @@
+name: "minimax-m2.5-vllm-disagg-b300-1p1d-tp4ep-hi-conc"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "256x512"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-1p1d-tp4ep.yaml
@@ -1,0 +1,67 @@
+name: "minimax-m2.5-vllm-disagg-b300-1p1d-tp4ep"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "16x64x128"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp2.yaml
@@ -1,0 +1,68 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p1d-tp2"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 2
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 2
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "32"
+  use_chat_template: false
+  req_rate: "inf"
+  random_range_ratio: 1.0

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
@@ -1,0 +1,67 @@
+name: "minimax-m2.5-vllm-disagg-b300-2p1d-tp4ep"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 2
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256x512"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-2p1d-tp4ep.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
@@ -1,0 +1,72 @@
+name: "minimax-m2.5-vllm-disagg-b300-3p1d-dep4-hi-conc"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 3
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1024x2048"
+  use_chat_template: false
+  req_rate: "inf"
+  random_range_ratio: 1.0

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4-hi-conc.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-dep4.yaml
@@ -1,0 +1,72 @@
+name: "minimax-m2.5-vllm-disagg-b300-3p1d-dep4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 3
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "256x512"
+  use_chat_template: false
+  req_rate: "inf"
+  random_range_ratio: 1.0

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-3p1d-tp4.yaml
@@ -1,0 +1,68 @@
+name: "minimax-m2.5-vllm-disagg-b300-3p1d-tp4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 3
+  decode_workers: 1
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 4
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64"
+  use_chat_template: false
+  req_rate: "inf"
+  random_range_ratio: 1.0

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
@@ -1,0 +1,69 @@
+name: "minimax-m2.5-vllm-disagg-b300-5p2d-dep4"
+
+model:
+  path: "minimax-m2.5-fp8"
+  container: "vllm/vllm-openai:v0.20.1"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260526"
+
+setup_script: install-deps.sh
+
+resources:
+  gpu_type: "b300"
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 5
+  decode_workers: 2
+  gpus_per_prefill: 1
+  gpus_per_decode: 4
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+
+backend:
+  type: vllm
+  connector: null
+  allow_prefill_decode_colocation: true
+
+  prefill_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  decode_environment:
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
+
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      kv-cache-dtype: "fp8"
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      safetensors-load-strategy: "prefetch"
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      stream-interval: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "512x1024x2048"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: install-deps.sh
+setup_script: vllm-container-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/8k1k/disagg-b300-5p2d-dep4.yaml
@@ -9,7 +9,7 @@ dynamo:
   install: true
   wheel: "1.2.0.dev20260526"
 
-setup_script: vllm-container-deps.sh
+setup_script: install-deps.sh
 
 resources:
   gpu_type: "b300"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3458,3 +3458,10 @@
     - "Add MiniMax-M2.5 FP8 GB200 disaggregated multinode vLLM benchmarks via Dynamo"
     - "Add 1k1k/8k1k FP8 recipe set under benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-gb200-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1648
+
+- config-keys:
+    - minimaxm2.5-fp8-b300-dynamo-vllm
+  description:
+    - "Add MiniMax-M2.5 FP8 B300 disaggregated multinode vLLM benchmarks via Dynamo"
+    - "Add 1k1k/8k1k FP8 recipe set under benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1663

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -42,8 +42,11 @@ elif [[ $MODEL_PREFIX == "dsv4" && $PRECISION == "fp4" && $FRAMEWORK == "dynamo-
 elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" && $FRAMEWORK == "dynamo-vllm" ]]; then
     export MODEL_PATH="/data/models/MiniMax-M2.5-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.5-nvfp4"
+elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp8" && $FRAMEWORK == "dynamo-vllm" ]]; then
+    export MODEL_PATH="/data/models/MiniMax-M2.5"
+    export SRT_SLURM_MODEL_PREFIX="minimax-m2.5-fp8"
 else
-    echo "Unsupported model: $MODEL_PREFIX-$PRECISION. Supported models are: dsr1-fp4, dsr1-fp8, dsv4-fp4 with dynamo-vllm, minimaxm2.5-fp4 with dynamo-vllm"
+    echo "Unsupported model: $MODEL_PREFIX-$PRECISION. Supported models are: dsr1-fp4, dsr1-fp8, dsv4-fp4 with dynamo-vllm, minimaxm2.5-fp4 with dynamo-vllm, minimaxm2.5-fp8 with dynamo-vllm"
     exit 1
 fi
 
@@ -64,12 +67,18 @@ elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv4" ]]; then
     git checkout aflowers/vllm-gb200-v0.20.0
     mkdir -p recipes/vllm/deepseek-v4
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4" recipes/vllm/deepseek-v4
-elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" ]]; then
+elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR" || exit 1
     git checkout main
     mkdir -p recipes/vllm/minimax-m2.5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300" recipes/vllm/minimax-m2.5
+elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp8" ]]; then
+    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
+    cd "$SRT_REPO_DIR" || exit 1
+    git checkout main
+    mkdir -p recipes/vllm/minimax-m2.5-fp8
+    cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8" recipes/vllm/minimax-m2.5-fp8
 else
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR" || exit 1


### PR DESCRIPTION
Adds MiniMax-M2.5 FP8 B300 Dynamo vLLM recipes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI configuration only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **MiniMax-M2.5 FP8** disaggregated **Dynamo + vLLM** benchmark coverage on the **B300** runner, mirroring the existing GB200/GB300 FP8 pattern.
> 
> A new `minimaxm2.5-fp8-b300-dynamo-vllm` entry in `nvidia-master.yaml` wires **fixed-seq-len** scenarios for **1k×1k** and **8k×1k** with many prefill/decode topology and concurrency search points, each pointing at `recipes/vllm/minimax-m2.5-fp8/...` config files. **Fifteen** new Slurm recipes under `benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5-b300-fp8/` define B300 GPU layouts, Nixl KV transfer, FP8 KV cache, and varying TP/EP/DP decode shapes.
> 
> `runners/launch_b300-nv.sh` now selects the FP8 model path/prefix and copies the new recipe tree into `srt-slurm` (distinct from the existing FP4 `minimax-m2.5-b300` branch). `perf-changelog.yaml` documents the new config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bcbdd9a94a99e8aa7e738c7fd4d292584edec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->