### PR TITLE
[Klaud Cold][NVIDIA] feat: MiniMax M3 Day 0 support H200

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4807,6 +4807,41 @@ minimaxm2.5-fp8-h200-vllm-agentic:
       - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 24, 28, 32, 36, 48] }
       - { tp: 4, offloading: cpu,  conc-list: [24, 28, 32, 36, 40, 48] }
 
+# Day-zero MiniMax-M3 recipe (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3).
+# 427B total / 26B active MoE with MSA sparse attention. M3 support has not
+# shipped in a stable vLLM release; the dedicated vllm/vllm-openai:minimax-m3
+# image is the supported path. MXFP8 variant (NVIDIA-quantized, ~427 GB
+# weights) is the lowest precision available; on 8x H200 (1128 GB) it leaves
+# ample KV headroom where BF16 (~854 GB) is a tight fit. TP4 (~112 GB
+# weights/GPU) is memory-tight — swept only at low/mid conc.
+# dp-attn: true maps to the recipe's "DP8 + Expert Parallel" serve mode
+# (vLLM --data-parallel-size 8 --enable-expert-parallel).
+minimaxm3-fp8-h200-vllm:
+  image: vllm/vllm-openai:minimax-m3
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: h200
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 32 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
+
 dsr1-fp4-gb200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
   model: nvidia/DeepSeek-R1-0528-NVFP4-v2

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4829,16 +4829,16 @@ minimaxm3-fp8-h200-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 32 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 1, conc-end: 32 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_h200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_h200.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+# MiniMax-M3 MXFP8 H200 single-node vLLM recipe
+# (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3). 427B/26B-active MoE with MSA
+# sparse attention. --block-size 128 is mandatory (MSA sparse_block_size is
+# 128; the default 16 misaligns sparse indexing). The benchmark is text-only,
+# so --language-model-only skips the vision encoder and frees VRAM for KV.
+# dp-attn=true maps to DP×EP (DEP) per the recipe's "DP8 + Expert Parallel"
+# layout; ep>1 maps to TP+EP (TEP). Hopper has no native MX tensor cores, so
+# the MXFP8 MoE runs through vLLM's Hopper-compatible backends (Marlin /
+# DeepGEMM) selected by the mxfp8 oracle in the minimax-m3 image.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+# The shared HF cache lives on a network FS; concurrent day-zero downloads of
+# the same ~444 GB checkpoint from sibling nodes hit huggingface_hub's
+# WeakFileLock "[Errno 116] Stale file handle" race. Retry the download (it
+# resumes), then serve with HF_HUB_OFFLINE=1 so vllm's snapshot_download does
+# a lock-free local-cache read instead of re-contending the lock files.
+SERVE_OFFLINE=()
+if [[ "$MODEL" != /* ]]; then
+  for attempt in 1 2 3 4 5; do
+    hf download "$MODEL" && break
+    if [ "$attempt" = 5 ]; then echo "hf download failed after $attempt attempts" >&2; exit 1; fi
+    echo "hf download attempt $attempt failed; retrying in 60s" >&2
+    sleep 60
+  done
+  SERVE_OFFLINE=(env HF_HUB_OFFLINE=1)
+fi
+
+SERVER_LOG=/workspace/server.log
+
+export PYTHONNOUSERSITE=1
+# ~444 GB of MXFP8 weights off shared FS; engine startup can exceed the
+# default 600s readiness window.
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+if [ "${DP_ATTENTION}" = "true" ]; then
+  PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
+elif [ "$EP_SIZE" -gt 1 ]; then
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
+else
+  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+fi
+
+# Fixed-seq-len runs don't need graphs past the request concurrency: capture
+# up to the next power of two >= CONC (per-DP-rank batch is CONC/DP but ragged
+# arrival makes the full CONC bound safer), capped at vLLM's 2048 ceiling.
+CAPTURE_SIZE=4
+while (( CAPTURE_SIZE < CONC )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
+(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+"${SERVE_OFFLINE[@]}" vllm serve $MODEL --port $PORT \
+$PARALLEL_ARGS \
+--gpu-memory-utilization 0.90 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size 128 \
+--language-model-only \
+--max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-num-batched-tokens "$((ISL * 2 ))" \
+--stream-interval 20 --no-enable-prefix-caching \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3636,3 +3636,11 @@
     - "Add MiniMax-M2.5 FP4 (NVFP4) B300 TensorRT-LLM benchmark (model: nvidia/MiniMax-M2.5-NVFP4)"
     - "Image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1712
+
+- config-keys:
+    - minimaxm3-fp8-h200-vllm
+  description:
+    - "Day-zero MiniMax-M3 MXFP8 single-node recipe for H200 (vLLM)."
+    - "Image: vllm/vllm-openai:minimax-m3 (dedicated day-zero image; M3 not in a stable release yet)."
+    - "Sweeps TP4/TP8, TP+EP (TEP), and DP-attention+EP (DEP) per https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3643,4 +3643,4 @@
     - "Day-zero MiniMax-M3 MXFP8 single-node recipe for H200 (vLLM)."
     - "Image: vllm/vllm-openai:minimax-m3 (dedicated day-zero image; M3 not in a stable release yet)."
     - "Sweeps TP4/TP8, TP+EP (TEP), and DP-attention+EP (DEP) per https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1728


### PR DESCRIPTION
## Summary

Day-zero single-node vLLM recipe for **MiniMaxAI/MiniMax-M3-MXFP8** on **H200**, following the official vLLM recipe (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3). Sibling of the B200 (#1723) / B300 (#1724) / MI355X (#1725) day-zero PRs.

- New config key: `minimaxm3-fp8-h200-vllm` (runner pool: `h200`)
- New script: `benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_h200.sh`
- `perf-changelog.yaml` entry

## Model & image

- **Model:** `MiniMaxAI/MiniMax-M3-MXFP8` — 427B total / 26B active MoE with MSA sparse attention, NVIDIA-quantized MXFP8 (~427 GB weights, roughly half of BF16). Verified on HF.
- **Image:** `vllm/vllm-openai:minimax-m3` — dedicated day-zero image (M3 support has not shipped in a stable vLLM release). Tag verified on Docker Hub (amd64 + arm64, pushed 2026-06-12).

## Recipe details (per recipes.vllm.ai + repo conventions)

- `--block-size 128` is **mandatory**: MSA sparse_block_size is 128; the default 16 misaligns sparse indexing.
- `--language-model-only`: the benchmark is text-only, skipping the vision encoder frees VRAM for KV.
- Parallelism maps: `ep > 1` → TP+EP (`--enable-expert-parallel`); `dp-attn: true` → the recipe's "DP8 + Expert Parallel" mode (`--data-parallel-size 8 --enable-expert-parallel`).
- Fixed-seq-len scenarios use the harness-provided `MAX_MODEL_LEN = isl + osl + 256` (not the model's full 1M context), and CUDA graph capture is bounded at the next power of two ≥ CONC (`--max-cudagraph-capture-size`), matching the other day-zero M3 recipes.
- `VLLM_ENGINE_READY_TIMEOUT_S=3600` (~444 GB weights off shared FS can exceed the default 600 s readiness window) plus a retrying `hf download` + `HF_HUB_OFFLINE=1` serve to dodge the shared-FS WeakFileLock race on day-zero concurrent downloads.

## Sweep space

Concurrency/parallelism chosen from the official recipe's serve modes plus existing H200 large-MoE configs (`dsv4-fp8-h200-vllm`, `minimaxm2.5-fp8-h200-vllm`). On 8x H200 (1128 GB), TP8 leaves ~70 GB/GPU of KV headroom; TP4 (~112 GB weights/GPU) is memory-tight and only swept at low/mid concurrency.

| Scenario | Search space |
|---|---|
| 1k1k | TP4 (1–64), TP4+EP4 (128–256), TP8 (1–128), TP8+EP8 (256–512), DEP8 (256–1024) |
| 8k1k | TP4 (1–32), TP8 (1–128), TP8+EP8 (256), DEP8 (256–512) |

Validated with `generate_sweep_configs.py test-config` → 39 sweep points, including eval entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive benchmark harness and CI config only; no changes to production serving, auth, or application runtime paths.
> 
> **Overview**
> Adds **day-zero single-node benchmarking** for **MiniMax-M3 MXFP8** on **H200** via vLLM, aligned with the official vLLM recipe.
> 
> A new config key **`minimaxm3-fp8-h200-vllm`** in `nvidia-master.yaml` points at `vllm/vllm-openai:minimax-m3` and `MiniMaxAI/MiniMax-M3-MXFP8`, with **fixed-seq-len** sweeps at **1k/1k** and **8k/1k** over **TP4/TP8**, **TP+EP**, and **DP-attention + EP** concurrency ranges tuned for H200 memory headroom.
> 
> The companion script **`minimaxm3_fp8_h200.sh`** implements serve flags required for M3 (**`--block-size 128`**, **`--language-model-only`**), maps **`dp-attn` / EP** to the right vLLM parallel args, bounds CUDA graph capture to concurrency, retries large **`hf download`** on shared FS lock races, and extends engine readiness timeout for the ~444 GB checkpoint. **`perf-changelog.yaml`** documents the new config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086f643d3aefa9efbf546a6c5d1121fd595e9388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
