### PR TITLE
[codex] perf: fuse MiniMax M3 allreduce and Gemma RMSNorm on MI300X

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -87,6 +87,11 @@ on:
         required: false
         type: string
         default: '1800'
+      m3-aiter-ar-rms-mode:
+        description: "MiniMax M3 MI300X AITER AR+RMS experiment mode"
+        required: false
+        type: string
+        default: 'off'
 env:
   RANDOM_RANGE_RATIO: 0.8
   HF_TOKEN: ${{ secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN }}
@@ -114,6 +119,8 @@ env:
   OFFLOADING: ${{ inputs.offloading }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   DURATION: ${{ inputs.duration }}
+  M3_AITER_AR_RMS_MODE: ${{ inputs.m3-aiter-ar-rms-mode }}
+  EXPERIMENT_SUFFIX: ${{ inputs.m3-aiter-ar-rms-mode != 'off' && format('_m3ar-{0}', inputs.m3-aiter-ar-rms-mode) || '' }}
   RESULT_DIR: /workspace/results
   PYTHONDONTWRITEBYTECODE: '1'
   PYTHONPYCACHEPREFIX: /tmp/inferencex-pycache
@@ -125,7 +132,7 @@ jobs:
   benchmark:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 500
-    name: "${{ inputs.exp-name }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }} | tp=${{ inputs.tp }} ep=${{ inputs.ep }} dpa=${{ inputs.dp-attn }} | disagg-${{ inputs.disagg }} spec-${{ inputs.spec-decoding }} conc-${{ inputs.conc }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}"
+    name: "${{ inputs.exp-name }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }} | tp=${{ inputs.tp }} ep=${{ inputs.ep }} dpa=${{ inputs.dp-attn }} | disagg-${{ inputs.disagg }} spec-${{ inputs.spec-decoding }} conc-${{ inputs.conc }}${{ inputs.m3-aiter-ar-rms-mode != 'off' && format(' | m3ar-{0}', inputs.m3-aiter-ar-rms-mode) || '' }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}"
     steps:
       - name: Resource cleanup (pre-run)
         run: &resource-cleanup |
@@ -177,7 +184,7 @@ jobs:
           RUNNER_NAME: ${{ runner.name }}
           RUNNER_TYPE: ${{ inputs.runner }}
           # Hash uniquely on {EXP_NAME}_{PRECISION}_{FRAMEWORK}_tp{}-ep{}-dpa{}_disagg-{}_spec-{}_conc{}_{runner}
-          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_tp${{ env.TP }}-ep${{ env.EP_SIZE }}-dpa${{ env.DP_ATTENTION }}_disagg-${{ env.DISAGG }}_spec-${{ env.SPEC_DECODING }}_conc${{ env.CONC }}_${{ runner.name }}
+          RESULT_FILENAME: ${{ env.EXP_NAME }}_${{ env.PRECISION }}_${{ env.FRAMEWORK }}_tp${{ env.TP }}-ep${{ env.EP_SIZE }}-dpa${{ env.DP_ATTENTION }}_disagg-${{ env.DISAGG }}_spec-${{ env.SPEC_DECODING }}_conc${{ env.CONC }}_${{ runner.name }}${{ env.EXPERIMENT_SUFFIX }}
           # Suppress per-job eval markdown from being appended to the step summary.
           # We'll publish a single combined eval table in the collection job instead.
           GITHUB_STEP_SUMMARY: ''

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,15 @@ on:
                 required: false
                 type: string
                 default: ""
+            m3-aiter-ar-rms-mode:
+                description: "MiniMax M3 MI300X AITER AR+RMS experiment mode"
+                required: false
+                type: choice
+                options:
+                    - "off"
+                    - control
+                    - fused
+                default: "off"
     workflow_call:
         inputs:
             generate-cli-command:
@@ -40,6 +49,11 @@ on:
                 required: false
                 type: string
                 default: ""
+            m3-aiter-ar-rms-mode:
+                description: "MiniMax M3 MI300X AITER AR+RMS experiment mode"
+                required: false
+                type: string
+                default: "off"
 
 jobs:
     get-jobs:
@@ -65,10 +79,32 @@ jobs:
                 ref: ${{ github.sha }}
 
             - id: get-jobs
+              env:
+                  M3_AITER_AR_RMS_MODE: ${{ inputs.m3-aiter-ar-rms-mode }}
               run: |
                   pip install pydantic
                   CONFIG_JSON=$(python3 ${GITHUB_WORKSPACE}/utils/matrix_logic/generate_sweep_configs.py \
                     ${{ inputs.generate-cli-command || github.event.inputs.generate-cli-command }})
+                  if [ "$M3_AITER_AR_RMS_MODE" != "off" ]; then
+                    python3 -c '
+                  import json
+                  import sys
+
+                  data = json.load(sys.stdin)
+                  invalid = [
+                      item
+                      for item in data
+                      if item.get("runner") != "mi300x"
+                      or item.get("model-prefix") != "minimaxm3"
+                      or item.get("framework") != "vllm"
+                  ]
+                  if invalid:
+                      raise SystemExit(
+                          "M3 AITER AR+RMS mode only supports MiniMax M3 "
+                          "vLLM jobs on MI300X"
+                      )
+                  ' <<< "$CONFIG_JSON"
+                  fi
                   AGENTIC=$(echo "$CONFIG_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps([x for x in d if x.get('scenario-type') == 'agentic-coding' and 'prefill' not in x]))")
                   MULTI_AGENTIC=$(echo "$CONFIG_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps([x for x in d if x.get('scenario-type') == 'agentic-coding' and 'prefill' in x]))")
                   SINGLE=$(echo "$CONFIG_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(json.dumps([x for x in d if 'prefill' not in x and x.get('scenario-type') != 'agentic-coding' and not x.get('eval-only', False)]))")
@@ -263,6 +299,7 @@ jobs:
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
             run-eval: false
+            m3-aiter-ar-rms-mode: ${{ inputs.m3-aiter-ar-rms-mode }}
             ref: ${{ inputs.ref }}
 
     test-sweep-evals:
@@ -294,6 +331,7 @@ jobs:
             disagg: ${{ matrix.config.disagg }}
             run-eval: true
             eval-only: true
+            m3-aiter-ar-rms-mode: ${{ inputs.m3-aiter-ar-rms-mode }}
             ref: ${{ inputs.ref }}
 
     collect-results:

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -5,6 +5,7 @@
 # is mandatory for MSA sparse attention. Keep the default BF16 KV cache on
 # gfx942: the checkpoint has no calibrated q/prob scales for ROCm FP8
 # attention, and vLLM's fallback scale of 1.0 corrupts model accuracy.
+# Target image vLLM revision: 4a560dd8db67c270f5e2afb614558271b76f2294.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -33,6 +34,88 @@ fi
 SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+
+M3_AITER_AR_RMS_MODE="${M3_AITER_AR_RMS_MODE:-off}"
+if [ "$M3_AITER_AR_RMS_MODE" = "fused" ] && [ "$CONC" -eq 1 ]; then
+    # The graph-safe two-stage AITER primitive regresses same-node c1 by 2.2%.
+    M3_AITER_AR_RMS_MODE=off
+    echo "M3 AITER AR+RMS graph policy: using off for concurrency 1"
+fi
+export M3_AITER_AR_RMS_MODE
+case "$M3_AITER_AR_RMS_MODE" in
+    off)
+        ;;
+    control|fused)
+        VLLM_PACKAGE_ROOT="$(
+            python - <<'PY'
+from pathlib import Path
+
+import vllm
+
+print(Path(vllm.__file__).resolve().parent.parent)
+PY
+        )"
+
+        # Enable only the AITER custom all-reduce dependency. M3 does not
+        # support torch.compile, so the runtime patch invokes this primitive
+        # directly from the existing allreduce+Gemma RMSNorm helper.
+        export VLLM_ROCM_USE_AITER=1
+        export VLLM_ROCM_USE_AITER_PAGED_ATTN=0
+        export VLLM_ROCM_USE_AITER_LINEAR=0
+        export VLLM_ROCM_USE_AITER_LINEAR_HIPBMM=0
+        export VLLM_ROCM_USE_AITER_MOE=0
+        export VLLM_ROCM_USE_AITER_RMSNORM=0
+        export VLLM_ROCM_USE_AITER_MLA=0
+        export VLLM_ROCM_USE_AITER_MHA=0
+        export VLLM_ROCM_USE_AITER_FP4_ASM_GEMM=0
+        export VLLM_ROCM_USE_AITER_TRITON_ROPE=0
+        export VLLM_ROCM_USE_AITER_FP8BMM=0
+        export VLLM_ROCM_USE_AITER_FP4BMM=0
+        export VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=0
+        export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
+        export VLLM_ROCM_USE_AITER_TRITON_GEMM=0
+
+        if [ "$M3_AITER_AR_RMS_MODE" = "fused" ]; then
+            # The image's AITER build predates the two-stage memory-ordering fix.
+            python3 /workspace/utils/install_minimaxm3_aiter.py
+        fi
+
+        python3 /workspace/utils/patch_minimaxm3_aiter_ar_rms.py
+
+        DEFERRED_FFN_AR_PATCH="$(dirname "$0")/minimaxm3_mi300x_deferred_ffn_ar.patch"
+        M3_MODEL_SOURCE="$VLLM_PACKAGE_ROOT/vllm/models/minimax_m3/amd/model.py"
+        M3_MODEL_SOURCE_SHA256="91d81f8613e32f7afbd65c289f7885c5371263f70503bd053f97880989bf7536"
+        M3_MODEL_PATCHED_SHA256="d26aa77cfce7c6162b0d1ebe2b403b854f5abe8f656b3a8deda2db1d89318ea8"
+        m3_model_sha256="$(sha256sum "$M3_MODEL_SOURCE" | awk '{print $1}')"
+        if [ "$m3_model_sha256" = "$M3_MODEL_SOURCE_SHA256" ]; then
+            if ! patch --batch --dry-run -d "$VLLM_PACKAGE_ROOT" -p1 \
+                < "$DEFERRED_FFN_AR_PATCH"; then
+                echo "Failed to validate the M3 deferred FFN allreduce patch" >&2
+                exit 1
+            fi
+            if ! patch --batch -d "$VLLM_PACKAGE_ROOT" -p1 \
+                < "$DEFERRED_FFN_AR_PATCH"; then
+                echo "Failed to apply the M3 deferred FFN allreduce patch" >&2
+                exit 1
+            fi
+        elif [ "$m3_model_sha256" != "$M3_MODEL_PATCHED_SHA256" ]; then
+            echo "M3 model source fingerprint mismatch: $m3_model_sha256" >&2
+            exit 1
+        fi
+        python3 -m py_compile "$M3_MODEL_SOURCE"
+        m3_model_sha256="$(sha256sum "$M3_MODEL_SOURCE" | awk '{print $1}')"
+        if [ "$m3_model_sha256" != "$M3_MODEL_PATCHED_SHA256" ]; then
+            echo "M3 model patched fingerprint mismatch: $m3_model_sha256" >&2
+            exit 1
+        fi
+        echo "M3 deferred FFN allreduce patch ready: $m3_model_sha256"
+        echo "M3 AITER AR+RMS experiment mode: $M3_AITER_AR_RMS_MODE"
+        ;;
+    *)
+        echo "Invalid M3_AITER_AR_RMS_MODE: $M3_AITER_AR_RMS_MODE" >&2
+        exit 2
+        ;;
+esac
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_mi300x_deferred_ffn_ar.patch
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_mi300x_deferred_ffn_ar.patch
@@ -1,0 +1,141 @@
+diff --git a/vllm/models/minimax_m3/amd/model.py b/vllm/models/minimax_m3/amd/model.py
+index 27650c8e6..ac5e260a8 100644
+--- a/vllm/models/minimax_m3/amd/model.py
++++ b/vllm/models/minimax_m3/amd/model.py
+@@ -17,6 +17,7 @@ The MiniMax-M3-preview config selects a single set of branches:
+       "index" attention branch.
+ """
+
++import os
+ from collections.abc import Iterable
+
+ import torch
+@@ -37,10 +38,12 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+ from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
+     fused_allreduce_gemma_rms_norm,
++    initialize_m3_aiter_allreduce,
+ )
+ from vllm.model_executor.layers.fused_moe import (
+     FusedMoE,
+     GateLinear,
++    MoERunner,
+     fused_moe_make_expert_params_mapping,
+ )
+ )
+ from vllm.model_executor.layers.linear import (
+@@ -117,6 +119,17 @@ def _is_moe_layer(config: PretrainedConfig, layer_id: int) -> bool:
+     return moe_layer_freq[layer_id] != 0
+
+
++def _defer_ffn_allreduce() -> bool:
++    """Whether M3 FFN reductions are completed by the following Gemma norm."""
++    parallel_config = get_current_vllm_config().parallel_config
++    return (
++        os.getenv("M3_AITER_AR_RMS_MODE") in {"control", "fused"}
++        and parallel_config.tensor_parallel_size > 1
++        and parallel_config.pipeline_parallel_size == 1
++        and parallel_config.data_parallel_size == 1
++    )
++
++
+ def _build_rotary_emb(config: PretrainedConfig, head_dim: int):
+     """Build the (partial NeoX) RoPE, honoring an optional ``rope_scaling`` config.
+
+@@ -243,6 +256,25 @@ class MiniMaxM3MLP(nn.Module):
+         return x
+
+
++class MiniMaxM3DeferredMoERunner(MoERunner):
++    """Leave the M3 MoE output rank-local for the following fused AR+RMSNorm."""
++
++    def _maybe_reduce_final_output(
++        self,
++        states: torch.Tensor,
++        trunc_size: int | None,
++    ) -> torch.Tensor:
++        if self._fused_output_is_reduced:
++            raise RuntimeError(
++                "M3 deferred MoE allreduce requires an unreduced MoE backend"
++            )
++        if self.moe_config.is_sequence_parallel:
++            raise RuntimeError(
++                "M3 deferred MoE allreduce does not support sequence parallelism"
++            )
++        return states[..., :trunc_size] if trunc_size is not None else states
++
++
+ class MiniMaxM3MoE(nn.Module):
+     """Sigmoid-routed MoE block with a routing-bias correction and a shared
+     expert."""
+@@ -316,6 +348,9 @@ class MiniMaxM3MoE(nn.Module):
+             shared_experts=self.shared_experts,
+             quant_config=quant_config,
+             prefix=f"{prefix}.experts",
++            runner_cls=MiniMaxM3DeferredMoERunner
++            if _defer_ffn_allreduce()
++            else None,
+         )
+
+     @staticmethod
+@@ -732,6 +767,8 @@ class MiniMaxM3DecoderLayer(nn.Module):
+         # with the layer's index.
+         layer_id = int(prefix.split(sep=".")[-1])
+         self.layer_id = layer_id
++        self.defer_ffn_allreduce = _defer_ffn_allreduce()
++        self.fuse_input_allreduce = self.defer_ffn_allreduce and layer_id > 0
+
+         is_sparse_attention_layer = (
+             force_sparse_attn or layer_id in _sparse_attention_layer_ids(config)
+@@ -769,6 +806,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
+                 config=config,
+                 intermediate_size=config.dense_intermediate_size,
+                 quant_config=quant_config,
++                reduce_results=not self.defer_ffn_allreduce,
+                 prefix=f"{prefix}.mlp",
+             )
+
+@@ -787,11 +825,16 @@ class MiniMaxM3DecoderLayer(nn.Module):
+         residual: torch.Tensor | None,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         # Self Attention
+-        if residual is None:
+-            residual = hidden_states
+-            hidden_states = self.input_layernorm(hidden_states)
++        if self.fuse_input_allreduce and residual is not None:
++            hidden_states, residual = fused_allreduce_gemma_rms_norm(
++                hidden_states, residual, self.input_layernorm
++            )
+         else:
+-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
++            if residual is None:
++                residual = hidden_states
++                hidden_states = self.input_layernorm(hidden_states)
++            else:
++                hidden_states, residual = self.input_layernorm(hidden_states, residual)
+         hidden_states = self.self_attn(
+             positions=positions,
+             hidden_states=hidden_states,
+@@ -815,6 +858,9 @@ class MiniMaxM3Model(nn.Module):
+         cache_config = vllm_config.cache_config
+         quant_config = vllm_config.quant_config
+         self.config = config
++        self.defer_ffn_allreduce = _defer_ffn_allreduce()
++        if self.defer_ffn_allreduce:
++            initialize_m3_aiter_allreduce()
+
+         self.vocab_size = config.vocab_size
+
+@@ -856,7 +902,12 @@ class MiniMaxM3Model(nn.Module):
+         for layer in self.layers[self.start_layer : self.end_layer]:
+             hidden_states, residual = layer(positions, hidden_states, residual)
+
+-        hidden_states, _ = self.norm(hidden_states, residual)
++        if self.defer_ffn_allreduce:
++            hidden_states, _ = fused_allreduce_gemma_rms_norm(
++                hidden_states, residual, self.norm
++            )
++        else:
++            hidden_states, _ = self.norm(hidden_states, residual)
+         return hidden_states
+
+     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/utils/install_minimaxm3_aiter.py
+++ b/utils/install_minimaxm3_aiter.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Install the pinned MI300X AITER build used by the M3 fusion experiment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Wheel:
+    distribution: str
+    version: str
+    filename: str
+    url: str
+    sha256: str
+
+
+WHEELS = (
+    Wheel(
+        distribution="flydsl",
+        version="0.1.9.dev20260529+d7ae22d",
+        filename=(
+            "flydsl-0.1.9.dev20260529+d7ae22d-cp312-cp312-"
+            "manylinux_2_27_x86_64.whl"
+        ),
+        url=(
+            "https://rocm.frameworks-devreleases.amd.com/whl-staging/"
+            "gfx942-gfx950/flydsl-0.1.9.dev20260529%2Bd7ae22d-"
+            "cp312-cp312-manylinux_2_27_x86_64.whl"
+        ),
+        sha256="8f3de2a83c7f3775962edb4ac929612956c4b4bb358c0ea5fa97643d3397791d",
+    ),
+    Wheel(
+        distribution="amd-aiter",
+        version="0.1.15.post1+rocm7.2.manylinux.2.28",
+        filename=(
+            "amd_aiter-0.1.15.post1+rocm7.2.manylinux.2.28-"
+            "cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+        ),
+        url=(
+            "https://github.com/ROCm/aiter/releases/download/v0.1.15.post1/"
+            "amd_aiter-0.1.15.post1%2Brocm7.2.manylinux.2.28-"
+            "cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+        ),
+        sha256="c4ccc510f223f36d9ca69f70cd817e373869e2caac98465e6ab527d9b2cfc1e1",
+    ),
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def installed_wheels_match() -> bool:
+    for wheel in WHEELS:
+        try:
+            installed = importlib.metadata.version(wheel.distribution)
+        except importlib.metadata.PackageNotFoundError:
+            return False
+        if installed != wheel.version:
+            return False
+    return True
+
+
+def download_wheel(wheel: Wheel, destination: Path, attempts: int = 3) -> None:
+    request = urllib.request.Request(
+        wheel.url,
+        headers={"User-Agent": "InferenceX-MiniMaxM3-AITER-installer"},
+    )
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=180) as response:
+                with destination.open("wb") as file:
+                    shutil.copyfileobj(response, file, length=1024 * 1024)
+            actual_sha256 = sha256_file(destination)
+            if actual_sha256 != wheel.sha256:
+                raise RuntimeError(
+                    f"{wheel.filename}: expected sha256 {wheel.sha256}, "
+                    f"got {actual_sha256}"
+                )
+            return
+        except Exception:
+            destination.unlink(missing_ok=True)
+            if attempt == attempts:
+                raise
+            time.sleep(attempt * 2)
+
+
+def verify_installation() -> None:
+    for wheel in WHEELS:
+        installed = importlib.metadata.version(wheel.distribution)
+        if installed != wheel.version:
+            raise RuntimeError(
+                f"{wheel.distribution}: expected {wheel.version}, got {installed}"
+            )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import inspect; import aiter; "
+                "from aiter.dist.device_communicators.custom_all_reduce "
+                "import CustomAllreduce; "
+                "assert 'use_1stage' in "
+                "inspect.signature(CustomAllreduce.fused_ar_rms).parameters"
+            ),
+        ],
+        check=True,
+    )
+
+
+def install_wheels() -> None:
+    if installed_wheels_match():
+        verify_installation()
+        print("Pinned MiniMax M3 AITER wheels are already installed")
+        return
+
+    torch_version = importlib.metadata.version("torch")
+    with tempfile.TemporaryDirectory(prefix="inferencex-m3-aiter-") as temp_dir:
+        paths: list[Path] = []
+        for wheel in WHEELS:
+            path = Path(temp_dir) / wheel.filename
+            print(f"Downloading {wheel.distribution} {wheel.version}")
+            download_wheel(wheel, path)
+            paths.append(path)
+
+        for wheel, path in zip(WHEELS, paths, strict=True):
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-cache-dir",
+                    "--no-deps",
+                    "--force-reinstall",
+                    str(path),
+                ],
+                check=True,
+            )
+            print(f"Installed {wheel.distribution} {wheel.version}")
+
+    if importlib.metadata.version("torch") != torch_version:
+        raise RuntimeError("Pinned AITER installation unexpectedly changed torch")
+    verify_installation()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate that the pinned wheels are already installed",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        if not installed_wheels_match():
+            raise SystemExit("Pinned MiniMax M3 AITER wheels are not installed")
+        verify_installation()
+        print("Pinned MiniMax M3 AITER wheels validated")
+        return
+    install_wheels()
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/patch_minimaxm3_aiter_ar_rms.py
+++ b/utils/patch_minimaxm3_aiter_ar_rms.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Apply the pinned vLLM direct-call patch for the M3 AITER AR+RMS experiment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import importlib.util
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+PATCH_MARKER = "InferenceX M3 AITER AR+RMS experiment"
+EXPECTED_SOURCE_SHA256 = {
+    "vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py": (
+        "0169300358b731605508407ff39e9376497866b102b105f1e96113b80a658eac"
+    ),
+}
+EXPECTED_PATCHED_SHA256 = {
+    "vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py": (
+        "6f7738bcf127f285de97a754b4ebf6df16a4d683ccbf7607fafdfeb321a1d38f"
+    ),
+}
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"{label}: expected one source anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def patch_helper_source(source: str) -> str:
+    """Use AITER directly from M3's allreduce+Gemma RMSNorm helper."""
+    if PATCH_MARKER in source:
+        return source
+
+    source = _replace_once(
+        source,
+        "import torch\n\nfrom vllm.distributed.communication_op",
+        "import os\n\nimport torch\n\nfrom vllm.distributed.communication_op",
+        "fused_allreduce_gemma_rms_norm import",
+    )
+    source = _replace_once(
+        source,
+        """_FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _max_token_num""",
+        """_FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def initialize_m3_aiter_allreduce() -> None:
+    \"\"\"Initialize AITER before vLLM enters its HIP-graph capture context.\"\"\"
+    if os.getenv("M3_AITER_AR_RMS_MODE") != "fused":
+        return
+
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    if rocm_aiter_ops.get_aiter_allreduce() is None:
+        rocm_aiter_ops.initialize_aiter_allreduce(
+            get_tp_group().cpu_group,
+            torch.device("cuda", torch.cuda.current_device()),
+        )
+    if rocm_aiter_ops.get_aiter_allreduce() is None:
+        raise RuntimeError("AITER custom allreduce initialization failed")
+
+
+def _max_token_num""",
+        "fused_allreduce_gemma_rms_norm initializer",
+    )
+    return _replace_once(
+        source,
+        """    # Fallback: explicit all-reduce + GemmaRMSNorm (matches the unfused model).
+    reduced = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(reduced, residual)
+""",
+        """    is_m3_rocm_norm = (
+        type(norm).__module__ == "vllm.models.minimax_m3.amd.model"
+        and type(norm).__name__ == "MiniMAXGemmaRMSNorm"
+    )
+    use_m3_aiter = (
+        os.getenv("M3_AITER_AR_RMS_MODE") == "fused"
+        and is_m3_rocm_norm
+        and hidden_states.dim() == 2
+        and hidden_states.is_contiguous()
+        and hidden_states.dtype in (torch.bfloat16, torch.float16)
+        and hidden_states.shape[0] <= 512
+    )
+    if use_m3_aiter:
+        # InferenceX M3 AITER AR+RMS experiment: invoke AITER directly
+        # instead of relying on a torch.compile fusion pass.
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        initialize_m3_aiter_allreduce()
+        aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
+        if aiter_ar is None:
+            raise RuntimeError("AITER custom allreduce initialization failed")
+        if not hasattr(aiter_ar, "_pool") and hidden_states.shape[-1] not in (
+            512,
+            1024,
+            2048,
+            4096,
+        ):
+            raise RuntimeError(
+                "AITER <0.1.12 does not support M3's allreduce hidden size"
+            )
+
+        gamma = getattr(norm, "_inferencex_aiter_gamma", None)
+        if (
+            gamma is None
+            or gamma.device != hidden_states.device
+            or gamma.dtype != hidden_states.dtype
+        ):
+            gamma = (
+                norm.weight.detach().to(
+                    device=hidden_states.device, dtype=hidden_states.dtype
+                )
+                + 1.0
+            ).contiguous()
+            norm._inferencex_aiter_gamma = gamma
+
+        # The pinned AITER 0.1.15 tag lacks the one-stage exit barrier fixed
+        # by ROCm/aiter#3514, so use the graph-safe two-stage implementation.
+        result = aiter_ar.fused_ar_rms(
+            hidden_states,
+            residual,
+            w=gamma,
+            eps=norm.variance_epsilon,
+            registered=torch.cuda.is_current_stream_capturing(),
+            use_1stage=False,
+        )
+        if result is None:
+            raise RuntimeError("AITER fused allreduce RMSNorm returned no result")
+        return result[0], result[1]
+
+    # Fallback: explicit all-reduce + GemmaRMSNorm (matches the unfused model).
+    reduced = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(reduced, residual)
+""",
+        "fused_allreduce_gemma_rms_norm fallback",
+    )
+
+
+def find_vllm_root() -> Path:
+    spec = importlib.util.find_spec("vllm")
+    if spec is None or spec.origin is None:
+        raise RuntimeError("Unable to locate the installed vLLM package")
+    return Path(spec.origin).resolve().parent.parent
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        delete=False,
+    ) as temp_file:
+        temp_file.write(text)
+        temp_path = Path(temp_file.name)
+    temp_path.chmod(mode)
+    os.replace(temp_path, path)
+
+
+def apply_runtime_patch(vllm_root: Path, check_only: bool = False) -> None:
+    transforms = {
+        "vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py": (
+            patch_helper_source
+        ),
+    }
+    originals: dict[Path, str] = {}
+    patched: dict[Path, str] = {}
+
+    for relative_path, transform in transforms.items():
+        path = vllm_root / relative_path
+        source = path.read_text(encoding="utf-8")
+        originals[path] = source
+        if PATCH_MARKER in source:
+            actual_sha = _sha256(source)
+            expected_sha = EXPECTED_PATCHED_SHA256[relative_path]
+            if actual_sha != expected_sha:
+                raise RuntimeError(
+                    f"{relative_path}: patched source fingerprint mismatch; "
+                    f"expected {expected_sha}, got {actual_sha}"
+                )
+            compile(source, str(path), "exec")
+            patched[path] = source
+            continue
+
+        actual_sha = _sha256(source)
+        expected_sha = EXPECTED_SOURCE_SHA256[relative_path]
+        if actual_sha != expected_sha:
+            raise RuntimeError(
+                f"{relative_path}: source fingerprint mismatch; "
+                f"expected {expected_sha}, got {actual_sha}"
+            )
+        patched_source = transform(source)
+        actual_patched_sha = _sha256(patched_source)
+        expected_patched_sha = EXPECTED_PATCHED_SHA256[relative_path]
+        if actual_patched_sha != expected_patched_sha:
+            raise RuntimeError(
+                f"{relative_path}: generated patch fingerprint mismatch; "
+                f"expected {expected_patched_sha}, got {actual_patched_sha}"
+            )
+        patched[path] = patched_source
+        compile(patched_source, str(path), "exec")
+
+    marker_count = sum(PATCH_MARKER in source for source in originals.values())
+    if marker_count not in (0, len(originals)):
+        raise RuntimeError("vLLM runtime patch is only partially applied")
+
+    try:
+        version = importlib.metadata.version("vllm")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    action = "validated" if check_only else "applied"
+    if not check_only:
+        for path, source in patched.items():
+            _write_atomic(path, source)
+
+    print(f"M3 AITER AR+RMS runtime patch {action} for vLLM {version}")
+    for path, source in patched.items():
+        print(f"  {path.relative_to(vllm_root)} sha256={_sha256(source)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vllm-root", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    root = args.vllm_root.resolve() if args.vllm_root else find_vllm_root()
+    apply_runtime_patch(root, check_only=args.check)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/test_install_minimaxm3_aiter.py
+++ b/utils/test_install_minimaxm3_aiter.py
@@ -1,0 +1,35 @@
+import hashlib
+import importlib.metadata
+
+from utils.install_minimaxm3_aiter import (
+    WHEELS,
+    installed_wheels_match,
+    sha256_file,
+)
+
+
+def test_sha256_file(tmp_path):
+    path = tmp_path / "wheel.whl"
+    path.write_bytes(b"pinned wheel")
+
+    assert sha256_file(path) == hashlib.sha256(b"pinned wheel").hexdigest()
+
+
+def test_installed_wheels_match(monkeypatch):
+    versions = {wheel.distribution: wheel.version for wheel in WHEELS}
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        lambda distribution: versions[distribution],
+    )
+
+    assert installed_wheels_match()
+
+    versions["amd-aiter"] = "0.1.13.post1"
+    assert not installed_wheels_match()
+
+
+def test_pinned_wheels_have_sha256_digests():
+    assert [wheel.distribution for wheel in WHEELS] == ["flydsl", "amd-aiter"]
+    assert all(len(wheel.sha256) == 64 for wheel in WHEELS)
+    assert all(int(wheel.sha256, 16) >= 0 for wheel in WHEELS)

--- a/utils/test_patch_minimaxm3_aiter_ar_rms.py
+++ b/utils/test_patch_minimaxm3_aiter_ar_rms.py
@@ -1,0 +1,176 @@
+from pathlib import Path
+
+import pytest
+
+from utils.patch_minimaxm3_aiter_ar_rms import (
+    EXPECTED_PATCHED_SHA256,
+    EXPECTED_SOURCE_SHA256,
+    PATCH_MARKER,
+    _replace_once,
+    _sha256,
+    apply_runtime_patch,
+    patch_helper_source,
+)
+
+
+def test_patch_helper_uses_aiter_directly_for_m3_decode():
+    source = """import torch
+
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+
+_FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _max_token_num():
+    pass
+
+
+def fused_allreduce_gemma_rms_norm(hidden_states, residual, norm):
+    # Fallback: explicit all-reduce + GemmaRMSNorm (matches the unfused model).
+    reduced = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(reduced, residual)
+"""
+
+    patched = patch_helper_source(source)
+
+    assert "import os" in patched
+    assert PATCH_MARKER in patched
+    assert 'os.getenv("M3_AITER_AR_RMS_MODE") == "fused"' in patched
+    assert "hidden_states.shape[0] <= 512" in patched
+    assert "def initialize_m3_aiter_allreduce()" in patched
+    assert 'torch.device("cuda", torch.cuda.current_device())' in patched
+    assert "rocm_aiter_ops.initialize_aiter_allreduce" in patched
+    assert "initialize_m3_aiter_allreduce()" in patched
+    assert "aiter_ar.fused_ar_rms" in patched
+    assert "registered=torch.cuda.is_current_stream_capturing()" in patched
+    assert "use_1stage=False" in patched
+    assert "get_fused_allreduce_rmsnorm_op" not in patched
+    assert "norm._inferencex_aiter_gamma = gamma" in patched
+    assert "return norm(reduced, residual)" in patched
+    assert patch_helper_source(patched) == patched
+
+
+def test_replace_once_rejects_source_drift():
+    with pytest.raises(RuntimeError, match="expected one source anchor"):
+        _replace_once("unchanged", "missing", "replacement", "test")
+
+
+def test_m3_model_patch_initializes_aiter_before_graph_capture():
+    patch = (
+        Path(__file__).resolve().parents[1]
+        / "benchmarks/single_node/fixed_seq_len"
+        / "minimaxm3_mi300x_deferred_ffn_ar.patch"
+    ).read_text(encoding="utf-8")
+
+    assert "+    initialize_m3_aiter_allreduce," in patch
+    assert "+            initialize_m3_aiter_allreduce()" in patch
+
+
+def test_mi300x_recipe_keeps_graph_concurrency_one_off_aiter():
+    recipe = (
+        Path(__file__).resolve().parents[1]
+        / "benchmarks/single_node/fixed_seq_len"
+        / "minimaxm3_fp8_mi300x.sh"
+    ).read_text(encoding="utf-8")
+
+    assert '[ "$CONC" -eq 1 ]' in recipe
+    assert "M3_AITER_AR_RMS_MODE=off" in recipe
+
+
+def test_apply_runtime_patch_rejects_patched_source_drift(tmp_path, monkeypatch):
+    helper_relative = (
+        "vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py"
+    )
+    helper_source = """import torch
+
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+
+_FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _max_token_num():
+    pass
+
+
+def fused_allreduce_gemma_rms_norm(hidden_states, residual, norm):
+    # Fallback: explicit all-reduce + GemmaRMSNorm (matches the unfused model).
+    reduced = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(reduced, residual)
+"""
+    source_by_path = {
+        helper_relative: helper_source,
+    }
+    patched_by_path = {
+        helper_relative: patch_helper_source(helper_source),
+    }
+
+    for relative_path, source in source_by_path.items():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+        monkeypatch.setitem(EXPECTED_SOURCE_SHA256, relative_path, _sha256(source))
+        monkeypatch.setitem(
+            EXPECTED_PATCHED_SHA256,
+            relative_path,
+            _sha256(patched_by_path[relative_path]),
+        )
+
+    apply_runtime_patch(tmp_path)
+    apply_runtime_patch(tmp_path, check_only=True)
+
+    helper_path = tmp_path / helper_relative
+    helper_path.write_text(
+        helper_path.read_text(encoding="utf-8") + "\n# unexpected drift\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="patched source fingerprint mismatch"):
+        apply_runtime_patch(tmp_path, check_only=True)
+
+
+def test_apply_runtime_patch_rejects_generated_patch_drift(tmp_path, monkeypatch):
+    helper_relative = (
+        "vllm/model_executor/layers/fused_allreduce_gemma_rms_norm.py"
+    )
+    helper_source = """import torch
+
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+
+_FI_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _max_token_num():
+    pass
+
+
+def fused_allreduce_gemma_rms_norm(hidden_states, residual, norm):
+    # Fallback: explicit all-reduce + GemmaRMSNorm (matches the unfused model).
+    reduced = tensor_model_parallel_all_reduce(hidden_states)
+    return norm(reduced, residual)
+"""
+    source_by_path = {
+        helper_relative: helper_source,
+    }
+    patched_by_path = {
+        helper_relative: patch_helper_source(helper_source),
+    }
+
+    for relative_path, source in source_by_path.items():
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+        monkeypatch.setitem(EXPECTED_SOURCE_SHA256, relative_path, _sha256(source))
+        monkeypatch.setitem(
+            EXPECTED_PATCHED_SHA256,
+            relative_path,
+            _sha256(patched_by_path[relative_path]),
+        )
+
+    monkeypatch.setitem(EXPECTED_PATCHED_SHA256, helper_relative, "0" * 64)
+
+    with pytest.raises(RuntimeError, match="generated patch fingerprint mismatch"):
+        apply_runtime_patch(tmp_path)
+
+    assert (tmp_path / helper_relative).read_text(encoding="utf-8") == helper_source


### PR DESCRIPTION
## Summary

- add an opt-in `m3-aiter-ar-rms-mode` switch for MiniMax M3 vLLM jobs on MI300X
- call AITER's fused custom-allreduce + Gemma RMSNorm primitive directly from M3's existing helper
- defer attention and FFN/MoE tensor-parallel reductions into the following Gemma RMSNorm boundary
- initialize the AITER communicator before HIP graph capture
- install pinned, checksummed AITER/FlyDSL wheels and reject unexpected vLLM source drift
- keep graph-mode concurrency 1 on the existing path after a measured 2.2% regression

This PR is intentionally isolated from the profiling branch. It does not include profile workflow changes, trace analysis, sparse-index tuning, MXFP8 changes, or the profiling report.

## Why

MiniMax M3 uses Gemma-style RMSNorm, and TP decode profiles show the separate custom allreduce and norm boundaries dominating low/medium-concurrency decode. vLLM already exposes AITER's `fused_ar_rms` primitive, but M3 cannot use the normal `torch.compile` pattern-matching path. This change invokes that primitive explicitly while preserving an `off` control path.

Only the AITER custom-allreduce dependency is enabled. Other independently selectable AITER attention, linear, MoE, RMSNorm, BMM, RoPE, and shared-expert paths remain disabled.

## Validation

- `165 passed`: installer, runtime patch, recipe policy, and matrix-generator tests
- both runtime transformations apply to pristine vLLM `4a560dd8db67c270f5e2afb614558271b76f2294`
- patched source SHA256 values match the recipe's pinned fingerprints
- patched Python files compile
- benchmark script passes `bash -n`
- workflow YAML parses successfully
- isolated branch validation: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27543360103
- graph-capture smoke: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27537660155
- combined experimental six-point run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27538604485
- c1 fallback validation: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27540379158

The isolated branch validation ran only the TP8/c16 1k1k and 8k1k configurations and completed successfully:

| Sequence | Total tok/s/GPU | Output tok/s/GPU | Mean TTFT | Mean TPOT |
| --- | ---: | ---: | ---: | ---: |
| 1k1k | 208.09 | 103.49 | 0.210 s | 0.019 s |
| 8k1k | 678.21 | 75.15 | 0.942 s | 0.025 s |

The earlier graph smoke measured 218.96 tok/s/GPU at 1k1k/c16, 1.87% above the same MXFP8 baseline. The broader experimental branch measured positive c16/c256 deltas but also contained separate index-launch work; those changes are not present in this PR.

GSM8K strict exact match in the combined experimental run was 0.95830 versus 0.95679 before the change.

## Upstream

The implementation builds on the vLLM AITER fused-allreduce/RMSNorm work in:

- https://github.com/vllm-project/vllm/pull/43953
- https://github.com/vllm-project/vllm/pull/44437

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Mutates installed vLLM sources and model forward/TP reduction behavior at runtime; incorrect fusion or patch drift could affect numerical correctness and decode performance on MI300X.
> 
> **Overview**
> Adds an opt-in **`m3-aiter-ar-rms-mode`** (`off` / `control` / `fused`) on benchmark and e2e workflows, wired through **`M3_AITER_AR_RMS_MODE`** and a distinct result filename suffix when not `off`. E2e matrix generation rejects non–MiniMax M3 vLLM MI300X jobs when the mode is enabled.
> 
> The **MI300X MiniMax M3** recipe applies pinned **AITER** wheels (fused path only), SHA256-guarded runtime patches to **`fused_allreduce_gemma_rms_norm`**, and a deferred-FFN vLLM model patch so TP reductions fuse with the next **Gemma RMSNorm** via **`fused_ar_rms`** (AITER custom AR only; **`fused` + concurrency 1** falls back to `off`). New installer/patch utilities and unit tests cover wheel pins and source fingerprint drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f83809f087c02f34961d2132b8d1567fc4ca5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->