### PR TITLE
[AMD][MI35X] Qwen3.5-fp8 SGLang single-node benchmark

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -261,7 +261,7 @@ qwen3.5-fp8-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x
@@ -283,7 +283,7 @@ qwen3.5-fp8-mi355x-sglang:
       - { tp: 4, ep: 1, conc-start: 32, conc-end: 256 }
 
 qwen3.5-fp8-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -273,14 +273,11 @@ qwen3.5-fp8-mi355x-sglang:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
-      - { tp: 8, ep: 8, conc-start: 64, conc-end: 256 }
-      - { tp: 2, ep: 2, conc-start: 128, conc-end: 256 }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 2, ep: 2, conc-start: 4, conc-end: 32 }
-      - { tp: 4, ep: 1, conc-start: 32, conc-end: 256 }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp8-mi355x-sglang-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
@@ -295,14 +292,11 @@ qwen3.5-fp8-mi355x-sglang-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 32, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 64, conc-end: 256, spec-decoding: mtp }
-      - { tp: 2, ep: 2, conc-start: 128, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 2, ep: 2, conc-start: 4, conc-end: 32, spec-decoding: mtp }
-      - { tp: 4, ep: 1, conc-start: 32, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 # Diverged from qwen3.5-fp8-mi355x-sglang (agentic-coding sibling). Metadata is
 # identical to origin/main's qwen3.5-fp8-mi355x-sglang; the split exists because this

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
@@ -22,11 +22,13 @@ export SGLANG_USE_AITER_UNIFIED_ATTN=1
 export SGLANG_USE_AITER=1
 
 SERVER_LOG=/workspace/server.log
+CONTEXT_LENGTH=$((ISL + OSL + 20))
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -41,7 +43,8 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --max-running-requests 512 \
+    --max-running-requests $CONC \
+    --cuda-graph-max-bs $CONC \
     --disable-radix-cache \
     --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
@@ -45,7 +45,7 @@ python3 -m sglang.launch_server \
     --disable-radix-cache \
     --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.9 \
+    --mem-fraction-static 0.8 \
     --model-loader-extra-config '{"enable_multithread_load": true}' \
     --page-size 16 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
@@ -18,21 +18,21 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
+export SGLANG_USE_AITER=1
+
 SERVER_LOG=/workspace/server.log
-CONTEXT_LENGTH=$((ISL + OSL + 20))
-MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -41,11 +41,13 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --cuda-graph-max-bs $CONC \
+    --max-running-requests 512 \
     --disable-radix-cache \
-    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.8 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.9 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    --page-size 16 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -18,21 +18,21 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
+export SGLANG_USE_AITER=1
+
 SERVER_LOG=/workspace/server.log
-CONTEXT_LENGTH=$((ISL + OSL + 20))
-MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -41,11 +41,13 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --cuda-graph-max-bs $CONC \
+    --max-running-requests 512 \
     --disable-radix-cache \
-    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.8 \
+    --mem-fraction-static 0.9 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    --page-size 16 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 3 \
     --speculative-eagle-topk 1 \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -28,7 +28,7 @@ EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length
+else EVAL_CONTEXT_ARGS="--context-length"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -45,7 +45,7 @@ python3 -m sglang.launch_server \
     --disable-radix-cache \
     --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.9 \
+    --mem-fraction-static 0.8 \
     --model-loader-extra-config '{"enable_multithread_load": true}' \
     --page-size 16 \
     --speculative-algorithm EAGLE \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -22,11 +22,13 @@ export SGLANG_USE_AITER_UNIFIED_ATTN=1
 export SGLANG_USE_AITER=1
 
 SERVER_LOG=/workspace/server.log
+CONTEXT_LENGTH=$((ISL + OSL + 20))
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
@@ -41,7 +43,8 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --max-running-requests 512 \
+    --max-running-requests $CONC \
+    --cuda-graph-max-bs $CONC \
     --disable-radix-cache \
     --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -28,7 +28,7 @@ EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,17 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
+    - "Update script for aiter attention backend."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang-mtp
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
+    - "Update script for aiter attention backend."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3477,16 +3477,10 @@
 
 - config-keys:
     - qwen3.5-fp8-mi355x-sglang
-  description:
-    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
-    - "Update script for aiter attention backend."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
-
-- config-keys:
     - qwen3.5-fp8-mi355x-sglang-mtp
   description:
     - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
-    - "Update script for aiter attention backend."
+    - "Update script for aiter attention backend from triton."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
 
 - config-keys:


### PR DESCRIPTION
Create branch from @yichiche [branch](https://github.com/yichiche/InferenceX/commits/amd/qwen3.5-fp8/).

Successful run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27002889438
Chart: https://inferencex.semianalysis.com/inference?unofficialRun=27002889438



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI config only; no application runtime or auth paths. Changes affect published perf numbers and sweep coverage, not production serving.
> 
> **Overview**
> Updates the **Qwen3.5-397B-A17B-FP8** MI355X SGLang single-node benchmark (base and MTP) to a newer ROCm image (`v0.5.12.post1-rocm720-mi35x-20260528`) and collapses the fixed-seq-len sweep to a single **TP4 / EP1** concurrency range (4–256) for both 1k/1k and 8k/1k, replacing the prior multi-row TP/EP grid.
> 
> The launch scripts switch attention from **triton** to **aiter** (`SGLANG_USE_AITER*` env vars), tie **`--max-running-requests`** to sweep concurrency, replace **`--max-prefill-tokens`** with **`--chunked-prefill-size 32768`**, and add multithreaded load plus **`--page-size 16`**. **`perf-changelog.yaml`** records the image and script changes for both config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 930b1f8ea553ae14b7b408311dd800eceec6318a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->