### PR TITLE
[Klaud Cold] minimaxm3-fp8-mi300x-vllm-mtp: run with CUDA graphs (drop --enforce-eager, VLLM_USE_BREAKABLE_CUDAGRAPH=0)

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x_mtp.sh
@@ -5,8 +5,10 @@
 # minimaxm3_fp8_mi300x.sh. Adds the Inferact/MiniMax-M3-EAGLE3 draft head via
 # --speculative-config with 3 speculative tokens. Everything else mirrors the
 # non-MTP MI300X recipe: mandatory --block-size 128, --language-model-only for
-# the text-only benchmark, --attention-backend TRITON_ATTN, --enforce-eager,
-# and --no-enable-prefix-caching. The default BF16 KV cache is retained (unlike
+# the text-only benchmark, --attention-backend TRITON_ATTN, and
+# --no-enable-prefix-caching. Runs with CUDA graphs (no --enforce-eager);
+# VLLM_USE_BREAKABLE_CUDAGRAPH=0 avoids the M3-decode breakable-cudagraph path.
+# The default BF16 KV cache is retained (unlike
 # the MI355X recipe's FP8 KV cache): gfx942 has no calibrated q/prob scales for
 # ROCm FP8 attention and vLLM's fallback scale of 1.0 corrupts accuracy.
 #
@@ -59,6 +61,7 @@ fi
 
 SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -176,7 +179,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \
-    --enforce-eager \
     --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS}" \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3761,3 +3761,10 @@
   description:
     - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI300X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 per AMD guidance"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1750
+
+- config-keys:
+    - minimaxm3-fp8-mi300x-vllm-mtp
+  description:
+    - "Run the MiniMax-M3 MXFP8 MI300X EAGLE3 MTP recipe with CUDA graphs instead of --enforce-eager"
+    - "Drop --enforce-eager and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 (matching the non-MTP MI300X recipe, #1750), which avoids the M3-decode breakable-cudagraph path that previously forced eager execution"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3767,4 +3767,4 @@
   description:
     - "Run the MiniMax-M3 MXFP8 MI300X EAGLE3 MTP recipe with CUDA graphs instead of --enforce-eager"
     - "Drop --enforce-eager and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 (matching the non-MTP MI300X recipe, #1750), which avoids the M3-decode breakable-cudagraph path that previously forced eager execution"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1756


### PR DESCRIPTION
## Summary

Runs the MiniMax-M3 MXFP8 **MI300X EAGLE3 MTP** recipe with CUDA graphs instead of eager execution — the MTP counterpart of #1750, which already did this for the non-MTP MI300X recipe.

- **Drop `--enforce-eager`** from the `vllm serve` line in `minimaxm3_fp8_mi300x_mtp.sh`.
- **Add `export VLLM_USE_BREAKABLE_CUDAGRAPH=0`** (same placement/value as the non-MTP recipe from #1750) — avoids the M3-decode breakable-cudagraph path that previously forced eager.

Everything else unchanged: BF16 KV cache (gfx942 has no calibrated FP8 attn scales), `--no-enable-prefix-caching`, TRITON_ATTN, block-size 128, EAGLE3 draft + the in-place `amd/model.py` patch.

Config key re-swept: `minimaxm3-fp8-mi300x-vllm-mtp` (perf-changelog entry added).

## Validation
- `bash -n` passes; serve-line `--enforce-eager` removed (only comments mention it); `VLLM_USE_BREAKABLE_CUDAGRAPH=0` exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only serve-flag and env tuning on an existing MI300X recipe; no application logic, auth, or data-path changes.
> 
> **Overview**
> Aligns the **MiniMax-M3 MXFP8 MI300X EAGLE3 MTP** benchmark with the non-MTP MI300X recipe (#1750) by running **CUDA graphs** instead of eager decode.
> 
> In `minimaxm3_fp8_mi300x_mtp.sh`, **`--enforce-eager` is removed** from `vllm serve`, and **`VLLM_USE_BREAKABLE_CUDAGRAPH=0`** is exported so vLLM skips the M3 breakable-cudagraph path that had required eager mode. Header comments are updated to describe graph execution.
> 
> A **`perf-changelog.yaml`** entry documents the change for config key `minimaxm3-fp8-mi300x-vllm-mtp`. EAGLE3 draft setup, TRITON_ATTN, BF16 KV cache, and the in-place `SupportsEagle3` patch are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c995c9b20982f5e2f937955fc230b77f454233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->