### PR TITLE
[NV] Speedbench-al: fix --chat-template-kwargs default quoting so thinking-on cells run

### DIFF
--- a/benchmarks/single_node/speedbench/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4_fp4_b300_vllm.sh
@@ -48,7 +48,8 @@ TEMPERATURE="${TEMPERATURE:-1.0}"
 # thinking-on chat_template_kwargs. MUST match the production/golden config:
 # the reference matrix (benchmarks/speedbench-reference-al.yaml) was measured
 # with reasoning_effort=high.
-CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-{\"thinking\": true, \"reasoning_effort\": \"high\"}}"
+DEFAULT_CHAT_TEMPLATE_KWARGS_ON='{"thinking": true, "reasoning_effort": "high"}'
+CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"
 
 SPEEDBENCH_DIR="${SPEEDBENCH_DIR:-/workspace/speed_bench_data}"
 RESULTS_DIR="${RESULTS_DIR:-/workspace/speedbench_results}"


### PR DESCRIPTION
The collector set `CHAT_TEMPLATE_KWARGS_ON="${VAR:-{...}}"`, but bash ends the parameter expansion at the first }, so the trailing } is appended as a literal. It worked locally because the var was unset (default path lands on a single brace), in CI the workflow passes the var in, so the value became {...}} invalid JSON. Fixed by moving the default into its own variable so there are no brace-literals in the expansion.

Parent PR: https://github.com/SemiAnalysisAI/InferenceX/pull/1650

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line bash env default change in a benchmark collector script; no production serving or auth paths affected.
> 
> **Overview**
> Fixes **thinking-on** SPEED-Bench AL collection in CI by correcting how the default `CHAT_TEMPLATE_KWARGS_ON` JSON is assigned in `dsv4_fp4_b300_vllm.sh`.
> 
> The previous inline default inside `${CHAT_TEMPLATE_KWARGS_ON:-{...}}` was parsed incorrectly by bash (expansion stops at the first `}`), which could yield malformed JSON when the workflow exports the variable. The default is now stored in `DEFAULT_CHAT_TEMPLATE_KWARGS_ON` and referenced via `${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}`, so `--chat-template-kwargs` gets valid `{"thinking": true, "reasoning_effort": "high"}` for thinking-on cells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e101f362f16e038a5a209c58f24ce7d12b70f7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->