### PR TITLE
[Klaud Cold] experimental: label-triggered Perfetto profiling (MiniMax-M3 MI325X MTP, TP4+TP8, conc 1-64)

### DIFF
--- a/.github/profile-target.env
+++ b/.github/profile-target.env
@@ -1,0 +1,9 @@
+# Target for the label-triggered Profile workflow (.github/workflows/profile.yml).
+# When a PR carries the 'profile-enabled' label, that workflow profiles this
+# config-key at this concurrency and emits a Perfetto trace (artifact + relay
+# link in the run summary). Edit these three values to retarget the experiment.
+#
+# Experiment: MiniMax-M3 MXFP8 on MI325X, single-node vLLM, concurrency 4.
+CONFIG_KEY=minimaxm3-fp8-mi325x-vllm
+CONFIG_FILE=.github/configs/amd-master.yaml
+CONC=4

--- a/.github/profile-target.env
+++ b/.github/profile-target.env
@@ -1,9 +1,11 @@
 # Target for the label-triggered Profile workflow (.github/workflows/profile.yml).
 # When a PR carries the 'profile-enabled' label, that workflow profiles this
-# config-key and emits a Perfetto trace per concurrency (artifact + relay link
-# in the run summary). CONC is space-separated; one profile job runs per value.
+# config-key and emits a Perfetto trace per (concurrency, tp) (artifact + relay
+# link in the run summary). CONC is space-separated; the workflow runs one job
+# per (conc, tp) — i.e. both TP4 and TP8 at each conc.
 #
-# Experiment: MiniMax-M3 MXFP8 on MI325X, single-node vLLM, conc 1..64.
-CONFIG_KEY=minimaxm3-fp8-mi325x-vllm
+# Experiment: MiniMax-M3 MXFP8 on MI325X, single-node vLLM, EAGLE3 MTP enabled,
+# TP4 + TP8, conc 1..64.
+CONFIG_KEY=minimaxm3-fp8-mi325x-vllm-mtp
 CONFIG_FILE=.github/configs/amd-master.yaml
 CONC=1 2 4 8 16 32 64

--- a/.github/profile-target.env
+++ b/.github/profile-target.env
@@ -1,9 +1,9 @@
 # Target for the label-triggered Profile workflow (.github/workflows/profile.yml).
 # When a PR carries the 'profile-enabled' label, that workflow profiles this
-# config-key at this concurrency and emits a Perfetto trace (artifact + relay
-# link in the run summary). Edit these three values to retarget the experiment.
+# config-key and emits a Perfetto trace per concurrency (artifact + relay link
+# in the run summary). CONC is space-separated; one profile job runs per value.
 #
-# Experiment: MiniMax-M3 MXFP8 on MI325X, single-node vLLM, concurrency 4.
+# Experiment: MiniMax-M3 MXFP8 on MI325X, single-node vLLM, conc 1..64.
 CONFIG_KEY=minimaxm3-fp8-mi325x-vllm
 CONFIG_FILE=.github/configs/amd-master.yaml
-CONC=4
+CONC=1 2 4 8 16 32 64

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -258,6 +258,12 @@ jobs:
           fi
 
       - name: Process result (json -> agg)
+        # Non-fatal: the profiling deliverable is the trace (already captured
+        # above), not the agg JSON. process_result.py divides by tpot and hits a
+        # ZeroDivisionError on degenerate single-request runs (conc 1, where the
+        # profile path caps num_prompts to 1), which must not block the trace
+        # upload / storage push / relay link.
+        continue-on-error: true
         env:
           RUNNER_TYPE: ${{ matrix.config.runner }}
         run: |
@@ -323,7 +329,17 @@ jobs:
           git config user.email "github-actions@github.com"
           git add -A
           git commit -m "Add profile: ${GITHUB_SHA} ${{ matrix.config['exp-name'] }} tp${{ matrix.config.tp }} ep${{ matrix.config.ep || 1 }} conc${{ matrix.config.conc }}" || echo "Nothing to commit"
-          git push
+          # Parallel matrix jobs (one per conc) all push to this same repo, so a
+          # plain push races and is rejected non-fast-forward. Rebase onto the
+          # latest remote and retry with jitter until it lands.
+          for attempt in 1 2 3 4 5 6 7 8; do
+            if git push; then break; fi
+            echo "push rejected (attempt ${attempt}); rebasing on origin/master"
+            git fetch origin master --quiet
+            git rebase origin/master
+            if [ "$attempt" = 8 ]; then echo "push failed after ${attempt} attempts" >&2; exit 1; fi
+            sleep $(( (RANDOM % 6) + 2 ))
+          done
           STORAGE_SHA="$(git rev-parse HEAD)"
           popd >/dev/null
 

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -126,15 +126,16 @@ jobs:
               f.write("filtered=[]\ncount=0\n")
             raise SystemExit(1)
 
-          # One job per concurrency: the first config generated for each conc
-          # (the leading search-space row), ordered by conc. A single conc value
-          # yields one job, matching the prior behaviour.
-          by_conc = {}
+          # One job per (concurrency, tp): the first config generated for each
+          # (conc, tp) pair — i.e. the leading 1k1k search-space row of each TP —
+          # ordered by (conc, tp). This profiles both TP4 and TP8 at every conc.
+          # A single conc/tp still yields one job (backward compatible).
+          by_key = {}
           for job in data:
-            c = job.get("conc")
-            if c not in by_conc:
-              by_conc[c] = job
-          filt = [by_conc[c] for c in sorted(by_conc)]
+            k = (job.get("conc"), job.get("tp"))
+            if k not in by_key:
+              by_key[k] = job
+          filt = [by_key[k] for k in sorted(by_key)]
 
           out = json.dumps(filt)
           print(out)
@@ -258,12 +259,6 @@ jobs:
           fi
 
       - name: Process result (json -> agg)
-        # Non-fatal: the profiling deliverable is the trace (already captured
-        # above), not the agg JSON. process_result.py divides by tpot and hits a
-        # ZeroDivisionError on degenerate single-request runs (conc 1, where the
-        # profile path caps num_prompts to 1), which must not block the trace
-        # upload / storage push / relay link.
-        continue-on-error: true
         env:
           RUNNER_TYPE: ${{ matrix.config.runner }}
         run: |

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -107,7 +107,7 @@ jobs:
           echo "raw=$CONFIG_JSON" >> $GITHUB_OUTPUT
 
       - id: filter
-        name: Take first generated job
+        name: Select one job per concurrency
         shell: python
         run: |
           import json, os, sys
@@ -126,7 +126,15 @@ jobs:
               f.write("filtered=[]\ncount=0\n")
             raise SystemExit(1)
 
-          filt = data[:1]
+          # One job per concurrency: the first config generated for each conc
+          # (the leading search-space row), ordered by conc. A single conc value
+          # yields one job, matching the prior behaviour.
+          by_conc = {}
+          for job in data:
+            c = job.get("conc")
+            if c not in by_conc:
+              by_conc[c] = job
+          filt = [by_conc[c] for c in sorted(by_conc)]
 
           out = json.dumps(filt)
           print(out)

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -26,6 +26,12 @@ on:
         description: "Ref (branch/sha) to checkout"
         required: false
         type: string
+  # Label-triggered profiling: add the 'profile-enabled' label to a PR and this
+  # workflow profiles the target declared in .github/profile-target.env
+  # (CONFIG_KEY / CONFIG_FILE / CONC), emitting a Perfetto trace as an artifact
+  # plus a relay link. Gated in the get-jobs `if` below so only labelled PRs run.
+  pull_request:
+    types: [labeled, synchronize, reopened]
 
 permissions:
   contents: read
@@ -40,21 +46,63 @@ env:
 
 jobs:
   get-jobs:
+    # Run for manual dispatch, or for a PR carrying the 'profile-enabled' label.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'pull_request' &&
+           contains(github.event.pull_request.labels.*.name, 'profile-enabled')) }}
     runs-on: ubuntu-latest
     outputs:
       filtered-matrix: ${{ steps.filter.outputs.filtered }}
       count: ${{ steps.filter.outputs.count }}
+      ref: ${{ steps.preref.outputs.ref }}
+      moe-debug: ${{ steps.target.outputs.moe_debug }}
     steps:
+      - name: Resolve checkout ref
+        id: preref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ inputs.ref || github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ steps.preref.outputs.ref }}
+
+      - name: Resolve profile target (dispatch inputs or PR target file)
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            f=.github/profile-target.env
+            if [ ! -f "$f" ]; then
+              echo "::error::$f is required for label-triggered profiling" >&2
+              exit 1
+            fi
+            ck=$(grep -E '^CONFIG_KEY=' "$f" | head -1 | cut -d= -f2-)
+            cf=$(grep -E '^CONFIG_FILE=' "$f" | head -1 | cut -d= -f2-)
+            cc=$(grep -E '^CONC=' "$f" | head -1 | cut -d= -f2-)
+            md=$(grep -E '^MOE_DEBUG=' "$f" | head -1 | cut -d= -f2- || true)
+            if [ -z "$ck" ]; then echo "::error::CONFIG_KEY missing in $f" >&2; exit 1; fi
+            echo "config_key=${ck}" >> "$GITHUB_OUTPUT"
+            echo "config_file=${cf:-.github/configs/nvidia-master.yaml}" >> "$GITHUB_OUTPUT"
+            echo "conc=${cc:-64}" >> "$GITHUB_OUTPUT"
+            echo "moe_debug=${md:-false}" >> "$GITHUB_OUTPUT"
+          else
+            echo "config_key=${{ inputs.config-key }}" >> "$GITHUB_OUTPUT"
+            echo "config_file=${{ inputs.config-file }}" >> "$GITHUB_OUTPUT"
+            echo "conc=${{ inputs.conc }}" >> "$GITHUB_OUTPUT"
+            echo "moe_debug=${{ inputs.moe-debug }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - id: gen
         name: Generate matrix via script
         run: |
           pip install pydantic
-          CLI_ARGS="test-config --config-files ${{ inputs.config-file }} --config-keys ${{ inputs.config-key }} --conc ${{ inputs.conc }}"
+          CLI_ARGS="test-config --config-files ${{ steps.target.outputs.config_file }} --config-keys ${{ steps.target.outputs.config_key }} --conc ${{ steps.target.outputs.conc }}"
           CONFIG_JSON=$(python3 ${GITHUB_WORKSPACE}/utils/matrix_logic/generate_sweep_configs.py $CLI_ARGS)
           echo "raw=$CONFIG_JSON" >> $GITHUB_OUTPUT
 
@@ -116,7 +164,7 @@ jobs:
       SPEC_DECODING: ${{ matrix.config.spec-decoding }}
       DISAGG: ${{ matrix.config.disagg }}
       MOE_DEBUG: '0'
-      MOE_DEBUG_LOG: ${{ (inputs.moe-debug) && '/workspace/moe_debug.tp0.log' || '' }}
+      MOE_DEBUG_LOG: ${{ needs.get-jobs.outputs.moe-debug == 'true' && '/workspace/moe_debug.tp0.log' || '' }}
     steps:
       - name: Resource cleanup
         run: |
@@ -145,7 +193,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ needs.get-jobs.outputs.ref }}
           clean: false
 
       - name: Launch + Profile (single-node sglang/vllm)

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -163,6 +163,12 @@ jobs:
       CONC: ${{ matrix.config.conc }}
       SPEC_DECODING: ${{ matrix.config.spec-decoding }}
       DISAGG: ${{ matrix.config.disagg }}
+      # The single-node launchers resolve the recipe path as
+      # benchmarks/single_node/${SCENARIO_SUBDIR}<exp>_<prec>_<hw>.sh and run
+      # under `set -u`; the sweep's benchmark-tmpl.yml sets this, so profile.yml
+      # must too. Profiling is fixed-seq-len (mi325x/mi300x launchers don't
+      # default it the way mi355x does).
+      SCENARIO_SUBDIR: fixed_seq_len/
       MOE_DEBUG: '0'
       MOE_DEBUG_LOG: ${{ needs.get-jobs.outputs.moe-debug == 'true' && '/workspace/moe_debug.tp0.log' || '' }}
     steps:

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -49,9 +49,20 @@ fi
 
 start_gpu_monitor
 
+# When PROFILE=1 (profile.yml), arm vLLM's torch profiler via --profiler-config.
+# This minimax-m3 image's vLLM does NOT honour the VLLM_TORCH_PROFILER_DIR env
+# var (it logs it as "unknown"), so the env var alone yields no trace; the serve
+# flag is what makes /start_profile emit one. Write to the dir benchmark_lib's
+# relay scans (VLLM_TORCH_PROFILER_DIR, default /workspace/).
+PROFILE_ARGS=()
+if [ "${PROFILE:-}" = "1" ]; then
+    PROFILE_ARGS=(--profiler-config "{\"profiler\": \"torch\", \"torch_profiler_dir\": \"${VLLM_TORCH_PROFILER_DIR:-/workspace/}\"}")
+fi
+
 set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
+    "${PROFILE_ARGS[@]}" \
     --block-size 128 \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x_mtp.sh
@@ -171,9 +171,19 @@ PYEOF
 
 start_gpu_monitor
 
+# When PROFILE=1 (profile.yml), arm vLLM's torch profiler via --profiler-config.
+# This minimax-m3 image's vLLM does NOT honour the VLLM_TORCH_PROFILER_DIR env
+# var, so the serve flag is what makes /start_profile emit a trace. Write to the
+# dir benchmark_lib's relay scans (VLLM_TORCH_PROFILER_DIR, default /workspace/).
+PROFILE_ARGS=()
+if [ "${PROFILE:-}" = "1" ]; then
+    PROFILE_ARGS=(--profiler-config "{\"profiler\": \"torch\", \"torch_profiler_dir\": \"${VLLM_TORCH_PROFILER_DIR:-/workspace/}\"}")
+fi
+
 set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
+    "${PROFILE_ARGS[@]}" \
     --block-size 128 \
     --no-enable-prefix-caching \
     --language-model-only \

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -128,12 +128,8 @@ for key, value in bmk_result.items():
     if key.endswith('ms'):
         data[key.replace('_ms', '')] = float(value) / 1000.0
     if 'tpot' in key:
-        # intvty = 1000 / tpot_ms. tpot can be 0 on degenerate single-request
-        # runs (e.g. the profiler path caps num_prompts to 1 at conc 1), so guard
-        # the division instead of crashing; 0 tpot -> 0 interactivity.
-        tpot_ms = float(value)
         data[key.replace('_ms', '').replace(
-            'tpot', 'intvty')] = (1000.0 / tpot_ms) if tpot_ms else 0.0
+            'tpot', 'intvty')] = 1000.0 / float(value)
 
 print(json.dumps(data, indent=2))
 

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -128,8 +128,12 @@ for key, value in bmk_result.items():
     if key.endswith('ms'):
         data[key.replace('_ms', '')] = float(value) / 1000.0
     if 'tpot' in key:
+        # intvty = 1000 / tpot_ms. tpot can be 0 on degenerate single-request
+        # runs (e.g. the profiler path caps num_prompts to 1 at conc 1), so guard
+        # the division instead of crashing; 0 tpot -> 0 interactivity.
+        tpot_ms = float(value)
         data[key.replace('_ms', '').replace(
-            'tpot', 'intvty')] = 1000.0 / float(value)
+            'tpot', 'intvty')] = (1000.0 / tpot_ms) if tpot_ms else 0.0
 
 print(json.dumps(data, indent=2))
 


### PR DESCRIPTION
## What

**Experimental.** Adds **label-triggered Perfetto profiling**: add the `profile-enabled` label to a PR and `.github/workflows/profile.yml` profiles the target declared in `.github/profile-target.env`, emitting a **Perfetto trace** (artifact + relay link in the run summary).

This PR's target (`.github/profile-target.env`):

```
CONFIG_KEY=minimaxm3-fp8-mi325x-vllm
CONFIG_FILE=.github/configs/amd-master.yaml
CONC=4
```

→ **MiniMax-M3 MXFP8, MI325X, single-node vLLM, concurrency 4** (TP4, 1k/1k — the first generated conc-4 entry).

## How it works

`profile.yml` already does the heavy lifting on `workflow_dispatch` (sets `PROFILE=1` + `VLLM_TORCH_PROFILER_DIR=/workspace`; `benchmark_lib.sh` adds `--profile`, which hits vLLM's `/start_profile` + `/stop_profile`; the torch trace is relayed to `profile_<name>.trace.json.gz`, uploaded as an artifact, pushed to the trace-storage repo, and turned into a Perfetto relay URL). This PR just lets a **PR label** drive the same pipeline:

- `on:` adds `pull_request: types: [labeled, synchronize, reopened]`
- `get-jobs` is gated by an `if` (manual dispatch **or** the `profile-enabled` label) and gains a *Resolve profile target* step that picks dispatch inputs vs. the committed `profile-target.env`, threading `config-key` / `config-file` / `conc` / `ref` / `moe-debug` through job outputs
- the `profile` job checks out the resolved ref; the MoE-debug log is gated on the resolved output

`workflow_dispatch` behaviour is unchanged. To retarget, edit the three values in `profile-target.env`.

## Output

The run summary prints a **Perfetto Relay URL** and uploads `profile_<exp>.trace.json.gz` as an artifact (also pushed to `InferenceX-trace-storage`). Open the relay link in [ui.perfetto.dev](https://ui.perfetto.dev/) to view the trace.

> Experimental / infra — not a recipe change. Labelling this PR `profile-enabled` will launch the MI325X M3 conc-4 profile run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only changes that fan out many hardware profile runs and add concurrent git pushes to trace storage; benchmark scripts only alter vLLM serve args when profiling is enabled.
> 
> **Overview**
> Adds **label-triggered profiling**: PRs with the `profile-enabled` label run `.github/workflows/profile.yml` using targets from **`.github/profile-target.env`** (this PR sets MiniMax-M3 MXFP8 + EAGLE3 MTP on MI325X, **TP4 and TP8**, conc **1–64**).
> 
> The workflow now checks out the **PR head SHA**, reads `CONFIG_KEY` / `CONFIG_FILE` / `CONC` (and optional `MOE_DEBUG`) from that file on PR events, and builds a matrix with **one job per `(conc, tp)`** instead of a single job. It sets **`SCENARIO_SUBDIR: fixed_seq_len/`** for MI325X launchers and routes MoE debug via job outputs. **Trace-storage pushes** retry with fetch/rebase and jitter when parallel matrix jobs race on `git push`.
> 
> **MiniMax MI325X** base and **MTP** recipes pass **`--profiler-config`** when `PROFILE=1`, because this image’s vLLM ignores `VLLM_TORCH_PROFILER_DIR` and needs the serve flag to emit traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7d4e962f504f02ea92f3e7fd7c7b1306a399ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->