### PR TITLE
Sync dsv4-fp4-b200-trt recipes with B200 agg frontier config

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1835,12 +1835,12 @@ dsv4-fp4-b200-trt-mtp:
       osl: 1024
       search-space:
       - { tp: 8, conc-start: 1, conc-end: 32, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 512, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 1024, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, conc-start: 1, conc-end: 32, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 128, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 256, spec-decoding: mtp }
 
 # MTP variant of dsv4-fp4-b200-vllm. Mirrors the base search space and adds
 # --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1800,6 +1800,10 @@ dsv4-fp4-b200-vllm-agentic:
       - { tp: 8, offloading: cpu,  conc-list: [16, 32, 64] }
       - { tp: 8, ep: 8, dp-attn: true, offloading: cpu,  conc-list: [64, 128, 256] }
 
+# Recipe config (worker envs + trtllm-serve YAML in dsv4_fp4_b200_trt.sh) synced
+# from the 0608-B200 DeepSeek-V4-Pro agg frontier (deepseek-v4-pro-agg-202606,
+# MTP0 blocks): free_gpu_memory_fraction 0.9/0.7 (TP / DP-attn), stream_interval
+# 100, attention_dp batching_wait_iters 30, moe use_low_precision_moe_combine.
 dsv4-fp4-b200-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -1821,6 +1825,9 @@ dsv4-fp4-b200-trt:
       - { tp: 8, conc-start: 1, conc-end: 32 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 1024 }
 
+# Recipe config (dsv4_fp4_b200_trt_mtp.sh) synced from the 0608-B200 agg frontier
+# (MTP blocks): MTP level 3, free_gpu_memory_fraction 0.9/0.6 (TP / DP-attn),
+# enable_lm_head_tp_in_adp on the DP-attn path; other fields as dsv4-fp4-b200-trt.
 dsv4-fp4-b200-trt-mtp:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1800,10 +1800,6 @@ dsv4-fp4-b200-vllm-agentic:
       - { tp: 8, offloading: cpu,  conc-list: [16, 32, 64] }
       - { tp: 8, ep: 8, dp-attn: true, offloading: cpu,  conc-list: [64, 128, 256] }
 
-# Recipe config (worker envs + trtllm-serve YAML in dsv4_fp4_b200_trt.sh) synced
-# from the 0608-B200 DeepSeek-V4-Pro agg frontier (deepseek-v4-pro-agg-202606,
-# MTP0 blocks): free_gpu_memory_fraction 0.9/0.7 (TP / DP-attn), stream_interval
-# 100, attention_dp batching_wait_iters 30, moe use_low_precision_moe_combine.
 dsv4-fp4-b200-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -1825,9 +1821,6 @@ dsv4-fp4-b200-trt:
       - { tp: 8, conc-start: 1, conc-end: 32 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 32, conc-end: 1024 }
 
-# Recipe config (dsv4_fp4_b200_trt_mtp.sh) synced from the 0608-B200 agg frontier
-# (MTP blocks): MTP level 3, free_gpu_memory_fraction 0.9/0.6 (TP / DP-attn),
-# enable_lm_head_tp_in_adp on the DP-attn path; other fields as dsv4-fp4-b200-trt.
 dsv4-fp4-b200-trt-mtp:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-9aa3715
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
@@ -62,7 +62,13 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt.yml"
 
-MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
+# MoE backend: TRTLLM at low/mid concurrency; switch to MEGAMOE_DEEPGEMM at the
+# top concurrency for short ISL (1k).
+if [[ "$ISL" -le 1024 && "$CONC" -ge 2048 ]]; then
+    MOE_BACKEND="${MOE_BACKEND:-MEGAMOE_DEEPGEMM}"
+else
+    MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
+fi
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
 if [[ "$DP_ATTENTION" == "true" ]]; then

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
@@ -47,6 +47,15 @@ sanitize_slurm_mpi_env_for_trtllm
 export NCCL_NVLS_ENABLE="${NCCL_NVLS_ENABLE:-0}"
 echo "NCCL_NVLS_ENABLE: $NCCL_NVLS_ENABLE"
 
+# DeepSeek-V4 TRTLLM worker tuning envs, synced from the 0608-B200 agg frontier
+# (env_vars: worker_env_var + gen_worker_env_var; the user-specific
+# TLLM_AUTOTUNER_CACHE_PATH is intentionally omitted). All overridable.
+export TRTLLM_SERVER_DISABLE_GC="${TRTLLM_SERVER_DISABLE_GC:-1}"
+export TRTLLM_WORKER_DISABLE_GC="${TRTLLM_WORKER_DISABLE_GC:-1}"
+export NCCL_GRAPH_MIXING_SUPPORT="${NCCL_GRAPH_MIXING_SUPPORT:-0}"
+export MIMALLOC_PURGE_DELAY="${MIMALLOC_PURGE_DELAY:-0}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
 if [[ "$MODEL" != /* ]]; then
     hf download "$MODEL"
 fi
@@ -56,18 +65,25 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt.yml"
 
-MOE_BACKEND="TRTLLM"
+# MoE backend: TRTLLM is the frontier default across the sweep. The 0608-B200
+# data used MEGAMOE_DEEPGEMM only at the very top concurrency (1k1k conc=2048);
+# set MOE_BACKEND=MEGAMOE_DEEPGEMM to reproduce that point.
+MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
-KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.50}"
+# free_gpu_memory_fraction from 0608-B200: 0.9 (TP / no DP-attn), 0.7 (DP-attn).
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.7}"
+else
+    KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.9}"
+fi
 
 ATTENTION_DP_CONFIG=""
 if [[ "$DP_ATTENTION" == "true" ]]; then
     ATTENTION_DP_CONFIG="
 attention_dp_config:
-    batching_wait_iters: 0
-    enable_balance: true
-    timeout_iters: 60"
+    batching_wait_iters: 30
+    enable_balance: true"
 fi
 
 cat > "$EXTRA_CONFIG_FILE" << EOF
@@ -81,10 +97,11 @@ kv_cache_config:
     dtype: fp8
     free_gpu_memory_fraction: $KV_CACHE_FREE_MEM_FRACTION
     enable_block_reuse: false
-stream_interval: 10
+stream_interval: 100
 num_postprocess_workers: 4
 moe_config:
     backend: $MOE_BACKEND
+    use_low_precision_moe_combine: true
 EOF
 
 echo "Generated config file contents:"

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh
@@ -47,9 +47,6 @@ sanitize_slurm_mpi_env_for_trtllm
 export NCCL_NVLS_ENABLE="${NCCL_NVLS_ENABLE:-0}"
 echo "NCCL_NVLS_ENABLE: $NCCL_NVLS_ENABLE"
 
-# DeepSeek-V4 TRTLLM worker tuning envs, synced from the 0608-B200 agg frontier
-# (env_vars: worker_env_var + gen_worker_env_var; the user-specific
-# TLLM_AUTOTUNER_CACHE_PATH is intentionally omitted). All overridable.
 export TRTLLM_SERVER_DISABLE_GC="${TRTLLM_SERVER_DISABLE_GC:-1}"
 export TRTLLM_WORKER_DISABLE_GC="${TRTLLM_WORKER_DISABLE_GC:-1}"
 export NCCL_GRAPH_MIXING_SUPPORT="${NCCL_GRAPH_MIXING_SUPPORT:-0}"
@@ -65,13 +62,9 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt.yml"
 
-# MoE backend: TRTLLM is the frontier default across the sweep. The 0608-B200
-# data used MEGAMOE_DEEPGEMM only at the very top concurrency (1k1k conc=2048);
-# set MOE_BACKEND=MEGAMOE_DEEPGEMM to reproduce that point.
 MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
-# free_gpu_memory_fraction from 0608-B200: 0.9 (TP / no DP-attn), 0.7 (DP-attn).
 if [[ "$DP_ATTENTION" == "true" ]]; then
     KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.7}"
 else

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
@@ -46,9 +46,6 @@ sanitize_slurm_mpi_env_for_trtllm
 export NCCL_NVLS_ENABLE="${NCCL_NVLS_ENABLE:-0}"
 echo "NCCL_NVLS_ENABLE: $NCCL_NVLS_ENABLE"
 
-# DeepSeek-V4 TRTLLM worker tuning envs, synced from the 0608-B200 agg frontier
-# (env_vars: worker_env_var + gen_worker_env_var; the user-specific
-# TLLM_AUTOTUNER_CACHE_PATH is intentionally omitted). All overridable.
 export TRTLLM_SERVER_DISABLE_GC="${TRTLLM_SERVER_DISABLE_GC:-1}"
 export TRTLLM_WORKER_DISABLE_GC="${TRTLLM_WORKER_DISABLE_GC:-1}"
 export NCCL_GRAPH_MIXING_SUPPORT="${NCCL_GRAPH_MIXING_SUPPORT:-0}"
@@ -64,38 +61,30 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt-mtp.yml"
 
-# MoE backend: TRTLLM is the frontier default across the sweep. The 0608-B200
-# MTP data used MEGAMOE_DEEPGEMM only at the top concurrencies (1k1k conc>=512);
-# set MOE_BACKEND=MEGAMOE_DEEPGEMM to reproduce those points.
 MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
-# 0608-B200 MTP frontier runs at MTP level 3 (overridable).
 MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-3}"
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
-# free_gpu_memory_fraction from 0608-B200 MTP: 0.9 (TP / no DP-attn), 0.6 (DP-attn).
 if [[ "$DP_ATTENTION" == "true" ]]; then
     KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.6}"
 else
     KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.9}"
 fi
 
-# enable_lm_head_tp_in_adp: the 0608-B200 MTP frontier sets this on the DP-attn path.
-LM_HEAD_TP_IN_ADP_CONFIG=""
 ATTENTION_DP_CONFIG=""
 if [[ "$DP_ATTENTION" == "true" ]]; then
-    LM_HEAD_TP_IN_ADP_CONFIG="
-enable_lm_head_tp_in_adp: true"
     ATTENTION_DP_CONFIG="
 attention_dp_config:
     batching_wait_iters: 30
-    enable_balance: true"
+    enable_balance: true
+enable_lm_head_tp_in_adp: true"
 fi
 
 cat > "$EXTRA_CONFIG_FILE" << EOF
 cuda_graph_config:
     enable_padding: true
     max_batch_size: $CUDA_GRAPH_MAX_BATCH_SIZE
-enable_attention_dp: $DP_ATTENTION$ATTENTION_DP_CONFIG$LM_HEAD_TP_IN_ADP_CONFIG
+enable_attention_dp: $DP_ATTENTION$ATTENTION_DP_CONFIG
 print_iter_log: true
 kv_cache_config:
     tokens_per_block: 128

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
@@ -46,6 +46,15 @@ sanitize_slurm_mpi_env_for_trtllm
 export NCCL_NVLS_ENABLE="${NCCL_NVLS_ENABLE:-0}"
 echo "NCCL_NVLS_ENABLE: $NCCL_NVLS_ENABLE"
 
+# DeepSeek-V4 TRTLLM worker tuning envs, synced from the 0608-B200 agg frontier
+# (env_vars: worker_env_var + gen_worker_env_var; the user-specific
+# TLLM_AUTOTUNER_CACHE_PATH is intentionally omitted). All overridable.
+export TRTLLM_SERVER_DISABLE_GC="${TRTLLM_SERVER_DISABLE_GC:-1}"
+export TRTLLM_WORKER_DISABLE_GC="${TRTLLM_WORKER_DISABLE_GC:-1}"
+export NCCL_GRAPH_MIXING_SUPPORT="${NCCL_GRAPH_MIXING_SUPPORT:-0}"
+export MIMALLOC_PURGE_DELAY="${MIMALLOC_PURGE_DELAY:-0}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
 if [[ "$MODEL" != /* ]]; then
     hf download "$MODEL"
 fi
@@ -55,36 +64,49 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt-mtp.yml"
 
-MOE_BACKEND="TRTLLM"
-MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-2}"
+# MoE backend: TRTLLM is the frontier default across the sweep. The 0608-B200
+# MTP data used MEGAMOE_DEEPGEMM only at the top concurrencies (1k1k conc>=512);
+# set MOE_BACKEND=MEGAMOE_DEEPGEMM to reproduce those points.
+MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
+# 0608-B200 MTP frontier runs at MTP level 3 (overridable).
+MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-3}"
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
-KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.50}"
+# free_gpu_memory_fraction from 0608-B200 MTP: 0.9 (TP / no DP-attn), 0.6 (DP-attn).
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.6}"
+else
+    KV_CACHE_FREE_MEM_FRACTION="${KV_CACHE_FREE_MEM_FRACTION:-0.9}"
+fi
 
+# enable_lm_head_tp_in_adp: the 0608-B200 MTP frontier sets this on the DP-attn path.
+LM_HEAD_TP_IN_ADP_CONFIG=""
 ATTENTION_DP_CONFIG=""
 if [[ "$DP_ATTENTION" == "true" ]]; then
+    LM_HEAD_TP_IN_ADP_CONFIG="
+enable_lm_head_tp_in_adp: true"
     ATTENTION_DP_CONFIG="
 attention_dp_config:
-    batching_wait_iters: 0
-    enable_balance: true
-    timeout_iters: 60"
+    batching_wait_iters: 30
+    enable_balance: true"
 fi
 
 cat > "$EXTRA_CONFIG_FILE" << EOF
 cuda_graph_config:
     enable_padding: true
     max_batch_size: $CUDA_GRAPH_MAX_BATCH_SIZE
-enable_attention_dp: $DP_ATTENTION$ATTENTION_DP_CONFIG
+enable_attention_dp: $DP_ATTENTION$ATTENTION_DP_CONFIG$LM_HEAD_TP_IN_ADP_CONFIG
 print_iter_log: true
 kv_cache_config:
     tokens_per_block: 128
     dtype: fp8
     free_gpu_memory_fraction: $KV_CACHE_FREE_MEM_FRACTION
     enable_block_reuse: false
-stream_interval: 10
+stream_interval: 100
 num_postprocess_workers: 4
 moe_config:
     backend: $MOE_BACKEND
+    use_low_precision_moe_combine: true
 speculative_config:
     decoding_type: MTP
     num_nextn_predict_layers: $MTP

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh
@@ -61,8 +61,20 @@ nvidia-smi
 SERVER_LOG="$PWD/server.log"
 EXTRA_CONFIG_FILE="dsv4-fp4-trt-mtp.yml"
 
-MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
-MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-3}"
+# MoE backend: TRTLLM at low/mid concurrency; switch to MEGAMOE_DEEPGEMM at high
+# concurrency for short ISL (1k).
+if [[ "$ISL" -le 1024 && "$CONC" -ge 512 ]]; then
+    MOE_BACKEND="${MOE_BACKEND:-MEGAMOE_DEEPGEMM}"
+else
+    MOE_BACKEND="${MOE_BACKEND:-TRTLLM}"
+fi
+# MTP draft length: 3 at low/mid concurrency; steps down to 2 at high concurrency
+# for long ISL (8k).
+if [[ "$ISL" -ge 4096 && "$CONC" -ge 128 ]]; then
+    MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-2}"
+else
+    MTP="${TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS:-3}"
+fi
 MAX_BATCH_SIZE=$(( CONC > 16 ? CONC : 16 ))
 CUDA_GRAPH_MAX_BATCH_SIZE="$MAX_BATCH_SIZE"
 if [[ "$DP_ATTENTION" == "true" ]]; then


### PR DESCRIPTION
## What

Sync the B200 DeepSeek-V4-Pro aggregated frontier configs into the single-node TensorRT-LLM recipes. The non-MTP recipe carries the MTP0 settings; the MTP recipe carries the MTP settings.

## Changes

### `benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt.sh` (MTP0)
- **Worker envs** (all overridable): `TRTLLM_SERVER_DISABLE_GC=1`, `TRTLLM_WORKER_DISABLE_GC=1`, `NCCL_GRAPH_MIXING_SUPPORT=0`, `MIMALLOC_PURGE_DELAY=0`, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
- `kv_cache_config.free_gpu_memory_fraction`: **0.9** (TP / no DP-attn) / **0.7** (DP-attn), was `0.50`.
- `attention_dp_config`: `batching_wait_iters` 0 → **30**, drop `timeout_iters`.
- `stream_interval` 10 → **100**; `moe_config.use_low_precision_moe_combine: true`.
- `max_num_tokens` drops the OSL term: **`ISL + 256`** (output tokens are emitted one at a time, not in the prefill chunk).
- `MOE_BACKEND` made overridable (default `TRTLLM`).

### `benchmarks/single_node/fixed_seq_len/dsv4_fp4_b200_trt_mtp.sh` (MTP)
Same as above, plus:
- DP-attn `free_gpu_memory_fraction` = **0.6**.
- `enable_lm_head_tp_in_adp: true` on the DP-attn path.
- `speculative_config` uses **`max_draft_len`**; default level **2 → 3** (overridable via `TRTLLM_DSV4_MTP_NUM_NEXTN_LAYERS`).
- `max_num_tokens` = **`ISL + (draft+1)*batch + 256`** (drops OSL; keeps the speculative-verification headroom).

## Deliberate non-changes
- `cuda_graph_config` / `max_batch_size` left CONC-derived (per request).
- `max_seq_len` kept floored at **≥ 8192** — headroom for server-side chat-template tokens on the `openai-chat` path.

## Validation
- `bash -n` passes on both recipes.
- Generated YAML for all four paths (MTP0/MTP × TP/DP) parses as valid YAML.