### PR TITLE
[Do Not Merge] kimik2.5-fp4-b300-vllm: align server launch with B200 recipe

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -57,7 +57,7 @@ vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
 --tool-call-parser kimi_k2 \
 --compilation_config.pass_config.fuse_allreduce_rms true \
 --kv-cache-dtype fp8 \
---max-cudagraph-capture-size 2048 \
+--max-cudagraph-capture-size 8192 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 \
 --no-enable-prefix-caching \

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -38,6 +38,12 @@ nvidia-smi
 export TORCH_CUDA_ARCH_LIST="10.0"
 export PYTHONNOUSERSITE=1
 
+# vLLM v0.20.2+'s CUDA-graph memory profiler pre-reserves a large chunk of GPU
+# memory upfront, which collides with --gpu-memory-utilization=0.90 and shrinks
+# the effective budget left for the KV cache. Disable the profiler so 0.90 means
+# 0.90 (same pattern as benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b200.sh).
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
+
 SERVER_LOG=/workspace/server.log
 
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -58,9 +64,8 @@ vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
 --compilation_config.pass_config.fuse_allreduce_rms true \
 --kv-cache-dtype fp8 \
 --max-cudagraph-capture-size 8192 \
---max-num-batched-tokens "$((ISL * 2 ))" \
---stream-interval 20 \
---no-enable-prefix-caching \
+--max-num-batched-tokens 8192 \
+--stream-interval 20 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -56,6 +56,10 @@ vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
 --reasoning-parser kimi_k2 \
 --tool-call-parser kimi_k2 \
 --compilation_config.pass_config.fuse_allreduce_rms true \
+--kv-cache-dtype fp8 \
+--max-cudagraph-capture-size 2048 \
+--max-num-batched-tokens "$((ISL * 2 ))" \
+--stream-interval 20 \
 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3536,4 +3536,4 @@
     - kimik2.5-fp4-b300-vllm
   description:
     - "Align server launch with the B200 recipe by adding the tuning args that were missing on B300: --kv-cache-dtype fp8, --max-cudagraph-capture-size 2048, --max-num-batched-tokens \"$((ISL * 2))\", and --stream-interval 20."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1698

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3535,5 +3535,5 @@
 - config-keys:
     - kimik2.5-fp4-b300-vllm
   description:
-    - "Align server launch with the B200 recipe by adding the tuning args that were missing on B300: --kv-cache-dtype fp8, --max-cudagraph-capture-size 2048, --max-num-batched-tokens \"$((ISL * 2))\", and --stream-interval 20."
+    - "Tune the B300 vLLM server launch: set --kv-cache-dtype fp8, --max-cudagraph-capture-size 8192, --max-num-batched-tokens 8192 (matched to the cudagraph capture size), and --stream-interval 20; disable the CUDA-graph memory profiler (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0) so --gpu-memory-utilization is honored in full."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1698

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3531,3 +3531,9 @@
     - "The Rust frontend replaces only the Python serving/API layer (HTTP, tokenization, scheduling glue, detokenization) and spawns the same Python EngineCore, so GPU kernels/attention/MoE GEMM/KV cache are untouched"
     - "A/B sweep (28 single-node points, 1k1k + 8k1k, TP 1/2/4) vs the Python-frontend baseline (run 26696260751): throughput Pareto-neutral (peak tok/s/GPU within <1.5%, frontiers coincident) and TPOT flat (+-0.5%); TTFT improves ~8% at 1k1k and ~22% at 8k1k (every point), the expected signature of lower frontend CPU latency before first token, scaling with input length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1634
+
+- config-keys:
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Align server launch with the B200 recipe by adding the tuning args that were missing on B300: --kv-cache-dtype fp8, --max-cudagraph-capture-size 2048, --max-num-batched-tokens \"$((ISL * 2))\", and --stream-interval 20."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/<TODO>


### PR DESCRIPTION
Bring the B300 fixed-seq-len server launch to parity with the B200 vLLM recipe. The B300 script (`benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh`) reuses the B200 recipe but was missing these serve args, so add them:

- `--kv-cache-dtype fp8`
- `--max-cudagraph-capture-size 2048`
- `--max-num-batched-tokens "$((ISL * 2))"`
- `--stream-interval 20`

Appends a perf-changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only launch and changelog changes; no application or auth paths, only affects how the B300 vLLM server is started for sweeps.
> 
> **Overview**
> Tunes **Kimi-K2.5 FP4 B300** fixed-seq-len vLLM launch in `kimik2.5_fp4_b300.sh` so serving matches the tuned B200-style recipe and documents it under `kimik2.5-fp4-b300-vllm` in `perf-changelog.yaml`.
> 
> Sets **`VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0`** so vLLM’s CUDA-graph memory profiler does not pre-reserve GPU memory and shrink the KV cache budget under **`--gpu-memory-utilization 0.90`**. Adds **`--kv-cache-dtype fp8`**, **`--max-cudagraph-capture-size 8192`**, **`--max-num-batched-tokens 8192`** (both aligned to 8192, not the B200 script’s 2048 / `ISL*2`), **`--stream-interval 20`**, and keeps **`--no-enable-prefix-caching`** on the serve line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993085b56f1dd441c461dd911f402226230fd967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->