### PR TITLE
kimik2.5-fp4-b300-vllm: bump vLLM image to v0.22.0 and expand concurrency sweep

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2713,13 +2713,13 @@ kimik2.5-fp4-b300-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
 
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2701,7 +2701,7 @@ kimik2.5-fp4-b200-vllm-agentic:
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3474,3 +3474,9 @@
     - "Use scheduler-recv-interval values 2/60/30/1200/600/1920 for conc 1-4/8/16/32/64/128-256"
     - "Set max-running-requests=256, chunked-prefill-size=16384, mem-fraction-static=0.8, cuda-graph-max-bs=CONC, and enable symm-mem"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1544
+
+- config-keys:
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Update vLLM image from v0.21.0 to v0.22.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3507,3 +3507,9 @@
   description:
     - "Update vLLM image from v0.21.0 to v0.22.0"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1674
+
+- config-keys:
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Expand concurrency sweep for the 1k/1k and 8k/1k cells: TP4/EP1 conc 4-64 -> 1-128, TP8/EP1 conc-start 4 -> 1 (conc-end 4 unchanged)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1674

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3506,10 +3506,5 @@
     - kimik2.5-fp4-b300-vllm
   description:
     - "Update vLLM image from v0.21.0 to v0.22.0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1674
-
-- config-keys:
-    - kimik2.5-fp4-b300-vllm
-  description:
     - "Expand concurrency sweep for the 1k/1k and 8k/1k cells: TP4/EP1 conc 4-64 -> 1-128, TP8/EP1 conc-start 4 -> 1 (conc-end 4 unchanged)."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1674

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3479,4 +3479,4 @@
     - kimik2.5-fp4-b300-vllm
   description:
     - "Update vLLM image from v0.21.0 to v0.22.0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1674


### PR DESCRIPTION
Two changes to `kimik2.5-fp4-b300-vllm`:

1. **vLLM image bump** — `vllm/vllm-openai:v0.21.0` → `vllm/vllm-openai:v0.22.0`.
2. **Concurrency sweep** — for both the 1k/1k and 8k/1k cells: TP4/EP1 `conc 4-64` → `1-128`, TP8/EP1 `conc-start 4` → `1` (`conc-end 4` unchanged).

Appends a perf-changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only YAML and changelog updates; no runtime application or auth/data-path changes, though wider sweeps increase benchmark run time and cost.
> 
> **Overview**
> Updates the **`kimik2.5-fp4-b300-vllm`** benchmark recipe in `nvidia-master.yaml`: the vLLM container moves from **v0.21.0** to **v0.22.0**, and the fixed-seq-len concurrency sweeps for the **1k/1k** and **8k/1k** cells are widened so low-concurrency points are included and TP4 can be searched up to **128** concurrent requests (previously TP4 started at 4 and capped at 64; TP8 now sweeps from **1** through 4 instead of starting at 4).
> 
> A matching **`perf-changelog.yaml`** entry documents the image bump and sweep changes for **`kimik2.5-fp4-b300-vllm`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014787e8faeade6bbfc94e05b7a995dee51994c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->