### PR TITLE
Per-model gsm8k eval thresholds derived from IQR analysis

### DIFF
--- a/utils/evals/thresholds.json
+++ b/utils/evals/thresholds.json
@@ -1,4 +1,32 @@
 {
-  "gsm8k": 0.85,
-  "gpqa_diamond_cot_n_shot": 0.30
+  "default": {
+    "gsm8k": 0.90,
+    "gpqa_diamond_cot_n_shot": 0.30
+  },
+  "models": {
+    "dsr1": {
+      "gsm8k": 0.91
+    },
+    "dsv4": {
+      "gsm8k": 0.91
+    },
+    "glm5": {
+      "gsm8k": 0.94
+    },
+    "glm5.1": {
+      "gsm8k": 0.93
+    },
+    "gptoss": {
+      "gsm8k": 0.91
+    },
+    "kimik2.5": {
+      "gsm8k": 0.90
+    },
+    "minimaxm2.5": {
+      "gsm8k": 0.92
+    },
+    "qwen3.5": {
+      "gsm8k": 0.94
+    }
+  }
 }

--- a/utils/evals/validate_scores.py
+++ b/utils/evals/validate_scores.py
@@ -2,25 +2,87 @@
 """Validate eval scores against minimum thresholds.
 
 Reads lm-eval results JSON files and checks that scored metrics meet the
-required minimum.  Thresholds are configured per-task in a JSON config file
-(default: utils/evals/thresholds.json).
+required minimum.  Thresholds are configured per-task, with optional per-model
+overrides, in a JSON config file (default: utils/evals/thresholds.json):
+
+    {
+      "default": { "gsm8k": 0.85, "gpqa_diamond_cot_n_shot": 0.30 },
+      "models": {
+        "dsv4": { "gsm8k": 0.90 },
+        "glm5": { "gsm8k": 0.92 }
+      }
+    }
+
+The model is identified by its `infmax_model_prefix` (e.g. "dsv4", "glm5"),
+read from meta_env.json in the current directory -- written alongside the
+results*.json files by the eval harness.  For each task the threshold is
+resolved most-specific-first:
+
+    models[<prefix>][<task>]  ->  default[<task>]  ->  --min-score
+
+Models without an entry under "models" (or runs where the prefix can't be
+determined) fall back to the global default, then to --min-score.
+
+A legacy flat config ({"gsm8k": 0.85, ...}) is still accepted and treated as
+the global default with no per-model overrides.
 
 Usage:
     python3 utils/evals/validate_scores.py
     python3 utils/evals/validate_scores.py --thresholds my_thresholds.json
-    python3 utils/evals/validate_scores.py --min-score 0.90  # flat threshold, no config
+    python3 utils/evals/validate_scores.py --model-prefix dsv4
+    python3 utils/evals/validate_scores.py --min-score 0.90  # flat fallback
 """
 import argparse
 import glob
 import json
+import os
 import sys
 from pathlib import Path
 
 
-def load_thresholds(path: str) -> dict[str, float]:
-    """Load thresholds config. Returns {task_name: min_score}."""
+def load_config(path: str) -> dict:
+    """Load thresholds config, normalized to {"default": {...}, "models": {...}}.
+
+    Accepts both the per-model format ({"default": {...}, "models": {...}}) and
+    the legacy flat format ({task: min_score}), which is treated as the global
+    default with no per-model overrides.
+    """
     with open(path) as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if not isinstance(cfg, dict):
+        raise ValueError("thresholds config must be a JSON object")
+    if "default" not in cfg and "models" not in cfg:
+        # Legacy flat format: the whole object is the per-task default.
+        return {"default": cfg, "models": {}}
+    return {"default": cfg.get("default", {}), "models": cfg.get("models", {})}
+
+
+def detect_model_prefix(meta_env_path: str, override: str | None) -> str | None:
+    """Resolve the model prefix: explicit override > meta_env.json > env var."""
+    if override:
+        return override
+    try:
+        with open(meta_env_path) as f:
+            prefix = json.load(f).get("infmax_model_prefix")
+        if prefix and prefix != "unknown":
+            return prefix
+    except (json.JSONDecodeError, OSError, AttributeError):
+        pass
+    env_prefix = os.environ.get("MODEL_PREFIX")
+    if env_prefix and env_prefix != "unknown":
+        return env_prefix
+    return None
+
+
+def resolve_threshold(config: dict, prefix: str | None, task: str, fallback: float):
+    """Return (min_score, source) for a task, most-specific-first."""
+    models = config.get("models", {})
+    if prefix and task in models.get(prefix, {}):
+        return models[prefix][task], f"models.{prefix}"
+    default = config.get("default", {})
+    if task in default:
+        return default[task], "default"
+    return fallback, "min-score"
 
 
 def main() -> int:
@@ -34,6 +96,14 @@ def main() -> int:
         help="Path to thresholds JSON config (default: utils/evals/thresholds.json)",
     )
     parser.add_argument(
+        "--meta-env", default="meta_env.json",
+        help="Path to meta_env.json used to detect the model prefix (default: meta_env.json)",
+    )
+    parser.add_argument(
+        "--model-prefix", default=None,
+        help="Override the detected model prefix (default: read from meta_env.json / $MODEL_PREFIX)",
+    )
+    parser.add_argument(
         "--metric-prefix", default="exact_match,",
         help="Only check metrics whose name starts with this prefix (default: 'exact_match,')",
     )
@@ -44,7 +114,7 @@ def main() -> int:
     args = parser.parse_args()
 
     # Load thresholds config
-    thresholds = {}
+    config = {"default": {}, "models": {}}
     thresholds_path = args.thresholds
     if thresholds_path is None:
         default_path = Path(__file__).parent / "thresholds.json"
@@ -52,10 +122,19 @@ def main() -> int:
             thresholds_path = str(default_path)
     if thresholds_path:
         try:
-            thresholds = load_thresholds(thresholds_path)
+            config = load_config(thresholds_path)
             print(f"Loaded thresholds from {thresholds_path}")
-        except (json.JSONDecodeError, OSError) as e:
+        except (json.JSONDecodeError, OSError, ValueError) as e:
             print(f"WARN: could not load thresholds from {thresholds_path}: {e}", file=sys.stderr)
+
+    # Identify the model so per-model thresholds can apply
+    prefix = detect_model_prefix(args.meta_env, args.model_prefix)
+    if prefix and prefix in config.get("models", {}):
+        print(f"Model prefix: {prefix} (per-model thresholds apply)")
+    elif prefix:
+        print(f"Model prefix: {prefix} (no per-model override; using global default)")
+    else:
+        print("Model prefix: <unknown> (using global default thresholds)")
 
     failed = False
     checked = 0
@@ -64,7 +143,7 @@ def main() -> int:
         with open(f) as fh:
             data = json.load(fh)
         for task, metrics in data.get("results", {}).items():
-            min_score = thresholds.get(task, args.min_score)
+            min_score, source = resolve_threshold(config, prefix, task, args.min_score)
             for name, val in metrics.items():
                 if not name.startswith(args.metric_prefix) or "stderr" in name:
                     continue
@@ -73,12 +152,12 @@ def main() -> int:
                 checked += 1
                 if val < min_score:
                     print(
-                        f"FAIL: {task} {name} = {val:.4f} (< {min_score})",
+                        f"FAIL: {task} {name} = {val:.4f} (< {min_score} from {source})",
                         file=sys.stderr,
                     )
                     failed = True
                 else:
-                    print(f"PASS: {task} {name} = {val:.4f} (>= {min_score})")
+                    print(f"PASS: {task} {name} = {val:.4f} (>= {min_score} from {source})")
 
     if checked == 0:
         print("WARN: no metrics matched prefix '{}'".format(args.metric_prefix), file=sys.stderr)


### PR DESCRIPTION
## Summary

- Restructure `thresholds.json` from a flat per-task config to per-model overrides keyed by `infmax_model_prefix`, with the global default as fallback for new/unkeyed models
- Update `validate_scores.py` to read the model prefix from `meta_env.json` (already in the working directory at validation time) and resolve thresholds most-specific-first: `models[prefix][task]` → `default[task]` → `--min-score`
- Per-model gsm8k floors computed from 1,374 eval runs via the InferenceX `/api/v1/evaluations` endpoint using box-and-whisker IQR analysis: `floor = max(0.90, floor(Q1 − 1.5×IQR − 0.02, 2dp))`

### Thresholds

| Model | n | Q1 | IQR | Low Fence | **Floor** |
|---|---|---|---|---|---|
| dsr1 | 284 | 0.9464 | 0.0104 | 0.9307 | **0.91** |
| dsv4 | 209 | 0.9500 | 0.0121 | 0.9318 | **0.91** |
| glm5 | 97 | 0.9659 | 0.0030 | 0.9613 | **0.94** |
| glm5.1 | 8 | 0.9693 | 0.0064 | 0.9596 | **0.93** |
| gptoss | 183 | 0.9538 | 0.0099 | 0.9390 | **0.91** |
| kimik2.5 | 113 | 0.8946 | 0.0788 | 0.7763 | **0.90** |
| minimaxm2.5 | 221 | 0.9568 | 0.0053 | 0.9488 | **0.92** |
| qwen3.5 | 259 | 0.9674 | 0.0038 | 0.9617 | **0.94** |

### Backward compatibility

- Legacy flat config format (`{"gsm8k": 0.85}`) is still accepted and treated as the global default with no per-model overrides
- No workflow changes required — `meta_env.json` is already written by the eval harness before the "Verify eval scores" step runs
- PASS/FAIL output now reports the threshold source, e.g. `(>= 0.91 from models.dsv4)` or `(>= 0.90 from default)`

## Test plan

- [ ] Verify per-model threshold applies when `meta_env.json` contains a known prefix
- [ ] Verify global default fallback when prefix is absent or unrecognized
- [ ] Verify legacy flat config format still loads correctly
- [ ] Verify `--model-prefix` CLI override works
- [ ] Run eval-only job for at least one model and confirm PASS/FAIL output includes source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI pass/fail criteria per model; mis-detected prefixes or wrong floors could block or greenlight builds incorrectly, though legacy config and fallbacks limit breakage.
> 
> **Overview**
> Restructures eval score gates so **gsm8k** (and other tasks) can use **per-model minimums** instead of one flat bar for every run.
> 
> `thresholds.json` now has a **`default`** block (global gsm8k raised to **0.90**) and a **`models`** map keyed by `infmax_model_prefix` with IQR-derived gsm8k floors for eight prefixes (e.g. **glm5**/**qwen3.5** at **0.94**, **kimik2.5** at **0.90**).
> 
> `validate_scores.py` loads that shape (still accepting legacy flat JSON), detects the prefix from **`meta_env.json`**, **`--model-prefix`**, or **`$MODEL_PREFIX`**, and resolves thresholds **`models[prefix][task]` → `default[task]` → `--min-score`**. PASS/FAIL lines now show which source was used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721018f41c842ba77d492de6588e67610d5c9190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->