### PR TITLE
[AMD] perf: enable FlyDSL w4a16 MoE for Kimi INT4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -751,11 +751,13 @@ kimik2.5-int4-mi355x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
 
 kimik2.5-int4-mi325x-vllm:
   image: vllm/vllm-openai-rocm:v0.21.0

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_int4_mi355x.sh
@@ -42,6 +42,8 @@ vllm serve $MODEL --port $PORT \
 --trust-remote-code \
 --no-enable-prefix-caching \
 --max-num-seqs 256 \
+--moe-backend flydsl \
+--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}' \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!


### PR DESCRIPTION
This PR replaces default triton w4a16 MoE kernel with more performant FlyDSL implementation in Kimi int4