### PR TITLE
[AMD] feat: MiniMax M3 day-zero benchmark for MI300X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2847,9 +2847,10 @@ minimaxm3-fp8-mi355x-vllm-mtp:
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
-# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image
-# and serving flags validated on MI355X, with the TP8-only H100 search space:
-# TP8 for latency and TP8+EP8 (TEP) for the high-concurrency regime.
+# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image and
+# MI355X serving shape, but retain the default BF16 KV cache because this
+# checkpoint lacks calibrated ROCm FP8 attention scales. Use the TP8-only H100
+# search space: TP8 for latency and TP8+EP8 (TEP) at high concurrency.
 minimaxm3-fp8-mi300x-vllm:
   image: vllm/vllm-openai-rocm:minimax-m3
   model: MiniMaxAI/MiniMax-M3-MXFP8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2810,3 +2810,27 @@ minimaxm3-fp8-mi355x-vllm:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
+
+# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image
+# and serving flags validated on MI355X, with the TP8-only H100 search space:
+# TP8 for latency and TP8+EP8 (TEP) for the high-concurrency regime.
+minimaxm3-fp8-mi300x-vllm:
+  image: vllm/vllm-openai-rocm:minimax-m3
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: mi300x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# MiniMax-M3 MXFP8 MI300X (gfx942) single-node vLLM recipe.
+# Reuses the dedicated ROCm image and serving flags validated on MI355X.
+# Block size 128 is mandatory for MSA sparse attention.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+SERVER_LOG=/workspace/server.log
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(
+        --tensor-parallel-size 1
+        --data-parallel-size "$TP"
+        --enable-expert-parallel
+    )
+elif [ "$EP_SIZE" -gt 1 ]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL" --port "$PORT" \
+    "${PARALLEL_ARGS[@]}" \
+    --block-size 128 \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --kv-cache-dtype fp8 \
+    --attention-backend TRITON_ATTN \
+    --enforce-eager \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -52,6 +52,7 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
+    --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 # MiniMax-M3 MXFP8 MI300X (gfx942) single-node vLLM recipe.
-# Reuses the dedicated ROCm image and serving flags validated on MI355X.
-# Block size 128 is mandatory for MSA sparse attention.
+# Reuses the dedicated ROCm image and the MI355X serving shape. Block size 128
+# is mandatory for MSA sparse attention. Keep the default BF16 KV cache on
+# gfx942: the checkpoint has no calibrated q/prob scales for ROCm FP8
+# attention, and vLLM's fallback scale of 1.0 corrupts model accuracy.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -55,7 +57,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
-    --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
     --enforce-eager \
     --tool-call-parser minimax_m3 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3740,7 +3740,8 @@
     - minimaxm3-fp8-mi300x-vllm
   description:
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI300X / gfx942"
-    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, prefix caching disabled, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
+    - "Image and serving shape reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, prefix caching disabled, TRITON_ATTN, language-model-only, and eager execution"
+    - "Use the default BF16 KV cache on MI300X because MiniMax-M3-MXFP8 lacks calibrated q/prob scales for ROCm FP8 attention; vLLM warns that its fallback scale of 1.0 may cause accuracy issues"
     - "H100-aligned layouts and concurrency ranges: TP8 and TP8+EP8 across 1k1k and 8k1k"
     - "Fix launch_mi300x-amds.sh node exclusion to use the current short Slurm node name"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1746

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3724,3 +3724,12 @@
   description:
     - "Start the TP-only latency rows of the MiniMax-M3 EAGLE3 MTP sweeps (H200, H100) at concurrency 1 instead of 4, matching the conc-1 start used on the non-MTP day-zero recipes — captures the single-request latency point. TEP/DEP rows keep their higher concurrency starts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1743
+
+- config-keys:
+    - minimaxm3-fp8-mi300x-vllm
+  description:
+    - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI300X / gfx942"
+    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
+    - "H100-aligned layouts and concurrency ranges: TP8 and TP8+EP8 across 1k1k and 8k1k"
+    - "Fix launch_mi300x-amds.sh node exclusion to use the current short Slurm node name"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3732,4 +3732,4 @@
     - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
     - "H100-aligned layouts and concurrency ranges: TP8 and TP8+EP8 across 1k1k and 8k1k"
     - "Fix launch_mi300x-amds.sh node exclusion to use the current short Slurm node name"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1746

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3740,7 +3740,7 @@
     - minimaxm3-fp8-mi300x-vllm
   description:
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI300X / gfx942"
-    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
+    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, prefix caching disabled, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
     - "H100-aligned layouts and concurrency ranges: TP8 and TP8+EP8 across 1k1k and 8k1k"
     - "Fix launch_mi300x-amds.sh node exclusion to use the current short Slurm node name"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1746

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -10,8 +10,8 @@ LOCK_FILE="${SQUASH_FILE}.lock"
 set -x
 
 # Exclude known-bad nodes; let Slurm pick from anything else:
-#   chi-mi300x-049: drained (persistent /nvme_home disk-full)
-JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049.ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+#   chi-mi300x-049: persistent /nvme_home disk-full
+JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -31,7 +31,7 @@ srun --jobid=$JOB_ID --job-name="$RUNNER_NAME" bash -c "
 "
 srun --jobid=$JOB_ID \
 --container-image=$SQUASH_FILE \
---container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,/dev/kfd:/dev/kfd,/dev/dri:/dev/dri \
 --container-mount-home \
 --container-writable \
 --container-remap-root \


### PR DESCRIPTION
## Summary

- add `minimaxm3-fp8-mi300x-vllm` using the dedicated `vllm/vllm-openai-rocm:minimax-m3` image already used by MI355X
- add a MI300X fixed-sequence launcher with the MI355X M3 serving flags: block size 128, prefix caching disabled, TRITON_ATTN, default BF16 KV cache, language-model-only, and eager execution
- use the exact H100 non-MTP TP8/TEP8 search space across 1k1k and 8k1k
- fix the MI300X Slurm exclusion to use the current short node name (`chi-mi300x-049`)
- explicitly mount `/dev/kfd` and `/dev/dri` into the rootless Pyxis/Enroot container
- disable prefix caching to match the H100 MiniMax M3 benchmark behavior

## Validation

- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh runners/launch_mi300x-amds.sh`
- generated MI300X sweep matches H100 exactly: 14 TP/EP/concurrency configurations
- `python -m pytest utils/matrix_logic/ -q` (156 passed)
- dedicated ROCm image imported successfully to the shared runner squash cache (~29 GB)
- `MiniMaxAI/MiniMax-M3-MXFP8` staged successfully in node-local `/raid/hf-hub-cache` (~414 GB)

## Hardware Validation

Single-job GHA smoke: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27480947060

The TP8, EP1, 1k1k, concurrency-4 smoke completed successfully on `chi-mi300x-054`, including result processing and artifact upload:

- total throughput: 11 tok/s/GPU
- output throughput: 5 tok/s/GPU
- mean TTFT: 287 ms
- mean TPOT: 92 ms

The model loaded on all 8 MI300X GPUs, the vLLM API became healthy, all requests completed successfully, and the benchmark artifact was uploaded. The earlier Slurm, cache-directory, and rootless GPU-device permission blockers are resolved.

The slow throughput is expected for this image on MI300X: vLLM reports no native MXFP8 MoE backend on gfx942, so the MoE runs through the BF16 emulation path with eager execution.

## Accuracy Validation

The original full sweep exposed a real ROCm FP8-attention accuracy failure: vLLM warned that MiniMax-M3-MXFP8 has no calibrated q/prob scales and fell back to scale 1.0. GSM8K scored 0.0099 strict and 0.0296 flexible, with degenerate non-terminating outputs.

The MI300X launcher now keeps the default BF16 KV cache. Direct TEP8 compute-node checks answered three known GSM8K prompts correctly. The matching one-job GHA eval passed: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27485772194

- GSM8K strict: 0.9666
- GSM8K flexible: 0.9659
- required threshold: 0.90

## Sweep

Full sweep passed on all 14 H100-aligned throughput points and both GSM8K eval jobs: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27485974465

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are benchmark config, a new launch script, and MI300X Slurm/container plumbing; no production inference or auth paths are touched.
> 
> **Overview**
> Adds a **day-zero** `minimaxm3-fp8-mi300x-vllm` matrix entry for **MiniMax-M3 MXFP8** on MI300X using the same `vllm/vllm-openai-rocm:minimax-m3` image as MI355X, with an **H100-aligned** fixed-seq sweep (TP8 and TP8+EP8 on 1k1k and 8k1k).
> 
> Introduces `minimaxm3_fp8_mi300x.sh`, which mirrors the MI355X MiniMax-M3 vLLM serve shape (block size 128, prefix caching off, TRITON_ATTN, eager, language-model-only, MiniMax parsers) but **omits FP8 KV cache** on gfx942 so attention stays on default BF16—documented as avoiding bad accuracy from missing ROCm FP8 q/prob scales.
> 
> **MI300X runner fixes:** Slurm `--exclude` now uses short node name `chi-mi300x-049`, and the Enroot container mounts **`/dev/kfd` and `/dev/dri`** for rootless GPU access. Documents the new config in `perf-changelog.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c47fbe6cbc17abdb27f7a4cb8ea42d5dfdc7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->