### PR TITLE
dsv4-fp4-b300-sglang: align env vars to GB300

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -2003,7 +2003,7 @@ dsr1-fp8-b300-sglang:
 # DeepSeek-V4-Pro on B300 with sglang (non-MTP).
 # Uses nightly image with megamoe backend for high-concurrency profiles.
 dsv4-fp4-b300-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260529-a8cfae0b
+  image: lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
@@ -30,8 +30,11 @@ fi
 
 nvidia-smi
 
-# ─── Common env vars (all profiles) ───────────────────────────────────────────
-export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
+# ─── Common env vars (all profiles, GB300-aligned) ──────────────────────────
+export SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
+export SGLANG_RADIX_FORCE_MISS=1
+export SGLANG_DEFAULT_THINKING=1
+export SGLANG_DSV4_REASONING_EFFORT=max
 export SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT=1
 
 SERVER_LOG="$PWD/server.log"
@@ -46,9 +49,25 @@ fi
 
 start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 
+# ─── DP-attention env vars (GB300-aligned) ───────────────────────────────────
+# Shared across all DP-attention profiles (conc >= 512). Set before per-conc
+# tuning so individual blocks only carry NVSHMEM / batch-size overrides.
+if [ "$CONC" != "1" ] && [ "$CONC" != "32" ]; then
+    export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
+    export SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1
+    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1
+    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1
+    export SGLANG_OPT_USE_ONLINE_COMPRESS=1
+    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8192
+    export SGLANG_LOG_FORWARD_ITERS=1
+    export SGLANG_LOG_MS=1
+    export SGLANG_REQUEST_STATE_WAIT_TIMEOUT=60
+    export SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION=8
+fi
+
 # ─── Per-concurrency launch profile ──────────────────────────────────────────
 # Each block sets: PARALLEL_ARGS, MEM_FRACTION_STATIC, SWA_FULL_TOKENS_RATIO,
-# and optionally MAX_RUNNING_REQUESTS plus profile-specific env vars.
+# and optionally MAX_RUNNING_REQUESTS.
 #
 # SWA ratio: 1k inputs need more SWA cache headroom than 8k inputs; 0.5 was
 # tuned empirically for the 1k1k recipe, while 0.1 is the cookbook default.
@@ -61,11 +80,11 @@ if [ "$CONC" = "1" ] || [ "$CONC" = "32" ]; then
         --moe-runner-backend flashinfer_mxfp4
         --chunked-prefill-size 8192
         --disable-flashinfer-autotune
+        --enable-deepseek-v4-fp4-indexer
     )
 
 elif [ "$CONC" = "512" ]; then
     # DP attention, flashinfer_mxfp4
-    export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     MEM_FRACTION_STATIC=0.94
     SWA_FULL_TOKENS_RATIO=$([[ "$ISL" == "1024" ]] && echo 0.5 || echo 0.1)
     PARALLEL_ARGS=(
@@ -75,15 +94,12 @@ elif [ "$CONC" = "512" ]; then
         --disable-flashinfer-autotune
         --chunked-prefill-size 16384
         --enable-prefill-delayer
+        --enable-deepseek-v4-fp4-indexer
     )
 
 elif [ "$CONC" = "2048" ]; then
     # DP attention, megamoe
-    export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     export NVSHMEM_DISABLE_IB=1
-    export SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1
-    export SGLANG_LOG_FORWARD_ITERS=1
-    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320
     MEM_FRACTION_STATIC=0.87
     SWA_FULL_TOKENS_RATIO=0.06
     MAX_RUNNING_REQUESTS=2560
@@ -95,14 +111,12 @@ elif [ "$CONC" = "2048" ]; then
         --chunked-prefill-size 65536
         --tokenizer-worker-num 4
         --enable-prefill-delayer
+        --enable-deepseek-v4-fp4-indexer
     )
 
 elif [ "$CONC" = "4096" ]; then
     # DP attention, megamoe
-    export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     export NVSHMEM_DISABLE_IB=1
-    export SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1
-    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320
     MEM_FRACTION_STATIC=0.835
     SWA_FULL_TOKENS_RATIO=0.075
     MAX_RUNNING_REQUESTS=4352
@@ -115,15 +129,12 @@ elif [ "$CONC" = "4096" ]; then
         --tokenizer-worker-num 8
         --enable-prefill-delayer
         --decode-log-interval 5
+        --enable-deepseek-v4-fp4-indexer
     )
 
 elif [ "$CONC" = "8192" ]; then
     # DP attention, megamoe
-    export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     export NVSHMEM_DISABLE_IB=1
-    export SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW=1
-    export SGLANG_OPT_USE_ONLINE_COMPRESS=1
-    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8256
     MEM_FRACTION_STATIC=0.80
     SWA_FULL_TOKENS_RATIO=0.3
     MAX_RUNNING_REQUESTS=8192
@@ -136,6 +147,7 @@ elif [ "$CONC" = "8192" ]; then
         --tokenizer-worker-num 16
         --enable-prefill-delayer
         --stream-interval 30
+        --enable-deepseek-v4-fp4-indexer
     )
 
 else


### PR DESCRIPTION
## Summary
- Align B300 single-node SGLang DSV4 environment variables to match GB300 disaggregated configs (excluding NCCL/communication vars)
- Add `--enable-deepseek-v4-fp4-indexer` flag to all concurrency profiles
- Extract shared DP-attention env vars into a common block to reduce duplication

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark launch configuration and SGLang image version, which can shift CI performance and stability for high-concurrency MegaMoE DP-attention runs without touching application runtime code.
> 
> **Overview**
> Updates **DeepSeek-V4 FP4 B300 single-node SGLang** CI to a newer nightly image and retunes `dsv4_fp4_b300_sglang.sh` so launch env and flags track **GB300 disaggregated** SGLang recipes (excluding NCCL/comm settings).
> 
> **Global profile changes:** drops `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` in favor of `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1`, plus radix/thinking/reasoning-effort env vars used on GB300. **All concurrency blocks** now pass `--enable-deepseek-v4-fp4-indexer`.
> 
> **DP-attention (CONC ≥ 512):** duplicated SWA/MegaMoE/logging env exports are moved into one shared block (including FP4/MXF4 acts, online compress, `MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8192`, and `SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION=8`). Per-profile megamoe blocks shed those repeats and no longer set profile-specific `MEGA_MOE_NUM_MAX_TOKENS_PER_RANK` values (8320/8256); megamoe profiles keep only overrides like `NVSHMEM_DISABLE_IB=1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ad3bdb2e9a43ccbc757f02afabf2f1c22ded92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->