### PR TITLE
[AMD] feat: MiniMax M3 day-zero benchmark for MI325X

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2901,3 +2901,32 @@ minimaxm3-fp8-mi300x-vllm-mtp:
       search-space:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 128, conc-end: 256, spec-decoding: mtp }
+
+# MiniMax-M3 MXFP8 MI325X day-zero recipe. Reuse the dedicated ROCm image
+# and serving flags validated on MI355X, with the H200 search space: TP4 and
+# TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention.
+minimaxm3-fp8-mi325x-vllm:
+  image: vllm/vllm-openai-rocm:minimax-m3
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: mi325x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 32 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2846,3 +2846,32 @@ minimaxm3-fp8-mi355x-vllm-mtp:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
+
+# MiniMax-M3 MXFP8 MI325X day-zero recipe. Reuse the dedicated ROCm image
+# and serving flags validated on MI355X, with the H200 search space: TP4 and
+# TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention.
+minimaxm3-fp8-mi325x-vllm:
+  image: vllm/vllm-openai-rocm:minimax-m3
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: mi325x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, conc-start: 4, conc-end: 32 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# MiniMax-M3 MXFP8 MI325X (gfx942) single-node vLLM recipe.
+# https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3?hardware=mi325x&variant=mxfp8
+# MXFP8 runs from TP=4 on gfx942; block size 128 is mandatory for MSA.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+SERVER_LOG=/workspace/server.log
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(
+        --tensor-parallel-size 1
+        --data-parallel-size "$TP"
+        --enable-expert-parallel
+    )
+elif [ "$EP_SIZE" -gt 1 ]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL" --port "$PORT" \
+    "${PARALLEL_ARGS[@]}" \
+    --block-size 128 \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --attention-backend TRITON_ATTN \
+    --no-enable-prefix-caching \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -56,6 +56,7 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
+    --no-enable-prefix-caching \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
     --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # MiniMax-M3 MXFP8 MI325X (gfx942) single-node vLLM recipe.
-# Reuses the dedicated ROCm image and serving flags validated on MI355X.
-# Block size 128 is mandatory for MSA sparse attention.
+# https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3?hardware=mi325x&variant=mxfp8
+# MXFP8 runs from TP=4 on gfx942; block size 128 is mandatory for MSA.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -56,7 +56,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
-    --enforce-eager \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
     --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# MiniMax-M3 MXFP8 MI325X (gfx942) single-node vLLM recipe.
+# Reuses the dedicated ROCm image and serving flags validated on MI355X.
+# Block size 128 is mandatory for MSA sparse attention.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    DP_ATTENTION \
+    CONC \
+    ISL \
+    OSL \
+    MAX_MODEL_LEN \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+SERVER_LOG=/workspace/server.log
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(
+        --tensor-parallel-size 1
+        --data-parallel-size "$TP"
+        --enable-expert-parallel
+    )
+elif [ "$EP_SIZE" -gt 1 ]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+start_gpu_monitor
+
+set -x
+vllm serve "$MODEL" --port "$PORT" \
+    "${PARALLEL_ARGS[@]}" \
+    --block-size 128 \
+    --language-model-only \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --kv-cache-dtype fp8 \
+    --attention-backend TRITON_ATTN \
+    --enforce-eager \
+    --tool-call-parser minimax_m3 \
+    --reasoning-parser minimax_m3 \
+    --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --trust-remote-code
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -54,7 +54,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --block-size 128 \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
-    --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
     --no-enable-prefix-caching \
     --tool-call-parser minimax_m3 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3735,3 +3735,12 @@
     - "Layouts: TP8 / TP4 (latency), TP8+EP8 / TP4+EP4 (TEP), TP8+EP8 dp-attn (DEP) across 1k1k and 8k1k — non-MTP search space trimmed at the extreme-concurrency end, tp2-ep2 dropped, mirroring the minimaxm3-fp8-b300-vllm-mtp search space"
     - "[AI generated draft test] The shipped ROCm image's AMD MiniMax-M3 model lacks SupportsEagle3, so the recipe patches it in-place at runtime (functionstackx/vllm#1, ported from nvidia/model.py) before serving — validates EAGLE3 on MI355X ahead of an image rebuild"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1745
+
+- config-keys:
+    - minimaxm3-fp8-mi325x-vllm
+  description:
+    - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
+    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
+    - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
+    - "Route the MI325X Hugging Face cache to node-local /local_nvme/hf-hub-cache and mount ROCm GPU devices explicitly"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3740,7 +3740,7 @@
     - minimaxm3-fp8-mi325x-vllm
   description:
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
-    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, FP8 KV cache, and a scenario-specific max model length"
+    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, FP8 KV cache, disabled prefix caching, and a scenario-specific max model length"
     - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
-    - "Route the MI325X Hugging Face cache to node-local /local_nvme/hf-hub-cache and mount ROCm GPU devices explicitly"
+    - "Route the MI325X Hugging Face cache to node-local /local-nvme/hf-hub-cache and mount ROCm GPU devices explicitly"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3742,5 +3742,5 @@
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
     - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, FP8 KV cache, disabled prefix caching, and a scenario-specific max model length"
     - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
-    - "Route the MI325X Hugging Face cache to node-local /local-nvme/hf-hub-cache and mount ROCm GPU devices explicitly"
+    - "Route the MI325X Hugging Face cache and runtime compiler caches to node-local storage, and mount ROCm GPU devices explicitly"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3740,7 +3740,7 @@
     - minimaxm3-fp8-mi325x-vllm
   description:
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
-    - "Image and serving flags reuse the MI355X recipe: vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, FP8 KV cache, language-model-only, and eager execution"
+    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, FP8 KV cache, and a scenario-specific max model length"
     - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
     - "Route the MI325X Hugging Face cache to node-local /local_nvme/hf-hub-cache and mount ROCm GPU devices explicitly"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3761,3 +3761,12 @@
   description:
     - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI300X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 per AMD guidance"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1750
+
+- config-keys:
+    - minimaxm3-fp8-mi325x-vllm
+  description:
+    - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
+    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, the default BF16 KV cache, disabled prefix caching, and a scenario-specific max model length"
+    - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
+    - "Route the MI325X Hugging Face cache and runtime compiler caches to node-local storage, and mount ROCm GPU devices explicitly"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3740,7 +3740,7 @@
     - minimaxm3-fp8-mi325x-vllm
   description:
     - "Initial submission: MiniMax-M3 MXFP8 day-zero single-node vLLM benchmark on MI325X / gfx942"
-    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, FP8 KV cache, disabled prefix caching, and a scenario-specific max model length"
+    - "Follows the official MI325X MXFP8 recipe with vllm/vllm-openai-rocm:minimax-m3, block size 128, TRITON_ATTN, and MiniMax-M3 tool/reasoning parsers; fixed-sequence text benchmarking adds language-model-only, the default BF16 KV cache, disabled prefix caching, and a scenario-specific max model length"
     - "H200-aligned layouts and concurrency ranges: TP4 and TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k"
     - "Route the MI325X Hugging Face cache and runtime compiler caches to node-local storage, and mount ROCm GPU devices explicitly"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1748

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HF_HUB_CACHE_MOUNT="/nfsdata/sa/gharunner/gharunners/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/local-nvme/hf-hub-cache/"
 
 PARTITION="compute"
 SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
@@ -17,6 +17,8 @@ if [ -z "$JOB_ID" ]; then
 fi
 
 export PORT=$(( 40000 + (JOB_ID % 10000) ))
+export XDG_CACHE_HOME="/tmp/xdg-cache-$JOB_ID"
+export TRITON_CACHE_DIR="/tmp/triton-cache-$JOB_ID"
 
 trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 
@@ -34,7 +36,7 @@ srun --jobid="$JOB_ID" --job-name="$RUNNER_NAME" bash -c "
 "
 srun --jobid="$JOB_ID" \
 --container-image="$SQUASH_FILE" \
---container-mounts="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+--container-mounts="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,/dev/kfd:/dev/kfd,/dev/dri:/dev/dri" \
 --container-mount-home \
 --container-writable \
 --container-remap-root \

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HF_HUB_CACHE_MOUNT="/local_nvme/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/local-nvme/hf-hub-cache/"
 
 PARTITION="compute"
 SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -17,6 +17,8 @@ if [ -z "$JOB_ID" ]; then
 fi
 
 export PORT=$(( 40000 + (JOB_ID % 10000) ))
+export XDG_CACHE_HOME="/tmp/xdg-cache-$JOB_ID"
+export TRITON_CACHE_DIR="/tmp/triton-cache-$JOB_ID"
 
 trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HF_HUB_CACHE_MOUNT="/nfsdata/sa/gharunner/gharunners/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/local_nvme/hf-hub-cache/"
 
 PARTITION="compute"
 SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
@@ -34,7 +34,7 @@ srun --jobid="$JOB_ID" --job-name="$RUNNER_NAME" bash -c "
 "
 srun --jobid="$JOB_ID" \
 --container-image="$SQUASH_FILE" \
---container-mounts="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+--container-mounts="$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,/dev/kfd:/dev/kfd,/dev/dri:/dev/dri" \
 --container-mount-home \
 --container-writable \
 --container-remap-root \


### PR DESCRIPTION
## Summary

- add `minimaxm3-fp8-mi325x-vllm` for MiniMax M3 MXFP8 on MI325X
- use `vllm/vllm-openai-rocm:minimax-m3` and the official MI325X MXFP8 recipe shape
- mirror the H200 non-MTP search space: TP4/TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention across 1k1k and 8k1k
- route Hugging Face cache to node-local `/local-nvme/hf-hub-cache/` and runtime compiler caches to container-local `/tmp`
- disable prefix caching for random-dataset benchmarks
- mount `/dev/kfd` and `/dev/dri` explicitly for ROCm
- use the default BF16 KV cache because FP8 KV corrupts MiniMax M3 generation on this MI325X/gfx942 image

## Recipe Alignment

- model: `MiniMaxAI/MiniMax-M3-MXFP8`
- image: `vllm/vllm-openai-rocm:minimax-m3`
- `--block-size 128`
- `--attention-backend TRITON_ATTN`
- `--language-model-only`
- `--no-enable-prefix-caching`
- MiniMax M3 tool/reasoning parsers with automatic tool choice
- no MI355X-specific `--enforce-eager` workaround

Upstream reference: https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3?hardware=mi325x&variant=mxfp8

## Validation

Representative throughput smoke: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27482912444

- vLLM started successfully on MI325X with the PR command
- model downloaded through node-local `/local-nvme/hf-hub-cache`
- all checkpoint shards loaded; CUDA graph capture completed
- 40 random 1k1k requests at TP4 / EP1 / concurrency 4 completed per runner
- result processing, result upload, server-log upload, GPU-metrics upload, aggregation, and success-rate calculation succeeded

Targeted DPA accuracy validation: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27484953170

- exact failed full-sweep point: TP1 x DP8 + EP, concurrency 512, 8k1k eval-only
- server startup and all 1,319 GSM8K requests completed
- GSM8K strict exact match: `0.9575`
- GSM8K flexible exact match: `0.9568`
- score validation, server-log upload, GPU-metrics upload, eval artifact upload, aggregation, and success-rate calculation succeeded

Failure diagnosis: `--kv-cache-dtype fp8` produced deterministic repetitive/cross-prompt generation corruption and 1-2% GSM8K. On the same node, image, weights, and layouts, removing only FP8 KV restored correct generation with and without CUDA graphs. The PR therefore leaves KV cache at vLLM's default dtype.

Additional validation:

- shell syntax, YAML parsing, matrix generation, and `git diff --check` pass
- matrix matches the H200-aligned 31-point search space
- `/enroot` resolves to local NVMe on every healthy compute node
- `XDG_CACHE_HOME` and `TRITON_CACHE_DIR` use per-job local paths, avoiding stale NFS compiler artifacts

Full PR sweep (green, 43 successful jobs): https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27487160980

## Changelog Integrity

`perf-changelog.yaml` is current main byte-for-byte followed only by this PR's entry at the tail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and Slurm launcher configuration only; no application auth or data-path logic. MI325X launcher changes apply broadly to jobs using that script (cache paths and GPU device mounts).
> 
> **Overview**
> Adds **MiniMax-M3 MXFP8** single-node vLLM benchmarking on **MI325X** via a new `minimaxm3-fp8-mi325x-vllm` matrix entry and `minimaxm3_fp8_mi325x.sh` runner script.
> 
> The config uses `vllm/vllm-openai-rocm:minimax-m3`, an **H200-aligned** fixed-seq-len search space (TP4/TP8, EP, TP8 data-parallel attention for 1k1k and 8k1k), and serving flags aligned with the official MI325X recipe (`--block-size 128`, `TRITON_ATTN`, `language-model-only`, disabled prefix caching, MiniMax M3 parsers, `VLLM_USE_BREAKABLE_CUDAGRAPH=0`).
> 
> **`launch_mi325x-amds.sh`** is updated for all MI325X jobs: Hugging Face hub cache mount moves from NFS to **`/local-nvme/hf-hub-cache/`**, per-job **`XDG_CACHE_HOME`** and **`TRITON_CACHE_DIR`** under `/tmp`, and explicit **`/dev/kfd`** / **`/dev/dri`** container mounts for ROCm.
> 
> Documents the addition in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7eec8a1b1785e93405a3a567eabeb45b37d4cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->