### PR TITLE
[AMD] perf: enable FlyDSL w4a16 MoE for Kimi INT4

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -739,7 +739,7 @@ glm5.1-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 256 }
 
 kimik2.5-int4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly
+  image: vllm/vllm-openai-rocm:nightly-b8336c3c7c298e0878f22a7bf70f4e295b2f4e01
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi355x

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -739,7 +739,7 @@ glm5.1-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 256 }
 
 kimik2.5-int4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:nightly
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi355x
@@ -751,11 +751,13 @@ kimik2.5-int4-mi355x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 8, conc-start: 4, conc-end: 128 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
 
 kimik2.5-int4-mi325x-vllm:
   image: vllm/vllm-openai-rocm:v0.21.0

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_int4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_int4_mi355x.sh
@@ -42,6 +42,8 @@ vllm serve $MODEL --port $PORT \
 --trust-remote-code \
 --no-enable-prefix-caching \
 --max-num-seqs 256 \
+--moe-backend flydsl \
+--compilation-config '{"pass_config": {"fuse_allreduce_rms": false}}' \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3850,3 +3850,4 @@
     - "Image: vllm/vllm-openai-rocm:nightly"
     - "Add more sweep points"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1777
+

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3842,3 +3842,11 @@
     - "Recipes sourced from NVIDIA/srt-slurm branch sa-submission-q2-2026"
     - "Runner script updated to support dsv4 model prefix with dynamo-trt framework on GB300"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1689
+
+- config-keys:
+    - kimik2.5-int4-mi355x-vllm
+  description:
+    - "Replace triton w4a16 MoE with FlyDSL w4a16 MoE"
+    - "Image: vllm/vllm-openai-rocm:nightly"
+    - "Add more sweep points"
+  pr-link:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3849,4 +3849,4 @@
     - "Replace triton w4a16 MoE with FlyDSL w4a16 MoE"
     - "Image: vllm/vllm-openai-rocm:nightly"
     - "Add more sweep points"
-  pr-link:
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1777


### PR DESCRIPTION
Replace default triton w4a16 MoE kernel with more performant FlyDSL implementation for Kimi INT4 MI355X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and serving-flag changes only; no application auth or data paths. Risk is limited to reproducibility and CI cost from expanded sweeps and a nightly container pin.
> 
> **Overview**
> Updates the **Kimi K2.5 INT4 vLLM MI355X** benchmark to use **FlyDSL** for w4a16 MoE instead of the default Triton path, and pins a **digest-suffixed ROCm nightly** image (`vllm-openai-rocm:nightly-b8336c3…`).
> 
> The runner script `kimik2.5_int4_mi355x.sh` adds `--moe-backend flydsl` and a compilation pass that sets `fuse_allreduce_rms` to false. CI config expands the fixed-seq-len sweep: concurrency up to **128** (from 64) and an additional **TP=4** row for both 1k/1k and 8k/1k scenarios.
> 
> `perf-changelog.yaml` records the config-key change for PR #1777.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be23347d4ee132914be30eb73017186bb201db18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->