### PR TITLE
[AMD] qwen3.5-mxfp4-mi355x: enable fp8_e4m3 KV cache for fp4 and MTP benchmarks

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh
@@ -42,6 +42,7 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --disable-radix-cache \
 --enable-aiter-allreduce-fusion --max-running-requests $CONC \
 --page-size 16 \
+--kv-cache-dtype fp8_e4m3 \
 > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
@@ -42,6 +42,7 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --disable-radix-cache \
 --enable-aiter-allreduce-fusion --max-running-requests $CONC \
 --page-size 16 \
+--kv-cache-dtype fp8_e4m3 \
 --speculative-algorithm EAGLE \
 --speculative-num-steps 3 \
 --speculative-eagle-topk 1 \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3842,3 +3842,10 @@
     - "Recipes sourced from NVIDIA/srt-slurm branch sa-submission-q2-2026"
     - "Runner script updated to support dsv4 model prefix with dynamo-trt framework on GB300"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1689
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+    - qwen3.5-fp4-mi355x-sglang-mtp
+  description:
+    - "Enable fp8 (fp8_e4m3) KV cache by adding --kv-cache-dtype fp8_e4m3 to the qwen3.5-mxfp4 MI355X non-MTP and MTP benchmark scripts"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1776


### PR DESCRIPTION
## Summary

- Enable fp8 (`fp8_e4m3`) KV cache for the Qwen3.5-MXFP4 MI355X single-node benchmarks.
- Adds `--kv-cache-dtype fp8_e4m3` to both the standard (`qwen3.5_fp4_mi355x.sh`) and MTP/EAGLE (`qwen3.5_fp4_mi355x_mtp.sh`) launch commands.

## Details

The two MI355X Qwen3.5-MXFP4 recipes previously ran with the default (bf16) KV cache. This change switches them to an fp8_e4m3 KV cache to reduce KV memory footprint and improve decode throughput at higher concurrency.

The flag is inserted after `--page-size 16` in each `sglang.launch_server` invocation:

- `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x.sh`
- `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh` (before the speculative/EAGLE flags)

No other recipe parameters were changed.

## Benchmarking

Pending — to be added after the MI355X sweep.

## Accuracy

Pending — to be added after the gsm8k eval run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only SGLang launch flag and changelog entry; aligns with existing MI355X fp8 KV cache patterns and does not touch auth, data paths, or core application code.
> 
> **Overview**
> Switches the **Qwen3.5-MXFP4 MI355X** single-node SGLang recipes from the default KV cache to **`fp8_e4m3`** by adding `--kv-cache-dtype fp8_e4m3` on `sglang.launch_server`.
> 
> The flag is applied in both **`qwen3.5_fp4_mi355x.sh`** (standard throughput) and **`qwen3.5_fp4_mi355x_mtp.sh`** (EAGLE/MTP), placed after `--page-size 16`; no other launch parameters change. **`perf-changelog.yaml`** records the update for `qwen3.5-fp4-mi355x-sglang` and `qwen3.5-fp4-mi355x-sglang-mtp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ee6775a1669fed6fbe3214fcd9d961b44e24cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->