### PR TITLE
AMD][MI35X] Qwen3.5-fp8 SGLang mtp single-node benchmark

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -261,7 +261,7 @@ qwen3.5-fp8-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x
@@ -283,7 +283,7 @@ qwen3.5-fp8-mi355x-sglang:
       - { tp: 4, ep: 1, conc-start: 32, conc-end: 256 }
 
 qwen3.5-fp8-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -261,7 +261,7 @@ qwen3.5-fp8-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
@@ -18,21 +18,21 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
-export SGLANG_USE_AITER_UNIFIED_ATTN=1
-export SGLANG_USE_AITER=1
-
 SERVER_LOG=/workspace/server.log
+CONTEXT_LENGTH=$((ISL + OSL + 20))
+MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
 python3 -m sglang.launch_server \
-    --attention-backend aiter \
+    --attention-backend triton \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -41,13 +41,11 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --max-running-requests 512 \
+    --cuda-graph-max-bs $CONC \
     --disable-radix-cache \
-    --chunked-prefill-size 32768 \
+    --max-prefill-tokens $MAX_PREFILL_TOKENS \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.9 \
-    --model-loader-extra-config '{"enable_multithread_load": true}' \
-    --page-size 16 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.8 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x.sh
@@ -18,21 +18,21 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
+export SGLANG_USE_AITER=1
+
 SERVER_LOG=/workspace/server.log
-CONTEXT_LENGTH=$((ISL + OSL + 20))
-MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -41,11 +41,13 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --cuda-graph-max-bs $CONC \
+    --max-running-requests 512 \
     --disable-radix-cache \
-    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.8 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+    --mem-fraction-static 0.9 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    --page-size 16 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh
@@ -18,21 +18,21 @@ fi
 
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
+export SGLANG_USE_AITER=1
+
 SERVER_LOG=/workspace/server.log
-CONTEXT_LENGTH=$((ISL + OSL + 20))
-MAX_PREFILL_TOKENS=32768
 
 EVAL_CONTEXT_ARGS=""
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
     EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
-else EVAL_CONTEXT_ARGS="--context-length $CONTEXT_LENGTH"
 fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
 python3 -m sglang.launch_server \
-    --attention-backend triton \
+    --attention-backend aiter \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
@@ -41,11 +41,13 @@ python3 -m sglang.launch_server \
     --trust-remote-code \
     --tokenizer-worker-num 6 \
     --enable-aiter-allreduce-fusion \
-    --cuda-graph-max-bs $CONC \
+    --max-running-requests 512 \
     --disable-radix-cache \
-    --max-prefill-tokens $MAX_PREFILL_TOKENS \
+    --chunked-prefill-size 32768 \
     --scheduler-recv-interval 30 \
-    --mem-fraction-static 0.8 \
+    --mem-fraction-static 0.9 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    --page-size 16 \
     --speculative-algorithm EAGLE \
     --speculative-num-steps 3 \
     --speculative-eagle-topk 1 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,17 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
+    - "Update script for aiter attention backend."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang-mtp
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
+    - "Update script for aiter attention backend."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3476,15 +3476,8 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
 
 - config-keys:
-    - qwen3.5-fp8-mi355x-sglang
-  description:
-    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
-    - "Update script for aiter attention backend."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
-
-- config-keys:
     - qwen3.5-fp8-mi355x-sglang-mtp
   description:
     - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528."
     - "Update script for aiter attention backend."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1669
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1671


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark-only image and launch-flag changes; no application or security-sensitive code paths.
> 
> **Overview**
> Updates the **Qwen3.5 FP8 MI355X SGLang MTP** single-node benchmark to a newer ROCm image and retunes the launch recipe for AITER.
> 
> The `qwen3.5-fp8-mi355x-sglang-mtp` config in `.github/configs/amd-master.yaml` now points at `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528` (was `...20260517`). `benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi355x_mtp.sh` enables `SGLANG_USE_AITER` / unified AITER attention, switches `--attention-backend` from **triton** to **aiter**, and adjusts serving limits: fixed `--max-running-requests 512`, `--chunked-prefill-size 32768`, `--mem-fraction-static 0.9`, `--page-size 16`, multithreaded model load—while dropping the prior ISL/OSL-derived `--context-length`, `--max-prefill-tokens`, and concurrency-tied `--cuda-graph-max-bs`. `perf-changelog.yaml` documents the config key change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50efc8fe8138e0b905354891e2d1e29c6682bdcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->