### PR TITLE
Update benchmark_serving.py

### DIFF
--- a/utils/bench_serving/benchmark_serving.py
+++ b/utils/bench_serving/benchmark_serving.py
@@ -915,8 +915,6 @@ def main(args: argparse.Namespace):
         if not args.save_detailed:
             # Remove fields with too many data points
             for field in [
-                "input_lens",
-                "output_lens",
                 "ttfts",
                 "itls",
                 "generated_texts",


### PR DESCRIPTION
We need to have input and output token length for performance tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to which fields are written in benchmark result JSON; no serving or metric calculation logic is affected.
> 
> **Overview**
> When saving benchmark results without `--save-detailed`, the JSON output **now keeps** per-request `input_lens` and `output_lens` instead of dropping them with the other large per-request arrays.
> 
> Aggregated metrics are unchanged; only the default saved result file grows slightly so runs can be correlated with input/output token lengths for performance tracking. `ttfts`, `itls`, `generated_texts`, and `errors` are still omitted unless `--save-detailed` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1150f393025f22b70fbed339f6179545ea5b3bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->