### PR TITLE
[DO NOT MERGE][Klaud Cold][TEST] minimaxm3 MI355X: CUDA graphs WITHOUT VLLM_USE_BREAKABLE_CUDAGRAPH=0 (control)

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi355x.sh
@@ -56,7 +56,6 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --kv-cache-dtype fp8 \
     --attention-backend TRITON_ATTN \
-    --enforce-eager \
     --tool-call-parser minimax_m3 \
     --reasoning-parser minimax_m3 \
     --enable-auto-tool-choice > "$SERVER_LOG" 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3766,25 +3766,4 @@
     - minimaxm3-fp8-mi355x-vllm
   description:
     - "TEST/control: run the MiniMax-M3 MXFP8 MI355X non-MTP recipe with CUDA graphs by removing --enforce-eager, WITHOUT setting VLLM_USE_BREAKABLE_CUDAGRAPH=0 — isolates whether the env var is required for cudagraphs (matched control for #1755, which removes eager and sets the env var)"
-  pr-link: unknown flag: --jq
-
-Usage:  gh pr create [flags]
-
-Flags:
-  -a, --assignee login       Assign people by their login. Use "@me" to self-assign.
-  -B, --base branch          The branch into which you want your code merged
-  -b, --body string          Body for the pull request
-  -F, --body-file file       Read body text from file (use "-" to read from standard input)
-  -d, --draft                Mark pull request as a draft
-  -f, --fill                 Do not prompt for title/body and just use commit info
-  -H, --head branch          The branch that contains commits for your pull request (default: current branch)
-  -l, --label name           Add labels by name
-  -m, --milestone name       Add the pull request to a milestone by name
-      --no-maintainer-edit   Disable maintainer's ability to modify pull request
-  -p, --project name         Add the pull request to projects by name
-      --recover string       Recover input from a failed run of create
-  -r, --reviewer handle      Request reviews from people or teams by their handle
-  -t, --title string         Title for the pull request
-  -w, --web                  Open the web browser to create a pull request
-  
-https://github.com/SemiAnalysisAI/InferenceX/pull/1757
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1757

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3766,4 +3766,25 @@
     - minimaxm3-fp8-mi355x-vllm
   description:
     - "TEST/control: run the MiniMax-M3 MXFP8 MI355X non-MTP recipe with CUDA graphs by removing --enforce-eager, WITHOUT setting VLLM_USE_BREAKABLE_CUDAGRAPH=0 — isolates whether the env var is required for cudagraphs (matched control for #1755, which removes eager and sets the env var)"
-  pr-link: TBD
+  pr-link: unknown flag: --jq
+
+Usage:  gh pr create [flags]
+
+Flags:
+  -a, --assignee login       Assign people by their login. Use "@me" to self-assign.
+  -B, --base branch          The branch into which you want your code merged
+  -b, --body string          Body for the pull request
+  -F, --body-file file       Read body text from file (use "-" to read from standard input)
+  -d, --draft                Mark pull request as a draft
+  -f, --fill                 Do not prompt for title/body and just use commit info
+  -H, --head branch          The branch that contains commits for your pull request (default: current branch)
+  -l, --label name           Add labels by name
+  -m, --milestone name       Add the pull request to a milestone by name
+      --no-maintainer-edit   Disable maintainer's ability to modify pull request
+  -p, --project name         Add the pull request to projects by name
+      --recover string       Recover input from a failed run of create
+  -r, --reviewer handle      Request reviews from people or teams by their handle
+  -t, --title string         Title for the pull request
+  -w, --web                  Open the web browser to create a pull request
+  
+https://github.com/SemiAnalysisAI/InferenceX/pull/1757

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3761,3 +3761,9 @@
   description:
     - "Enable CUDA graphs for MiniMax-M3 MXFP8 on MI300X and set VLLM_USE_BREAKABLE_CUDAGRAPH=0 per AMD guidance"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1750
+
+- config-keys:
+    - minimaxm3-fp8-mi355x-vllm
+  description:
+    - "TEST/control: run the MiniMax-M3 MXFP8 MI355X non-MTP recipe with CUDA graphs by removing --enforce-eager, WITHOUT setting VLLM_USE_BREAKABLE_CUDAGRAPH=0 — isolates whether the env var is required for cudagraphs (matched control for #1755, which removes eager and sets the env var)"
+  pr-link: TBD


### PR DESCRIPTION
## Summary — control experiment (not for merge)

Removes `--enforce-eager` from the MiniMax-M3 MXFP8 **MI355X non-MTP** recipe (`minimaxm3_fp8_mi355x.sh`) so it runs with CUDA graphs, but **deliberately does NOT set `VLLM_USE_BREAKABLE_CUDAGRAPH=0`**.

Matched control for **#1755** (which removes `--enforce-eager` *and* sets `VLLM_USE_BREAKABLE_CUDAGRAPH=0`). Goal: confirm whether the env var is what actually makes CUDA graphs work for MiniMax-M3 on AMD — i.e., does dropping eager alone fail/regress?

- Only script change: the `--enforce-eager` line is removed. No env var added.
- perf-changelog entry added (`minimaxm3-fp8-mi355x-vllm`) so the sweep runs.

**Expected:** if the breakable-cudagraph env var is required, this sweep fails (M3 breakable-cudagraph path at engine init / decode), whereas #1755 passes.

**This is a test/control PR and is not intended to merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only control change on a test PR; no production paths or auth/data handling affected.
> 
> **Overview**
> **Control sweep (not for merge)** for MiniMax-M3 MXFP8 on MI355X: the non-MTP vLLM recipe drops `--enforce-eager` so serving can use CUDA graphs, but **does not** set `VLLM_USE_BREAKABLE_CUDAGRAPH=0`.
> 
> That pairs with **#1755** (same eager removal **plus** the env var) and **#1750** (MI300X uses the env var). The goal is to see whether MI355X needs the breakable-cudagraph disable for stable graphs, or if turning off eager alone is enough.
> 
> A `perf-changelog.yaml` entry for `minimaxm3-fp8-mi355x-vllm` documents the experiment so the matrix re-runs this variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed5aa112a5dce3f1fa2896edd193f27ace4a561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->