### PR TITLE
[codex] Remove MI325X runner workarounds

### DIFF
--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -7,21 +7,9 @@ PARTITION="compute"
 SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 LOCK_FILE="${SQUASH_FILE}.lock"
 
-cleanup_stale_benchmark_logs() {
-    if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
-        sudo -n rm -rf "$GITHUB_WORKSPACE/benchmark_logs" 2>/dev/null || \
-            rm -rf "$GITHUB_WORKSPACE/benchmark_logs" 2>/dev/null || true
-    fi
-}
-cleanup_stale_benchmark_logs
-
 set -x
 
-# Exclude known-broken mi325x nodes:
-#   chi-mi325x-pod1-121: enroot-aufs2ovlfs setcap fails on this node's NFS-backed
-#                        squash dir; container image import never completes
-#                        (root-caused via #1467/#1468/#1469 sweep failures).
-JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --exclude=chi-mi325x-pod1-121.ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job" >&2
@@ -30,7 +18,7 @@ fi
 
 export PORT=$(( 40000 + (JOB_ID % 10000) ))
 
-trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; cleanup_stale_benchmark_logs; exit "$rc"' EXIT
+trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 
 # Use flock to serialize concurrent imports to the same squash file
 srun --jobid="$JOB_ID" --job-name="$RUNNER_NAME" bash -c "


### PR DESCRIPTION
- Remove stale benchmark log cleanup from the MI325X AMD launcher.
- Allow Slurm to schedule `chi-mi325x-pod1-121.ord.vultr.cpe.ice.amd.com`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher-only script changes with no auth or data handling; main risk is jobs landing on a previously excluded node if the enroot/NFS issue regresses.
> 
> **Overview**
> Removes temporary mitigations from **`runners/launch_mi325x-amds.sh`** now that the underlying issues are addressed.
> 
> **Slurm scheduling:** `salloc` no longer passes `--exclude` for `chi-mi325x-pod1-121`, so that node can receive jobs again.
> 
> **Cleanup:** Deletes `cleanup_stale_benchmark_logs` and all invocations (startup and on `EXIT`), including the `benchmark_logs` removal under `GITHUB_WORKSPACE`. The exit trap only cancels the job and preserves the exit code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0d7cb4184149965e45dd9e5091c1fe3982393f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->