### PR TITLE
[AMD][MI355X] update model for gpt-oss

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1134,7 +1134,7 @@ gptoss-fp4-mi325x-vllm:
 
 gptoss-fp4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.22.0
-  model: amd/gpt-oss-120b-w-mxfp4-a-fp8
+  model: openai/gpt-oss-120b
   model-prefix: gptoss
   runner: mi355x
   precision: fp4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,9 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - gptoss-fp4-mi355x-vllm
+  description:
+    - "Update GPT-OSS model for MI355X vLLM from amd/gpt-oss-120b-w-mxfp4-a-fp8 to openai/gpt-oss-120b"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1638

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3479,4 +3479,4 @@
     - gptoss-fp4-mi355x-vllm
   description:
     - "Update GPT-OSS model for MI355X vLLM from amd/gpt-oss-120b-w-mxfp4-a-fp8 to openai/gpt-oss-120b"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1638
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1670


### PR DESCRIPTION
Author: @ukannika

Switch the MoE backend to CK to leverage the benefits from this PR: https://github.com/vllm-project/vllm/pull/42098

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only model ID and changelog update; no serving code or sweep matrix changes in the diff.
> 
> **Overview**
> Updates the **GPT-OSS FP4 MI355X vLLM** benchmark entry to load **`openai/gpt-oss-120b`** instead of **`amd/gpt-oss-120b-w-mxfp4-a-fp8`**, aligning this MI355X sweep with the other AMD GPT-OSS vLLM configs that already point at the OpenAI checkpoint. Image (`vllm/vllm-openai-rocm:v0.22.0`), runner, and fixed-seq-len search space are unchanged.
> 
> Adds a **`perf-changelog.yaml`** record for `gptoss-fp4-mi355x-vllm` documenting the model swap (PR #1670).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770268c51c2b368e9d669096041c003520f14c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->