### PR TITLE
Fix CHAT_TEMPLATE_KWARGS_ON default quoting in dsv4_fp4_b300_vllm

### DIFF
--- a/benchmarks/single_node/speedbench/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4_fp4_b300_vllm.sh
@@ -48,7 +48,8 @@ TEMPERATURE="${TEMPERATURE:-1.0}"
 # thinking-on chat_template_kwargs. MUST match the production/golden config:
 # the reference matrix (benchmarks/speedbench-reference-al.yaml) was measured
 # with reasoning_effort=high.
-CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-{\"thinking\": true, \"reasoning_effort\": \"high\"}}"
+DEFAULT_CHAT_TEMPLATE_KWARGS_ON='{"thinking": true, "reasoning_effort": "high"}'
+CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"
 
 SPEEDBENCH_DIR="${SPEEDBENCH_DIR:-/workspace/speed_bench_data}"
 RESULTS_DIR="${RESULTS_DIR:-/workspace/speedbench_results}"


### PR DESCRIPTION
The collector set `CHAT_TEMPLATE_KWARGS_ON="${VAR:-{...}}"`, but bash ends the parameter expansion at the first }, so the trailing } is appended as a literal. It worked locally because the var was unset (default path lands on a single brace), in CI the workflow passes the var in, so the value became {...}} invalid JSON. Fixed by moving the default into its own variable so there are no brace-literals in the expansion.

Parent PR: #1685 and #1650


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line bash default-value fix in a benchmark script; no production runtime or security impact.
> 
> **Overview**
> Fixes how the SPEED-Bench AL collector sets the default **thinking-on** `chat_template_kwargs` JSON in `dsv4_fp4_b300_vllm.sh`.
> 
> The default is now stored in `DEFAULT_CHAT_TEMPLATE_KWARGS_ON` and assigned via `CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"`, avoiding a `:-{...}` expansion that bash truncates at the first `}` when CI sets the variable—previously producing invalid JSON with an extra trailing `}` for `--chat-template-kwargs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab04adbeb78a8c5c0840aefffcfa5c7110b216d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->