### PR TITLE
kimik2.5-fp4-b200-vllm: expand concurrency sweep to 1-128

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2660,13 +2660,13 @@ kimik2.5-fp4-b200-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 4, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3502,3 +3502,9 @@
     - "Update GPT-OSS model for MI355X vLLM from amd/gpt-oss-120b-w-mxfp4-a-fp8 to openai/gpt-oss-120b"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1670
 
+- config-keys:
+    - kimik2.5-fp4-b200-vllm
+  description:
+    - "Expand concurrency sweep for the 1k/1k and 8k/1k cells: TP4/EP1 conc 4-64 -> 1-128, TP8/EP1 conc-start 4 -> 1 (conc-end 4 unchanged)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3506,5 +3506,5 @@
     - kimik2.5-fp4-b200-vllm
   description:
     - "Expand concurrency sweep for the 1k/1k and 8k/1k cells: TP4/EP1 conc 4-64 -> 1-128, TP8/EP1 conc-start 4 -> 1 (conc-end 4 unchanged)."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1677
 


### PR DESCRIPTION
Expand the concurrency sweep for `kimik2.5-fp4-b200-vllm` across both the 1k/1k and 8k/1k cells:

- TP4/EP1: `conc 4-64` → `1-128`
- TP8/EP1: `conc-start 4` → `1` (`conc-end 4` unchanged)

Appends a perf-changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark YAML and changelog only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Widens the **fixed-seq-len** perf search space for `kimik2.5-fp4-b200-vllm` on B200 vLLM for both **1k/1k** and **8k/1k** cells.
> 
> For **TP4/EP1**, concurrency is swept from **4–64** to **1–128**. For **TP8/EP1**, **conc-start** moves from **4** to **1** while **conc-end** stays **4**. A matching **perf-changelog** entry is added for `kimik2.5-fp4-b200-vllm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e243c2d7a3d4d648d08235fe933c4b36adff69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->