### PR TITLE
chore: use INFERENCEX_OFFICIAL_RO_HF_TOKEN secret in workflows

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -89,7 +89,7 @@ on:
         default: '1800'
 env:
   RANDOM_RANGE_RATIO: 0.8
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN }}
   HF_HUB_CACHE: '/mnt/hf_hub_cache/'
   EXP_NAME: ${{ inputs.exp-name }}
   MODEL: ${{ inputs.model }}

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -31,7 +31,7 @@ permissions:
   contents: read
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN }}
   HF_HUB_CACHE: '/mnt/hf_hub_cache/'
   RANDOM_RANGE_RATIO: '0.8'
   PERFETTO_RELAY_URL: https://semianalysisai.github.io/InferenceX-trace-storage

--- a/.github/workflows/speedbench-al.yml
+++ b/.github/workflows/speedbench-al.yml
@@ -73,7 +73,7 @@ permissions:
   contents: read
 
 env:
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  HF_TOKEN: ${{ secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN }}
   HF_HUB_CACHE: '/mnt/hf_hub_cache/'
   # Drive the single-node path in runners/launch_b300-nv.sh. MODEL is the HF id;
   # its basename (e.g. DeepSeek-V4-Pro) must be in the launcher's STAGED_MODELS so


### PR DESCRIPTION
Switch the HF token secret reference from `secrets.HF_TOKEN` to `secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN` in `benchmark-tmpl.yml`, `profile.yml`, and `speedbench-al.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to CI secret wiring; jobs will fail to access gated models if the new secret is missing or invalid, with no application auth or runtime code changes.
> 
> **Overview**
> Benchmark, profile, and SpeedBench AL GitHub Actions workflows now source **`HF_TOKEN`** from **`secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN`** instead of **`secrets.HF_TOKEN`**. The runtime env name is unchanged; only which repository secret backs Hugging Face Hub access in CI is updated (including the reusable **`benchmark-tmpl.yml`** template used by downstream benchmark jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 707d0c6569d7fbfdd94e9cff49392b49c626f4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->