### PR TITLE
[AMD][MI35X] 0610 DSV4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2140,7 +2140,7 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
 # image tag, so bumping sglang is just an image tag bump here. Sweeps
 # DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:rocm720-mi35x-f96ac98-20260526-DSv4
+  image: rocm/sgl-dev:v0.5.12.post1-rocm720-mi35x-20260610
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2136,12 +2136,8 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
           - "DECODE_MTP_SIZE=1"
 
 
-# DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
-# amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
-# image tag, so bumping sglang is just an image tag bump here. Sweeps
-# DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: rocm/sgl-dev:v0.5.12.post1-rocm720-mi35x-20260610
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260610
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_sglang.sh
@@ -46,41 +46,28 @@ else:
     print(f"No patch needed: model_type is {config.get('model_type')!r}")
 PYEOF
 
-# DSv4 FP4-experts path. Tracks the env block in python/run_dsv4.sh on the
-# amd/deepseek_v4 branch (HEAD's active block is FP8; we override the two
-# FP4-specific flags below):
-#   SGLANG_DSV4_FP4_EXPERTS=True   -> route experts through the FP4 kernels
-#   SGLANG_FORCE_TRITON_MOE_FP8=0  -> dispatch MoE through aiter and apply
-#                                    the swiglu_limit clamp in the triton
-#                                    MoE fallback path.
-export SGLANG_REASONING_EFFORT=max
-export SGLANG_OPT_USE_FUSED_COMPRESS=true
-export SGLANG_OPT_USE_OLD_COMPRESSOR=false
-export SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false
-export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false
-export SGLANG_OPT_USE_FUSED_HASH_TOPK=true
+export SGLANG_DEFAULT_THINKING=1
+export SGLANG_DSV4_REASONING_EFFORT=max
 export SGLANG_OPT_DEEPGEMM_HC_PRENORM=false
+export SGLANG_USE_AITER=1
+export SGLANG_USE_ROCM700A=0
+export SGLANG_OPT_USE_FUSED_COMPRESS=true
+export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton
+export SGLANG_OPT_FP8_WO_A_GEMM=false
+export SGLANG_OPT_USE_JIT_INDEXER_METADATA=false
+export SGLANG_OPT_USE_TOPK_V2=false
+export SGLANG_OPT_USE_AITER_INDEXER=true
+export SGLANG_OPT_USE_TILELANG_INDEXER=false
 export SGLANG_OPT_USE_TILELANG_MHC_PRE=false
 export SGLANG_OPT_USE_TILELANG_MHC_POST=false
-export SGLANG_OPT_USE_AITER_MHC_PRE=true
-export SGLANG_OPT_USE_AITER_MHC_POST=true
-export SGLANG_ENABLE_THINKING=1
-export SGLANG_USE_AITER=1
-export SGLANG_USE_ROCM700A=1
-export SGLANG_TOPK_TRANSFORM_512_TORCH=0
 export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
-export SGLANG_DSV4_FP4_EXPERTS=True
-export SGLANG_OPT_DPSK_V4_RADIX=1
-export SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false
-export SGLANG_OPT_USE_FUSED_STORE_CACHE=true
-export SGLANG_FORCE_TRITON_MOE_FP8=0
-export SGLANG_HACK_FLASHMLA_BACKEND=triton
-export SGLANG_OPT_USE_TILELANG_INDEXER=true
-export SGLANG_OPT_USE_TRITON_SWA_PREPARE=true
+export SGLANG_OPT_USE_FUSED_COMPRESS_TRITON=true
 export AITER_BF16_FP8_MOE_BOUND=0
-export SGLANG_OPT_FUSE_WQA_WKV=true
-export SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=true
-export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=0
+export SGLANG_EAGER_INPUT_NO_COPY=true
+
+# multi-stream
+export SGLANG_OPT_USE_MULTI_STREAM_OVERLAP=false
+export SGLANG_ROCM_USE_MULTI_STREAM=false
 
 SERVER_LOG=/workspace/server.log
 
@@ -100,20 +87,21 @@ if [ "${DP_ATTENTION}" = "true" ]; then
         --dp "$TP"
         --enable-dp-attention
         --enable-prefill-delayer
+	--prefill-delayer-max-delay-ms 5000
     )
 fi
 if [ "${EP_SIZE:-1}" -gt 1 ]; then
     PARALLEL_ARGS+=(--ep-size "$EP_SIZE")
 fi
 
-python3 -m sglang.launch_server \
+sglang serve \
     --model-path $MODEL \
     --host=0.0.0.0 \
     --port $PORT \
     "${PARALLEL_ARGS[@]}" \
     --trust-remote-code \
     --disable-radix-cache \
-    --attention-backend compressed \
+    --attention-backend dsv4 \
     --max-running-requests ${CONC} \
     --mem-fraction-static 0.90 \
     --swa-full-tokens-ratio 0.15 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3531,3 +3531,11 @@
     - "The Rust frontend replaces only the Python serving/API layer (HTTP, tokenization, scheduling glue, detokenization) and spawns the same Python EngineCore, so GPU kernels/attention/MoE GEMM/KV cache are untouched"
     - "A/B sweep (28 single-node points, 1k1k + 8k1k, TP 1/2/4) vs the Python-frontend baseline (run 26696260751): throughput Pareto-neutral (peak tok/s/GPU within <1.5%, frontiers coincident) and TPOT flat (+-0.5%); TTFT improves ~8% at 1k1k and ~22% at 8k1k (every point), the expected signature of lower frontend CPU latency before first token, scaling with input length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1634
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "to be updated"
+  pr-link: 
+    https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3535,7 +3535,10 @@
 - config-keys:
     - dsv4-fp4-mi355x-sglang
   description:
-    - "to be updated"
+    - "Switch back to the main branch on InferenceX benchmarking. Since the AMD v4 model code has been merged into main, we now use the main branch instead of the previously used amd/deepseek_v4 branch. The image is bumped to the main branch image rocm/sgl-dev:v0.5.12.post1-rocm720-mi35x-20260610."
+    - "Refresh the script's env vars. The main branch introduced several env var renames and new default settings, so we refreshed the env vars in the script accordingly."
+    - "Enable the unified KV attention kernel. Set export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton for better performance."
+    - "Specify the prefill delay explicitly. Set --prefill-delayer-max-delay-ms 5000 to define a concrete prefill delay, allowing DP to batch more requests together per execution."
   pr-link: 
     https://github.com/SemiAnalysisAI/InferenceX/pull/1701
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3537,5 +3537,5 @@
   description:
     - "to be updated"
   pr-link: 
-    https://github.com/SemiAnalysisAI/InferenceX/pull/xxxx
+    https://github.com/SemiAnalysisAI/InferenceX/pull/1701
 


### PR DESCRIPTION
**The unified kv kernel is from [ATOM repo](https://github.com/ROCm/ATOM/tree/6a2638b588dec65e938359ab957b264397b7b776/atom/model_ops/v4_kernels).**

Successful run:
see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=27274233340
see unofficial run visualizer at https://inferencex.semianalysis.com/evaluation?unofficialRun=27274233340


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Benchmark recipe and container image swap affect published DSv4 MI355X numbers and kernel/attention paths; scope is benchmarking config only, not production serving code.
> 
> **Overview**
> **Moves the MI355X DeepSeek-V4-Pro FP4 SGLang benchmark off the custom `amd/deepseek_v4` image** to mainline `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260610`, now that DSv4 support is on SGLang main.
> 
> **`dsv4_fp4_mi355x_sglang.sh` is realigned with main defaults:** reasoning env vars (`SGLANG_DEFAULT_THINKING`, `SGLANG_DSV4_REASONING_EFFORT`), indexer/compress paths (`unified_kv_triton`, aiter indexer), and multi-stream overlap disabled. Branch-only FP4 MoE flags (`SGLANG_DSV4_FP4_EXPERTS`, `SGLANG_FORCE_TRITON_MOE_FP8`, etc.) are dropped.
> 
> **Serve invocation changes:** `sglang serve` instead of `python3 -m sglang.launch_server`, **`--attention-backend dsv4`** (was `compressed`), and **`--prefill-delayer-max-delay-ms 5000`** when DP attention is on. **`perf-changelog.yaml`** documents the config-key update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c23d118339ad74adc768b9bcef69f8194b2ea76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->