### PR TITLE
[Klaud Cold] minimaxm3 MI300X/MI325X non-MTP: start TP-only latency rows at conc 1

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2864,12 +2864,12 @@ minimaxm3-fp8-mi300x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, conc-start: 1, conc-end: 64 }
       - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
@@ -2918,16 +2918,16 @@ minimaxm3-fp8-mi325x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 32 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 1, conc-end: 32 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
       - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3800,3 +3800,10 @@
     - "H200-style search space (TP4/TP8 latency, TP4+EP4/TP8+EP8 TEP, TP8+EP8 dp-attn DEP) trimmed at the extreme-concurrency end with TP-only latency rows started at conc 1"
     - "[AI generated draft test] The shipped ROCm image's AMD MiniMax-M3 model lacks SupportsEagle3, so the recipe patches it in-place at runtime (functionstackx/vllm#1, upstream vllm-project/vllm#45546; validated green on MI355X/MI300X) before serving; also adds SPEC_SUFFIX to launch_mi325x-amds.sh so spec-decoding=mtp routes to the _mtp script"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1759
+
+- config-keys:
+    - minimaxm3-fp8-mi300x-vllm
+    - minimaxm3-fp8-mi325x-vllm
+  description:
+    - "Extend the MiniMax-M3 MXFP8 MI300X and MI325X non-MTP sweeps down to concurrency 1 on the TP-only latency rows (was conc 4), to capture the single-request latency point; TEP/DEP rows keep their higher concurrency starts"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3806,4 +3806,4 @@
     - minimaxm3-fp8-mi325x-vllm
   description:
     - "Extend the MiniMax-M3 MXFP8 MI300X and MI325X non-MTP sweeps down to concurrency 1 on the TP-only latency rows (was conc 4), to capture the single-request latency point; TEP/DEP rows keep their higher concurrency starts"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1760


### PR DESCRIPTION
## Summary

Extends the MiniMax-M3 MXFP8 **MI300X** and **MI325X** non-MTP sweeps down to **concurrency 1** on the TP-only latency rows (were starting at conc 4), to capture the single-request latency point. Mirrors the H100/H200 conc-1 change (#1743).

- `minimaxm3-fp8-mi300x-vllm`: TP8 latency rows (1k1k + 8k1k) now start at conc 1.
- `minimaxm3-fp8-mi325x-vllm`: TP4 and TP8 latency rows (1k1k + 8k1k) now start at conc 1.

TEP (`tp+ep`) and DEP (`tp+ep+dp-attn`) rows keep their higher concurrency starts (128/256) — they only pay off at scale. Config/search-space change only; no script changes.

## Validation
- `generate_sweep_configs.py test-config` → 57 configs; min concurrency confirms the TP-only rows now start at 1 (mi300x tp8 / mi325x tp4 / mi325x tp8 → 1), TEP/DEP unchanged (128/256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark search-space YAML only; adds low-concurrency sweep points without changing runtime code or serve recipes.
> 
> **Overview**
> Lowers the **starting concurrency** on **TP-only** fixed-seq-len rows for `minimaxm3-fp8-mi300x-vllm` and `minimaxm3-fp8-mi325x-vllm` from **4 → 1**, so sweeps include the single-request latency point (aligned with the prior H100/H200 change in #1743).
> 
> On **MI300X**, only **TP8** latency rows for 1k1k and 8k1k change. On **MI325X**, **TP4** and **TP8** latency rows for both ISL/OS pairs change. Rows with **expert parallelism** (`tp+ep`) or **dp-attn** keep their existing higher `conc-start` values.
> 
> `perf-changelog.yaml` documents the two config keys. No launch scripts or serving flags are touched—search-space YAML only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c221e5f6c298e81f46d3576c54f699e183f0789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->