### PR TITLE
[WIP] [NV] Update MiniMax B200/B300 aggregate vLLM settings

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4358,7 +4358,7 @@ minimaxm2.5-fp8-b200-vllm-agentic:
   # MiniMax-M2.5 FP8 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 minimaxm2.5-fp8-b300-vllm:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.22.0
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
   runner: b300
@@ -4462,7 +4462,7 @@ minimaxm2.5-fp4-b200-vllm-agentic:
   # MiniMax-M2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 minimaxm2.5-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/MiniMax-M2.5-NVFP4
   model-prefix: minimaxm2.5
   runner: b300

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp4_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp4_b200.sh
@@ -25,6 +25,7 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 SERVER_LOG=/workspace/server.log
 
 export VLLM_FLOAT32_MATMUL_PRECISION=high
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp4_b300.sh
@@ -40,6 +40,7 @@ nvidia-smi
 SERVER_LOG=/workspace/server.log
 
 export VLLM_FLOAT32_MATMUL_PRECISION=high
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size 1 --data-parallel-size $TP --enable-expert-parallel"

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_b200.sh
@@ -24,6 +24,7 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 SERVER_LOG=/workspace/server.log
 
 export VLLM_FLOAT32_MATMUL_PRECISION=high
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
 if [ "$EP_SIZE" -gt 1 ]; then
   EP=" --enable-expert-parallel"

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.5_fp8_b300.sh
@@ -39,6 +39,7 @@ nvidia-smi
 SERVER_LOG=/workspace/server.log
 
 export VLLM_FLOAT32_MATMUL_PRECISION=high
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
 if [ "$EP_SIZE" -gt 1 ]; then
   EP=" --enable-expert-parallel"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3531,3 +3531,13 @@
     - "The Rust frontend replaces only the Python serving/API layer (HTTP, tokenization, scheduling glue, detokenization) and spawns the same Python EngineCore, so GPU kernels/attention/MoE GEMM/KV cache are untouched"
     - "A/B sweep (28 single-node points, 1k1k + 8k1k, TP 1/2/4) vs the Python-frontend baseline (run 26696260751): throughput Pareto-neutral (peak tok/s/GPU within <1.5%, frontiers coincident) and TPOT flat (+-0.5%); TTFT improves ~8% at 1k1k and ~22% at 8k1k (every point), the expected signature of lower frontend CPU latency before first token, scaling with input length"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1634
+
+- config-keys:
+    - minimaxm2.5-fp8-b200-vllm
+    - minimaxm2.5-fp8-b300-vllm
+    - minimaxm2.5-fp4-b200-vllm
+    - minimaxm2.5-fp4-b300-vllm
+  description:
+    - "Use vLLM image v0.22.0 for MiniMax-M2.5 FP8/FP4 B200/B300 aggregate benchmarks."
+    - "Set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 in the B200/B300 MiniMax aggregate launch scripts."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3540,4 +3540,4 @@
   description:
     - "Use vLLM image v0.22.0 for MiniMax-M2.5 FP8/FP4 B200/B300 aggregate benchmarks."
     - "Set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 in the B200/B300 MiniMax aggregate launch scripts."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1704


### PR DESCRIPTION
Updates MiniMax B200/B300 aggregate vLLM image/settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only image and environment tweaks for MiniMax aggregate configs; no application auth or production serving paths.
> 
> **Overview**
> Aligns **MiniMax-M2.5** aggregate vLLM benchmarks on **B200/B300** (FP8 and FP4) with **vLLM `v0.22.0`** on B300 in `nvidia-master.yaml` (from `v0.21.0`) and documents the rollout in `perf-changelog.yaml`.
> 
> All four fixed-seq-len launch scripts (`minimaxm2.5_fp{4,8}_b{200,300}.sh`) now set **`VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0`** before serve, matching other NVIDIA recipes that disable v0.21+ CUDA-graph memory profiling to avoid startup OOM / inflated KV reservations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1934cb630ba2a5c231225a97816b3d405d048d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->