### PR TITLE
[Klaud Cold] minimaxm3 H100/H200 non-MTP: conc-1 latency + full TEP coverage (1-256)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -4635,13 +4635,13 @@ minimaxm3-fp8-h100-vllm:
       # ~52 GB expert shard, and KV-cache init fails at high conc (sweep
       # 27441767143, conc 256/512: "No available memory for the cache
       # blocks"). TEP8 covers the high-concurrency regime instead.
-      - { tp: 8, conc-start: 4, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
+      - { tp: 8, conc-start: 1, conc-end: 64 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256 }
 
 dsr1-fp8-h100-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8-cu130
@@ -4888,17 +4888,18 @@ minimaxm3-fp8-h200-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
-      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
+      - { tp: 4, conc-start: 1, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 1, conc-end: 256 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 32 }
-      - { tp: 8, conc-start: 4, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
+      - { tp: 4, conc-start: 1, conc-end: 32 }
+      - { tp: 4, ep: 4, conc-start: 1, conc-end: 256 }
+      - { tp: 8, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
 
 dsr1-fp4-gb200-dynamo-trt:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3806,4 +3806,4 @@
     - minimaxm3-fp8-h200-vllm
   description:
     - "Extend MiniMax-M3 MXFP8 H100/H200 non-MTP sweeps to concurrency 1 on the latency rows (H100: TP8; H200: TP4 and TP8) and add full TEP coverage from conc 1 to 256 (H100: TP8+EP8; H200: TP4+EP4 and TP8+EP8, incl. a new TP4+EP4 row for 8k1k). H200 TP8+EP8 upper bound moves 512->256 (high concurrency stays covered by the TP8+EP8 dp-attn DEP rows). DEP rows unchanged"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1761

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3800,3 +3800,10 @@
     - "H200-style search space (TP4/TP8 latency, TP4+EP4/TP8+EP8 TEP, TP8+EP8 dp-attn DEP) trimmed at the extreme-concurrency end with TP-only latency rows started at conc 1"
     - "[AI generated draft test] The shipped ROCm image's AMD MiniMax-M3 model lacks SupportsEagle3, so the recipe patches it in-place at runtime (functionstackx/vllm#1, upstream vllm-project/vllm#45546; validated green on MI355X/MI300X) before serving; also adds SPEC_SUFFIX to launch_mi325x-amds.sh so spec-decoding=mtp routes to the _mtp script"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1759
+
+- config-keys:
+    - minimaxm3-fp8-h100-vllm
+    - minimaxm3-fp8-h200-vllm
+  description:
+    - "Extend MiniMax-M3 MXFP8 H100/H200 non-MTP sweeps to concurrency 1 on the latency rows (H100: TP8; H200: TP4 and TP8) and add full TEP coverage from conc 1 to 256 (H100: TP8+EP8; H200: TP4+EP4 and TP8+EP8, incl. a new TP4+EP4 row for 8k1k). H200 TP8+EP8 upper bound moves 512->256 (high concurrency stays covered by the TP8+EP8 dp-attn DEP rows). DEP rows unchanged"
+  pr-link: TBD


### PR DESCRIPTION
## Summary

Extends the MiniMax-M3 MXFP8 **H100** and **H200** non-MTP sweeps to **concurrency 1** on the latency rows and adds full **TEP** coverage from conc 1 to 256.

**H100** (`minimaxm3-fp8-h100-vllm`):
- TP8 latency rows (1k1k + 8k1k) now start at conc 1.
- TP8+EP8 (TEP8) now sweeps conc **1→256** (was 256-256 / 128-256).

**H200** (`minimaxm3-fp8-h200-vllm`):
- TP4 and TP8 latency rows (1k1k + 8k1k) now start at conc 1.
- TP4+EP4 (TEP4) and TP8+EP8 (TEP8) now sweep conc **1→256**, including a **new TEP4 row added to 8k1k** (which previously had none).
- TP8+EP8 dp-attn (DEP) rows are unchanged (256→1024 / 256→512), so high concurrency stays covered.

> Note: H200 1k1k TEP8 upper bound moves **512 → 256** to make the TEP rows uniformly 1-256 as requested; conc 512 remains covered by the DEP (dp-attn) row. Say the word if you'd rather keep TEP8 at 1-512.

Config/search-space change only; no script changes.

## Validation
- `generate_sweep_configs.py test-config` → 103 configs; per-layout ranges confirm latency rows start at conc 1 and TEP4/TEP8 span 1-256; DEP rows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only benchmark sweep range changes; no application logic, auth, or data paths.
> 
> **Overview**
> Benchmark sweep **search-space** updates for **MiniMax-M3 MXFP8** on **H100** and **H200** (`minimaxm3-fp8-h100-vllm`, `minimaxm3-fp8-h200-vllm`); no runtime or script changes.
> 
> **Latency (TP-only) rows** now start at **concurrency 1** instead of 4 (H100: TP8 on 1k1k and 8k1k; H200: TP4 and TP8 on both sequence lengths).
> 
> **TEP rows** sweep **1→256** end-to-end: H100 TP8+EP8; H200 TP4+EP4 and TP8+EP8, including a **new TP4+EP4** row for **8k1k** where TEP4 was missing. On H200 1k1k, **TP8+EP8** upper bound is **512→256** so TEP aligns with 1–256; **dp-attn DEP** rows are unchanged and still cover higher concurrency.
> 
> `perf-changelog.yaml` documents the same scope for PR #1761.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c072cbf25e995f8e80fcbbe5a23a6c4e649294cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->