### PR TITLE
[AMD] perf: enable MiniMax M3 CUDA graphs on MI355X

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
@@ -53,6 +53,7 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
+    --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
@@ -30,6 +30,7 @@ fi
 
 SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -56,7 +57,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
-    --enforce-eager \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
     --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3765,5 +3765,5 @@
 - config-keys:
     - minimaxm3-fp8-mi355x-vllm
   description:
-    - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI355X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+    - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI355X, set VLLM_USE_BREAKABLE_CUDAGRAPH=0, and disable prefix caching"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3761,3 +3761,9 @@
   description:
     - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI300X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 per AMD guidance"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1750
+
+- config-keys:
+    - minimaxm3-fp8-mi355x-vllm
+  description:
+    - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI355X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD


### PR DESCRIPTION
Remove `--enforce-eager`, set `VLLM_USE_BREAKABLE_CUDAGRAPH=0`, and disable prefix caching for the non-MTP MI355X recipe.

Validation: shell syntax and MI355X sweep generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only launch flags for a single AMD recipe; no auth, serving API, or shared runtime code changes.
> 
> **Overview**
> Aligns the **MiniMax-M3 MXFP8 MI355X** non-MTP vLLM recipe with the recent MI300X CUDA-graph change (#1750).
> 
> The benchmark script now exports `VLLM_USE_BREAKABLE_CUDAGRAPH=0`, drops `--enforce-eager` so CUDA graphs can run, and passes `--no-enable-prefix-caching` on `vllm serve` (consistent with other MiniMax random-dataset sweeps). `perf-changelog.yaml` documents the update for `minimaxm3-fp8-mi355x-vllm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bbb947cb71ff6a99e54c8812fc059465bda070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->