### PR TITLE
feat(ci): add dispatchable fail-fast-cancel workflow

### DIFF
--- a/.github/workflows/fail-fast-cancel.yml
+++ b/.github/workflows/fail-fast-cancel.yml
@@ -1,0 +1,45 @@
+name: "Fail-Fast Cancel Run"
+run-name: Fail-fast cancel for run ${{ inputs.run-id }}
+
+# Dispatched by the benchmark templates when a job fails with fail-fast
+# enabled. Cancelling a run from inside one of its own jobs flips the
+# failing job's conclusion from 'failure' to 'cancelled' (the job is still
+# in progress when the cancellation is processed), which hides which job
+# caused the cascade. This workflow runs outside the target run: it waits
+# for the failing job to actually conclude as 'failure' (keeping its red X)
+# before cancelling everything else.
+
+on:
+    workflow_dispatch:
+        inputs:
+            run-id:
+                description: "Workflow run ID to cancel once its failing job has concluded"
+                required: true
+                type: string
+
+permissions:
+    actions: write
+
+jobs:
+    cancel:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - name: Wait for the failing job to conclude, then cancel the run
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+                  RUN_ID: ${{ inputs.run-id }}
+              run: |
+                  for _ in $(seq 1 60); do
+                      failed=$(gh api --paginate \
+                          "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+                          --jq '.jobs[] | select(.conclusion == "failure") | .id' | wc -l)
+                      if [ "${failed:-0}" -gt 0 ]; then
+                          echo "Found ${failed} concluded failed job(s) in run ${RUN_ID}; cancelling."
+                          break
+                      fi
+                      sleep 10
+                  done
+                  # Cancel even if the poll timed out: failing toward
+                  # cancellation is the point of fail-fast mode.
+                  gh api -X POST "repos/${{ github.repository }}/actions/runs/${RUN_ID}/cancel"


### PR DESCRIPTION
Companion to #1718 (`full-sweep-fail-fast` label). Contains only `.github/workflows/fail-fast-cancel.yml`.

- `workflow_dispatch` can only target workflows registered on the default branch — #1718's test sweep dispatched this and got a 404, so the run was never cancelled. It needs to land on main before the label can work (including for testing #1718 itself).
- Inert by itself: triggers only on explicit dispatch from the benchmark templates' fail-fast path, then waits for the failing job to conclude (keeping its red failure status) before cancelling the target run.
- No sweep is triggered by merging this (doesn't touch `perf-changelog.yaml`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with scoped `actions: write`; no application, auth, or data-path impact.
> 
> **Overview**
> Adds a new **`fail-fast-cancel`** GitHub Actions workflow that benchmark sweeps can dispatch when fail-fast mode is on.
> 
> Instead of cancelling the workflow run from inside a failing matrix job (which can rewrite that job’s conclusion from **failure** to **cancelled**), this runs as a separate workflow: it polls the target run until at least one job has concluded as **failure**, then calls the Actions API to cancel the rest of the run. It only runs on manual **`workflow_dispatch`** with a **`run-id`** input, uses **`actions: write`**, and still attempts cancellation if the poll times out (~10 minutes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9cdd223c2100f9d22b6eb4ce86912263c2b235d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->