### PR TITLE
[AMD][MI355X] Bump qwen3.5-bf16 single-node SGLang image to v0.5.12.post1 / 升级 Qwen3.5 BF16 单节点 SGLang 镜像至 v0.5.12.post1

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -166,7 +166,7 @@ dsr1-fp8-mi355x-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
 qwen3.5-bf16-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi355x
@@ -185,7 +185,7 @@ qwen3.5-bf16-mi355x-sglang:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-bf16-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3502,3 +3502,12 @@
     - "Update GPT-OSS model for MI355X vLLM from amd/gpt-oss-120b-w-mxfp4-a-fp8 to openai/gpt-oss-120b"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1670
 
+- config-keys:
+    - qwen3.5-bf16-mi355x-sglang
+    - qwen3.5-bf16-mi355x-sglang-mtp
+  description:
+    - "Bump image from lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 to lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x to fix MTP performance drop."
+    - "Root cause: the old image shipped an AITER build that lacked Qwen3.5-397B TP8 MoE kernel tuning and kernel-selection coverage. EAGLE/MTP ran functionally, but the verify and MoE decode paths selected suboptimal AITER kernels, erasing the expected speculative-decoding speedup on MI355X. The newer v0.5.12.post1 image includes later AITER changes (candidate PRs: aiter#3453, aiter#3341) that add proper Qwen3.5-397B TP8 MoE kernel coverage and retuning, restoring the MTP throughput gap to +34..69% (conc 1..32)."
+    - "On the new image, EAGLE-MTP delivers +34..69% total token throughput and -28..42% median TPOT over non-MTP at conc 1..32 (1k/1k, TP=8, EP=1, triton attention). conc=64 throughput speedup limited to +6.9% by EAGLE silent max_running_requests=48 cap, while TPOT speedup stays at 1.39x."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1673
+


### PR DESCRIPTION
## Summary

The motivation of this PR is there is a performance drop noticed of `qwen3.5-bf16-mi355x-sglang-mtp` compared with `qwen3.5-bf16-mi355x-sglang`, more details can be checked in the [issue](https://github.com/sgl-project/sglang/issues/23123).

The fix is to update the docker image for both `qwen3.5-bf16-mi355x-sglang` and `qwen3.5-bf16-mi355x-sglang-mtp` from `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517` to `lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x`. The root cause leading to the perf drop is potentially **the regression of sglang docker image update or docker setting mis-alignment**. The e2e smoke test runs on the image where the MTP EAGLE acceleration was empirically validated and details can be referred to the table below.

## Measured MTP performance on the new image

**Setup:** single MI355X node, `Qwen/Qwen3.5-397B-A17B`, 1k input / 1k output, `tp=8`, `ep=1`, `dp-attn=false`, `--attention-backend triton`, EAGLE `num_steps=3` / `eagle_topk=1` / `num_draft_tokens=4`. 14-run sweep with `bench_serving`, paired non-MTP and MTP back-to-back per concurrency.

| conc | non-MTP tok/s | MTP tok/s | tok/s speedup | non-MTP TPOT (ms) | MTP TPOT (ms) | TPOT speedup |
|-----:|--------------:|----------:|--------------:|------------------:|--------------:|-------------:|
|    1 |        223.12 |    367.33 | **1.65×** |              8.72 |          5.05 | **1.73×** |
|    2 |        421.49 |    712.84 | **1.69×** |              9.14 |          5.27 | **1.73×** |
|    4 |        781.42 |   1226.04 | **1.57×** |              9.75 |          6.02 | **1.62×** |
|    8 |       1425.58 |   2046.63 | **1.44×** |             10.70 |          7.22 | **1.48×** |
|   16 |       2545.06 |   3413.03 | **1.34×** |             12.14 |          8.65 | **1.40×** |
|   32 |       3980.16 |   5367.44 | **1.35×** |             15.49 |         10.78 | **1.44×** |
|   64 |       6217.16 |   6645.44 | **1.07×** |             19.58 |         14.05 | **1.39×** |

EAGLE acceptance rate ≈ 1.4–1.7 verified tokens per main forward (theoretical max = 4 with `num_draft_tokens=4`), monotonically declining with conc as expected.

## Commands used

**Serve (non-MTP):**

```bash
python3 -m sglang.launch_server \
    --attention-backend triton \
    --model-path Qwen/Qwen3.5-397B-A17B \
    --host 0.0.0.0 --port 8888 \
    --tensor-parallel-size 8 --ep-size 1 \
    --trust-remote-code \
    --tokenizer-worker-num 6 \
    --enable-aiter-allreduce-fusion \
    --cuda-graph-max-bs 64 \
    --disable-radix-cache \
    --max-prefill-tokens 32768 \
    --scheduler-recv-interval 30 \
    --mem-fraction-static 0.8 \
    --context-length 2068
```

**Serve (with MTP — adds 4 EAGLE flags):**

```bash
python3 -m sglang.launch_server \
    --attention-backend triton \
    --model-path Qwen/Qwen3.5-397B-A17B \
    --host 0.0.0.0 --port 8888 \
    --tensor-parallel-size 8 --ep-size 1 \
    --trust-remote-code \
    --tokenizer-worker-num 6 \
    --enable-aiter-allreduce-fusion \
    --cuda-graph-max-bs 64 \
    --disable-radix-cache \
    --max-prefill-tokens 32768 \
    --scheduler-recv-interval 30 \
    --mem-fraction-static 0.8 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --context-length 2068
```

## Co-authors
@ChangLiu0709 
@chunfangamd 

## Test plan

- [x] `python3 utils/matrix_logic/generate_sweep_configs.py test-config --config-keys qwen3.5-bf16-mi355x-sglang qwen3.5-bf16-mi355x-sglang-mtp --config-files .github/configs/amd-master.yaml` validates and resolves both entries to the new image.
- [x] Local smoke at 1k1k / conc=64 succeeds on `mia1-p01-g09` for both `none` and `mtp` spec-decoding (results JSONs above are from these runs).
- [ ] Trigger `End-to-End Tests` GH Action with `test-config --config-keys qwen3.5-bf16-mi355x-sglang qwen3.5-bf16-mi355x-sglang-mtp --config-files .github/configs/amd-master.yaml` and confirm the per-conc result JSONs match the local-smoke numbers within the usual noise envelope.


Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Docker image pin and changelog; no application code or serve-flag changes.
> 
> **Overview**
> Updates the **MI355X** single-node Qwen3.5 BF16 SGLang benchmark pins so baseline and MTP sweeps use the same container: `lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x` instead of `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517`. Applies to **`qwen3.5-bf16-mi355x-sglang`** and **`qwen3.5-bf16-mi355x-sglang-mtp`** in `amd-master.yaml`; model, TP/EP, and concurrency grids are unchanged.
> 
> `perf-changelog.yaml` records that the older image's AITER build lacked proper Qwen3.5-397B TP8 MoE tuning, which made EAGLE/MTP verify paths pick slow kernels and wiped the expected MTP win; the post1 image is documented as restoring roughly **+34–69%** throughput vs non-MTP at conc 1–32.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba55e9e88578987ae6a2dadf0a5a2a887849ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## 中文说明
更新 MI355X 单节点 Qwen3.5 BF16 SGLang 基准测试镜像，将 `qwen3.5-bf16-mi355x-sglang` 和 `qwen3.5-bf16-mi355x-sglang-mtp` 的容器镜像从 `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517` 升级为 `lmsysorg/sglang:v0.5.12.post1-rocm720-mi35x`。旧镜像的 AITER 构建缺少针对 Qwen3.5-397B TP8 MoE 的调优，导致 EAGLE/MTP 验证路径选择了低效内核，抵消了预期的 MTP 加速效果。新镜像在并发度 1-32 范围内恢复约 34-69% 的吞吐量提升。
