### PR TITLE
minimaxm2.5-fp8-h200-vllm: switch 8k/1k attention backend to FLASH_ATTN

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_h200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_h200.sh
@@ -42,6 +42,14 @@ else
   EP=()
 fi
 
+if [ "$ISL" = "8192" ]; then
+  ATTN_BACKEND="FLASH_ATTN"
+  AUTOTUNE_FLAG=()
+else
+  ATTN_BACKEND="FLASHINFER"
+  AUTOTUNE_FLAG=(--enable-flashinfer-autotune)
+fi
+
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
@@ -55,8 +63,8 @@ vllm serve "$MODEL" --port "$PORT" \
 --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
 --kv-cache-dtype fp8 \
 --moe-backend triton \
---attention-backend FLASHINFER \
---enable-flashinfer-autotune \
+--attention-backend "$ATTN_BACKEND" \
+"${AUTOTUNE_FLAG[@]}" \
 --compilation-config "$COMPILATION_CONFIG" \
 --no-enable-prefix-caching \
 --trust-remote-code > "$SERVER_LOG" 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3480,4 +3480,4 @@
   description:
     - "Switch attention backend from FLASHINFER to FLASH_ATTN for the 8k/1k cell of MiniMax-M2.5 FP8 H200 vLLM."
     - "1k/1k cell not changed in this PR: at 1k/1k all three measured configs."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TODO
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1667

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,10 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - minimaxm2.5-fp8-h200-vllm
+  description:
+    - "Switch attention backend from FLASHINFER to FLASH_ATTN for the 8k/1k cell of MiniMax-M2.5 FP8 H200 vLLM."
+    - "1k/1k cell not changed in this PR: at 1k/1k all three measured configs."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TODO


### PR DESCRIPTION
Switch the attention backend for the 8k/1k cell of minimaxm2.5-fp8-h200-vllm from FLASHINFER to FLASH_ATTN. ISL-conditional: the 1k/1k cell is unchanged (keeps FLASHINFER + --enable-flashinfer-autotune, byte-identical to prior behavior); only ISL=8192 triggers the swap.

Appends a perf-changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only vLLM flag selection for one ISL cell; no auth, data, or production serving paths.
> 
> **Overview**
> For **MiniMax-M2.5 FP8 H200 vLLM** (`minimaxm2.5_fp8_h200.sh`), `vllm serve` now picks the attention stack from **`ISL`**: when **`ISL=8192`** (8k/1k), it uses **`FLASH_ATTN`** and does **not** pass `--enable-flashinfer-autotune`; for all other input lengths it keeps **`FLASHINFER`** plus FlashInfer autotune, matching prior 1k/1k behavior.
> 
> A **`perf-changelog.yaml`** entry documents this under **`minimaxm2.5-fp8-h200-vllm`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424fe77c31711e374b6500c3a8e67d3052c85d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->