### PR TITLE
[Klaud Cold] minimaxm3-fp8-b300-vllm-mtp: day-zero MiniMax-M3 EAGLE3 (MTP) B300 recipe

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11718,8 +11718,8 @@ minimaxm3-fp8-b300-vllm:
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
 # minimaxm3-fp8-b300-vllm, pairing MiniMaxAI/MiniMax-M3-MXFP8 with the
-# Inferact/MiniMax-M3-EAGLE3 draft head (2 speculative tokens, house default
-# for vLLM spec decoding). Search space mirrors the non-MTP entry trimmed at
+# Inferact/MiniMax-M3-EAGLE3 draft head (3 speculative tokens).
+# Search space mirrors the non-MTP entry trimmed at
 # the extreme-concurrency end, per the dsv4-fp4-b300-vllm-mtp precedent:
 # spec decode pays off at low/mid concurrency while acceptance dilutes in
 # big batches, and the draft weights + draft KV shave headroom — tp2-ep2 is

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11715,3 +11715,37 @@ minimaxm3-fp8-b300-vllm:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
+
+# EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
+# minimaxm3-fp8-b300-vllm, pairing MiniMaxAI/MiniMax-M3-MXFP8 with the
+# Inferact/MiniMax-M3-EAGLE3 draft head (2 speculative tokens, house default
+# for vLLM spec decoding). Search space mirrors the non-MTP entry trimmed at
+# the extreme-concurrency end, per the dsv4-fp4-b300-vllm-mtp precedent:
+# spec decode pays off at low/mid concurrency while acceptance dilutes in
+# big batches, and the draft weights + draft KV shave headroom — tp2-ep2 is
+# dropped entirely since its KV headroom was already thin without a draft.
+minimaxm3-fp8-b300-vllm-mtp:
+  image: vllm/vllm-openai:minimax-m3
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: b300
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -3,9 +3,8 @@
 # MiniMax-M3 MXFP8 B300 single-node vLLM recipe with EAGLE3 speculative
 # decoding — the repo's spec-decoding=mtp variant of minimaxm3_fp8_b300.sh
 # (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3). Adds the
-# Inferact/MiniMax-M3-EAGLE3 draft head via --speculative-config with 2
-# speculative tokens (house default for vLLM spec decoding, see
-# dsv4_fp4_b300_vllm_mtp.sh). Everything else keeps the non-MTP serve shape:
+# Inferact/MiniMax-M3-EAGLE3 draft head via --speculative-config with 3
+# speculative tokens. Everything else keeps the non-MTP serve shape:
 # --block-size 128 is mandatory (MSA sparse/index cache); the benchmark is
 # text-only, so --language-model-only frees the vision encoder's VRAM.
 
@@ -66,8 +65,8 @@ else
   PARALLEL_ARGS="--tensor-parallel-size=$TP"
 fi
 
-# use 2 speculative tokens for all configs for now
-NUM_SPEC_TOKENS=2
+# use 3 speculative tokens for all configs for now
+NUM_SPEC_TOKENS=3
 
 # Fixed-seq-len runs don't need graphs past the decode step's token count:
 # with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# MiniMax-M3 MXFP8 B300 single-node vLLM recipe with EAGLE3 speculative
+# decoding — the repo's spec-decoding=mtp variant of minimaxm3_fp8_b300.sh
+# (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3). Adds the
+# Inferact/MiniMax-M3-EAGLE3 draft head via --speculative-config with 2
+# speculative tokens (house default for vLLM spec decoding, see
+# dsv4_fp4_b300_vllm_mtp.sh). Everything else keeps the non-MTP serve shape:
+# --block-size 128 is mandatory (MSA sparse/index cache); the benchmark is
+# text-only, so --language-model-only frees the vision encoder's VRAM.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+DRAFT_MODEL="Inferact/MiniMax-M3-EAGLE3"
+
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE.
+# Either way, MODEL_PATH is what the server is launched with. The EAGLE3
+# draft follows the same split: it lands next to the target weights (writable
+# /data/models on b300 via the launcher's MODEL/MODEL_PATH split) when
+# MODEL_PATH is set, in the HF cache otherwise.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+    DRAFT_MODEL_PATH="$(dirname "$MODEL_PATH")/${DRAFT_MODEL##*/}"
+    if [[ ! -d "$DRAFT_MODEL_PATH" || -z "$(ls -A "$DRAFT_MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$DRAFT_MODEL" --local-dir "$DRAFT_MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+    hf download "$DRAFT_MODEL"
+    DRAFT_MODEL_PATH="$DRAFT_MODEL"
+fi
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+SERVER_LOG=/workspace/server.log
+
+# 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
+# default 600s readiness window.
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+if [ "${DP_ATTENTION}" = "true" ]; then
+  PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
+elif [ "$EP_SIZE" -gt 1 ]; then
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
+else
+  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+fi
+
+# use 2 speculative tokens for all configs for now
+NUM_SPEC_TOKENS=2
+
+# Fixed-seq-len runs don't need graphs past the decode step's token count:
+# with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS
+# tokens per step, so capture up to the next power of two >=
+# CONC * (1 + NUM_SPEC_TOKENS), capped at vLLM's 2048 ceiling.
+CAPTURE_SIZE=4
+while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
+(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    MAX_MODEL_LEN="$EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL_PATH" --served-model-name "$MODEL" --host 0.0.0.0 --port $PORT \
+$PARALLEL_ARGS \
+--gpu-memory-utilization 0.90 \
+--max-model-len $MAX_MODEL_LEN \
+--block-size 128 \
+--language-model-only \
+--max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-num-batched-tokens "$((ISL * 2 ))" \
+--speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS}" \
+--stream-interval 20 --no-enable-prefix-caching \
+--trust-remote-code > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+# Spec-decode acceptance rate degrades on raw random tokens; route prompts
+# through the chat template as the other MTP recipes do.
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code \
+    --use-chat-template
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -7,6 +7,12 @@
 # speculative tokens. Everything else keeps the non-MTP serve shape:
 # --block-size 128 is mandatory (MSA sparse/index cache); the benchmark is
 # text-only, so --language-model-only frees the vision encoder's VRAM.
+#
+# The drafter is pinned to FLASH_ATTN: the EAGLE3 head is MHA, and FlashInfer
+# only supports page size 128 through its trtllm-gen kernel, which requires
+# GQA/MQA — engine init dies in FlashInferMetadataBuilder otherwise. The
+# target keeps its default (FlashInfer) backend; FLASH_ATTN takes any
+# multiple-of-16 block size, so the mandatory 128 is fine for the draft.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -92,7 +98,7 @@ $PARALLEL_ARGS \
 --language-model-only \
 --max-cudagraph-capture-size $CAPTURE_SIZE \
 --max-num-batched-tokens "$((ISL * 2 ))" \
---speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS}" \
+--speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3653,5 +3653,6 @@
     - "Initial submission: MiniMax-M3 MXFP8 B300 vLLM benchmark with EAGLE3 speculative decoding (target: MiniMaxAI/MiniMax-M3-MXFP8, draft: Inferact/MiniMax-M3-EAGLE3, 3 speculative tokens)"
     - "Image: vllm/vllm-openai:minimax-m3 (same m3_release-branch build as the non-MTP entry)"
     - "Serve shape follows minimaxm3-fp8-b300-vllm (--block-size 128, --language-model-only); cudagraph capture scaled to CONC * (1 + spec tokens); prompts routed through the chat template for realistic acceptance"
+    - "Drafter pinned to FLASH_ATTN via speculative-config attention_backend: the EAGLE3 head is MHA and FlashInfer only supports the mandatory page size 128 through its GQA-only trtllm-gen kernel"
     - "Layouts: TP8 / TP4 (latency), TP8+EP8 / TP4+EP4 (TEP), TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k — non-MTP search space trimmed at the extreme-concurrency end, tp2-ep2 dropped (draft weights + draft KV headroom)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1733

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3646,3 +3646,12 @@
     - "Layouts: TP8 and TP4 (latency), TP4+EP4 / TP8+EP8 (TEP throughput), tp2-ep2, TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k"
     - "Serves from the launch_b300-nv.sh MODEL/MODEL_PATH split (model not in the SRE-staged /scratch/models list -> writable /data/models)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1724
+
+- config-keys:
+    - minimaxm3-fp8-b300-vllm-mtp
+  description:
+    - "Initial submission: MiniMax-M3 MXFP8 B300 vLLM benchmark with EAGLE3 speculative decoding (target: MiniMaxAI/MiniMax-M3-MXFP8, draft: Inferact/MiniMax-M3-EAGLE3, 2 speculative tokens)"
+    - "Image: vllm/vllm-openai:minimax-m3 (same m3_release-branch build as the non-MTP entry)"
+    - "Serve shape follows minimaxm3-fp8-b300-vllm (--block-size 128, --language-model-only); cudagraph capture scaled to CONC * (1 + spec tokens); prompts routed through the chat template for realistic acceptance"
+    - "Layouts: TP8 / TP4 (latency), TP8+EP8 / TP4+EP4 (TEP), TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k — non-MTP search space trimmed at the extreme-concurrency end, tp2-ep2 dropped (draft weights + draft KV headroom)"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3654,4 +3654,4 @@
     - "Image: vllm/vllm-openai:minimax-m3 (same m3_release-branch build as the non-MTP entry)"
     - "Serve shape follows minimaxm3-fp8-b300-vllm (--block-size 128, --language-model-only); cudagraph capture scaled to CONC * (1 + spec tokens); prompts routed through the chat template for realistic acceptance"
     - "Layouts: TP8 / TP4 (latency), TP8+EP8 / TP4+EP4 (TEP), TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k — non-MTP search space trimmed at the extreme-concurrency end, tp2-ep2 dropped (draft weights + draft KV headroom)"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1733

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3650,7 +3650,7 @@
 - config-keys:
     - minimaxm3-fp8-b300-vllm-mtp
   description:
-    - "Initial submission: MiniMax-M3 MXFP8 B300 vLLM benchmark with EAGLE3 speculative decoding (target: MiniMaxAI/MiniMax-M3-MXFP8, draft: Inferact/MiniMax-M3-EAGLE3, 2 speculative tokens)"
+    - "Initial submission: MiniMax-M3 MXFP8 B300 vLLM benchmark with EAGLE3 speculative decoding (target: MiniMaxAI/MiniMax-M3-MXFP8, draft: Inferact/MiniMax-M3-EAGLE3, 3 speculative tokens)"
     - "Image: vllm/vllm-openai:minimax-m3 (same m3_release-branch build as the non-MTP entry)"
     - "Serve shape follows minimaxm3-fp8-b300-vllm (--block-size 128, --language-model-only); cudagraph capture scaled to CONC * (1 + spec tokens); prompts routed through the chat template for realistic acceptance"
     - "Layouts: TP8 / TP4 (latency), TP8+EP8 / TP4+EP4 (TEP), TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k — non-MTP search space trimmed at the extreme-concurrency end, tp2-ep2 dropped (draft weights + draft KV headroom)"


### PR DESCRIPTION
## Summary

Adds the EAGLE3 speculative-decoding (`spec-decoding: mtp`) sibling of `minimaxm3-fp8-b300-vllm` (#1724): MiniMax-M3 MXFP8 on B300 single-node vLLM, pairing **MiniMaxAI/MiniMax-M3-MXFP8** with the **Inferact/MiniMax-M3-EAGLE3** draft head.

- **New script** `benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh`, based on `minimaxm3_fp8_b300.sh` (same serve shape: mandatory `--block-size 128` for the MSA sparse/index cache, `--language-model-only`, scenario-trimmed `MAX_MODEL_LEN` from the matrix). Adds:
  - `--speculative-config '{"method": "eagle3", "model": <draft path>, "num_speculative_tokens": 3}'`.
  - Draft download follows the same `MODEL`/`MODEL_PATH` split as the target: lands next to the MXFP8 weights in writable `/data/models` on b300, HF cache for stand-alone runs.
  - Cudagraph capture scaled to `CONC * (1 + NUM_SPEC_TOKENS)` (each running request contributes the extra draft tokens per decode step), still capped at vLLM's 2048 ceiling.
  - Benchmark prompts routed through the chat template (`--use-chat-template`) so draft acceptance reflects real text rather than raw random tokens, matching the other MTP recipes.
- **Config** `minimaxm3-fp8-b300-vllm-mtp` in `nvidia-master.yaml`, same `vllm/vllm-openai:minimax-m3` image. Search space mirrors the non-MTP entry trimmed at the extreme-concurrency end, per the `dsv4-fp4-b300-vllm-mtp` precedent (spec decode pays off at low/mid concurrency; acceptance dilutes in big batches; draft weights + draft KV shave headroom):
  - **1k1k:** TP8 (1–64), TP8+EP8 (1–256), TP4 (1–64), TP4+EP4 (64–256), TP8+EP8 dp-attn (256–512)
  - **8k1k:** TP8 (1–64), TP8+EP8 (1–256), TP4 (1–64), TP8+EP8 dp-attn (128–256)
  - tp2-ep2 dropped entirely — KV headroom was already thin without a draft.
- **perf-changelog** entry for the new config key.

## Validation

- `generate_sweep_configs.py test-config --config-keys minimaxm3-fp8-b300-vllm-mtp` generates the full matrix cleanly (scenario-trimmed max-model-len 2304 / 9472, eval points auto-assigned).
- `bash -n` on the new script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only additions (YAML matrix, shell recipe, changelog) with no changes to production services or security-sensitive paths.
> 
> **Overview**
> Adds a **spec-decoding (MTP)** benchmark track for **MiniMax-M3 MXFP8 on B300**: target `MiniMaxAI/MiniMax-M3-MXFP8` plus draft `Inferact/MiniMax-M3-EAGLE3` (3 speculative tokens), alongside the existing non-MTP `minimaxm3-fp8-b300-vllm` entry.
> 
> New shell recipe `minimaxm3_fp8_b300_mtp.sh` extends the base MiniMax B300 serve shape with `--speculative-config` (EAGLE3), draft weight download beside the target, **FLASH_ATTN** on the drafter, cudagraph capture sized for `CONC * (1 + spec tokens)`, and **`--use-chat-template`** on serving benchmarks. **`minimaxm3-fp8-b300-vllm-mtp`** in `nvidia-master.yaml` wires the sweep with `spec-decoding: mtp` and a **trimmed concurrency search space** (high-concurrency points and tp2-ep2 dropped vs non-MTP). **`perf-changelog.yaml`** documents the new config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e032b162e7c1f1fa580e1af966462777fdd9f1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->