### PR TITLE
MI355x DSR1-FP4: Include TP4 configurations for 8k1k

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -16,6 +16,7 @@ dsr1-fp4-mi355x-sglang:
     - isl: 8192
       osl: 1024
       search-space:
+      - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 64 }
     # Agentic-coding sweep commented out for this image-bump PR — the
     # 10-conc agentic matrix amplifies sweep cost and the bump validation

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3531,3 +3531,10 @@
     - "The Rust frontend replaces only the Python serving/API layer (HTTP, tokenization, scheduling glue, detokenization) and spawns the same Python EngineCore, so GPU kernels/attention/MoE GEMM/KV cache are untouched"
     - "A/B sweep (28 single-node points, 1k1k + 8k1k, TP 1/2/4) vs the Python-frontend baseline (run 26696260751): throughput Pareto-neutral (peak tok/s/GPU within <1.5%, frontiers coincident) and TPOT flat (+-0.5%); TTFT improves ~8% at 1k1k and ~22% at 8k1k (every point), the expected signature of lower frontend CPU latency before first token, scaling with input length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1634
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang
+  description:
+    - "MI355x DSR1-FP4: Include TP4 configurations for 8k1k"
+    - "Expand the TP sweep (included TP=4) for 8k/1k configuration for conc=4 to 64"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1692


### PR DESCRIPTION
Updating the DSR1-FP4 SGLang configuration with TP=4 option. This was missing in the 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only perf sweep expansion; no runtime or application code changes.
> 
> **Overview**
> Adds **TP=4** to the MI355X **DSR1-FP4 SGLang** fixed-seq-len perf sweep for the **8k input / 1k output** case (`isl: 8192`, `osl: 1024`), with concurrency **4–64**—the same shape already used for **1k/1k** and for **TP=8** on 8k/1k.
> 
> Documents the change in `perf-changelog.yaml` under `dsr1-fp4-mi355x-sglang`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e62b5a496761f6636fd22f370e23ec0348db3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->