### PR TITLE
[NV] Update MiniMax M3 B200 vLLM serving settings

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -12656,6 +12656,7 @@ minimaxm3-fp8-b200-vllm:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
     - isl: 8192
       osl: 1024
@@ -12663,6 +12664,8 @@ minimaxm3-fp8-b200-vllm:
       - { tp: 8, conc-start: 1, conc-end: 64 }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256 }
       - { tp: 4, conc-start: 1, conc-end: 64 }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256 }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
@@ -38,6 +38,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -46,13 +47,6 @@ elif [ "$EP_SIZE" -gt 1 ]; then
 else
   PARALLEL_ARGS="--tensor-parallel-size=$TP"
 fi
-
-# Fixed-seq-len runs don't need graphs past the request concurrency: capture
-# up to the next power of two >= CONC (per-DP-rank batch is CONC/DP but ragged
-# arrival makes the full CONC bound safer), capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -68,7 +62,8 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--kv-cache-dtype fp8 \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
@@ -62,7 +62,6 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---kv-cache-dtype fp8 \
 --max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 --no-enable-prefix-caching \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3847,4 +3847,4 @@
     - minimaxm3-fp8-b200-vllm
   description:
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high, using FP8 KV cache, and restoring max cudagraph capture size 2048."
-  pr-link: TODO
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3842,3 +3842,9 @@
     - "Recipes sourced from NVIDIA/srt-slurm branch sa-submission-q2-2026"
     - "Runner script updated to support dsv4 model prefix with dynamo-trt framework on GB300"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1689
+
+- config-keys:
+    - minimaxm3-fp8-b200-vllm
+  description:
+    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high, using FP8 KV cache, and restoring max cudagraph capture size 2048."
+  pr-link: TODO

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3847,4 +3847,5 @@
     - minimaxm3-fp8-b200-vllm
   description:
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3846,5 +3846,5 @@
 - config-keys:
     - minimaxm3-fp8-b200-vllm
   description:
-    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high, using FP8 KV cache, and restoring max cudagraph capture size 2048."
+    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779


### PR DESCRIPTION
Updates MiniMax M3 B200 vLLM fixed-sequence serving settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark runner env/CLI and CI search-space YAML only; no production serving, auth, or data-path changes.
> 
> **Overview**
> Updates **MiniMax-M3 B200 vLLM** fixed-sequence serving to match the **MiniMax-M2.5 FP8 B200** recipe: `minimaxm3_fp8_b200.sh` now exports `VLLM_FLOAT32_MATMUL_PRECISION=high` and always passes `--max-cudagraph-capture-size 2048`, replacing the prior concurrency-derived capture cap.
> 
> **`minimaxm3-fp8-b200-vllm`** in `nvidia-master.yaml` gains additional **TP4+EP4** sweep rows—DP-attention for 1k/1k and 8k/1k, plus a non-DP-attention 8k/1k row that was missing. `perf-changelog.yaml` documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6296b3c85a524653678ef40b54cc26ffa369b16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->