### PR TITLE
[Klaud Cold] minimaxm3 H200/H100 MTP: start TP-only latency rows at conc 1

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11934,16 +11934,16 @@ minimaxm3-fp8-h200-vllm-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 4, ep: 4, conc-start: 128, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 32, spec-decoding: mtp }
-      - { tp: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 4, conc-start: 1, conc-end: 32, spec-decoding: mtp }
+      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256, spec-decoding: mtp }
 
@@ -11966,10 +11966,10 @@ minimaxm3-fp8-h100-vllm-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 128, conc-end: 256, spec-decoding: mtp }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3723,4 +3723,4 @@
     - minimaxm3-fp8-h100-vllm-mtp
   description:
     - "Start the TP-only latency rows of the MiniMax-M3 EAGLE3 MTP sweeps (H200, H100) at concurrency 1 instead of 4, matching the conc-1 start used on the non-MTP day-zero recipes — captures the single-request latency point. TEP/DEP rows keep their higher concurrency starts."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1743

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3717,3 +3717,10 @@
     - "B300-parity layouts and concurrency ranges: TP8, TP8+EP8, TP4, TP4+EP4, TP2+EP2, and TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k"
     - "launch_mi355x-amds.sh routes M3 weights to NFS /it-share/hf-hub-cache instead of node-local /var/lib NVMe"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1725
+
+- config-keys:
+    - minimaxm3-fp8-h200-vllm-mtp
+    - minimaxm3-fp8-h100-vllm-mtp
+  description:
+    - "Start the TP-only latency rows of the MiniMax-M3 EAGLE3 MTP sweeps (H200, H100) at concurrency 1 instead of 4, matching the conc-1 start used on the non-MTP day-zero recipes — captures the single-request latency point. TEP/DEP rows keep their higher concurrency starts."
+  pr-link: TBD


### PR DESCRIPTION
## Summary

Follow-up to #1739 ([6e8ebf56](https://github.com/SemiAnalysisAI/InferenceX/commit/6e8ebf5688ac2826e93c08282f672c36d71b8e7d)). Drops the `conc-start` of the **TP-only (latency) rows** from 4 → 1 for the two MiniMax-M3 EAGLE3 MTP configs, so the sweeps capture the single-request latency point — matching the conc-1 start already used on the non-MTP day-zero recipes.

- **`minimaxm3-fp8-h200-vllm-mtp`**: TP4 and TP8 (plain) rows in both 1k1k and 8k1k now start at conc 1.
- **`minimaxm3-fp8-h100-vllm-mtp`**: TP8 (plain) rows in both 1k1k and 8k1k now start at conc 1.

TEP (`tp+ep`) and DEP (`tp+ep+dp-attn`) rows keep their higher concurrency starts (128 / 256) — they only make sense at scale. Config/search-space change only; no script changes.

## Validation
- `generate_sweep_configs.py test-config --config-keys minimaxm3-fp8-h200-vllm-mtp minimaxm3-fp8-h100-vllm-mtp` generates 54 configs; min concurrency per layout confirms TP-only rows now start at 1 (h100 tp8 / h200 tp4 / h200 tp8 → 1), TEP/DEP unchanged (128 / 256).
- perf-changelog entry added so the changelog-driven sweep picks up both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark search-space tuning only in YAML; no runtime, auth, or application logic changes.
> 
> **Overview**
> Aligns **MiniMax-M3 EAGLE3 MTP** benchmark sweeps on **H200** and **H100** with the non-MTP day-zero recipes by lowering **`conc-start` from 4 to 1** on **TP-only (latency) search-space rows** in both **1k1k** and **8k1k** scenarios for `minimaxm3-fp8-h200-vllm-mtp` (TP4/TP8 plain) and `minimaxm3-fp8-h100-vllm-mtp` (TP8 plain).
> 
> **TEP** (`tp+ep`) and **DEP** (`tp+ep+dp-attn`) rows keep their existing higher concurrency starts (128/256). Adds a **`perf-changelog.yaml`** entry for the two config keys so changelog-driven sweeps pick up the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8615e80608aafccdcbdc9c463425de247a2f501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->