### PR TITLE
[AMD][MI35X] Qwen3.5-fp4 SGLang single-node benchmark

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -480,12 +480,12 @@ qwen3.5-fp4-mi355x-sglang-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
 
 qwen3.5-fp4-mi355x-sglang-disagg:

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -426,7 +426,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
           - "DECODE_MTP_SIZE=0"
 
 qwen3.5-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260604
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x
@@ -468,7 +468,7 @@ qwen3.5-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 16 }
 
 qwen3.5-fp4-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260604
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
@@ -39,7 +39,7 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --model-loader-extra-config '{"enable_multithread_load": true}' \
 --watchdog-timeout 1200  \
 --disable-radix-cache \
---enable-aiter-allreduce-fusion --max-running-requests 512 \
+--enable-aiter-allreduce-fusion --max-running-requests $CONC \
 --page-size 16 \
 > $SERVER_LOG 2>&1 &
 

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
@@ -18,6 +18,7 @@ fi
 if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
 export SGLANG_USE_AITER=1
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
 
 SERVER_LOG=/workspace/server.log
 MEM_FRAC_STATIC=${MEM_FRAC_STATIC:-0.8}
@@ -38,6 +39,8 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --model-loader-extra-config '{"enable_multithread_load": true}' \
 --watchdog-timeout 1200  \
 --disable-radix-cache \
+--enable-aiter-allreduce-fusion --max-running-requests 512 \
+--page-size 16 \
 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
@@ -18,6 +18,7 @@ fi
 hf download "$MODEL"
 
 export SGLANG_USE_AITER=1
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
 
 SERVER_LOG=/workspace/server.log
 MEM_FRAC_STATIC=${MEM_FRAC_STATIC:-0.8}
@@ -38,6 +39,8 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --model-loader-extra-config '{"enable_multithread_load": true}' \
 --watchdog-timeout 1200  \
 --disable-radix-cache \
+--enable-aiter-allreduce-fusion --max-running-requests $CONC \
+--page-size 16 \
 --speculative-algorithm EAGLE \
 --speculative-num-steps 3 \
 --speculative-eagle-topk 1 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3523,3 +3523,13 @@
     - "Aligned decode params with Weiliang config: swa-full-tokens-ratio=0.20, max-running-requests=18432, moe-dense-tp-size=1; added prefill enable-dp-lm-head and cuda-graph-max-bs=512"
     - "Remove 4 dominated old configs (4p-dep16-8n, 8p-dep16-12n, 10p-dep16-14n, 12p-dep12-15n) superseded by wide-EP frontier"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1586
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+    - qwen3.5-fp4-mi355x-sglang-mtp
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260604."
+    - "Update script for aiter attention backend from triton."
+    - "Enable aiter unfied attention."
+    - "Enable aiter allreduce fusion."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1680

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3532,4 +3532,5 @@
     - "Update script for aiter attention backend from triton."
     - "Enable aiter unfied attention."
     - "Enable aiter allreduce fusion."
+    - "Remove sweep config mtp+cc256+tp2, which may OOM."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1680


### PR DESCRIPTION
Create branch from @yichiche [branch](https://github.com/yichiche/InferenceX/tree/qwen3.5-fp4-mi355x-perf-flags).

Successful run:
see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=27130906063
see unofficial run visualizer at https://inferencex.semianalysis.com/evaluation?unofficialRun=27130906063


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI config only; no production serving or auth paths. Main operational risk is sweep coverage change (MTP conc cap) and dependency on the new container image.
> 
> **Overview**
> Updates **Qwen3.5 FP4 MI355X** single-node SGLang benchmarks (base and MTP) to a newer ROCm image and AITER-focused serve settings.
> 
> **CI (`amd-master.yaml`):** Both `qwen3.5-fp4-mi355x-sglang` and `qwen3.5-fp4-mi355x-sglang-mtp` now use `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260604`. For MTP, **TP=2** concurrency sweeps cap at **128** instead of **256** on 1k1k and 8k1k to avoid OOM.
> 
> **Benchmark scripts:** `qwen3.5_fp4_mi355x.sh` and `qwen3.5_fp4_mi355x_mtp.sh` set `SGLANG_USE_AITER_UNIFIED_ATTN=1` and add `--enable-aiter-allreduce-fusion`, `--max-running-requests $CONC`, and `--page-size 16` alongside the existing aiter attention backend.
> 
> **`perf-changelog.yaml`:** Documents the image bump, script/kernel path changes, and MTP sweep trim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bd5c63fcaea4ec05b25f803d2d8868ace87ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->