### PR TITLE
fix(ci): gate reusable PR sweeps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -192,19 +192,29 @@ comment before merging:
 
 That reuses the latest successful `run-sweep.yml` `pull_request` run whose
 commit is still part of the PR. To select a particular eligible successful
-run, pin the source run explicitly:
+or failed run, pin the source run explicitly:
 
 ```
 /reuse-sweep-run <run_id>
 ```
 
+Only an explicitly pinned run may have a `failure` conclusion. An unpinned
+command always selects the latest successful eligible run. Pinned failed runs
+must still contain complete artifacts for the merge run's expected matrix.
+
 The comment is the reuse authorization, so adding it does not trigger or cancel
-a PR sweep. On the push-to-main run, `run-sweep.yml` resolves the merged PR
-from the merge commit, verifies the source run is a successful `pull_request`
-`run-sweep.yml` run for the same PR, downloads the ingest-relevant artifacts,
-validates that `results_bmk` covers the merge run's expected benchmark matrix,
-and uploads them as `reused-ingest-artifacts`. The normal database ingest then
-publishes those artifacts with the merge run's changelog metadata.
+a PR sweep. Once the comment is present, later commits pushed to a PR with a
+full-sweep label do not start another benchmark sweep. GitHub still creates a
+lightweight `pull_request` workflow run so it can inspect the PR comments, but
+the sweep setup and benchmark jobs are skipped. Removing and re-adding a sweep
+label explicitly starts a new sweep.
+
+On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
+commit, verifies the source run is an eligible `pull_request` `run-sweep.yml`
+run for the same PR, downloads the ingest-relevant artifacts, validates that
+`results_bmk` covers the merge run's expected benchmark matrix, and uploads
+them as `reused-ingest-artifacts`. The normal database ingest then publishes
+those artifacts with the merge run's changelog metadata.
 
 Only comments from `OWNER`, `MEMBER`, or `COLLABORATOR` users authorize reuse.
 The most recent matching comment wins, so a maintainer can supersede an earlier

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -34,9 +34,54 @@ on:
             - "perf-changelog.yaml"
 
 jobs:
+    reuse-sweep-gate:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            issues: read
+            pull-requests: read
+        if: >-
+            github.event_name == 'pull_request' &&
+            github.event.action == 'synchronize' &&
+            !github.event.pull_request.draft &&
+            (
+              contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled') ||
+              contains(github.event.pull_request.labels.*.name, 'non-canary-full-sweep-enabled') ||
+              contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast') ||
+              contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast-no-canary')
+            )
+        outputs:
+            skip-pr-sweep: ${{ steps.gate.outputs.skip-pr-sweep }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Check for reusable sweep authorization
+              id: gate
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  python3 "${GITHUB_WORKSPACE}/utils/find_reusable_sweep_run.py" \
+                    --repo "${{ github.repository }}" \
+                    --commit-sha "${{ github.event.pull_request.head.sha }}" \
+                    --event-name "${{ github.event_name }}" \
+                    --event-action "${{ github.event.action }}" \
+                    --pr-number "${{ github.event.pull_request.number }}" \
+                    --ref "${{ github.ref }}" \
+                    --workflow-id "run-sweep.yml"
+
     check-newline:
+        needs: reuse-sweep-gate
         runs-on: ubuntu-latest
         if: >-
+            always() &&
+            (
+              needs.reuse-sweep-gate.result == 'skipped' ||
+              (
+                needs.reuse-sweep-gate.result == 'success' &&
+                needs.reuse-sweep-gate.outputs.skip-pr-sweep != 'true'
+              )
+            ) &&
             github.event_name == 'pull_request' &&
             !github.event.pull_request.draft &&
             (
@@ -60,30 +105,41 @@ jobs:
                   fi
 
     setup:
+        needs: reuse-sweep-gate
         runs-on: ubuntu-latest
         if: >-
+            always() &&
             (
-              github.event_name == 'pull_request' &&
-              !github.event.pull_request.draft &&
+              needs.reuse-sweep-gate.result == 'skipped' ||
               (
-                contains(github.event.pull_request.labels.*.name, 'sweep-enabled') ||
-                contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled') ||
-                contains(github.event.pull_request.labels.*.name, 'non-canary-full-sweep-enabled') ||
-                contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast') ||
-                contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast-no-canary')
-              ) &&
-              (
-                (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-                github.event.label.name == 'sweep-enabled' ||
-                github.event.label.name == 'full-sweep-enabled' ||
-                github.event.label.name == 'non-canary-full-sweep-enabled' ||
-                github.event.label.name == 'full-sweep-fail-fast' ||
-                github.event.label.name == 'full-sweep-fail-fast-no-canary'
+                needs.reuse-sweep-gate.result == 'success' &&
+                needs.reuse-sweep-gate.outputs.skip-pr-sweep != 'true'
               )
-            ) ||
+            ) &&
             (
-              github.event_name != 'pull_request' &&
-              !contains(github.event.head_commit.message, '[skip-sweep]')
+              (
+                github.event_name == 'pull_request' &&
+                !github.event.pull_request.draft &&
+                (
+                  contains(github.event.pull_request.labels.*.name, 'sweep-enabled') ||
+                  contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled') ||
+                  contains(github.event.pull_request.labels.*.name, 'non-canary-full-sweep-enabled') ||
+                  contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast') ||
+                  contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast-no-canary')
+                ) &&
+                (
+                  (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+                  github.event.label.name == 'sweep-enabled' ||
+                  github.event.label.name == 'full-sweep-enabled' ||
+                  github.event.label.name == 'non-canary-full-sweep-enabled' ||
+                  github.event.label.name == 'full-sweep-fail-fast' ||
+                  github.event.label.name == 'full-sweep-fail-fast-no-canary'
+                )
+              ) ||
+              (
+                github.event_name != 'pull_request' &&
+                !contains(github.event.head_commit.message, '[skip-sweep]')
+              )
             )
         outputs:
             search-space-config: ${{ steps.setup.outputs.search-space-config }}
@@ -743,9 +799,11 @@ jobs:
                 collect-evals,
                 calc-success-rate,
                 upload-changelog-metadata,
+                setup,
             ]
         if: >-
             always() &&
+            needs.setup.result == 'success' &&
             github.event_name == 'pull_request' &&
             !github.event.pull_request.draft &&
             (

--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -100,6 +100,7 @@ def result(
     *,
     enabled: bool,
     reason: str,
+    skip_pr_sweep: bool = False,
     source_run_id: str = "",
     source_run_attempt: str = "",
     source_run_url: str = "",
@@ -109,6 +110,7 @@ def result(
     """Build the result payload."""
     return {
         "reuse-enabled": "true" if enabled else "false",
+        "skip-pr-sweep": "true" if skip_pr_sweep else "false",
         "reuse-source-run-id": source_run_id,
         "reuse-source-run-attempt": source_run_attempt,
         "reuse-source-run-url": source_run_url,
@@ -224,13 +226,21 @@ def validate_reusable_run(
     pr_number: int,
     run: dict[str, Any],
     token: str,
+    allow_failed: bool = False,
 ) -> None:
     """Fail closed unless an Actions run is a valid reusable source run."""
     run_id = int(run["id"])
     if run.get("event") != "pull_request":
         raise RuntimeError(f"Reusable source run {run_id} is not a pull_request run.")
-    if run.get("status") != "completed" or run.get("conclusion") != "success":
-        raise RuntimeError(f"Reusable source run {run_id} did not complete successfully.")
+    if run.get("status") != "completed":
+        raise RuntimeError(f"Reusable source run {run_id} is not completed.")
+    allowed_conclusions = {"success", "failure"} if allow_failed else {"success"}
+    if run.get("conclusion") not in allowed_conclusions:
+        expected = "success or failure" if allow_failed else "success"
+        raise RuntimeError(
+            f"Reusable source run {run_id} has conclusion {run.get('conclusion')!r}; "
+            f"expected {expected}."
+        )
     expected_path = workflow_path(workflow_id)
     run_path = str(run.get("path") or "")
     if run_path and run_path != expected_path:
@@ -274,6 +284,8 @@ def main() -> int:
     parser.add_argument("--repo", required=True)
     parser.add_argument("--commit-sha", required=True)
     parser.add_argument("--event-name", required=True)
+    parser.add_argument("--event-action", default="")
+    parser.add_argument("--pr-number", type=int)
     parser.add_argument("--ref", required=True)
     parser.add_argument("--workflow-id", default="run-sweep.yml")
     parser.add_argument(
@@ -298,6 +310,36 @@ def main() -> int:
         for value in args.allowed_author_associations.split(",")
         if value.strip()
     }
+
+    if args.event_name == "pull_request":
+        if args.event_action != "synchronize":
+            outputs = result(
+                enabled=False,
+                reason=f"pull_request action {args.event_action or 'unknown'} is not synchronize",
+            )
+        else:
+            if args.pr_number is None:
+                raise RuntimeError("--pr-number is required for pull_request synchronize")
+            authorized, _ = find_reuse_authorization(
+                args.repo,
+                args.pr_number,
+                token,
+                args.pinned_run_command,
+                allowed_author_associations,
+            )
+            outputs = result(
+                enabled=False,
+                skip_pr_sweep=authorized,
+                reason=(
+                    f"PR #{args.pr_number} has {args.pinned_run_command} authorization"
+                    if authorized
+                    else f"PR #{args.pr_number} has no {args.pinned_run_command} authorization"
+                ),
+                source_pr_number=str(args.pr_number),
+            )
+        write_outputs(args.github_output, outputs)
+        print(json.dumps(outputs, indent=2))
+        return 0
 
     if args.event_name != "push" or args.ref != "refs/heads/main":
         outputs = result(enabled=False, reason="not a push to main")
@@ -397,7 +439,14 @@ def main() -> int:
         )
 
     run_id = int(run["id"])
-    validate_reusable_run(args.repo, args.workflow_id, pr_number, run, token)
+    validate_reusable_run(
+        args.repo,
+        args.workflow_id,
+        pr_number,
+        run,
+        token,
+        allow_failed=pinned_run_id is not None,
+    )
 
     outputs = result(
         enabled=True,

--- a/utils/merge_with_reuse.sh
+++ b/utils/merge_with_reuse.sh
@@ -6,8 +6,8 @@
 #   2. Merge origin/main into the PR branch.  Any `perf-changelog.yaml`
 #      conflict is auto-resolved by accepting main's entries and re-appending
 #      the PR's entry at the bottom with `XXX` -> the PR number.
-#   3. Push the merge commit and cancel the sweep it triggers (the prior
-#      successful sweep is what the merge run will reuse).
+#   3. Push the merge commit. The PR synchronize run observes the reuse
+#      authorization and skips sweep setup and benchmark jobs.
 #   4. Squash-merge the PR to main (--admin).
 #
 # Usage: utils/merge_with_reuse.sh <pr-number>
@@ -186,30 +186,13 @@ fi
 
 POST_MERGE="$(git rev-parse HEAD)"
 
-# --- step 3: push and cancel triggered sweep --------------------------------
+# --- step 3: push merge commit -----------------------------------------------
 if [ "$PRE_MERGE" = "$POST_MERGE" ]; then
-    log "PR already up to date with main; skipping push + cancel"
+    log "PR already up to date with main; skipping push"
 else
     log "Pushing merge commit ${POST_MERGE:0:8}"
     git push origin "${LOCAL_BRANCH}:${HEAD_BRANCH}"
-
-    log "Waiting for triggered sweep run to register"
-    RUN_ID=""
-    for _ in 1 2 3 4 5; do
-        sleep 5
-        RUN_ID="$(gh run list --repo "$REPO" --branch "$HEAD_BRANCH" \
-            --workflow run-sweep.yml --limit 5 \
-            --json databaseId,headSha,status \
-            --jq ".[] | select(.headSha==\"${POST_MERGE}\" and (.status==\"queued\" or .status==\"in_progress\")) | .databaseId" | head -1)"
-        [ -n "$RUN_ID" ] && break
-    done
-    if [ -n "$RUN_ID" ]; then
-        log "Cancelling sweep run ${RUN_ID}"
-        gh run cancel "$RUN_ID" --repo "$REPO" >/dev/null
-        ok "Sweep cancelled"
-    else
-        echo "  No queued/in-progress sweep found after 25s — proceeding."
-    fi
+    ok "Push complete; the reuse authorization will suppress the synchronize sweep"
 fi
 
 # --- step 4: squash-merge to main -------------------------------------------

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -102,6 +102,166 @@ def test_find_reuse_authorization_ignores_inline_mentions(monkeypatch) -> None:
     ) == (False, None)
 
 
+def test_find_latest_successful_pr_run_skips_newer_failed_run(monkeypatch) -> None:
+    failed_run = {
+        "id": 222,
+        "conclusion": "failure",
+        "head_sha": "abc123",
+    }
+    successful_run = {
+        "id": 111,
+        "conclusion": "success",
+        "head_sha": "abc123",
+    }
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        assert path == "/actions/workflows/run-sweep.yml/runs"
+        return [failed_run, successful_run]
+
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+
+    assert (
+        reuse.find_latest_successful_pr_run(
+            "SemiAnalysisAI/InferenceX",
+            "run-sweep.yml",
+            "feature-branch",
+            {"abc123"},
+            "token",
+        )
+        == successful_run
+    )
+
+
+def test_main_skips_pr_synchronize_with_reuse_authorization(
+    monkeypatch, tmp_path
+) -> None:
+    comments = [
+        {
+            "created_at": "2026-05-13T00:00:00Z",
+            "author_association": "MEMBER",
+            "body": "/reuse-sweep-run",
+        },
+    ]
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        assert path == "/issues/1321/comments"
+        return comments
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "abc123",
+            "--event-name",
+            "pull_request",
+            "--event-action",
+            "synchronize",
+            "--pr-number",
+            "1321",
+            "--ref",
+            "refs/pull/1321/merge",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "false"
+    assert outputs["skip-pr-sweep"] == "true"
+    assert outputs["reuse-source-pr-number"] == "1321"
+
+
+def test_main_allows_pr_synchronize_without_reuse_authorization(
+    monkeypatch, tmp_path
+) -> None:
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        assert path == "/issues/1321/comments"
+        return [
+            {
+                "created_at": "2026-05-13T00:00:00Z",
+                "author_association": "CONTRIBUTOR",
+                "body": "/reuse-sweep-run",
+            },
+        ]
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "abc123",
+            "--event-name",
+            "pull_request",
+            "--event-action",
+            "synchronize",
+            "--pr-number",
+            "1321",
+            "--ref",
+            "refs/pull/1321/merge",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "false"
+    assert outputs["skip-pr-sweep"] == "false"
+
+
+def test_main_does_not_check_reuse_comment_for_label_event(
+    monkeypatch, tmp_path
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("comments should not be queried for label events")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "paginated_github_api", fail_if_called)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "abc123",
+            "--event-name",
+            "pull_request",
+            "--event-action",
+            "labeled",
+            "--pr-number",
+            "1321",
+            "--ref",
+            "refs/pull/1321/merge",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["skip-pr-sweep"] == "false"
+
+
 def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> None:
     monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
     monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
@@ -121,6 +281,54 @@ def test_validate_reusable_run_accepts_successful_same_pr_run(monkeypatch) -> No
         },
         "token",
     )
+
+
+def test_validate_reusable_run_accepts_failed_run_when_explicitly_allowed(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
+
+    reuse.validate_reusable_run(
+        "SemiAnalysisAI/InferenceX",
+        "run-sweep.yml",
+        1321,
+        {
+            "id": 25763404168,
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "failure",
+            "path": ".github/workflows/run-sweep.yml",
+            "head_sha": "abc123",
+        },
+        "token",
+        allow_failed=True,
+    )
+
+
+def test_validate_reusable_run_rejects_failed_run_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
+
+    try:
+        reuse.validate_reusable_run(
+            "SemiAnalysisAI/InferenceX",
+            "run-sweep.yml",
+            1321,
+            {
+                "id": 25763404168,
+                "event": "pull_request",
+                "status": "completed",
+                "conclusion": "failure",
+                "path": ".github/workflows/run-sweep.yml",
+                "head_sha": "abc123",
+            },
+            "token",
+        )
+    except RuntimeError as error:
+        assert "expected success" in str(error)
+    else:
+        raise AssertionError("expected an unpinned failed run to be rejected")
 
 
 def test_validate_reusable_run_accepts_run_for_older_pr_commit(monkeypatch) -> None:
@@ -254,6 +462,76 @@ def test_main_enables_pinned_reuse_without_extra_label(monkeypatch, tmp_path) ->
     assert outputs["reuse-source-run-id"] == "25763404168"
     assert outputs["reuse-source-pr-number"] == "1321"
     assert outputs["reuse-source-head-sha"] == "abc123"
+
+
+def test_main_enables_explicitly_pinned_failed_run(monkeypatch, tmp_path) -> None:
+    comments = [
+        {
+            "created_at": "2026-05-13T00:00:00Z",
+            "author_association": "OWNER",
+            "body": "/reuse-sweep-run 25763404168",
+        },
+    ]
+    run = {
+        "id": 25763404168,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "failure",
+        "path": ".github/workflows/run-sweep.yml",
+        "run_attempt": 1,
+        "html_url": "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25763404168",
+        "head_sha": "abc123",
+    }
+
+    def fake_github_api(repo, path, token, params=None):
+        if path == "/commits/merge-sha/pulls":
+            return [{"number": 1321}]
+        if path == "/pulls/1321":
+            return {
+                "merged_at": "2026-05-13T00:01:00Z",
+                "labels": [{"name": "full-sweep-enabled"}],
+                "head": {"sha": "abc123"},
+            }
+        if path == "/actions/runs/25763404168":
+            return run
+        raise AssertionError(f"unexpected GitHub API path: {path}")
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        if path == "/issues/1321/comments":
+            return comments
+        if path == "/pulls/1321/commits":
+            return [{"sha": "abc123"}]
+        if path == "/actions/runs/25763404168/artifacts":
+            return [{"name": "results_bmk"}]
+        raise AssertionError(f"unexpected paginated GitHub API path: {path}")
+
+    output_path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(reuse, "github_api", fake_github_api)
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse.sys,
+        "argv",
+        [
+            "find_reusable_sweep_run.py",
+            "--repo",
+            "SemiAnalysisAI/InferenceX",
+            "--commit-sha",
+            "merge-sha",
+            "--event-name",
+            "push",
+            "--ref",
+            "refs/heads/main",
+            "--github-output",
+            str(output_path),
+        ],
+    )
+
+    assert reuse.main() == 0
+
+    outputs = dict(line.split("=", 1) for line in output_path.read_text().splitlines())
+    assert outputs["reuse-enabled"] == "true"
+    assert outputs["reuse-source-run-id"] == "25763404168"
 
 
 def test_main_resolves_no_arg_command_to_latest_head_sweep(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- skip PR sweep setup and benchmark jobs on `synchronize` after an authorized `/reuse-sweep-run` comment
- keep sweep-label events available as an explicit retrigger
- allow `/reuse-sweep-run <run-id>` to reuse completed failed runs when their artifacts cover the expected matrix
- keep unpinned `/reuse-sweep-run` selection restricted to the latest successful eligible run
- update the merge helper and workflow documentation for the new behavior

## Root cause

`run-sweep.yml` receives a `synchronize` event for every new PR commit. Because GitHub evaluates the `paths` filter against the whole PR diff and full-sweep labels remain attached, later commits started replacement sweeps even after reuse had been authorized.

## Validation

- `python -m pytest utils/test_find_reusable_sweep_run.py utils/test_validate_reusable_sweep_artifacts.py -v`
- `python -m pytest utils/matrix_logic/ -q`
- `actionlint .github/workflows/run-sweep.yml`
- `shellcheck utils/merge_with_reuse.sh`
- `python -m py_compile utils/find_reusable_sweep_run.py utils/validate_reusable_sweep_artifacts.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when cluster sweeps run and which Actions conclusions can feed merge ingest; incorrect gating could skip needed PR sweeps or accept the wrong source run, though validation and fail-closed merge paths remain.
> 
> **Overview**
> Adds a **`reuse-sweep-gate`** job on full-sweep PR **`synchronize`** events so an authorized **`/reuse-sweep-run`** comment sets **`skip-pr-sweep`** and downstream **`setup`**, benchmark, and related jobs are skipped instead of starting a replacement sweep. **Label** add/remove still runs sweeps as an explicit retrigger.
> 
> **`find_reusable_sweep_run.py`** now handles PR **`synchronize`** (maintainer comment check only) and emits **`skip-pr-sweep`**. On merge, unpinned reuse still requires the latest **successful** run; **`/reuse-sweep-run <run_id>`** may reuse a **failed** run when **`allow_failed`** is set, with artifact validation unchanged.
> 
> **`merge_with_reuse.sh`** drops post-push sweep **cancellation** and relies on the gate. Workflow README documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831a4bb17a6639b585b6c0884428e9db64d041d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->