### PR TITLE
[DO NOT MERGE] Run-only: gb300 dsr1 measured power+temp validation

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11502,15 +11502,17 @@ minimaxm2.5-fp8-gb300-dynamo-vllm:
 # Minimal single-job validation of the perfmon plumbing on GB300 before the
 # full dsr1-disagg-NVIDIA measured sweep. Identical to the 1k1k low-latency
 # scenario of dsr1-fp4-gb300-dynamo-sglang (same recipe + topology), trimmed
-# to one concurrency so it runs as ONE gb300 job. runner: gb300 routes to
-# runners/launch_gb300-nv.sh, whose dsr1 branch clones the perfmon fork and
+# to one concurrency so it runs as ONE gb300 job. runner: gb300-nv pins the
+# NVIDIA pool (the bare 'gb300' label is SHARED with gb300-cw, whose launcher
+# hard-rejects dsr1 with exit 1) and routes to runners/launch_gb300-nv.sh,
+# whose dsr1 branch clones the perfmon fork and
 # injects monitoring: -> per-node perf_samples_*.csv -> measured per-phase
 # board power. Remove once the path is proven (or keep as a power canary).
 dsr1-fp4-gb300-dynamo-sglang-powercheck:
   image: "lmsysorg/sglang:v0.5.8.post1-cu130-runtime"
   model: nvidia/DeepSeek-R1-0528-NVFP4-v2
   model-prefix: dsr1
-  runner: gb300
+  runner: gb300-nv
   precision: fp4
   framework: dynamo-sglang
   multinode: true

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11502,17 +11502,16 @@ minimaxm2.5-fp8-gb300-dynamo-vllm:
 # Minimal single-job validation of the perfmon plumbing on GB300 before the
 # full dsr1-disagg-NVIDIA measured sweep. Identical to the 1k1k low-latency
 # scenario of dsr1-fp4-gb300-dynamo-sglang (same recipe + topology), trimmed
-# to one concurrency so it runs as ONE gb300 job. runner: gb300-nv pins the
-# NVIDIA pool (the bare 'gb300' label is SHARED with gb300-cw, whose launcher
-# hard-rejects dsr1 with exit 1) and routes to runners/launch_gb300-nv.sh,
-# whose dsr1 branch clones the perfmon fork and
+# to one concurrency so it runs as ONE gb300 job. runner: gb300-cw (CoreWeave
+# fallback — the gb300-nv fleet was wedged on pre-run cleanup) routes to
+# runners/launch_gb300-cw.sh, whose new dsr1 branch clones the perfmon fork and
 # injects monitoring: -> per-node perf_samples_*.csv -> measured per-phase
 # board power. Remove once the path is proven (or keep as a power canary).
 dsr1-fp4-gb300-dynamo-sglang-powercheck:
   image: "lmsysorg/sglang:v0.5.8.post1-cu130-runtime"
   model: nvidia/DeepSeek-R1-0528-NVFP4-v2
   model-prefix: dsr1
-  runner: gb300-nv
+  runner: gb300-cw
   precision: fp4
   framework: dynamo-sglang
   multinode: true

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11497,3 +11497,40 @@ minimaxm2.5-fp8-gb300-dynamo-vllm:
           tp: 4
           ep: 4
           dp-attn: true
+
+# --- Measured-power campaign (dsr1-disagg-NVIDIA) ---------------------------
+# Minimal single-job validation of the perfmon plumbing on GB300 before the
+# full dsr1-disagg-NVIDIA measured sweep. Identical to the 1k1k low-latency
+# scenario of dsr1-fp4-gb300-dynamo-sglang (same recipe + topology), trimmed
+# to one concurrency so it runs as ONE gb300 job. runner: gb300 routes to
+# runners/launch_gb300-nv.sh, whose dsr1 branch clones the perfmon fork and
+# injects monitoring: -> per-node perf_samples_*.csv -> measured per-phase
+# board power. Remove once the path is proven (or keep as a power canary).
+dsr1-fp4-gb300-dynamo-sglang-powercheck:
+  image: "lmsysorg/sglang:v0.5.8.post1-cu130-runtime"
+  model: nvidia/DeepSeek-R1-0528-NVFP4-v2
+  model-prefix: dsr1
+  runner: gb300
+  precision: fp4
+  framework: dynamo-sglang
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - spec-decoding: "none"
+        conc-list: [ 8 ]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/gb300-fp4/1k1k/low_latency.yaml"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 1
+          dp-attn: false

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -178,6 +178,13 @@ jobs:
               sleep 5
             done
           fi
+          # Drop root-owned leftovers from a prior (often cancelled) multinode
+          # run. The benchmark container runs as root and writes benchmark_logs/;
+          # if the job was cancelled its cleanup trap never ran, leaving
+          # root-owned dirs that actions/checkout (clean: true) can't rmdir
+          # (EACCES) — which then poison-fails EVERY subsequent job on that
+          # runner. Runs in both pre- and post-run cleanup (shared anchor).
+          sudo rm -rf "${GITHUB_WORKSPACE}/benchmark_logs" 2>/dev/null || true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3531,3 +3531,11 @@
     - "The Rust frontend replaces only the Python serving/API layer (HTTP, tokenization, scheduling glue, detokenization) and spawns the same Python EngineCore, so GPU kernels/attention/MoE GEMM/KV cache are untouched"
     - "A/B sweep (28 single-node points, 1k1k + 8k1k, TP 1/2/4) vs the Python-frontend baseline (run 26696260751): throughput Pareto-neutral (peak tok/s/GPU within <1.5%, frontiers coincident) and TPOT flat (+-0.5%); TTFT improves ~8% at 1k1k and ~22% at 8k1k (every point), the expected signature of lower frontend CPU latency before first token, scaling with input length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1634
+
+- config-keys:
+    - dsr1-fp4-gb300-dynamo-sglang-powercheck
+  description:
+    - "Minimal single-job GB300 validation of the measured-power perfmon plumbing before the full dsr1-disagg-NVIDIA sweep (NVIDIA analogue of the AMD smoke run in PR #1574). Same recipe + disagg topology as the 1k/1k low-latency cell of dsr1-fp4-gb300-dynamo-sglang (1 prefill TP4 + 2 decode TP4), trimmed to one concurrency (8) so the changelog matrix expands to exactly ONE gb300 job and the shared cluster stays clear."
+    - "Exercises the runner-side wiring added to runners/launch_gb300-nv.sh: the dsr1 branch clones SemiAnalysisAI/srt-slurm@feat/inferencex-perfmon (NVIDIA/srt-slurm PR #35) instead of upstream sa-submission, recursively injects `monitoring:` into every recipes/<hw>/<seq>/*.yaml (find -type f, never a flat glob — the flat glob is what silently produced 0 power rows in sweep #26548110246), and stages the per-node perf_samples_*.csv to $GITHUB_WORKSPACE before `rm -rf outputs`, setting GPU_METRICS_CSV_GLOB for the Process-result step."
+    - "Success criteria: job green AND the agg JSON patched with avg_power_w + per-stage prefill_avg_power_w/decode_avg_power_w + workers[] (role-labelled prefill/decode) from utils/aggregate_power.py. If those fields are absent the plumbing is not yet proven and the full dsr1-disagg-NVIDIA sweep stays gated. Remove this key (or keep as a GB300 power canary) once validated."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1686

--- a/runners/launch_gb300-cw.sh
+++ b/runners/launch_gb300-cw.sh
@@ -177,6 +177,15 @@ if [ "${PERFMON_ENABLED:-0}" = "1" ] && [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_F
         printf '\nmonitoring:\n  enabled: true\n  sample_interval: 1.0\n' >> "$CONFIG_FILE"
         echo "[perfmon] injected monitoring: into $CONFIG_FILE"
     fi
+    # CoreWeave: request unlimited node memory so pyxis/enroot can extract the
+    # 15-30 GB container squashfs without the cgroup OOM-killing unsquashfs
+    # (exit 137 -> prefill container never starts -> etcd down -> decode workers
+    # crash with "Could not connect to etcd"). The fork's gb300-fp4 recipe omits
+    # this; every working CW recipe (dsv4/glm5) sets sbatch_directives.mem: "0".
+    if ! grep -q '^sbatch_directives:' "$CONFIG_FILE"; then
+        printf '\nsbatch_directives:\n  mem: "0"\n' >> "$CONFIG_FILE"
+        echo "[perfmon] injected sbatch_directives.mem=0 into $CONFIG_FILE"
+    fi
 fi
 
 echo "Installing srtctl..."

--- a/runners/launch_gb300-cw.sh
+++ b/runners/launch_gb300-cw.sh
@@ -186,6 +186,16 @@ if [ "${PERFMON_ENABLED:-0}" = "1" ] && [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_F
         printf '\nsbatch_directives:\n  mem: "0"\n' >> "$CONFIG_FILE"
         echo "[perfmon] injected sbatch_directives.mem=0 into $CONFIG_FILE"
     fi
+    # dsr1 warmup (load 671B weights + FlashInfer autotune + capture 36 CUDA-graph
+    # batch sizes up to cuda-graph-max-bs 256) takes ~35 min, exceeding the default
+    # health_check ceiling (max_attempts 180 x interval 10 = 1800s/30min) — the
+    # orchestrator timed out and killed etcd mid-capture. Raise the ceiling to
+    # 90 min. It is a CEILING, not a fixed wait: the sweep proceeds the instant the
+    # servers report healthy, so generous headroom costs nothing.
+    if ! grep -q '^health_check:' "$CONFIG_FILE"; then
+        printf '\nhealth_check:\n  max_attempts: 540\n  interval_seconds: 10\n' >> "$CONFIG_FILE"
+        echo "[perfmon] injected health_check (90min ceiling) into $CONFIG_FILE"
+    fi
 fi
 
 echo "Installing srtctl..."

--- a/runners/launch_gb300-cw.sh
+++ b/runners/launch_gb300-cw.sh
@@ -59,8 +59,22 @@ elif [[ $MODEL_PREFIX == "glm5" && $PRECISION == "fp8" ]]; then
         echo "Unsupported framework on gb300-cw for glm5/fp8: $FRAMEWORK. Currently supported: dynamo-sglang"
         exit 1
     fi
+elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
+    # MEASURED-POWER CAMPAIGN — CoreWeave fallback for dsr1 (the gb300-nv fleet
+    # was wedged on its pre-run cleanup). Clone the perfmon fork directly: it
+    # already carries BOTH the gb300-fp4 dsr1 recipes (recipes/gb300-fp4/1k1k/
+    # *.yaml) AND the nvidia-smi perfmon machinery, so no hand-rolled recipe
+    # overlay is needed. Weights are pre-staged on CoreWeave at
+    # /mnt/vast/models/dsr1-fp4; the recipe's `model.path: dsr1` alias is mapped
+    # to that path in the srtslurm.yaml model_paths block below.
+    export MODEL_PATH="/mnt/vast/models/dsr1-fp4"
+    SRT_SLURM_RECIPES_REPO="https://github.com/SemiAnalysisAI/srt-slurm.git"
+    SRT_SLURM_RECIPES_REF="feat/inferencex-perfmon"
+    SRT_RECIPE_SRC=""   # fork ships the recipes; skip the overlay step
+    SRT_RECIPE_DST=""
+    export PERFMON_ENABLED=1
 else
-    echo "Unsupported model prefix/precision combination on gb300-cw: $MODEL_PREFIX/$PRECISION. Currently supported: dsv4/fp4, glm5/fp8"
+    echo "Unsupported model prefix/precision combination on gb300-cw: $MODEL_PREFIX/$PRECISION. Currently supported: dsv4/fp4, glm5/fp8, dsr1/fp4"
     exit 1
 fi
 
@@ -145,9 +159,25 @@ git clone "$SRT_SLURM_RECIPES_REPO" "$SRT_REPO_DIR"
 cd "$SRT_REPO_DIR"
 git checkout "$SRT_SLURM_RECIPES_REF"
 
-# Overlay the hand-rolled DSV4 recipes onto the selected srt-slurm checkout.
-mkdir -p "$SRT_RECIPE_DST"
-cp -rT "$SRT_RECIPE_SRC" "$SRT_RECIPE_DST"
+# Overlay the hand-rolled recipes onto the selected srt-slurm checkout — unless
+# the chosen repo already ships them (the dsr1 perfmon fork leaves
+# SRT_RECIPE_SRC empty because its recipes/gb300-fp4 dsr1 recipes are built in).
+if [ -n "$SRT_RECIPE_SRC" ]; then
+    mkdir -p "$SRT_RECIPE_DST"
+    cp -rT "$SRT_RECIPE_SRC" "$SRT_RECIPE_DST"
+fi
+
+# MEASURED-POWER CAMPAIGN: enable per-node nvidia-smi perfmon. `monitoring` is a
+# top-level SrtConfig field (defaults to None) that the orchestrator reads to
+# spawn perfmon.py, which writes perf_samples_*.csv. Inject it into the chosen
+# CONFIG_FILE recipe when running the perfmon fork (idempotent). srtctl applies
+# only this CONFIG_FILE, so injecting here is sufficient.
+if [ "${PERFMON_ENABLED:-0}" = "1" ] && [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+    if ! grep -q '^monitoring:' "$CONFIG_FILE"; then
+        printf '\nmonitoring:\n  enabled: true\n  sample_interval: 1.0\n' >> "$CONFIG_FILE"
+        echo "[perfmon] injected monitoring: into $CONFIG_FILE"
+    fi
+fi
 
 echo "Installing srtctl..."
 # CRITICAL — uv install location.
@@ -233,6 +263,10 @@ model_paths:
   deepseek-v4-pro: "${MODEL_PATH}"
   # GLM-5 FP8 sglang recipes use `model.path: glm-5-fp8`.
   glm-5-fp8: "${MODEL_PATH}"
+  # dsr1 fp4 sglang recipe (perfmon fork) uses `model.path: dsr1`; for dsr1 runs
+  # MODEL_PATH points at /mnt/vast/models/dsr1-fp4. Harmless on dsv4/glm5 runs
+  # (their recipes never reference the `dsr1` alias).
+  dsr1: "${MODEL_PATH}"
 containers:
   dynamo-trtllm: ${SQUASH_FILE}
   dynamo-sglang: ${SQUASH_FILE}
@@ -345,6 +379,24 @@ if [ -d "$LOGS_DIR" ]; then
     echo "multinode_server_logs.tar.gz will be (re)produced on script EXIT."
 else
     echo "Warning: Logs directory not found at $LOGS_DIR"
+fi
+
+# MEASURED-POWER CAMPAIGN: stage per-node perfmon CSVs for the downstream
+# "Process result" workflow step. The fork's perfmon writes perf_samples_*.csv
+# under the srt-slurm job logs dir; copy them into $GITHUB_WORKSPACE and export
+# GPU_METRICS_CSV_GLOB so process_result.py runs aggregate_power.py over them and
+# patches the agg JSON with measured power + temp/util/mem. Guarded on
+# PERFMON_ENABLED so dsv4/glm5 runs on this launcher are unaffected.
+if [ "${PERFMON_ENABLED:-0}" = "1" ] && [ -d "$LOGS_DIR" ]; then
+    if find "$LOGS_DIR" -name 'perf_samples_*.csv' 2>/dev/null | grep -q .; then
+        mkdir -p "$GITHUB_WORKSPACE/perf_samples"
+        find "$LOGS_DIR" -name 'perf_samples_*.csv' -exec cp {} "$GITHUB_WORKSPACE/perf_samples/" \;
+        perf_csv_count=$(ls "$GITHUB_WORKSPACE/perf_samples"/perf_samples_*.csv 2>/dev/null | wc -l | tr -d ' ')
+        echo "GPU_METRICS_CSV_GLOB=$GITHUB_WORKSPACE/perf_samples/perf_samples_*.csv" >> "$GITHUB_ENV"
+        echo "[perfmon] staged $perf_csv_count per-node perf_samples_*.csv to \$GITHUB_WORKSPACE/perf_samples/"
+    else
+        echo "[perfmon] WARNING: monitoring enabled but no perf_samples_*.csv found under $LOGS_DIR — measured power aggregation will be skipped" >&2
+    fi
 fi
 
 if [[ "${EVAL_ONLY:-false}" != "true" ]]; then

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -155,6 +155,39 @@ elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" && $PRECIS
     git checkout main
     mkdir -p recipes/vllm/minimax-m2.5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m2.5" recipes/vllm/minimax-m2.5
+elif [[ $MODEL_PREFIX == "dsr1" ]]; then
+    # MEASURED-POWER CAMPAIGN (dsr1-disagg-NVIDIA): clone the SemiAnalysisAI
+    # fork pinned to NVIDIA/srt-slurm PR #35 (feat/inferencex-perfmon) instead
+    # of upstream sa-submission-q2-2026 (the else branch). The fork is a
+    # SUPERSET: byte-identical dsr1 recipes (verified — under recipes/gb300-*
+    # only glm5.yaml differs, never the dsr1 recipes) PLUS the per-node
+    # nvidia-smi perfmon machinery (src/srtctl/monitor/perfmon.py) that writes
+    # perf_samples_*.csv when a recipe declares `monitoring:`. Pointing dsr1
+    # here is what turns the dsr1-disagg-NVIDIA energy charts MEASURED.
+    git clone https://github.com/SemiAnalysisAI/srt-slurm.git "$SRT_REPO_DIR"
+    cd "$SRT_REPO_DIR"
+    git checkout feat/inferencex-perfmon
+    export PERFMON_ENABLED=1
+    # Enable per-node GPU perfmon on every recipe. `monitoring` is a top-level
+    # SrtConfig field defaulting to None, so without this the orchestrator's
+    # _start_perf_monitor short-circuits and no perf_samples_*.csv is written.
+    # Idempotent. Use a RECURSIVE find, never a flat *.yaml glob: recipes live
+    # in recipes/<hw>/<seq>/*.yaml, and a flat glob matched zero files in PR
+    # #1574's sweep #26548110246 — it completed "success" with NO power data.
+    FOUND_COUNT=0
+    INJECTED_COUNT=0
+    while IFS= read -r recipe; do
+        FOUND_COUNT=$((FOUND_COUNT + 1))
+        if ! grep -q '^monitoring:' "$recipe"; then
+            printf '\nmonitoring:\n  enabled: true\n  sample_interval: 1.0\n' >> "$recipe"
+            INJECTED_COUNT=$((INJECTED_COUNT + 1))
+        fi
+    done < <(find recipes -type f -name '*.yaml')
+    if [ "$FOUND_COUNT" -eq 0 ]; then
+        echo "[perfmon] WARNING: zero recipe YAMLs found under recipes/ — power data will be MISSING from this run." >&2
+    else
+        echo "[perfmon] injected monitoring: into $INJECTED_COUNT of $FOUND_COUNT recipes."
+    fi
 else
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
@@ -407,6 +440,25 @@ fi
 # (it runs AFTER the rm below, since EXIT traps are last-thing-before-exit).
 # Without this inline call, R25 lost both 1p6d shards' logs.
 _snapshot_server_logs
+
+# MEASURED-POWER CAMPAIGN: stage per-node perfmon CSVs to a cleanup-proof
+# location and hand them to the downstream "Process result" step (a SEPARATE
+# workflow job step, run after this launch step finishes). srt-slurm perfmon
+# writes perf_samples_*.csv into $LOGS_DIR; the `rm -rf outputs` below would
+# delete them before Process result reads GPU_METRICS_CSV_GLOB — unlike
+# gb300-cw, which keeps outputs/ — so copy them under $GITHUB_WORKSPACE first.
+# Guarded on PERFMON_ENABLED so non-dsr1 models on this runner stay silent.
+if [ "${PERFMON_ENABLED:-0}" = "1" ] && [ -d "$LOGS_DIR" ]; then
+    perf_csv_count=$(ls "$LOGS_DIR"/perf_samples_*.csv 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$perf_csv_count" -gt 0 ]; then
+        mkdir -p "$GITHUB_WORKSPACE/perf_samples"
+        cp "$LOGS_DIR"/perf_samples_*.csv "$GITHUB_WORKSPACE/perf_samples/"
+        echo "GPU_METRICS_CSV_GLOB=$GITHUB_WORKSPACE/perf_samples/perf_samples_*.csv" >> "$GITHUB_ENV"
+        echo "[perfmon] staged $perf_csv_count per-node perf_samples_*.csv to \$GITHUB_WORKSPACE/perf_samples/"
+    else
+        echo "[perfmon] WARNING: monitoring enabled but no perf_samples_*.csv found in $LOGS_DIR — measured power aggregation will be skipped" >&2
+    fi
+fi
 
 # Clean up srt-slurm outputs to prevent NFS silly-rename lock files
 # from blocking the next job's checkout on this runner

--- a/utils/aggregate_power.py
+++ b/utils/aggregate_power.py
@@ -1,21 +1,77 @@
-"""Aggregate measured GPU power from a vendor SMI CSV into the agg result JSON.
+"""Aggregate measured GPU telemetry (power, temp, utilization, memory) from a
+vendor SMI CSV into the agg result JSON.
 
-Reads a GPU-metrics CSV produced by `start_gpu_monitor` (nvidia-smi or amd-smi),
-filters samples to the benchmark load window using start/end Unix timestamps
-written by benchmark_serving.py, and patches two keys into the aggregated
-result JSON consumed by InferenceX-app's ETL:
+Reads a GPU-metrics CSV produced by `start_gpu_monitor` (nvidia-smi or amd-smi)
+or by srt-slurm's per-node perfmon (multinode), filters samples to the benchmark
+load window using start/end Unix timestamps written by benchmark_serving.py, and
+patches the aggregated result JSON with cluster-wide and per-worker telemetry
+consumed by InferenceX-app's ETL.
 
+Cluster-wide fields (always written when any power data exists):
   - avg_power_w:               mean per-GPU power draw (W) during the load window
-  - joules_per_output_token:   (avg_power_w * num_gpus * duration_s) / total_output_tokens
+  - joules_per_output_token:   energy / total_output_tokens. CLUSTER-WIDE
+                               (total_system_energy) on single-node / non-disagg;
+                               OVERRIDDEN to per-stage decode_energy for disagg
+                               (see below).
+  - joules_per_total_token:    total_system_energy / (input + output) tokens
+                               (cluster-wide; always — overall efficiency number)
+  - avg_temp_c:                mean per-GPU temperature (Celsius), when the
+                               CSV exposes a temperature column
+  - peak_temp_c:               max instantaneous per-GPU temperature in window
+  - avg_util_pct:              mean per-GPU GPU-utilization percent
+  - avg_mem_used_mb:           mean per-GPU memory used (MiB/MB)
 
-The ETL (`packages/db/src/etl/benchmark-mapper.ts`) auto-captures any numeric
-field in the agg JSON into the `metrics` JSONB column, so no schema migration
-is required.
+For disaggregated multinode runs (DISAGG=true) where filenames carry the perfmon
+role/index encoding AND both prefill+decode workers are present, the per-token
+energy metrics use PER-STAGE attribution — each token type is divided by only the
+GPUs of the stage that produces it (the standard disagg-serving convention):
 
-Vendor schema detection is regex-based: any timestamp-like column + any column
-whose name contains "power" (excluding "limit"/"cap"/"max") is picked up.
-NVIDIA emits "power.draw [W]"; AMD's amd-smi varies by version. Both are
-handled.
+  - joules_per_input_token:    prefill_energy / total_input_tokens — input tokens
+                               are processed by the prefill GPUs only.
+  - joules_per_output_token:   decode_energy / total_output_tokens — output tokens
+                               are produced by the decode GPUs only. (For
+                               single-node / non-disagg this stays the cluster-wide
+                               total_system_energy / output_tokens.)
+  - prefill_avg_power_w:       per-GPU mean power across prefill workers
+  - decode_avg_power_w:        per-GPU mean power across decode workers
+
+Per-worker breakdown (multinode only — single-node has no role concept), emitted
+under the `workers` key to match InferenceX-app's BenchmarkRow.workers shape:
+  - workers: list of {role, worker_idx, hosts[], num_gpus, avg_power_w,
+                       avg_temp_c?, peak_temp_c?, avg_util_pct?, avg_mem_used_mb?}
+             where role is "prefill", "decode", "agg", or "frontend".
+
+Both multinode paths encode the worker role and index in the perfmon CSV
+filename: `perf_samples_<role>_w<worker_idx>_<host>.csv` — NVIDIA via the
+srt-slurm fork's benchmark_stage._start_perf_monitor, AMD via start_perf_monitor
+in benchmarks/benchmark_lib.sh (each SGLang/vLLM disagg node starts its own
+amd-smi monitor). Filenames that don't match this pattern (e.g. single-node
+`gpu_metrics.csv`) fall back to a single cluster-wide bucket.
+
+Multinode: accepts multiple CSV paths (one per worker node). GPU indices are
+namespaced by source CSV stem to avoid the same-index collision across nodes —
+e.g. 8 nodes each reporting indices 0..3 would otherwise be miscounted as 4
+total GPUs instead of 32.
+
+Vendor schema detection is regex-based:
+  - Power: timestamp + column whose name contains "power" (excluding
+    "limit"/"cap"/"max"/"min"). NVIDIA: "power.draw [W]". AMD: "socket_power".
+    srt-slurm: "power_w".
+  - Temperature: column name contains "temp"; hotspot/junction columns are
+    preferred over the first match because data-center AMD parts report edge
+    temperature as N/A. NVIDIA: "temperature.gpu". AMD amd-smi: "edge_temperature"
+    / "hotspot_temperature" (junction picked). srt-slurm: "temp_c". Unit: Celsius.
+  - Utilization: column starts with "utilization" or contains "util", or is
+    amd-smi's "gfx_activity" (umc_activity / mm_activity are not matched).
+    NVIDIA: "utilization.gpu". srt-slurm: "util_pct". Unit: percent.
+  - Memory used: column mentions memory/vram AND "used" — picks NVIDIA
+    "memory.used [MiB]", srt-slurm "mem_used_mb", amd-smi "used_vram"; rejects
+    decoys lacking "used" (memory.total / total_vram / free_vram, the memory
+    *clock* "clocks.current.memory", utilization.memory, mem_temperature,
+    mem_voltage). Unit: MiB/MB.
+
+Power is required for aggregation to fire; the other metrics degrade gracefully
+when their columns are absent (those fields are simply omitted from the output).
 
 This script is best-effort. Missing or malformed CSV exits 0 without patching
 so a monitoring hiccup never breaks the benchmark upload.
@@ -25,9 +81,11 @@ from __future__ import annotations
 
 import argparse
 import csv
+import glob as glob_module
 import json
 import re
 import sys
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -35,9 +93,41 @@ from statistics import mean
 
 _POWER_COL_RE = re.compile(r"power", re.IGNORECASE)
 _POWER_EXCLUDE_RE = re.compile(r"limit|cap|max|min", re.IGNORECASE)
+_TEMP_COL_RE = re.compile(r"temp", re.IGNORECASE)
+# Data-center AMD parts (MI300/MI355) report edge temperature as N/A and expose
+# the real die temperature as hotspot/junction; prefer those when present so
+# avg_temp_c isn't computed over an all-N/A edge column. NVIDIA's single
+# "temperature.gpu" and srt-slurm's "temp_c" have neither token and fall through
+# to the first temperature column unchanged.
+_TEMP_PREFER_RE = re.compile(r"hotspot|junction", re.IGNORECASE)
+# Utilization: NVIDIA "utilization.gpu", srt-slurm "util_pct", AMD amd-smi
+# "gfx_activity" (the GPU/graphics-engine busy percent). amd-smi's other usage
+# columns — umc_activity (memory controller), mm_activity (multimedia) — are
+# intentionally NOT matched so gfx_activity is the one picked.
+_UTIL_COL_RE = re.compile(r"^utilization|util|gfx_activity", re.IGNORECASE)
+# Memory *used*: match positively on a column that mentions both memory/vram and
+# "used" rather than broad "mem" + a growing exclude list. This naturally picks
+# NVIDIA "memory.used [MiB]", srt-slurm "mem_used_mb", and amd-smi "used_vram"
+# while rejecting same-prefix decoys that lack "used": memory.total / total_vram /
+# free_vram, clocks.current.memory (a frequency), utilization.memory (a percent),
+# and amd-smi's mem_temperature / mem_voltage.
+_MEM_COL_RE = re.compile(r"(?:mem|vram).*used|used.*(?:mem|vram)", re.IGNORECASE)
 _TIMESTAMP_COL_RE = re.compile(r"time", re.IGNORECASE)
 _GPU_INDEX_COL_RE = re.compile(r"^(index|gpu|gpu_id|gpu_index|card|device)$", re.IGNORECASE)
 _NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+# srt-slurm perfmon filename: perf_samples_<role>_w<worker_idx>_<host>.csv
+# Roles: prefill, decode, agg, frontend (see srt-slurm benchmark_stage._label).
+# Host may contain hyphens and digits; greedy `.+` is fine because the `_w<idx>_`
+# anchor is unambiguous.
+_PERFMON_LABEL_RE = re.compile(
+    r"^perf_samples_(?P<role>prefill|decode|agg|frontend)_w(?P<idx>\d+)_(?P<host>.+)$"
+)
+
+# Metric names recognized in the multi-metric row dicts. Power is special-cased
+# as required; others are best-effort.
+_METRICS_AVG = ("power", "temp", "util", "mem")  # mean across samples
+_METRICS_MAX = ("temp",)  # additionally compute peak (max raw)
 
 
 def _parse_timestamp(value: str) -> float | None:
@@ -74,11 +164,12 @@ def _parse_timestamp(value: str) -> float | None:
     return dt.astimezone(timezone.utc).timestamp()
 
 
-def _parse_power(value: str) -> float | None:
-    """Extract the first numeric value from a power cell.
+def _parse_numeric_cell(value: str) -> float | None:
+    """Extract the first numeric value from a cell.
 
-    nvidia-smi formats power as "412.34 W"; some configurations report
-    "[N/A]" when power capping is disabled. AMD reports a bare number.
+    Vendors decorate values with units ("412.34 W", "65 C", "85 %", "1024 MiB")
+    or report "[N/A]" when a sensor is unavailable. We strip and pull the first
+    signed-decimal token; returns None for empty / NA / non-numeric cells.
     """
     value = value.strip()
     if not value or value.lower() in {"[n/a]", "n/a", "na"}:
@@ -92,12 +183,19 @@ def _parse_power(value: str) -> float | None:
         return None
 
 
+# Back-compat shim — some external callers may have imported _parse_power.
+_parse_power = _parse_numeric_cell
+
+
 def _detect_columns(header: list[str]) -> tuple[str | None, str | None, str | None]:
     """Return (timestamp_col, power_col, gpu_index_col) from a CSV header.
 
     Power column: contains "power" and not "limit"/"cap"/"max"/"min".
     Timestamp column: contains "time".
     GPU index column: optional — used to count distinct GPUs per sample.
+
+    Kept for back-compat with tests that imported _detect_columns directly;
+    new code uses _detect_all_columns to also pick up temp/util/mem.
     """
     timestamp_col = next((c for c in header if _TIMESTAMP_COL_RE.search(c)), None)
     power_col = next(
@@ -108,93 +206,356 @@ def _detect_columns(header: list[str]) -> tuple[str | None, str | None, str | No
     return timestamp_col, power_col, gpu_col
 
 
+def _detect_all_columns(header: list[str]) -> dict[str, str | None]:
+    """Return a mapping of role -> column name for every metric we know about.
+
+    Roles: timestamp, gpu, power, temp, util, mem. Missing roles map to None.
+
+    The detection is greedy + first-match: with a vendor like NVIDIA whose
+    header lists `utilization.gpu` followed by `utilization.memory`, the
+    util slot picks the first; that's fine — we only need ONE util column and
+    `utilization.gpu` is the canonical one. Memory excludes "total" so
+    `memory.used` wins over `memory.total`.
+    """
+    timestamp_col = next((c for c in header if _TIMESTAMP_COL_RE.search(c)), None)
+    power_col = next(
+        (c for c in header if _POWER_COL_RE.search(c) and not _POWER_EXCLUDE_RE.search(c)),
+        None,
+    )
+    temp_cols = [c for c in header if _TEMP_COL_RE.search(c)]
+    # Prefer hotspot/junction (the real die temp on data-center AMD parts) over
+    # the first temperature column (edge on AMD, temperature.gpu on NVIDIA).
+    temp_col = next((c for c in temp_cols if _TEMP_PREFER_RE.search(c)), None) or (
+        temp_cols[0] if temp_cols else None
+    )
+    util_col = next((c for c in header if _UTIL_COL_RE.search(c)), None)
+    mem_col = next((c for c in header if _MEM_COL_RE.search(c)), None)
+    gpu_col = next((c for c in header if _GPU_INDEX_COL_RE.match(c.strip())), None)
+    return {
+        "timestamp": timestamp_col,
+        "gpu": gpu_col,
+        "power": power_col,
+        "temp": temp_col,
+        "util": util_col,
+        "mem": mem_col,
+    }
+
+
+def _parse_perfmon_label(path: Path) -> tuple[str, int, str] | None:
+    """Extract (role, worker_idx, host) from a srt-slurm perfmon CSV filename.
+
+    Returns None for filenames not matching the perfmon pattern (e.g.
+    single-node `gpu_metrics.csv`). Used to group node-level CSVs by the
+    worker(s) running on each node.
+    """
+    m = _PERFMON_LABEL_RE.match(path.stem)
+    if not m:
+        return None
+    return m.group("role"), int(m.group("idx")), m.group("host")
+
+
+def _read_samples(
+    path: Path, start_unix: float, end_unix: float
+) -> tuple[list[tuple[float, str | None, dict[str, float]]], bool] | None:
+    """Read one CSV → list of (timestamp_bucket, gpu_id, {metric: value}) in window.
+
+    Returns (rows, saw_gpu_col) on success, None if the file is unreadable /
+    missing the required power column. Empty rows list is valid (file readable
+    but no samples landed in the window).
+
+    Each row's metric dict carries whichever of power/temp/util/mem the CSV
+    exposed (power is always present — rows lacking it are skipped). Missing
+    metric columns simply don't appear in the dict; callers gracefully degrade.
+    """
+    if not path.is_file() or path.stat().st_size == 0:
+        return None
+    try:
+        with path.open("r", newline="", encoding="utf-8", errors="replace") as f:
+            reader = csv.DictReader(f, skipinitialspace=True)
+            header = [c.strip() for c in (reader.fieldnames or [])]
+            reader.fieldnames = header
+            cols = _detect_all_columns(header)
+            timestamp_col = cols["timestamp"]
+            power_col = cols["power"]
+            if not timestamp_col or not power_col:
+                return None
+            gpu_col = cols["gpu"]
+            # Map metric name -> CSV column. Power is required (we just
+            # checked); temp/util/mem are optional.
+            metric_cols: dict[str, str] = {"power": power_col}
+            for metric in ("temp", "util", "mem"):
+                col = cols[metric]
+                if col is not None:
+                    metric_cols[metric] = col
+            rows: list[tuple[float, str | None, dict[str, float]]] = []
+            for row in reader:
+                ts = _parse_timestamp((row.get(timestamp_col) or "").strip())
+                if ts is None:
+                    continue
+                if ts < start_unix or ts > end_unix:
+                    continue
+                # Power must parse; rows with [N/A] or empty power are useless
+                # for aggregation (same behavior as before the multi-metric
+                # extension).
+                pw = _parse_numeric_cell((row.get(power_col) or "").strip())
+                if pw is None:
+                    continue
+                values: dict[str, float] = {"power": pw}
+                for metric, col in metric_cols.items():
+                    if metric == "power":
+                        continue
+                    v = _parse_numeric_cell((row.get(col) or "").strip())
+                    if v is not None:
+                        values[metric] = v
+                gpu_id = (row.get(gpu_col) or "").strip() if gpu_col else None
+                rows.append((round(ts, 3), gpu_id or None, values))
+            return rows, gpu_col is not None
+    except (OSError, csv.Error):
+        return None
+
+
+def _aggregate_rows(
+    sources: list[tuple[Path, list[tuple[float, str | None, dict[str, float]]], bool]],
+    *,
+    namespace: bool,
+) -> dict | None:
+    """Merge rows across CSVs into a metric-dict + num_gpus.
+
+    `sources` is a list of (path, rows, saw_gpu_col) for the CSVs to roll up
+    together. Rows are bucketed by ms-rounded timestamp so nodes with sub-ms
+    clock drift land in the same bucket. GPU indices are namespaced by the
+    source path's stem when `namespace=True` (multi-source case) to keep
+    same-local-index across nodes from collapsing.
+
+    Returns a dict with at minimum {"power": float, "num_gpus": int}. Each
+    additional metric (temp/util/mem) is included only when at least one
+    source emitted it. peak_temp is the global max across the window
+    (instantaneous, not per-bucket-mean).
+    """
+    # Per-bucket totals keyed by metric name. Bucket = ms-rounded timestamp.
+    per_sample_total: dict[str, dict[float, float]] = {m: {} for m in _METRICS_AVG}
+    per_sample_count: dict[str, dict[float, int]] = {m: {} for m in _METRICS_AVG}
+    per_sample_row_count: dict[float, int] = {}  # for no-gpu-col GPU inference
+    per_sample_gpus: dict[float, set[str]] = {}
+    gpu_keys: set[str] = set()
+    saw_gpu_col_any = False
+    saw_metric: dict[str, bool] = {m: False for m in _METRICS_AVG}
+    peak_per_metric: dict[str, float] = {}
+
+    for path, rows, saw_gpu_col in sources:
+        if saw_gpu_col:
+            saw_gpu_col_any = True
+        for bucket, gpu_id, values in rows:
+            per_sample_row_count[bucket] = per_sample_row_count.get(bucket, 0) + 1
+            for metric, v in values.items():
+                if metric not in per_sample_total:
+                    continue
+                per_sample_total[metric][bucket] = (
+                    per_sample_total[metric].get(bucket, 0.0) + v
+                )
+                per_sample_count[metric][bucket] = (
+                    per_sample_count[metric].get(bucket, 0) + 1
+                )
+                saw_metric[metric] = True
+                if metric in _METRICS_MAX:
+                    cur = peak_per_metric.get(metric)
+                    peak_per_metric[metric] = v if cur is None else max(cur, v)
+            if gpu_id is not None:
+                ns_id = f"{path.stem}:{gpu_id}" if namespace else gpu_id
+                per_sample_gpus.setdefault(bucket, set()).add(ns_id)
+                gpu_keys.add(ns_id)
+
+    if not per_sample_total["power"]:
+        return None
+
+    # GPU count:
+    # - If any path exposed a GPU column, trust distinct (namespaced) GPU IDs.
+    # - Otherwise, infer from row count (one row per GPU per sample, summed
+    #   across all paths' rows that fell into the same timestamp bucket).
+    if saw_gpu_col_any and gpu_keys:
+        num_gpus = len(gpu_keys)
+    else:
+        num_gpus = max(per_sample_row_count.values())
+
+    def _avg_per_gpu(metric: str) -> float | None:
+        if not saw_metric.get(metric):
+            return None
+        totals = per_sample_total[metric]
+        if not totals:
+            return None
+        if saw_gpu_col_any and gpu_keys:
+            # bucket mean = sum / distinct GPU count in that bucket
+            per_sample_mean = [
+                total / max(len(per_sample_gpus.get(ts, ())), 1)
+                for ts, total in totals.items()
+            ]
+        else:
+            # bucket mean = sum / row count in that bucket (= GPU count when
+            # one row per GPU per sample, the universal vendor convention)
+            per_sample_mean = [
+                total / per_sample_count[metric][ts] for ts, total in totals.items()
+            ]
+        return mean(per_sample_mean) if per_sample_mean else None
+
+    result: dict = {"num_gpus": num_gpus, "power": _avg_per_gpu("power")}
+    for metric in ("temp", "util", "mem"):
+        avg = _avg_per_gpu(metric)
+        if avg is not None:
+            result[metric] = avg
+    # Peak (max raw value, not per-bucket-mean): meaningful for temperature
+    # where the worst-case GPU's hottest sample is the thermal-headroom signal.
+    if "temp" in peak_per_metric:
+        result["peak_temp"] = peak_per_metric["temp"]
+    return result
+
+
 def aggregate_power(
-    csv_path: Path,
+    csv_path: Path | Iterable[Path],
     start_unix: float,
     end_unix: float,
 ) -> tuple[float, int] | None:
     """Return (per_gpu_avg_power_w, num_gpus) for samples in [start, end].
 
-    Returns None if the CSV is missing, empty, has no detectable power column,
-    or no rows fall in the window.
+    Backward-compatible wrapper around aggregate_metrics that returns just the
+    legacy (avg_power_w, num_gpus) tuple for callers (and tests) that don't
+    need temperature/util/memory.
     """
-    if not csv_path.is_file() or csv_path.stat().st_size == 0:
+    res = aggregate_metrics(csv_path, start_unix, end_unix)
+    if res is None:
         return None
-    if end_unix <= start_unix:
-        return None
+    return res["power"], res["num_gpus"]
 
-    try:
-        with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
-            reader = csv.DictReader(f, skipinitialspace=True)
-            header = [c.strip() for c in (reader.fieldnames or [])]
-            reader.fieldnames = header
-            timestamp_col, power_col, gpu_col = _detect_columns(header)
-            if not timestamp_col or not power_col:
-                return None
 
-            # Group power readings by sample timestamp so per-sample total power
-            # (sum across GPUs) is computed correctly even if rows are interleaved.
-            #
-            # per_sample_row_count is the structural divisor: it's incremented for
-            # every contributing row regardless of whether a GPU-index column was
-            # detected. per_sample_gpus / gpu_keys are only populated when gpu_col
-            # is present and provide the canonical num_gpus via distinct-id count.
-            # When gpu_col is absent (vendor schema variant whose header doesn't
-            # match _GPU_INDEX_COL_RE), we fall back to inferring num_gpus from
-            # the modal row count per timestamp — assuming one row per GPU per
-            # sample, which is what every SMI tool we've seen actually emits.
-            per_sample_total: dict[float, float] = {}
-            per_sample_row_count: dict[float, int] = {}
-            per_sample_gpus: dict[float, set[str]] = {}
-            gpu_keys: set[str] = set()
+def aggregate_metrics(
+    csv_path: Path | Iterable[Path],
+    start_unix: float,
+    end_unix: float,
+) -> dict | None:
+    """Return a dict of cluster-wide per-GPU metrics for samples in [start, end].
 
-            for row in reader:
-                ts_raw = (row.get(timestamp_col) or "").strip()
-                pw_raw = (row.get(power_col) or "").strip()
-                ts = _parse_timestamp(ts_raw)
-                pw = _parse_power(pw_raw)
-                if ts is None or pw is None:
-                    continue
-                if ts < start_unix or ts > end_unix:
-                    continue
-                # Bucket by sample timestamp (rounded to ms to absorb sub-ms drift).
-                bucket = round(ts, 3)
-                per_sample_total[bucket] = per_sample_total.get(bucket, 0.0) + pw
-                per_sample_row_count[bucket] = per_sample_row_count.get(bucket, 0) + 1
-                if gpu_col:
-                    gpu_id = (row.get(gpu_col) or "").strip()
-                    if gpu_id:
-                        per_sample_gpus.setdefault(bucket, set()).add(gpu_id)
-                        gpu_keys.add(gpu_id)
-    except (OSError, csv.Error):
+    Accepts either a single Path (single-node case) or an iterable of Paths
+    (multinode case: one CSV per worker node, all written by srt-slurm's
+    perfmon). For multi-path inputs, GPU indices are namespaced by source
+    CSV stem so the distinct-id count reflects the true total — each node
+    independently reports indices 0..N, and without namespacing the union
+    would collapse to a single node's worth.
+
+    Returns None if no CSVs are usable, none have a detectable power column,
+    or no rows fall in the window across all paths.
+
+    Result keys: num_gpus, power (always when not None); temp, util, mem,
+    peak_temp (only when the corresponding column existed in at least one CSV).
+    """
+    paths = [csv_path] if isinstance(csv_path, Path) else list(csv_path)
+    if not paths or end_unix <= start_unix:
         return None
 
-    if not per_sample_total:
+    sources: list[tuple[Path, list[tuple[float, str | None, dict[str, float]]], bool]] = []
+    for path in paths:
+        read = _read_samples(path, start_unix, end_unix)
+        if read is None:
+            continue
+        rows, saw_gpu_col = read
+        sources.append((path, rows, saw_gpu_col))
+    if not sources:
         return None
 
-    # Per-sample divisor and overall num_gpus.
-    # - If a GPU column was detected, trust distinct GPU IDs (correct for any
-    #   sampling pattern, including hot-swap or partial visibility).
-    # - Otherwise, infer from row count (one row per GPU per sample).
-    if gpu_col and gpu_keys:
-        num_gpus = len(gpu_keys)
-        per_sample_mean_per_gpu = [
-            total / max(len(per_sample_gpus.get(ts, ())), 1)
-            for ts, total in per_sample_total.items()
-        ]
-    else:
-        num_gpus = max(per_sample_row_count.values())
-        per_sample_mean_per_gpu = [
-            total / per_sample_row_count[ts] for ts, total in per_sample_total.items()
-        ]
-    return mean(per_sample_mean_per_gpu), num_gpus
+    return _aggregate_rows(sources, namespace=len(paths) > 1)
+
+
+def aggregate_power_by_worker(
+    csv_paths: Iterable[Path],
+    start_unix: float,
+    end_unix: float,
+) -> list[dict] | None:
+    """Group CSVs by (role, worker_idx) and return per-worker telemetry rollups.
+
+    Each entry: {role, worker_idx, hosts: sorted list, num_gpus, avg_power_w,
+                  avg_temp_c?, peak_temp_c?, avg_util_pct?, avg_mem_used_mb?}.
+    The optional fields appear only when the CSVs for that worker carried
+    temperature / utilization / memory columns.
+
+    Returns None if no CSVs have parseable filenames OR no labeled CSV yields
+    usable samples. Unlabeled CSVs in the input are silently skipped — they
+    can't be attributed to a worker.
+
+    Hosts are listed because a single worker can span multiple nodes (e.g.
+    a 16-GPU decode worker over 4 nodes, all labeled decode_w0_<host>).
+    Multiple node-CSVs sharing the same (role, worker_idx) collapse into one
+    worker entry whose num_gpus is the sum across nodes.
+    """
+    paths = list(csv_paths)
+    if not paths or end_unix <= start_unix:
+        return None
+
+    # Group paths by (role, worker_idx); discard unlabeled.
+    by_worker: dict[tuple[str, int], list[Path]] = {}
+    hosts_by_worker: dict[tuple[str, int], set[str]] = {}
+    for p in paths:
+        label = _parse_perfmon_label(p)
+        if label is None:
+            continue
+        role, worker_idx, host = label
+        key = (role, worker_idx)
+        by_worker.setdefault(key, []).append(p)
+        hosts_by_worker.setdefault(key, set()).add(host)
+    if not by_worker:
+        return None
+
+    out: list[dict] = []
+    for (role, worker_idx), worker_paths in by_worker.items():
+        sources: list[tuple[Path, list[tuple[float, str | None, dict[str, float]]], bool]] = []
+        for path in worker_paths:
+            read = _read_samples(path, start_unix, end_unix)
+            if read is None:
+                continue
+            rows, saw_gpu_col = read
+            sources.append((path, rows, saw_gpu_col))
+        if not sources:
+            continue
+        # Namespace across paths within a worker too — a 16-GPU decode worker
+        # spans 4 nodes, each reporting local indices 0..3.
+        result = _aggregate_rows(sources, namespace=len(sources) > 1)
+        if result is None:
+            continue
+        entry: dict = {
+            "role": role,
+            "worker_idx": worker_idx,
+            "hosts": sorted(hosts_by_worker[(role, worker_idx)]),
+            "num_gpus": result["num_gpus"],
+            "avg_power_w": round(result["power"], 3),
+        }
+        if "temp" in result:
+            entry["avg_temp_c"] = round(result["temp"], 3)
+        if "peak_temp" in result:
+            entry["peak_temp_c"] = round(result["peak_temp"], 3)
+        if "util" in result:
+            entry["avg_util_pct"] = round(result["util"], 3)
+        if "mem" in result:
+            entry["avg_mem_used_mb"] = round(result["mem"], 3)
+        out.append(entry)
+    if not out:
+        return None
+    # Stable order: role (prefill < decode < agg < frontend), then worker_idx.
+    role_order = {"prefill": 0, "decode": 1, "agg": 2, "frontend": 3}
+    out.sort(key=lambda w: (role_order.get(w["role"], 99), w["worker_idx"]))
+    return out
 
 
 def _load_bench_window(
     bench_result_path: Path,
 ) -> tuple[float, float, float, int, int] | None:
     """Read (start_unix, end_unix, duration_s, total_output_tokens, total_input_tokens)
-    from the raw bench JSON. Returns None if any required field is missing.
+    from the raw bench JSON. Returns None if a window cannot be resolved.
+
+    Window resolution order, tried in turn:
+      1. benchmark_start_time_unix + benchmark_end_time_unix (our benchmark_serving.py
+         writes both — single-node, brackets the actual load window exactly).
+      2. date + duration (srt-slurm sa-bench writes "YYYYMMDD-HHMMSS" UTC as the
+         result write time — multinode; treat as bench end and subtract duration
+         for start. Overshoots by post-bench JSON serialization, typically <5s).
+      3. file mtime + duration (last resort if `date` is absent or unparseable —
+         same end-of-bench proxy as #2 via the result file's mtime).
 
     total_input_tokens defaults to 0 if absent (older bench JSONs may not have it);
     this only degrades joules_per_total_token to equal joules_per_output_token in
@@ -204,18 +565,52 @@ def _load_bench_window(
         bench = json.loads(bench_result_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    start = bench.get("benchmark_start_time_unix")
-    end = bench.get("benchmark_end_time_unix")
     duration = bench.get("duration")
     total_output = bench.get("total_output_tokens")
     total_input = bench.get("total_input_tokens", 0)
-    if not all(isinstance(v, (int, float)) for v in (start, end, duration)):
+    if not isinstance(duration, (int, float)):
         return None
     if not isinstance(total_output, int) or total_output <= 0:
         return None
     if not isinstance(total_input, int) or total_input < 0:
         total_input = 0
-    return float(start), float(end), float(duration), int(total_output), int(total_input)
+
+    # Tier 1: explicit Unix timestamps (single-node bench_serving.py).
+    start = bench.get("benchmark_start_time_unix")
+    end = bench.get("benchmark_end_time_unix")
+    if isinstance(start, (int, float)) and isinstance(end, (int, float)):
+        return float(start), float(end), float(duration), int(total_output), int(total_input)
+
+    # Tier 2: parse `date` field (srt-slurm sa-bench multinode). On observed
+    # runs the string matches file mtime to the second, confirming it's the
+    # JSON write time.
+    date_str = bench.get("date")
+    if isinstance(date_str, str):
+        try:
+            end_dt = datetime.strptime(date_str, "%Y%m%d-%H%M%S").replace(tzinfo=timezone.utc)
+            end_unix = end_dt.timestamp()
+            return (
+                float(end_unix - duration),
+                float(end_unix),
+                float(duration),
+                int(total_output),
+                int(total_input),
+            )
+        except ValueError:
+            pass
+
+    # Tier 3: file mtime as last-resort bench-end proxy.
+    try:
+        end_unix = bench_result_path.stat().st_mtime
+    except OSError:
+        return None
+    return (
+        float(end_unix - duration),
+        float(end_unix),
+        float(duration),
+        int(total_output),
+        int(total_input),
+    )
 
 
 def patch_agg_result(
@@ -223,18 +618,101 @@ def patch_agg_result(
     avg_power_w: float,
     joules_per_output_token: float,
     joules_per_total_token: float,
+    joules_per_input_token: float | None = None,
+    prefill_avg_power_w: float | None = None,
+    decode_avg_power_w: float | None = None,
+    avg_temp_c: float | None = None,
+    peak_temp_c: float | None = None,
+    avg_util_pct: float | None = None,
+    avg_mem_used_mb: float | None = None,
+    workers: list[dict] | None = None,
 ) -> None:
-    """Read the agg JSON, add the three power keys, and write it back atomically."""
+    """Read the agg JSON, add the telemetry keys, and write it back atomically.
+
+    All optional fields (anything except avg_power_w / joules_per_output_token /
+    joules_per_total_token) are omitted from the JSON when None — keeps the
+    pre-disagg / single-node agg JSONs from gaining meaningless null fields, and
+    keeps non-power-instrumented runs (e.g. no temp sensor) from emitting nulls.
+    """
     data = json.loads(agg_path.read_text(encoding="utf-8"))
     data["avg_power_w"] = round(avg_power_w, 3)
     data["joules_per_output_token"] = round(joules_per_output_token, 6)
     data["joules_per_total_token"] = round(joules_per_total_token, 6)
+    if joules_per_input_token is not None:
+        data["joules_per_input_token"] = round(joules_per_input_token, 6)
+    if prefill_avg_power_w is not None:
+        data["prefill_avg_power_w"] = round(prefill_avg_power_w, 3)
+    if decode_avg_power_w is not None:
+        data["decode_avg_power_w"] = round(decode_avg_power_w, 3)
+    if avg_temp_c is not None:
+        data["avg_temp_c"] = round(avg_temp_c, 3)
+    if peak_temp_c is not None:
+        data["peak_temp_c"] = round(peak_temp_c, 3)
+    if avg_util_pct is not None:
+        data["avg_util_pct"] = round(avg_util_pct, 3)
+    if avg_mem_used_mb is not None:
+        data["avg_mem_used_mb"] = round(avg_mem_used_mb, 3)
+    if workers is not None:
+        data["workers"] = workers
     tmp_path = agg_path.with_suffix(agg_path.suffix + ".tmp")
     tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     tmp_path.replace(agg_path)
 
 
-def run(csv_path: Path, bench_result: Path, agg_result: Path) -> int:
+def _disagg_stage_rollup(
+    workers: list[dict], duration: float
+) -> dict | None:
+    """Roll up per-worker entries into per-stage energy + per-GPU mean power.
+
+    Returns a dict with keys:
+      - prefill_energy_j, decode_energy_j: sum of (avg_power_w * num_gpus *
+        duration) across workers in each role
+      - prefill_avg_power_w, decode_avg_power_w: per-GPU mean power weighted
+        by num_gpus (matches the cluster avg_power_w semantics, but scoped to
+        each role)
+
+    Returns None if either stage is absent — without both stages we can't do
+    per-stage attribution and the caller should fall back to total-energy math.
+    """
+    prefill_energy = 0.0
+    decode_energy = 0.0
+    prefill_gpus = 0
+    decode_gpus = 0
+    prefill_pw_x_gpus = 0.0
+    decode_pw_x_gpus = 0.0
+    has_prefill = False
+    has_decode = False
+    for w in workers:
+        e = w["avg_power_w"] * w["num_gpus"] * duration
+        if w["role"] == "prefill":
+            prefill_energy += e
+            prefill_gpus += w["num_gpus"]
+            prefill_pw_x_gpus += w["avg_power_w"] * w["num_gpus"]
+            has_prefill = True
+        elif w["role"] == "decode":
+            decode_energy += e
+            decode_gpus += w["num_gpus"]
+            decode_pw_x_gpus += w["avg_power_w"] * w["num_gpus"]
+            has_decode = True
+        # "frontend" / "agg" / unknown roles deliberately excluded — they
+        # don't belong to either stage's per-token cost or per-stage power.
+    if not (has_prefill and has_decode):
+        return None
+    return {
+        "prefill_energy_j": prefill_energy,
+        "decode_energy_j": decode_energy,
+        "prefill_avg_power_w": prefill_pw_x_gpus / prefill_gpus if prefill_gpus else None,
+        "decode_avg_power_w": decode_pw_x_gpus / decode_gpus if decode_gpus else None,
+    }
+
+
+def run(
+    csv_path: Path | Iterable[Path],
+    bench_result: Path,
+    agg_result: Path,
+    *,
+    disagg: bool = False,
+) -> int:
     window = _load_bench_window(bench_result)
     if window is None:
         print(
@@ -244,25 +722,64 @@ def run(csv_path: Path, bench_result: Path, agg_result: Path) -> int:
         return 0
     start, end, duration, total_output, total_input = window
 
-    result = aggregate_power(csv_path, start, end)
-    if result is None:
+    paths = [csv_path] if isinstance(csv_path, Path) else list(csv_path)
+    cluster = aggregate_metrics(paths, start, end)
+    if cluster is None:
+        label = str(paths[0]) if len(paths) == 1 else f"{len(paths)} CSVs"
         print(
-            f"[aggregate_power] No usable power samples in {csv_path} for "
+            f"[aggregate_power] No usable power samples in {label} for "
             f"window [{start}, {end}] — skipping",
             file=sys.stderr,
         )
         return 0
-    avg_power_w, num_gpus = result
+    avg_power_w = cluster["power"]
+    num_gpus = cluster["num_gpus"]
+    avg_temp_c = cluster.get("temp")
+    peak_temp_c = cluster.get("peak_temp")
+    avg_util_pct = cluster.get("util")
+    avg_mem_used_mb = cluster.get("mem")
 
-    # Joules consumed by the system during the bench window, divided by either
-    # output tokens (for generation-cost metrics) or all tokens (for whole-
-    # workload efficiency).
+    # Per-worker rollup is best-effort: only emitted when CSV filenames carry
+    # the perfmon role/index encoding. Single-node `gpu_metrics.csv` won't
+    # parse, so aggregate_power_by_worker returns None and the field is omitted.
+    workers = aggregate_power_by_worker(paths, start, end)
+
+    # Per-token energy attribution.
+    #   - joules_per_total_token stays CLUSTER-WIDE on every topology
+    #     (total_system_energy / all tokens) — the overall efficiency number.
+    #   - For disagg with BOTH stages present, joules_per_output_token and
+    #     joules_per_input_token use PER-STAGE energy: output tokens are produced
+    #     by the decode GPUs (decode_energy / output), input tokens by the
+    #     prefill GPUs (prefill_energy / input). This is the standard per-stage
+    #     attribution requested for disagg serving.
+    #   - Single-node / non-disagg / single-stage fall back to the cluster-wide
+    #     output ratio so the field is always populated.
     total_system_energy_j = avg_power_w * num_gpus * duration
-    joules_per_output_token = total_system_energy_j / total_output
     total_tokens = total_output + total_input
+    joules_per_output_token = total_system_energy_j / total_output  # cluster fallback
     joules_per_total_token = (
         total_system_energy_j / total_tokens if total_tokens > 0 else joules_per_output_token
     )
+
+    joules_per_input_token: float | None = None
+    prefill_avg_power_w: float | None = None
+    decode_avg_power_w: float | None = None
+
+    if disagg and workers is not None:
+        stage = _disagg_stage_rollup(workers, duration)
+        if stage is not None:
+            # Per-stage attribution: decode GPUs produce output tokens, prefill
+            # GPUs process input tokens. Strictly more accurate than total-energy
+            # ratios when prefill/decode have different per-GPU power profiles
+            # (typical: prefill is compute-bound and draws more than memory-bound
+            # decode). joules_per_output_token is OVERRIDDEN to the decode-only
+            # value here (symmetric with the prefill-only joules_per_input_token).
+            prefill_avg_power_w = stage["prefill_avg_power_w"]
+            decode_avg_power_w = stage["decode_avg_power_w"]
+            joules_per_output_token = stage["decode_energy_j"] / total_output
+            joules_per_input_token = (
+                stage["prefill_energy_j"] / total_input if total_input > 0 else None
+            )
 
     if not agg_result.is_file():
         print(
@@ -273,29 +790,58 @@ def run(csv_path: Path, bench_result: Path, agg_result: Path) -> int:
 
     try:
         patch_agg_result(
-            agg_result, avg_power_w, joules_per_output_token, joules_per_total_token
+            agg_result,
+            avg_power_w,
+            joules_per_output_token,
+            joules_per_total_token,
+            joules_per_input_token=joules_per_input_token,
+            prefill_avg_power_w=prefill_avg_power_w,
+            decode_avg_power_w=decode_avg_power_w,
+            avg_temp_c=avg_temp_c,
+            peak_temp_c=peak_temp_c,
+            avg_util_pct=avg_util_pct,
+            avg_mem_used_mb=avg_mem_used_mb,
+            workers=workers,
         )
     except (OSError, json.JSONDecodeError) as exc:
         print(f"[aggregate_power] Failed to patch {agg_result}: {exc}", file=sys.stderr)
         return 0
 
+    worker_summary = (
+        f"workers={len(workers)}" if workers else "workers=cluster-only"
+    )
+    jpit_summary = (
+        f"joules_per_input_token={joules_per_input_token:.4f} "
+        if joules_per_input_token is not None
+        else ""
+    )
     print(
         f"[aggregate_power] avg_power_w={avg_power_w:.2f} (per GPU, n={num_gpus}) "
         f"joules_per_output_token={joules_per_output_token:.4f} "
+        f"{jpit_summary}"
         f"joules_per_total_token={joules_per_total_token:.4f} "
         f"duration={duration:.1f}s output_tokens={total_output} input_tokens={total_input} "
-        f"-> {agg_result}"
+        f"{worker_summary} -> {agg_result}"
     )
     return 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
         "--csv",
         type=Path,
-        default=Path("/workspace/gpu_metrics.csv"),
-        help="Path to gpu_metrics.csv from start_gpu_monitor (default: /workspace/gpu_metrics.csv)",
+        default=None,
+        help="Single gpu_metrics.csv from start_gpu_monitor (single-node). "
+        "Falls back to /workspace/gpu_metrics.csv when neither --csv nor --csv-glob is set.",
+    )
+    source.add_argument(
+        "--csv-glob",
+        type=str,
+        default=None,
+        help="Shell glob expanding to per-node perf_samples_*.csv files (multinode, "
+        "written by srt-slurm's perfmon). GPU indices are namespaced by source CSV stem.",
     )
     parser.add_argument(
         "--bench-result",
@@ -309,8 +855,33 @@ def main() -> int:
         required=True,
         help="Path to the agg_<run>.json output of process_result.py (will be patched in place)",
     )
+    parser.add_argument(
+        "--disagg",
+        action="store_true",
+        help="Treat as disaggregated inference: emit prefill_avg_power_w / "
+        "decode_avg_power_w, and use PER-STAGE energy attribution for "
+        "joules_per_input_token (prefill energy / input tokens) and "
+        "joules_per_output_token (decode energy / output tokens). "
+        "joules_per_total_token stays cluster-wide. Requires CSV filenames to "
+        "carry the perfmon role/index encoding.",
+    )
     args = parser.parse_args()
-    return run(args.csv, args.bench_result, args.agg_result)
+
+    if args.csv_glob:
+        paths = sorted(Path(p) for p in glob_module.glob(args.csv_glob))
+        if not paths:
+            print(
+                f"[aggregate_power] No CSVs matched glob {args.csv_glob!r} — skipping",
+                file=sys.stderr,
+            )
+            return 0
+        return run(paths, args.bench_result, args.agg_result, disagg=args.disagg)
+    return run(
+        args.csv or Path("/workspace/gpu_metrics.csv"),
+        args.bench_result,
+        args.agg_result,
+        disagg=args.disagg,
+    )
 
 
 if __name__ == "__main__":

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -139,22 +139,48 @@ with open(agg_path, 'w') as f:
 
 # Best-effort: patch measured power into the agg JSON. Never fails the run.
 try:
+    import glob as _glob_module
     from aggregate_power import run as _aggregate_power_run
 
-    _csv_candidates = [
-        os.environ.get('GPU_METRICS_CSV'),
-        'gpu_metrics.csv',
-        '/workspace/gpu_metrics.csv',
-    ]
-    _csv_path = next(
-        (Path(p) for p in _csv_candidates if p and Path(p).is_file()),
-        None,
-    )
-    if _csv_path is not None:
+    # Two mutually-exclusive sources, decided up front. If GPU_METRICS_CSV_GLOB
+    # is set, the run is multinode (the launcher set it deliberately) and we
+    # MUST NOT fall back to single-CSV — a stale gpu_metrics.csv left over from
+    # a previous single-node run on the same runner pod would silently publish
+    # wrong power numbers for the multinode run.
+    _csv_arg = None
+    _glob_pattern = os.environ.get('GPU_METRICS_CSV_GLOB')
+    if _glob_pattern:
+        # Multinode path: glob to per-node perf_samples_<role>_w<idx>_<host>.csv.
+        _matched = sorted(Path(p) for p in _glob_module.glob(_glob_pattern))
+        if _matched:
+            _csv_arg = _matched
+        else:
+            print(
+                f'[process_result] GPU_METRICS_CSV_GLOB={_glob_pattern!r} matched no files '
+                f'— skipping power aggregation (NOT falling back to single-CSV: the launcher '
+                f'set the glob, indicating a multinode run; any single-CSV present would be '
+                f'stale single-node data)',
+                file=sys.stderr,
+            )
+    else:
+        # Single-node path: gpu_metrics.csv written by start_gpu_monitor in the
+        # bench container.
+        _csv_candidates = [
+            os.environ.get('GPU_METRICS_CSV'),
+            'gpu_metrics.csv',
+            '/workspace/gpu_metrics.csv',
+        ]
+        _csv_arg = next(
+            (Path(p) for p in _csv_candidates if p and Path(p).is_file()),
+            None,
+        )
+
+    if _csv_arg is not None:
         _aggregate_power_run(
-            csv_path=_csv_path,
+            csv_path=_csv_arg,
             bench_result=Path(f'{result_filename}.json'),
             agg_result=agg_path,
+            disagg=disagg,
         )
 except Exception as exc:  # noqa: BLE001 — never block on telemetry
     print(f'[process_result] power aggregation skipped: {exc}', file=sys.stderr)

--- a/utils/test_aggregate_power.py
+++ b/utils/test_aggregate_power.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -23,10 +23,14 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent))
 
 from aggregate_power import (  # noqa: E402
+    _detect_all_columns,
     _detect_columns,
+    _parse_perfmon_label,
     _parse_power,
     _parse_timestamp,
+    aggregate_metrics,
     aggregate_power,
+    aggregate_power_by_worker,
     patch_agg_result,
     run,
 )
@@ -445,3 +449,1255 @@ def test_patch_agg_result_is_atomic_via_tempfile(tmp_path: Path):
     assert data["joules_per_total_token"] == 0.5
     # No .tmp leftover.
     assert not (tmp_path / "agg.json.tmp").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Multi-node CSV aggregation
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_power_multi_node_namespaces_local_gpu_indices(tmp_path: Path):
+    """Two per-node CSVs each report local GPU indices 0..3.
+
+    Without per-source namespacing the union of gpu_keys would collapse to 4
+    instead of 8 — the bug this whole multinode change exists to prevent."""
+    base = 1_700_000_000.0
+    node1 = tmp_path / "perf_samples_node1.csv"
+    node2 = tmp_path / "perf_samples_node2.csv"
+    _write_nvidia_csv(node1, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+    _write_nvidia_csv(node2, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    result = aggregate_power([node1, node2], base, base + 10)
+    assert result is not None
+    avg_power, num_gpus = result
+    assert avg_power == pytest.approx(500.0)
+    assert num_gpus == 8
+
+
+def test_aggregate_power_multi_node_with_sub_second_clock_drift(tmp_path: Path):
+    """Per-node polls drift sub-second even on NTP-synced clusters.
+
+    Node1 polls at base+s, node2 at base+s+0.3 — rows land in different ms
+    buckets. Each bucket is then a single-node 4-GPU slice averaging to 500W,
+    and the mean across all buckets is the cluster per-GPU mean."""
+    base = 1_700_000_000.0
+    node1 = tmp_path / "perf_samples_node1.csv"
+    node2 = tmp_path / "perf_samples_node2.csv"
+    _write_nvidia_csv(node1, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+    _write_nvidia_csv(node2, [(base + s + 0.3, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    result = aggregate_power([node1, node2], base, base + 10)
+    assert result is not None
+    avg_power, num_gpus = result
+    assert avg_power == pytest.approx(500.0)
+    assert num_gpus == 8
+
+
+def test_aggregate_power_multi_node_asymmetric_prefill_decode_power(tmp_path: Path):
+    """Disagg topologies draw different per-GPU power on prefill vs decode nodes.
+
+    4 prefill GPUs at 600W + 4 decode GPUs at 400W: cluster mean is the
+    weighted average across all 8 GPUs = (4*600 + 4*400)/8 = 500W."""
+    base = 1_700_000_000.0
+    prefill = tmp_path / "perf_samples_prefill0.csv"
+    decode = tmp_path / "perf_samples_decode0.csv"
+    _write_nvidia_csv(prefill, [(base + s, gpu, 600.0) for s in range(3) for gpu in range(4)])
+    _write_nvidia_csv(decode, [(base + s, gpu, 400.0) for s in range(3) for gpu in range(4)])
+
+    result = aggregate_power([prefill, decode], base, base + 10)
+    assert result is not None
+    avg_power, num_gpus = result
+    assert avg_power == pytest.approx(500.0)
+    assert num_gpus == 8
+
+
+def test_aggregate_power_multi_node_skips_missing_csv_silently(tmp_path: Path):
+    """If a node failed to start perfmon, its CSV will be absent.
+
+    Aggregating over the remaining nodes is preferable to returning None —
+    losing one node's power data should not zero out the whole metric."""
+    base = 1_700_000_000.0
+    present = tmp_path / "perf_samples_node1.csv"
+    missing = tmp_path / "perf_samples_node2.csv"  # never written
+    _write_nvidia_csv(present, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    result = aggregate_power([present, missing], base, base + 10)
+    assert result is not None
+    avg_power, num_gpus = result
+    assert avg_power == pytest.approx(500.0)
+    assert num_gpus == 4  # only the node that emitted data
+
+
+def test_aggregate_power_single_path_in_list_matches_bare_path(tmp_path: Path):
+    """Backward compat: aggregate_power([csv], ...) == aggregate_power(csv, ...).
+
+    Single-source behavior must not change when the caller wraps the path in a
+    list — otherwise process_result.py-style callers that defensively normalize
+    to a list would see different num_gpus values than legacy bare-path calls."""
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_nvidia_csv(csv, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(8)])
+
+    bare = aggregate_power(csv, base, base + 10)
+    listed = aggregate_power([csv], base, base + 10)
+    assert bare == listed
+    assert bare == (pytest.approx(500.0), 8)
+
+
+def test_aggregate_power_accepts_iterable_not_just_list(tmp_path: Path):
+    """Signature is Iterable[Path] — generators (e.g. Path.glob()) must work."""
+    base = 1_700_000_000.0
+    node1 = tmp_path / "perf_samples_node1.csv"
+    node2 = tmp_path / "perf_samples_node2.csv"
+    _write_nvidia_csv(node1, [(base + s, gpu, 500.0) for s in range(2) for gpu in range(4)])
+    _write_nvidia_csv(node2, [(base + s, gpu, 500.0) for s in range(2) for gpu in range(4)])
+
+    result = aggregate_power(tmp_path.glob("perf_samples_*.csv"), base, base + 10)
+    assert result is not None
+    _, num_gpus = result
+    assert num_gpus == 8
+
+
+def test_run_multi_node_e2e_computes_joules_from_total_gpus(tmp_path: Path):
+    """End-to-end multinode: run() with a list of CSVs patches the agg JSON.
+
+    8 GPUs total at 500W for 10s → 40_000 J → 2.0 J/output_token for 20_000 tokens."""
+    base = 1_700_000_000.0
+    node1 = tmp_path / "perf_samples_node1.csv"
+    node2 = tmp_path / "perf_samples_node2.csv"
+    _write_nvidia_csv(node1, [(base + 1 + s, gpu, 500.0) for s in range(2) for gpu in range(4)])
+    _write_nvidia_csv(node2, [(base + 1 + s, gpu, 500.0) for s in range(2) for gpu in range(4)])
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(bench, start=base, end=base + 10, duration=10.0, total_output=20_000)
+    agg.write_text(json.dumps({"hw": "gb300", "conc": 8192}), encoding="utf-8")
+
+    exit_code = run([node1, node2], bench, agg)
+    assert exit_code == 0
+
+    patched = json.loads(agg.read_text())
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    assert patched["joules_per_output_token"] == pytest.approx(2.0)
+
+
+def test_run_multi_node_skips_when_all_csvs_missing(tmp_path: Path):
+    """Entire monitoring failure (all per-node CSVs absent) skips cleanly without patching."""
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(bench, start=0.0, end=10.0, duration=10.0, total_output=1000)
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    exit_code = run([tmp_path / "absent1.csv", tmp_path / "absent2.csv"], bench, agg)
+    assert exit_code == 0
+
+    patched = json.loads(agg.read_text())
+    assert "avg_power_w" not in patched
+
+
+# --------------------------------------------------------------------------- #
+# _load_bench_window fallbacks for srt-slurm multinode result JSONs
+#
+# srt-slurm's sa-bench result writer emits `date` + `duration` but NOT the
+# benchmark_*_time_unix fields our single-node benchmark_serving.py adds.
+# Without a fallback, multinode runs would always hit "No bench window in
+# {bench_result}" and silently skip power aggregation end-to-end.
+# --------------------------------------------------------------------------- #
+
+
+def test_run_uses_date_field_when_unix_timestamps_absent(tmp_path: Path):
+    """Tier 2: parse `date` ("YYYYMMDD-HHMMSS" UTC) + `duration` for the window."""
+    # End of bench at a known UTC instant; CSV samples land in [end-10, end].
+    end_unix = datetime(2026, 5, 20, 3, 10, 29, tzinfo=timezone.utc).timestamp()
+    csv = tmp_path / "perf_samples_node0.csv"
+    _write_nvidia_csv(csv, [(end_unix - 1 - s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    bench = tmp_path / "bench.json"
+    bench.write_text(
+        json.dumps(
+            {
+                "date": "20260520-031029",
+                "duration": 10.0,
+                "total_output_tokens": 1000,
+                "total_input_tokens": 8000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run([csv], bench, agg) == 0
+    patched = json.loads(agg.read_text())
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    # 4 GPUs × 500W × 10s = 20_000 J / 1000 output tokens = 20.0 J/output_token.
+    assert patched["joules_per_output_token"] == pytest.approx(20.0)
+    # 20_000 J / (1000 + 8000) total tokens ≈ 2.222 J/total_token.
+    assert patched["joules_per_total_token"] == pytest.approx(20_000 / 9_000)
+
+
+def test_run_uses_mtime_when_date_unparseable(tmp_path: Path):
+    """Tier 3a: malformed `date` falls through to file mtime as bench-end proxy."""
+    csv = tmp_path / "perf_samples_node0.csv"
+    bench = tmp_path / "bench.json"
+    bench.write_text(
+        json.dumps({"date": "not-a-date", "duration": 10.0, "total_output_tokens": 1000}),
+        encoding="utf-8",
+    )
+    # CSV samples bracket bench file's mtime so they fall inside the derived window.
+    end_unix = bench.stat().st_mtime
+    _write_nvidia_csv(csv, [(end_unix - 1 - s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+    assert run([csv], bench, agg) == 0
+    patched = json.loads(agg.read_text())
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+
+
+def test_run_uses_mtime_when_no_date_field(tmp_path: Path):
+    """Tier 3b: bench JSON has only `duration` → file mtime is end-of-bench."""
+    csv = tmp_path / "perf_samples_node0.csv"
+    bench = tmp_path / "bench.json"
+    bench.write_text(
+        json.dumps({"duration": 10.0, "total_output_tokens": 1000}),
+        encoding="utf-8",
+    )
+    end_unix = bench.stat().st_mtime
+    _write_nvidia_csv(csv, [(end_unix - 1 - s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+    assert run([csv], bench, agg) == 0
+    patched = json.loads(agg.read_text())
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+
+
+def test_run_skips_when_duration_missing(tmp_path: Path):
+    """No tier can resolve a window without `duration` — skip cleanly."""
+    csv = tmp_path / "perf_samples_node0.csv"
+    _write_nvidia_csv(csv, [(1_700_000_000.0, 0, 400.0)])
+    bench = tmp_path / "bench.json"
+    bench.write_text(json.dumps({"total_output_tokens": 1000}), encoding="utf-8")
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run([csv], bench, agg) == 0
+    assert "avg_power_w" not in json.loads(agg.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Perfmon filename label parsing — drives per-worker grouping
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_perfmon_label_prefill(tmp_path: Path):
+    role, idx, host = _parse_perfmon_label(tmp_path / "perf_samples_prefill_w0_node1.csv")
+    assert (role, idx, host) == ("prefill", 0, "node1")
+
+
+def test_parse_perfmon_label_decode_high_worker_idx(tmp_path: Path):
+    """Worker index can be multi-digit (e.g. 16-way prefill)."""
+    role, idx, host = _parse_perfmon_label(tmp_path / "perf_samples_decode_w15_node-42.csv")
+    assert (role, idx, host) == ("decode", 15, "node-42")
+
+
+def test_parse_perfmon_label_host_with_hyphens_and_digits(tmp_path: Path):
+    """CoreWeave-style hostnames like `slurm-compute-gpu-019-42b` must round-trip."""
+    role, idx, host = _parse_perfmon_label(
+        tmp_path / "perf_samples_prefill_w3_slurm-compute-gpu-019-42b.csv"
+    )
+    assert (role, idx, host) == ("prefill", 3, "slurm-compute-gpu-019-42b")
+
+
+def test_parse_perfmon_label_agg_role(tmp_path: Path):
+    """Non-disagg multinode uses role='agg' (not prefill/decode)."""
+    role, idx, host = _parse_perfmon_label(tmp_path / "perf_samples_agg_w0_node1.csv")
+    assert (role, idx, host) == ("agg", 0, "node1")
+
+
+def test_parse_perfmon_label_frontend_role(tmp_path: Path):
+    """Head-only nodes (no backend workers) get role='frontend'."""
+    role, idx, host = _parse_perfmon_label(tmp_path / "perf_samples_frontend_w0_head.csv")
+    assert (role, idx, host) == ("frontend", 0, "head")
+
+
+def test_parse_perfmon_label_unlabeled_returns_none(tmp_path: Path):
+    """Single-node `gpu_metrics.csv` doesn't match — caller should treat as None."""
+    assert _parse_perfmon_label(tmp_path / "gpu_metrics.csv") is None
+    assert _parse_perfmon_label(tmp_path / "perf_samples_node1.csv") is None
+    assert _parse_perfmon_label(tmp_path / "perf_samples_unknownrole_w0_host.csv") is None
+
+
+# --------------------------------------------------------------------------- #
+# Per-worker aggregation — groups node-CSVs by (role, worker_idx)
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_power_by_worker_one_csv_per_worker(tmp_path: Path):
+    """4 prefill workers (one per node) + 1 decode worker on a single node.
+
+    Reflects the smallest disagg topology — every CSV is its own worker."""
+    base = 1_700_000_000.0
+    for w in range(4):
+        _write_nvidia_csv(
+            tmp_path / f"perf_samples_prefill_w{w}_pnode{w}.csv",
+            [(base + s, gpu, 600.0) for s in range(3) for gpu in range(4)],
+        )
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_decode_w0_dnode0.csv",
+        [(base + s, gpu, 400.0) for s in range(3) for gpu in range(4)],
+    )
+
+    workers = aggregate_power_by_worker(
+        list(tmp_path.glob("perf_samples_*.csv")), base, base + 10
+    )
+    assert workers is not None
+    # Ordered: prefill (w0..w3), then decode (w0).
+    assert [w["role"] for w in workers] == ["prefill"] * 4 + ["decode"]
+    assert [w["worker_idx"] for w in workers] == [0, 1, 2, 3, 0]
+    # Each worker is 4 GPUs at its respective wattage.
+    for w in workers[:4]:
+        assert w["num_gpus"] == 4
+        assert w["avg_power_w"] == pytest.approx(600.0)
+        assert len(w["hosts"]) == 1
+    assert workers[4]["num_gpus"] == 4
+    assert workers[4]["avg_power_w"] == pytest.approx(400.0)
+
+
+def test_aggregate_power_by_worker_one_worker_spans_multiple_nodes(tmp_path: Path):
+    """Decode_w0 spans 4 nodes × 4 GPUs = 16 GPUs.
+
+    Mirrors the typical wide-EP DSV4 topology (gpus_per_decode=16,
+    decode_workers=1). All 4 node-CSVs share the same (role, worker_idx)
+    and must collapse into ONE worker entry with num_gpus=16."""
+    base = 1_700_000_000.0
+    hosts = ["dnode0", "dnode1", "dnode2", "dnode3"]
+    for h in hosts:
+        _write_nvidia_csv(
+            tmp_path / f"perf_samples_decode_w0_{h}.csv",
+            [(base + s, gpu, 400.0) for s in range(3) for gpu in range(4)],
+        )
+
+    workers = aggregate_power_by_worker(
+        list(tmp_path.glob("perf_samples_*.csv")), base, base + 10
+    )
+    assert workers is not None
+    assert len(workers) == 1
+    w = workers[0]
+    assert w["role"] == "decode"
+    assert w["worker_idx"] == 0
+    assert w["num_gpus"] == 16  # 4 nodes × 4 GPUs
+    assert w["avg_power_w"] == pytest.approx(400.0)
+    assert w["hosts"] == sorted(hosts)
+
+
+def test_aggregate_power_by_worker_returns_none_when_no_labels(tmp_path: Path):
+    """Single-node `gpu_metrics.csv` has no perfmon label — returns None.
+
+    Caller (run()) then omits power_by_worker from the agg JSON entirely."""
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_nvidia_csv(csv, [(base + s, gpu, 500.0) for s in range(3) for gpu in range(4)])
+    assert aggregate_power_by_worker([csv], base, base + 10) is None
+
+
+def test_aggregate_power_by_worker_returns_none_for_empty_input(tmp_path: Path):
+    assert aggregate_power_by_worker([], 0.0, 100.0) is None
+
+
+def test_aggregate_power_by_worker_skips_unlabeled_silently(tmp_path: Path):
+    """Mixed input: one labeled CSV + one unlabeled. Only labeled is grouped."""
+    base = 1_700_000_000.0
+    labeled = tmp_path / "perf_samples_prefill_w0_n1.csv"
+    unlabeled = tmp_path / "gpu_metrics.csv"
+    _write_nvidia_csv(labeled, [(base + s, gpu, 600.0) for s in range(3) for gpu in range(4)])
+    _write_nvidia_csv(unlabeled, [(base + s, gpu, 999.0) for s in range(3) for gpu in range(4)])
+
+    workers = aggregate_power_by_worker([labeled, unlabeled], base, base + 10)
+    assert workers is not None
+    assert len(workers) == 1
+    assert workers[0]["role"] == "prefill"
+    # Unlabeled CSV's wattage must not bleed into the prefill worker.
+    assert workers[0]["avg_power_w"] == pytest.approx(600.0)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end disagg: run(..., disagg=True) emits per-worker + per-stage J/token
+# --------------------------------------------------------------------------- #
+
+
+def test_run_disagg_emits_workers_and_per_stage_joules(tmp_path: Path):
+    """Full disagg pipeline: workers[] breakdown + per-stage scalars next to
+    cluster-wide joules.
+
+    Topology: 2 prefill workers × 4 GPUs @ 600W, 1 decode worker × 8 GPUs @ 400W.
+    Over a 10s bench window with 8000 input + 1000 output tokens:
+      - prefill energy = 600 × 8 × 10 = 48_000 J  → J/input          = 6.0
+      - decode energy  = 400 × 8 × 10 = 32_000 J  → J/output_decode  = 32.0
+      - total energy   = 80_000 J                  → cluster J/output = 80.0
+                                                   → cluster J/total ≈ 8.889
+    Cluster-wide avg_power_w stays the weighted mean across all 16 GPUs.
+    The per-stage decode attribution is exposed as
+    `joules_per_output_token_decode` so the cluster-wide
+    `joules_per_output_token` stays comparable across topologies."""
+    base = 1_700_000_000.0
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(4)],
+    )
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_prefill_w1_pn1.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(4)],
+    )
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_decode_w0_dn0.csv",
+        [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(4)],
+    )
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_decode_w0_dn1.csv",
+        [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(4)],
+    )
+
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench,
+        start=base,
+        end=base + 10,
+        duration=10.0,
+        total_output=1000,
+        total_input=8000,
+    )
+    agg.write_text(json.dumps({"hw": "gb300", "disagg": True}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+
+    # Cluster-wide avg = (8*600 + 8*400) / 16 = 500W.
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+
+    # joules_per_total_token stays cluster-wide (all energy / all tokens).
+    assert patched["joules_per_total_token"] == pytest.approx(80_000 / 9000)    # ≈ 8.889
+
+    # Per-stage attribution: input divided by prefill energy, output by decode
+    # energy (the disagg convention).
+    assert patched["prefill_avg_power_w"] == pytest.approx(600.0)
+    assert patched["decode_avg_power_w"] == pytest.approx(400.0)
+    assert patched["joules_per_input_token"] == pytest.approx(48_000 / 8000)   # 6.0 (prefill)
+    assert patched["joules_per_output_token"] == pytest.approx(32_000 / 1000)  # 32.0 (decode)
+    assert "joules_per_output_token_decode" not in patched  # folded into joules_per_output_token
+
+    # workers[] (renamed from power_by_worker).
+    workers = patched["workers"]
+    assert [w["role"] for w in workers] == ["prefill", "prefill", "decode"]
+    assert [w["worker_idx"] for w in workers] == [0, 1, 0]
+    # Decode_w0 collapsed across 2 hosts → 8 GPUs total.
+    decode = workers[2]
+    assert decode["num_gpus"] == 8
+    assert decode["avg_power_w"] == pytest.approx(400.0)
+    assert decode["hosts"] == ["dn0", "dn1"]
+    # Each prefill worker is one node, 4 GPUs.
+    for w in workers[:2]:
+        assert w["num_gpus"] == 4
+        assert w["avg_power_w"] == pytest.approx(600.0)
+        assert len(w["hosts"]) == 1
+
+
+def test_run_disagg_excludes_frontend_from_per_stage_energy(tmp_path: Path):
+    """A frontend-only node's power must not contribute to per-stage scalars.
+
+    Frontend nodes don't run any backend worker — their (typically near-idle)
+    GPU draw would skew per-stage attribution if counted. They still appear
+    in workers[] for observability, and they DO contribute to the cluster-wide
+    avg_power_w / joules_per_*_token totals (which describe the whole
+    deployment's energy)."""
+    base = 1_700_000_000.0
+    # Prefill worker — 4 GPUs @ 600W → 24_000 J in 10s
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(4)],
+    )
+    # Decode worker — 4 GPUs @ 400W → 16_000 J
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_decode_w0_dn0.csv",
+        [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(4)],
+    )
+    # Frontend node — would erroneously bleed into per-stage scalars if counted,
+    # but DOES count toward cluster avg/joules (it's still energy consumed).
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_frontend_w0_head.csv",
+        [(base + 1 + s, gpu, 100.0) for s in range(8) for gpu in range(4)],
+    )
+
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0, total_output=1000, total_input=8000
+    )
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+
+    # Per-stage attribution excludes the frontend node.
+    # J/input  = prefill 24_000 / 8000 = 3.0.
+    # J/output = decode  16_000 / 1000 = 16.0 (frontend's 4_000 J NOT counted).
+    assert patched["joules_per_input_token"] == pytest.approx(3.0)
+    assert patched["joules_per_output_token"] == pytest.approx(16.0)
+    assert patched["prefill_avg_power_w"] == pytest.approx(600.0)
+    assert patched["decode_avg_power_w"] == pytest.approx(400.0)
+
+    # But the frontend's energy IS counted in the cluster-wide total efficiency:
+    # total energy = (600+400+100) × 4 × 10 = 44_000 J → / 9000 tokens ≈ 4.889.
+    assert patched["joules_per_total_token"] == pytest.approx(44_000 / 9000)
+
+    # Frontend still appears in the worker list for observability.
+    roles = [w["role"] for w in patched["workers"]]
+    assert "frontend" in roles
+
+
+def test_run_non_disagg_omits_per_stage_scalars(tmp_path: Path):
+    """Non-disagg runs (single-node or multinode-agg) keep the legacy schema.
+
+    No per-stage scalars (prefill_avg_power_w / decode_avg_power_w /
+    joules_per_input_token / joules_per_output_token_decode) and no workers[]
+    field — all of those need disagg + role-labeled CSVs to be meaningful.
+
+    Existing fields must keep their pre-disagg semantics
+    (total_system_energy / token_count)."""
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_nvidia_csv(
+        csv, [(base + 1 + s, gpu, 500.0) for s in range(8) for gpu in range(8)]
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0, total_output=20_000
+    )
+    agg.write_text(json.dumps({"hw": "h200"}), encoding="utf-8")
+
+    assert run(csv, bench, agg, disagg=False) == 0
+    patched = json.loads(agg.read_text())
+    for absent in (
+        "joules_per_input_token",
+        "joules_per_output_token_decode",
+        "prefill_avg_power_w",
+        "decode_avg_power_w",
+        "workers",
+        "power_by_worker",  # the old name must NOT leak through either
+    ):
+        assert absent not in patched, f"unexpected key {absent} in non-disagg output"
+    # Legacy semantics: total energy / token count.
+    assert patched["joules_per_output_token"] == pytest.approx(2.0)
+    assert patched["joules_per_total_token"] == pytest.approx(2.0)
+
+
+def test_run_disagg_falls_back_to_cluster_when_only_one_stage_present(tmp_path: Path):
+    """If only prefill or only decode CSVs survived, per-stage attribution
+    isn't possible — the per-stage scalars are omitted but cluster-wide ratios
+    are still published so the run isn't telemetry-blank."""
+    base = 1_700_000_000.0
+    # Only prefill CSVs — decode is missing entirely.
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(4)],
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0, total_output=1000, total_input=8000
+    )
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+    # workers[] still emitted (one prefill worker, useful for observability).
+    assert len(patched["workers"]) == 1
+    # Per-stage scalars absent (no decode stage to attribute to).
+    for absent in (
+        "joules_per_input_token",
+        "joules_per_output_token_decode",
+        "prefill_avg_power_w",
+        "decode_avg_power_w",
+    ):
+        assert absent not in patched, f"unexpected per-stage key {absent}"
+    # Cluster-wide J/output still emitted (total_energy / output_tokens).
+    assert patched["joules_per_output_token"] == pytest.approx(24_000 / 1000)
+
+
+def test_run_disagg_handles_zero_input_tokens(tmp_path: Path):
+    """total_input_tokens=0 (rare degenerate case) → joules_per_input_token
+    omitted, no ZeroDivisionError. Per-stage decode + per-stage power scalars
+    still emitted (those don't depend on input tokens)."""
+    base = 1_700_000_000.0
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(4)],
+    )
+    _write_nvidia_csv(
+        tmp_path / "perf_samples_decode_w0_dn0.csv",
+        [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(4)],
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0, total_output=1000, total_input=0
+    )
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+    assert "joules_per_input_token" not in patched
+    # Per-stage output still works — depends only on decode_energy / output.
+    assert patched["joules_per_output_token"] == pytest.approx(16_000 / 1000)  # decode
+    assert patched["prefill_avg_power_w"] == pytest.approx(600.0)
+    assert patched["decode_avg_power_w"] == pytest.approx(400.0)
+    # Cluster-wide total uses TOTAL energy. (600+400) × 4 × 10 = 40_000 J / 1000.
+    assert patched["joules_per_total_token"] == pytest.approx(40_000 / 1000)
+
+
+def test_patch_agg_result_with_workers_and_per_stage(tmp_path: Path):
+    """patch_agg_result emits the new optional fields when supplied."""
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+    workers = [
+        {"role": "prefill", "worker_idx": 0, "hosts": ["pn0"], "num_gpus": 4, "avg_power_w": 600.0},
+        {"role": "decode", "worker_idx": 0, "hosts": ["dn0"], "num_gpus": 4, "avg_power_w": 400.0},
+    ]
+    patch_agg_result(
+        agg,
+        avg_power_w=500.0,
+        joules_per_output_token=40.0,
+        joules_per_total_token=4.44,
+        joules_per_input_token=3.0,
+        prefill_avg_power_w=600.0,
+        decode_avg_power_w=400.0,
+        workers=workers,
+    )
+    data = json.loads(agg.read_text())
+    assert data["avg_power_w"] == 500.0
+    assert data["joules_per_output_token"] == 40.0
+    assert data["joules_per_input_token"] == 3.0
+    assert data["prefill_avg_power_w"] == 600.0
+    assert data["decode_avg_power_w"] == 400.0
+    assert data["workers"] == workers
+    # power_by_worker (old name) must NOT appear.
+    assert "power_by_worker" not in data
+
+
+def test_patch_agg_result_omits_optional_fields_when_none(tmp_path: Path):
+    """Backward compat: caller passing None for new fields → fields absent."""
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"hw": "h200"}), encoding="utf-8")
+    patch_agg_result(
+        agg,
+        avg_power_w=400.0,
+        joules_per_output_token=1.5,
+        joules_per_total_token=0.5,
+    )
+    data = json.loads(agg.read_text())
+    for absent in (
+        "joules_per_input_token",
+        "joules_per_output_token_decode",
+        "prefill_avg_power_w",
+        "decode_avg_power_w",
+        "avg_temp_c",
+        "peak_temp_c",
+        "avg_util_pct",
+        "avg_mem_used_mb",
+        "workers",
+        "power_by_worker",
+    ):
+        assert absent not in data, f"unexpected key {absent} in minimal patch"
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry: temperature, utilization, memory
+#
+# These extend aggregate_metrics()'s capability beyond power. Frontend already
+# wires avg_temp_c / avg_util_pct / avg_mem_used_mb / peak_temp_c as scalar
+# numerics (same convention as avg_power_w: per-GPU mean, unit-suffixed name).
+# Power remains required for aggregation to fire; the others degrade gracefully.
+# --------------------------------------------------------------------------- #
+
+
+def _write_csv_with_metrics(
+    path: Path,
+    samples: list[tuple[float, int, dict[str, float]]],
+    *,
+    columns: tuple[str, ...] = ("power.draw [W]", "temperature.gpu", "utilization.gpu", "memory.used [MiB]"),
+    column_map: dict[str, str] | None = None,
+) -> None:
+    """Write a CSV with arbitrary metric columns.
+
+    samples: list of (epoch_seconds, gpu_index, {metric_key: value}). The
+    metric_key in the dict must match one of: 'power', 'temp', 'util', 'mem'.
+    The columns parameter is the literal CSV header for those metrics, in order.
+    column_map maps each metric_key → its position in `columns` (default: assume
+    same order as ('power', 'temp', 'util', 'mem') for an NVIDIA-style header).
+    """
+    if column_map is None:
+        column_map = {"power": columns[0], "temp": columns[1], "util": columns[2], "mem": columns[3]}
+    header = "timestamp, index, " + ", ".join(columns)
+    lines = [header]
+    for ts, idx, vals in samples:
+        row = [_nvidia_ts(ts), str(idx)]
+        for col in columns:
+            metric_key = next((k for k, v in column_map.items() if v == col), None)
+            v = vals.get(metric_key)
+            if v is None:
+                row.append("[N/A]")
+            elif col == columns[0]:  # power
+                row.append(f"{v:.2f} W")
+            elif "temp" in col.lower():
+                row.append(f"{int(v)} C")
+            elif "util" in col.lower():
+                row.append(f"{int(v)} %")
+            elif "mem" in col.lower():
+                row.append(f"{int(v)} MiB")
+            else:
+                row.append(str(v))
+        lines.append(", ".join(row))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_detect_all_columns_nvidia():
+    """NVIDIA header has all four metrics — each maps to its canonical column."""
+    header = ["timestamp", "index", "power.draw [W]", "temperature.gpu",
+              "utilization.gpu", "memory.used [MiB]"]
+    cols = _detect_all_columns(header)
+    assert cols["timestamp"] == "timestamp"
+    assert cols["gpu"] == "index"
+    assert cols["power"] == "power.draw [W]"
+    assert cols["temp"] == "temperature.gpu"
+    assert cols["util"] == "utilization.gpu"
+    assert cols["mem"] == "memory.used [MiB]"
+
+
+def test_detect_all_columns_srt_slurm_style():
+    """srt-slurm perfmon uses bare-name columns: power_w, temp_c, util_pct, mem_used_mb."""
+    header = ["timestamp", "gpu", "power_w", "temp_c", "util_pct", "mem_used_mb"]
+    cols = _detect_all_columns(header)
+    assert cols["power"] == "power_w"
+    assert cols["temp"] == "temp_c"
+    assert cols["util"] == "util_pct"
+    assert cols["mem"] == "mem_used_mb"
+
+
+def test_detect_all_columns_amd_style():
+    """AMD amd-smi uses different conventions: socket_power, temperature."""
+    header = ["timestamp", "gpu", "socket_power", "temperature"]
+    cols = _detect_all_columns(header)
+    assert cols["power"] == "socket_power"
+    assert cols["temp"] == "temperature"
+    # No util/mem in this header — gracefully None.
+    assert cols["util"] is None
+    assert cols["mem"] is None
+
+
+def test_detect_all_columns_amd_smi_full():
+    """Real amd-smi `metric -p -c -t -u -m --csv` header on a data-center part.
+
+    Exercises: gfx_activity as util (not umc/mm_activity), used_vram as mem (not
+    total/free_vram, mem_clock, mem_voltage, or mem_temperature), and
+    hotspot_temperature preferred over the N/A edge_temperature.
+    """
+    header = [
+        "timestamp", "gpu",
+        "socket_power", "mem_voltage",            # -p
+        "gfx_clock", "mem_clock",                 # -c
+        "edge_temperature", "hotspot_temperature", "mem_temperature",  # -t
+        "gfx_activity", "umc_activity", "mm_activity",                 # -u
+        "total_vram", "used_vram", "free_vram",   # -m
+    ]
+    cols = _detect_all_columns(header)
+    assert cols["power"] == "socket_power"
+    assert cols["util"] == "gfx_activity"
+    assert cols["mem"] == "used_vram"
+    # Hotspot/junction preferred over edge (edge reads N/A on MI300/MI355).
+    assert cols["temp"] == "hotspot_temperature"
+
+
+def test_detect_all_columns_temp_prefers_junction():
+    """junction_temperature wins over a leading edge_temperature column."""
+    header = ["timestamp", "gpu", "socket_power",
+              "edge_temperature", "junction_temperature"]
+    assert _detect_all_columns(header)["temp"] == "junction_temperature"
+
+
+def test_detect_all_columns_mem_vram_used_variants():
+    """Both used_vram and vram_used resolve; total/free_vram never do."""
+    assert _detect_all_columns(
+        ["timestamp", "power_w", "total_vram", "vram_used", "free_vram"]
+    )["mem"] == "vram_used"
+    assert _detect_all_columns(
+        ["timestamp", "power_w", "total_vram", "free_vram"]
+    )["mem"] is None
+
+
+def test_detect_all_columns_excludes_memory_total():
+    """memory.total must not be picked as the memory column (we want USED memory)."""
+    header = ["timestamp", "index", "power.draw [W]", "memory.total [MiB]", "memory.used [MiB]"]
+    cols = _detect_all_columns(header)
+    assert cols["mem"] == "memory.used [MiB]"
+
+
+def test_detect_all_columns_mem_ignores_clock_and_util_memory():
+    """The real nvidia-smi query has NO used-memory column — only
+    clocks.current.memory (a frequency) and utilization.memory (a percent),
+    both of which contain "mem". Neither is memory *used*, so the mem column
+    must resolve to None rather than mislabeling the memory clock as
+    avg_mem_used_mb. Regression for the r"mem" over-match."""
+    header = [
+        "timestamp", "index", "power.draw [W]", "temperature.gpu",
+        "clocks.current.sm [MHz]", "clocks.current.memory [MHz]",
+        "utilization.gpu [%]", "utilization.memory [%]",
+    ]
+    cols = _detect_all_columns(header)
+    assert cols["mem"] is None, f"mem should be None, got {cols['mem']!r}"
+    # The real used-memory column, when present, is still picked.
+    cols2 = _detect_all_columns(header + ["memory.used [MiB]"])
+    assert cols2["mem"] == "memory.used [MiB]"
+
+
+def test_detect_all_columns_missing_optional_metrics():
+    """Only power present — temp/util/mem all None."""
+    header = ["timestamp", "index", "power.draw [W]"]
+    cols = _detect_all_columns(header)
+    assert cols["power"] == "power.draw [W]"
+    assert cols["temp"] is None
+    assert cols["util"] is None
+    assert cols["mem"] is None
+
+
+def test_aggregate_metrics_returns_all_telemetry_single_node(tmp_path: Path):
+    """Cluster-wide aggregation captures power, temp, util, mem in one pass."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    # 4 GPUs, 3 samples — uniform values per metric.
+    samples = []
+    for s in range(3):
+        for gpu in range(4):
+            samples.append(
+                (base + s, gpu, {"power": 500.0, "temp": 70.0, "util": 95.0, "mem": 60000.0})
+            )
+    _write_csv_with_metrics(csv, samples)
+    result = aggregate_metrics(csv, base, base + 10)
+    assert result is not None
+    assert result["num_gpus"] == 4
+    assert result["power"] == pytest.approx(500.0)
+    assert result["temp"] == pytest.approx(70.0)
+    assert result["util"] == pytest.approx(95.0)
+    assert result["mem"] == pytest.approx(60000.0)
+    assert result["peak_temp"] == pytest.approx(70.0)  # uniform → peak == avg
+
+
+def test_aggregate_metrics_peak_temp_is_max_not_mean(tmp_path: Path):
+    """peak_temp_c is the global max instantaneous reading, not a per-bucket mean.
+
+    Critical for thermal-headroom signals: a single GPU hitting 85C during the
+    run matters even if the cluster mean stays at 70C."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    samples = []
+    # 4 GPUs at 70C steadily, EXCEPT one GPU spikes to 85C in the middle sample.
+    for s in range(3):
+        for gpu in range(4):
+            temp = 85.0 if (s == 1 and gpu == 2) else 70.0
+            samples.append((base + s, gpu, {"power": 500.0, "temp": temp}))
+    _write_csv_with_metrics(
+        csv, samples,
+        columns=("power.draw [W]", "temperature.gpu"),
+        column_map={"power": "power.draw [W]", "temp": "temperature.gpu"},
+    )
+    result = aggregate_metrics(csv, base, base + 10)
+    assert result is not None
+    # Mean is dominated by the 11 readings at 70 + 1 at 85 = (11*70 + 85)/12 ≈ 71.25.
+    assert result["temp"] == pytest.approx((11 * 70 + 85) / 12, abs=0.01)
+    # Peak is the raw max sample, not any averaged value.
+    assert result["peak_temp"] == pytest.approx(85.0)
+
+
+def test_aggregate_metrics_missing_temp_column_omits_temp(tmp_path: Path):
+    """A CSV without a temp column → result dict has no 'temp' / 'peak_temp' keys.
+
+    Graceful degradation: callers using .get() / 'temp' in result handle this
+    naturally."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    # Header has ONLY power.
+    samples = [(base + s, gpu, {"power": 500.0}) for s in range(3) for gpu in range(4)]
+    _write_csv_with_metrics(
+        csv, samples,
+        columns=("power.draw [W]",),
+        column_map={"power": "power.draw [W]"},
+    )
+    result = aggregate_metrics(csv, base, base + 10)
+    assert result is not None
+    assert result["power"] == pytest.approx(500.0)
+    assert "temp" not in result
+    assert "peak_temp" not in result
+    assert "util" not in result
+    assert "mem" not in result
+
+
+def test_aggregate_metrics_missing_util_only_keeps_others(tmp_path: Path):
+    """Power + temp + mem present but no util column → util omitted, rest fine.
+
+    Mirrors the AMD case where amd-smi output may lack a utilization column."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    samples = [
+        (base + s, gpu, {"power": 500.0, "temp": 70.0, "mem": 60000.0})
+        for s in range(3) for gpu in range(4)
+    ]
+    _write_csv_with_metrics(
+        csv, samples,
+        columns=("power.draw [W]", "temperature.gpu", "memory.used [MiB]"),
+        column_map={"power": "power.draw [W]", "temp": "temperature.gpu", "mem": "memory.used [MiB]"},
+    )
+    result = aggregate_metrics(csv, base, base + 10)
+    assert result is not None
+    assert "util" not in result
+    assert result["temp"] == pytest.approx(70.0)
+    assert result["mem"] == pytest.approx(60000.0)
+
+
+def test_aggregate_metrics_multinode_aggregates_across_csvs(tmp_path: Path):
+    """Multinode telemetry rolls up across per-node CSVs same as power.
+
+    Per-GPU mean is weighted by the (per-sample, per-namespace) GPU count."""
+    base = 1_700_000_000.0
+    node1 = tmp_path / "perf_samples_node1.csv"
+    node2 = tmp_path / "perf_samples_node2.csv"
+    _write_csv_with_metrics(
+        node1,
+        [(base + s, gpu, {"power": 600.0, "temp": 75.0, "util": 95.0, "mem": 60000.0})
+         for s in range(3) for gpu in range(4)],
+    )
+    _write_csv_with_metrics(
+        node2,
+        [(base + s, gpu, {"power": 400.0, "temp": 65.0, "util": 85.0, "mem": 40000.0})
+         for s in range(3) for gpu in range(4)],
+    )
+    result = aggregate_metrics([node1, node2], base, base + 10)
+    assert result is not None
+    assert result["num_gpus"] == 8
+    # All metrics are weighted means across the 8 distinct GPUs.
+    assert result["power"] == pytest.approx(500.0)  # (600+400)/2
+    assert result["temp"] == pytest.approx(70.0)    # (75+65)/2
+    assert result["util"] == pytest.approx(90.0)
+    assert result["mem"] == pytest.approx(50000.0)
+    assert result["peak_temp"] == pytest.approx(75.0)
+
+
+def test_run_patches_cluster_wide_temp_util_mem(tmp_path: Path):
+    """End-to-end: run() patches cluster-wide telemetry into the agg JSON
+    when the CSV exposes the corresponding columns."""
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    samples = [
+        (base + 1 + s, gpu, {"power": 500.0, "temp": 70.0, "util": 95.0, "mem": 60000.0})
+        for s in range(2) for gpu in range(8)
+    ]
+    _write_csv_with_metrics(csv, samples)
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(bench, start=base, end=base + 10, duration=10.0, total_output=20_000)
+    agg.write_text(json.dumps({"hw": "h200"}), encoding="utf-8")
+
+    assert run(csv, bench, agg) == 0
+    patched = json.loads(agg.read_text())
+    # Power baseline still works.
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    # New cluster-wide scalars present and rounded to 3 decimals.
+    assert patched["avg_temp_c"] == pytest.approx(70.0)
+    assert patched["peak_temp_c"] == pytest.approx(70.0)
+    assert patched["avg_util_pct"] == pytest.approx(95.0)
+    assert patched["avg_mem_used_mb"] == pytest.approx(60000.0)
+
+
+def test_run_omits_cluster_telemetry_when_csv_has_no_extra_columns(tmp_path: Path):
+    """Power-only CSV → only avg_power_w + joules_per_*_token are emitted.
+
+    Backward compat with old CSVs / older monitoring setups that only captured
+    power. The agg JSON must not gain spurious null/zero values for the
+    metrics the CSV didn't carry."""
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    # Old NVIDIA CSV without temp/util/mem — the _write_nvidia_csv helper
+    # already includes temperature though. So use the metric helper with only power.
+    samples = [(base + 1 + s, gpu, {"power": 500.0}) for s in range(2) for gpu in range(8)]
+    _write_csv_with_metrics(
+        csv, samples,
+        columns=("power.draw [W]",),
+        column_map={"power": "power.draw [W]"},
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(bench, start=base, end=base + 10, duration=10.0, total_output=20_000)
+    agg.write_text(json.dumps({"hw": "h200"}), encoding="utf-8")
+
+    assert run(csv, bench, agg) == 0
+    patched = json.loads(agg.read_text())
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    for absent in ("avg_temp_c", "peak_temp_c", "avg_util_pct", "avg_mem_used_mb"):
+        assert absent not in patched, f"unexpected {absent} when CSV lacks that column"
+
+
+def test_run_disagg_emits_per_worker_temp_util_mem(tmp_path: Path):
+    """Disagg multinode: each entry in workers[] carries per-worker telemetry
+    in addition to avg_power_w. Frontend can render thermal/util breakdown
+    by worker role."""
+    base = 1_700_000_000.0
+    # Prefill worker runs hotter (compute-bound) than decode (memory-bound).
+    _write_csv_with_metrics(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, {"power": 600.0, "temp": 80.0, "util": 98.0, "mem": 50000.0})
+         for s in range(8) for gpu in range(4)],
+    )
+    _write_csv_with_metrics(
+        tmp_path / "perf_samples_decode_w0_dn0.csv",
+        [(base + 1 + s, gpu, {"power": 400.0, "temp": 65.0, "util": 70.0, "mem": 70000.0})
+         for s in range(8) for gpu in range(4)],
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0,
+        total_output=1000, total_input=8000,
+    )
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+
+    # Cluster-wide telemetry: weighted mean across all 8 GPUs.
+    assert patched["avg_temp_c"] == pytest.approx(72.5)        # (80+65)/2
+    assert patched["peak_temp_c"] == pytest.approx(80.0)
+    assert patched["avg_util_pct"] == pytest.approx(84.0)      # (98+70)/2
+    assert patched["avg_mem_used_mb"] == pytest.approx(60000.0)
+
+    workers = patched["workers"]
+    prefill = next(w for w in workers if w["role"] == "prefill")
+    decode = next(w for w in workers if w["role"] == "decode")
+    # Per-worker fields present alongside avg_power_w.
+    assert prefill["avg_temp_c"] == pytest.approx(80.0)
+    assert prefill["peak_temp_c"] == pytest.approx(80.0)
+    assert prefill["avg_util_pct"] == pytest.approx(98.0)
+    assert prefill["avg_mem_used_mb"] == pytest.approx(50000.0)
+    assert decode["avg_temp_c"] == pytest.approx(65.0)
+    assert decode["avg_util_pct"] == pytest.approx(70.0)
+    assert decode["avg_mem_used_mb"] == pytest.approx(70000.0)
+
+
+def test_run_per_worker_omits_missing_telemetry_columns(tmp_path: Path):
+    """If a worker's CSV lacks a temp/util/mem column, those keys are
+    omitted from that worker's entry — no nulls leak through."""
+    base = 1_700_000_000.0
+    # Prefill: full schema (power + temp + util + mem).
+    _write_csv_with_metrics(
+        tmp_path / "perf_samples_prefill_w0_pn0.csv",
+        [(base + 1 + s, gpu, {"power": 600.0, "temp": 80.0, "util": 98.0, "mem": 50000.0})
+         for s in range(8) for gpu in range(4)],
+    )
+    # Decode: power only — no other columns at all in its CSV.
+    _write_csv_with_metrics(
+        tmp_path / "perf_samples_decode_w0_dn0.csv",
+        [(base + 1 + s, gpu, {"power": 400.0}) for s in range(8) for gpu in range(4)],
+        columns=("power.draw [W]",),
+        column_map={"power": "power.draw [W]"},
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0,
+        total_output=1000, total_input=8000,
+    )
+    agg.write_text(json.dumps({"hw": "gb300"}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+    workers = patched["workers"]
+    decode = next(w for w in workers if w["role"] == "decode")
+    # Decode worker has avg_power_w but none of the optional telemetry fields.
+    assert decode["avg_power_w"] == pytest.approx(400.0)
+    for absent in ("avg_temp_c", "peak_temp_c", "avg_util_pct", "avg_mem_used_mb"):
+        assert absent not in decode, f"unexpected {absent} on power-only decode worker"
+    # Prefill still has all of them.
+    prefill = next(w for w in workers if w["role"] == "prefill")
+    assert "avg_temp_c" in prefill
+    assert "avg_util_pct" in prefill
+    assert "avg_mem_used_mb" in prefill
+
+
+# --------------------------------------------------------------------------- #
+# AMD multi-node disaggregated inference (mi355x)
+#
+# The AMD path has no srt-slurm orchestrator: each SGLang/vLLM disagg node
+# starts its own amd-smi monitor via start_perf_monitor (benchmarks/
+# benchmark_lib.sh), writing perf_samples_<role>_w<idx>_<host>.csv in the SAME
+# convention as the NVIDIA perfmon. These tests lock in that the (vendor-
+# agnostic) aggregation produces the full per-worker / per-stage schema when
+# fed amd-smi CSVs — ISO timestamps, bare-numeric power, "gpu"/"socket_power"
+# columns — over realistic MI355X (8 GPUs/node) disagg topologies and AMD
+# cluster hostnames. The NVIDIA-CSV tests above already cover the math; these
+# guard the AMD CSV format + filename round-trip end to end.
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_perfmon_label_amd_hostname():
+    """AMD mi355x cluster hostnames (e.g. mia1-p01-g09) round-trip cleanly.
+
+    start_perf_monitor builds the filename from `hostname -s` sanitized with
+    `tr -c 'A-Za-z0-9.-' '_'`; AMD short hostnames are already alnum+dash, so
+    the host segment survives intact through _parse_perfmon_label."""
+    assert _parse_perfmon_label(
+        Path("perf_samples_prefill_w0_mia1-p01-g09.csv")
+    ) == ("prefill", 0, "mia1-p01-g09")
+    assert _parse_perfmon_label(
+        Path("perf_samples_decode_w2_smci355-ccs-aus-12.csv")
+    ) == ("decode", 2, "smci355-ccs-aus-12")
+
+
+def test_aggregate_power_by_worker_amd_one_csv_per_worker(tmp_path: Path):
+    """AMD amd-smi CSVs, one prefill + one decode worker, 8 GPUs/node (MI355X).
+
+    Same grouping logic as the NVIDIA case, but proves the amd-smi CSV schema
+    (ISO timestamp, bare power, 'gpu' index col) parses through the per-worker
+    rollup."""
+    base = 1_700_000_000.0
+    _write_amd_csv(
+        tmp_path / "perf_samples_prefill_w0_mia1-p01-g01.csv",
+        [(base + s, gpu, 600.0) for s in range(3) for gpu in range(8)],
+    )
+    _write_amd_csv(
+        tmp_path / "perf_samples_decode_w0_mia1-p01-g02.csv",
+        [(base + s, gpu, 400.0) for s in range(3) for gpu in range(8)],
+    )
+
+    workers = aggregate_power_by_worker(
+        list(tmp_path.glob("perf_samples_*.csv")), base, base + 10
+    )
+    assert workers is not None
+    assert [w["role"] for w in workers] == ["prefill", "decode"]
+    assert [w["worker_idx"] for w in workers] == [0, 0]
+    assert workers[0]["num_gpus"] == 8
+    assert workers[0]["avg_power_w"] == pytest.approx(600.0)
+    assert workers[0]["hosts"] == ["mia1-p01-g01"]
+    assert workers[1]["num_gpus"] == 8
+    assert workers[1]["avg_power_w"] == pytest.approx(400.0)
+
+
+def test_aggregate_power_by_worker_amd_worker_spans_multiple_nodes(tmp_path: Path):
+    """A single decode worker spanning 2 MI355X nodes (DECODE_TP_SIZE=16).
+
+    Both node-CSVs share (decode, w0); amd-smi reports local indices 0..7 on
+    each, so without per-source namespacing the union would collapse to 8
+    instead of 16. Mirrors the SGLang DECODE_NODES_PER_WORKER>1 topology."""
+    base = 1_700_000_000.0
+    hosts = ["mia1-p01-g05", "mia1-p01-g06"]
+    for h in hosts:
+        _write_amd_csv(
+            tmp_path / f"perf_samples_decode_w0_{h}.csv",
+            [(base + s, gpu, 400.0) for s in range(3) for gpu in range(8)],
+        )
+
+    workers = aggregate_power_by_worker(
+        list(tmp_path.glob("perf_samples_*.csv")), base, base + 10
+    )
+    assert workers is not None
+    assert len(workers) == 1
+    w = workers[0]
+    assert w["role"] == "decode"
+    assert w["worker_idx"] == 0
+    assert w["num_gpus"] == 16  # 2 nodes × 8 GPUs
+    assert w["avg_power_w"] == pytest.approx(400.0)
+    assert w["hosts"] == sorted(hosts)
+
+
+def test_run_disagg_amd_emits_workers_and_per_stage_joules(tmp_path: Path):
+    """Full AMD mi355x disagg pipeline end to end with amd-smi CSVs.
+
+    Topology: 1 prefill worker × 8 GPUs @ 600W, 1 decode worker × 8 GPUs @ 400W.
+    Over a 10s window with 8000 input + 1000 output tokens:
+      - prefill energy = 600 × 8 × 10 = 48_000 J  → J/input         = 6.0
+      - decode energy  = 400 × 8 × 10 = 32_000 J  → J/output_decode = 32.0
+      - total energy   = 80_000 J                  → cluster J/output = 80.0
+      - cluster avg    = (8×600 + 8×400)/16 = 500W
+    This is the AMD analogue of test_run_disagg_emits_workers_and_per_stage_joules."""
+    base = 1_700_000_000.0
+    _write_amd_csv(
+        tmp_path / "perf_samples_prefill_w0_mia1-p01-g01.csv",
+        [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(8)],
+    )
+    _write_amd_csv(
+        tmp_path / "perf_samples_decode_w0_mia1-p01-g02.csv",
+        [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(8)],
+    )
+
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0,
+        total_output=1000, total_input=8000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x", "disagg": True}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+
+    # Cluster-wide total (vendor-agnostic, same math as single-node / NVIDIA).
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    assert patched["joules_per_total_token"] == pytest.approx(80_000 / 9000)   # ≈ 8.889
+
+    # Per-stage attribution from amd-smi CSVs: input=prefill energy, output=decode energy.
+    assert patched["prefill_avg_power_w"] == pytest.approx(600.0)
+    assert patched["decode_avg_power_w"] == pytest.approx(400.0)
+    assert patched["joules_per_input_token"] == pytest.approx(48_000 / 8000)   # 6.0 (prefill)
+    assert patched["joules_per_output_token"] == pytest.approx(32_000 / 1000)  # 32.0 (decode)
+
+    # workers[] breakdown.
+    workers = patched["workers"]
+    assert [w["role"] for w in workers] == ["prefill", "decode"]
+    assert all(w["num_gpus"] == 8 for w in workers)
+
+
+def test_run_disagg_amd_vllm_topology_one_worker_per_node(tmp_path: Path):
+    """vLLM AMD topology: xP=2 prefill + yD=2 decode, one worker per node.
+
+    server_vllm.sh labels ranks [0,xP) prefill (w=rank) and [xP, xP+yD) decode
+    (w=rank-xP). Four amd-smi CSVs, distinct worker indices per stage."""
+    base = 1_700_000_000.0
+    for w in range(2):
+        _write_amd_csv(
+            tmp_path / f"perf_samples_prefill_w{w}_mia1-p02-g0{w}.csv",
+            [(base + 1 + s, gpu, 600.0) for s in range(8) for gpu in range(8)],
+        )
+    for w in range(2):
+        _write_amd_csv(
+            tmp_path / f"perf_samples_decode_w{w}_mia1-p02-g1{w}.csv",
+            [(base + 1 + s, gpu, 400.0) for s in range(8) for gpu in range(8)],
+        )
+
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    _write_bench_result(
+        bench, start=base, end=base + 10, duration=10.0,
+        total_output=1000, total_input=8000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x", "disagg": True}), encoding="utf-8")
+
+    assert run(list(tmp_path.glob("perf_samples_*.csv")), bench, agg, disagg=True) == 0
+    patched = json.loads(agg.read_text())
+
+    workers = patched["workers"]
+    assert [w["role"] for w in workers] == ["prefill", "prefill", "decode", "decode"]
+    assert [w["worker_idx"] for w in workers] == [0, 1, 0, 1]
+    # 2 prefill workers × 8 GPUs @ 600W → 96_000 J / 8000 input = 12.0.
+    assert patched["joules_per_input_token"] == pytest.approx(96_000 / 8000)
+    # 2 decode workers × 8 GPUs @ 400W → 64_000 J / 1000 output = 64.0.
+    assert patched["joules_per_output_token"] == pytest.approx(64_000 / 1000)
+    assert patched["prefill_avg_power_w"] == pytest.approx(600.0)
+    assert patched["decode_avg_power_w"] == pytest.approx(400.0)

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -649,3 +649,213 @@ class TestPowerAggregationIntegration:
         patched = json.loads(agg_path.read_text())
         assert "avg_power_w" not in patched
         assert "joules_per_output_token" not in patched
+
+    def test_multinode_csv_glob_aggregates_across_per_node_csvs(self, tmp_path, single_node_env_vars):
+        """Multinode wiring: srt-slurm launchers set GPU_METRICS_CSV_GLOB to a
+        shell glob expanding to one perf_samples_<node>.csv per worker node.
+        process_result.py must expand it and hand the list to the aggregator,
+        which namespaces local GPU indices per source so they don't collide.
+
+        Without this bridge the launcher would set the env var, process_result.py
+        would ignore it (fall back to a non-existent /workspace/gpu_metrics.csv),
+        and the chart would silently show no power data — the failure mode that
+        motivated catching this in the contract check."""
+        start, end = 1_700_000_100.0, 1_700_000_160.0  # 60s bench window
+        # Two per-node CSVs at the same local indices 0-3. Without per-source
+        # namespacing the union would collapse to 4 GPUs instead of 8.
+        self._write_nvidia_csv(
+            tmp_path / "perf_samples_node1.csv", start, end, watts_per_gpu=600.0, num_gpus=4
+        )
+        self._write_nvidia_csv(
+            tmp_path / "perf_samples_node2.csv", start, end, watts_per_gpu=600.0, num_gpus=4
+        )
+
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 64,
+            "total_token_throughput": 1000.0,
+            "output_throughput": 500.0,
+            "benchmark_start_time_unix": start,
+            "benchmark_end_time_unix": end,
+            "duration": 60.0,
+            "total_output_tokens": 30_000,
+        }
+        env = {
+            **single_node_env_vars,
+            "GPU_METRICS_CSV_GLOB": str(tmp_path / "perf_samples_*.csv"),
+        }
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        agg_path = tmp_path / "agg_benchmark_result.json"
+        patched = json.loads(agg_path.read_text())
+        # 2 nodes × 4 GPUs = 8 total. Per-GPU mean stays at 600W.
+        assert patched["avg_power_w"] == pytest.approx(600.0, abs=0.5)
+        # 600W × 8 GPUs × 60s / 30_000 tokens = 9.6 J/tok.
+        # If namespacing failed we'd see ~4.8 (only 4 GPUs counted).
+        assert patched["joules_per_output_token"] == pytest.approx(9.6, abs=0.05)
+
+    def test_multinode_csv_glob_takes_precedence_over_single_csv(self, tmp_path, single_node_env_vars):
+        """If both GLOB and single CSV are set, the glob wins.
+
+        Reflects the ownership split: the multinode launcher sets the glob
+        after the job, while the single CSV env var is only meaningful for
+        single-node runs. If a stale single-CSV value leaks through (e.g. a
+        runner with persistent env), the glob should still take precedence."""
+        start, end = 1_700_000_100.0, 1_700_000_160.0
+        glob_csv = tmp_path / "perf_samples_node1.csv"
+        stale_csv = tmp_path / "stale_single.csv"
+        self._write_nvidia_csv(glob_csv, start, end, watts_per_gpu=600.0, num_gpus=4)
+        self._write_nvidia_csv(stale_csv, start, end, watts_per_gpu=100.0, num_gpus=1)
+
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 64,
+            "total_token_throughput": 1000.0,
+            "output_throughput": 500.0,
+            "benchmark_start_time_unix": start,
+            "benchmark_end_time_unix": end,
+            "duration": 60.0,
+            "total_output_tokens": 30_000,
+        }
+        env = {
+            **single_node_env_vars,
+            "GPU_METRICS_CSV_GLOB": str(tmp_path / "perf_samples_*.csv"),
+            "GPU_METRICS_CSV": str(stale_csv),
+        }
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        agg_path = tmp_path / "agg_benchmark_result.json"
+        patched = json.loads(agg_path.read_text())
+        # Glob respected → 600W (4 GPUs). Stale fallback would give 100W (1 GPU).
+        assert patched["avg_power_w"] == pytest.approx(600.0, abs=0.5)
+
+    def test_multinode_csv_glob_empty_match_falls_through_silently(self, tmp_path, single_node_env_vars):
+        """If GPU_METRICS_CSV_GLOB is set but matches no files (perfmon failed
+        to start on any node), process_result.py still succeeds and writes the
+        agg JSON without power fields. The run must not block on telemetry."""
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 64,
+            "total_token_throughput": 1000.0,
+            "output_throughput": 500.0,
+        }
+        env = {
+            **single_node_env_vars,
+            "GPU_METRICS_CSV_GLOB": str(tmp_path / "perf_samples_*.csv"),
+        }
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        agg_path = tmp_path / "agg_benchmark_result.json"
+        patched = json.loads(agg_path.read_text())
+        assert "avg_power_w" not in patched
+
+    def test_disagg_multinode_emits_workers_and_per_stage_joules(self, tmp_path, multinode_env_vars):
+        """End-to-end disagg wiring: DISAGG=true + per-node labeled CSVs →
+        process_result.py passes disagg through to aggregate_power, which emits
+        workers[] + per-stage scalars alongside the cluster-wide joules.
+
+        Without the disagg=disagg propagation in process_result.py, the
+        per-stage scalars (joules_per_input_token, joules_per_output_token_decode,
+        prefill_avg_power_w, decode_avg_power_w) would be missing."""
+        start, end = 1_700_000_100.0, 1_700_000_160.0  # 60s bench window
+        # 1 prefill worker × 4 GPUs @ 600W on its own node
+        self._write_nvidia_csv(
+            tmp_path / "perf_samples_prefill_w0_pn0.csv",
+            start, end, watts_per_gpu=600.0, num_gpus=4,
+        )
+        # 1 decode worker × 4 GPUs @ 400W on its own node
+        self._write_nvidia_csv(
+            tmp_path / "perf_samples_decode_w0_dn0.csv",
+            start, end, watts_per_gpu=400.0, num_gpus=4,
+        )
+
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 64,
+            "total_token_throughput": 1000.0,
+            "output_throughput": 500.0,
+            "benchmark_start_time_unix": start,
+            "benchmark_end_time_unix": end,
+            "duration": 60.0,
+            "total_output_tokens": 30_000,
+            "total_input_tokens": 240_000,
+        }
+        env = {
+            **multinode_env_vars,
+            "GPU_METRICS_CSV_GLOB": str(tmp_path / "perf_samples_*.csv"),
+        }
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        patched = json.loads((tmp_path / "agg_benchmark_result.json").read_text())
+
+        # Per-stage attribution: input divided by prefill energy, output by decode.
+        # Prefill: 600 × 4 × 60 = 144_000 J  → / 240_000 = 0.6 J/input_tok.
+        # Decode:  400 × 4 × 60 =  96_000 J  → /  30_000 = 3.2 J/output_tok.
+        assert patched["joules_per_input_token"] == pytest.approx(0.6, abs=0.01)
+        assert patched["joules_per_output_token"] == pytest.approx(3.2, abs=0.01)  # decode
+        assert "joules_per_output_token_decode" not in patched
+        assert patched["prefill_avg_power_w"] == pytest.approx(600.0, abs=0.5)
+        assert patched["decode_avg_power_w"] == pytest.approx(400.0, abs=0.5)
+
+        # Cluster-wide total efficiency still counts ALL energy.
+        # Total energy = (600+400) × 4 × 60 = 240_000 J → / 270_000 ≈ 0.889 J/total_tok.
+        assert patched["joules_per_total_token"] == pytest.approx(240_000 / 270_000, abs=0.01)
+
+        # Per-worker breakdown labeled with role.
+        workers = patched["workers"]
+        assert {w["role"] for w in workers} == {"prefill", "decode"}
+        for w in workers:
+            assert w["num_gpus"] == 4
+            assert w["worker_idx"] == 0
+
+    def test_non_disagg_multinode_keeps_cluster_wide_joules_math(self, tmp_path, multinode_env_vars):
+        """Multinode but DISAGG=false → keep cluster-wide ratios, no per-stage
+        scalars.
+
+        Sanity check that the disagg flag is the gate, not just multinode-ness."""
+        start, end = 1_700_000_100.0, 1_700_000_160.0
+        self._write_nvidia_csv(
+            tmp_path / "perf_samples_agg_w0_n0.csv",
+            start, end, watts_per_gpu=500.0, num_gpus=4,
+        )
+
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 64,
+            "total_token_throughput": 1000.0,
+            "output_throughput": 500.0,
+            "benchmark_start_time_unix": start,
+            "benchmark_end_time_unix": end,
+            "duration": 60.0,
+            "total_output_tokens": 30_000,
+            "total_input_tokens": 240_000,
+        }
+        # Multinode env, but DISAGG=false → non-disagg multinode (rare but valid).
+        env = {
+            **multinode_env_vars,
+            "DISAGG": "false",
+            "GPU_METRICS_CSV_GLOB": str(tmp_path / "perf_samples_*.csv"),
+        }
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        patched = json.loads((tmp_path / "agg_benchmark_result.json").read_text())
+        for absent in (
+            "joules_per_input_token",
+            "joules_per_output_token_decode",
+            "prefill_avg_power_w",
+            "decode_avg_power_w",
+        ):
+            assert absent not in patched, f"unexpected per-stage key {absent}"
+        # workers[] still emitted (filename labels exist) — useful for
+        # observability even on non-disagg runs.
+        assert patched["workers"][0]["role"] == "agg"


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — run-only validation PR

**Purpose:** produce the first **measured power + temperature** data for `dsr1` disagg on **GB300 now**, without waiting for #1574 to merge.

This branch carries #1574's self-contained consumer code (`utils/aggregate_power.py`, `utils/process_result.py` + their tests) on top of `main`, plus the `gb300-nv` launcher perfmon wiring and a single 1-job changelog entry (`dsr1-fp4-gb300-dynamo-sglang-powercheck`). The changelog diff expands to **exactly one** gb300 job (1k/1k, conc 8, 1×prefill TP4 + 2×decode TP4) — verified with `process_changelog.py --trim-conc`.

**Power AND temperature ride the same pipeline:** the srt-slurm fork perfmon captures `power.draw` + `temperature.gpu` + `utilization.gpu` + `memory.used`; `aggregate_power.py` emits `avg_power_w`, per-stage `prefill_avg_power_w`/`decode_avg_power_w`, and per-worker `avg_temp_c`/`peak_temp_c`/`avg_util_pct`/`avg_mem_used_mb`.

**Why not merge:** it duplicates #1574's `aggregate_power.py`. The production landing of the `gb300-nv` launcher happens via the clean post-#1574 path (cherry-pick onto merged `main`). This PR is **closed** once the measured data lands.

**Success criteria:** job green + `perf_samples_*.csv` staged + agg JSON patched with the power/temp fields above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark result JSON schema and multinode launcher behavior (fork checkout, recipe mutation, env-driven CSV selection); mistakes could publish wrong power numbers or break GB300 jobs, though aggregation remains best-effort and tests are broad.
> 
> **Overview**
> Adds a **GB300 measured-power validation path** for DeepSeek-R1 FP4 disagg before the full NVIDIA sweep: a single-job benchmark config (`dsr1-fp4-gb300-dynamo-sglang-powercheck`), changelog entry, and runner wiring on **`gb300-cw`** and **`gb300-nv`** to clone the **srt-slurm perfmon fork**, inject `monitoring:` into recipes, stage `perf_samples_*.csv` via `GPU_METRICS_CSV_GLOB`, and fix CoreWeave recipe gaps (unlimited mem, longer health checks).
> 
> **Telemetry pipeline** expands `aggregate_power.py` and `process_result.py` to merge **multi-node** CSVs (GPU index namespacing), parse perfmon filenames for **`workers[]`**, support **disagg per-stage** power/joules (`prefill_avg_power_w`, `decode_avg_power_w`, `joules_per_input_token`), add **temp/util/memory** fields, and resolve bench windows from srt-slurm `date` when Unix timestamps are absent. Multinode runs **must not** fall back to stale single-node `gpu_metrics.csv` when the glob is set.
> 
> **CI reliability:** multinode workflow pre/post cleanup now **`sudo rm -rf benchmark_logs`** so root-owned leftovers from cancelled jobs do not break checkout on shared runners.
> 
> Extensive tests cover multinode aggregation, disagg attribution, and `process_result` glob/disagg wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cbe194a9af3b9374ab741b69de47629680c0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->