### PR TITLE
[NV] Multi-node synthetic AL injection for MTP (dsv4 mtp2 bring-up)

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8714,6 +8714,8 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
           ep: 8
           dp-attn: true
           additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.27"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency-mtp2.yaml"
         decode:
           num-worker: 4
@@ -8731,6 +8733,8 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
           ep: 8
           dp-attn: true
           additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.27"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe-mtp2.yaml"
         decode:
           num-worker: 1
@@ -8748,6 +8752,8 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
           ep: 8
           dp-attn: true
           additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.27"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe-mtp2.yaml"
         decode:
           num-worker: 1

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8696,6 +8696,8 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
           ep: 1
           dp-attn: false
           additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.27"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/agg-gb200-low-latency-mtp2.yaml"
         decode:
           num-worker: 0

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -8755,6 +8755,87 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
           ep: 8
           dp-attn: true
 
+# Baseline (no synthetic acceptance) variant of dsv4-fp4-gb200-dynamo-vllm-mtp2
+# for before/after Pareto comparison. Identical topology and recipes, only the
+# agg cell's SYNTHETIC_ACCEPTANCE envs are removed.
+dsv4-fp4-gb200-dynamo-vllm-mtp2-nosynthetic:
+  image: vllm/vllm-openai:v0.20.1-ubuntu2404
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: gb200
+  precision: fp4
+  framework: dynamo-vllm
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      # Aggregate low latency: TP=8, max-num-seqs=4. No synthetic acceptance.
+      - conc-list: [1]
+        spec-decoding: mtp
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/agg-gb200-low-latency-mtp2.yaml"
+        decode:
+          num-worker: 0
+          tp: 8
+          ep: 1
+          dp-attn: false
+
+      # Low-latency bridge: 1 prefill (DEP=8) + 4 decode (TP=8), no offload.
+      - conc-list: [16, 32, 64]
+        spec-decoding: mtp
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency-mtp2.yaml"
+        decode:
+          num-worker: 4
+          tp: 8
+          ep: 1
+          dp-attn: false
+
+      # MegaMOE mid curve: 1 prefill (DEP=8) + 1 decode (DEP=8).
+      - conc-list: [128, 256, 512, 1024]
+        spec-decoding: mtp
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe-mtp2.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+
+      # MegaMOE high throughput: 2 prefill (DEP=8 each) + 1 decode (DEP=8).
+      - conc-list: [1024]
+        spec-decoding: mtp
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe-mtp2.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+
 dsv4-fp4-gb200-dynamo-sglang:
   image: lmsysorg/sglang:nightly-dev-cu13-20260528-0abe6a85
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/runners/inject_synthetic_acceptance.py
+++ b/runners/inject_synthetic_acceptance.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Inject synthetic acceptance parameters into an srt-slurm recipe YAML.
+
+When SYNTHETIC_ACCEPTANCE=true, every ``speculative-config`` JSON entry in the
+given recipe is rewritten to use synthetic rejection sampling (adds
+``rejection_sample_method=synthetic`` and ``synthetic_acceptance_length``).
+
+The script is a no-op (exit 0, file untouched) when:
+  - SYNTHETIC_ACCEPTANCE is unset/false, or
+  - the recipe contains no ``speculative-config`` entry,
+so existing callers that do not opt in get exactly the previous behavior.
+
+Environment variables:
+  SYNTHETIC_ACCEPTANCE         "true" to enable (default: "false")
+  SYNTHETIC_ACCEPTANCE_LENGTH  target mean acceptance length; if unset, it is
+                               auto-resolved from the reference AL YAML using
+                               MODEL_PREFIX (+ NUM_SPEC_TOKENS / THINKING_MODE)
+  NUM_SPEC_TOKENS              number of speculative tokens (for auto-lookup;
+                               falls back to the value parsed from the recipe)
+  MODEL_PREFIX                 model prefix key in the reference YAML (e.g. "dsv4")
+  THINKING_MODE                "thinking_on" / "thinking_off" — only used when the
+                               reference YAML is in the thinking matrix form
+                               (default: "thinking_on")
+
+Usage (from a runner; use an absolute path since runners cd into the srt-slurm
+clone before invoking this):
+  python3 "$GITHUB_WORKSPACE/runners/inject_synthetic_acceptance.py" "${CONFIG_FILE%%:*}"
+"""
+
+import json
+import os
+import re
+import sys
+
+# MODEL_PREFIX -> top-level key in speedbench-reference-al.yaml.
+MODEL_PREFIX_TO_YAML_KEY = {
+    "dsv4": "deepseek-v4-pro",
+    "dsr1": "deepseek-r1",
+}
+
+# Matches `speculative-config: '<json>'` (single-quoted JSON, as written in the
+# recipe YAML). Capturing the JSON lets us edit it with the json module instead
+# of string-munging, so we never produce malformed quoting.
+_SPEC_CONFIG_RE = re.compile(r"speculative-config:\s*'([^']+)'")
+
+
+def _log(msg):
+    print(f"[Synthetic AR] {msg}")
+
+
+def _yaml_key(model_prefix):
+    return MODEL_PREFIX_TO_YAML_KEY.get(model_prefix, model_prefix)
+
+
+def _spec_tokens_from_recipe(text):
+    """Best-effort: read num_speculative_tokens from the recipe itself."""
+    for m in _SPEC_CONFIG_RE.finditer(text):
+        try:
+            spec = json.loads(m.group(1))
+        except json.JSONDecodeError:
+            continue
+        n = spec.get("num_speculative_tokens")
+        if n:
+            return int(n)
+    return 2
+
+
+def _lookup_al(model_block, num_spec_tokens):
+    """Resolve AL for num_spec_tokens from either reference-YAML shape.
+
+    Flat list form:   [ {1: 1.90}, {2: 2.60}, ... ]
+    Thinking matrix:  { thinking_on: {1: ...}, thinking_off: {1: ...} }
+    """
+    # Flat list form (each item is a single-key {level: al} mapping).
+    if isinstance(model_block, list):
+        for item in model_block:
+            if num_spec_tokens in item:
+                return item[num_spec_tokens]
+        return None
+
+    if isinstance(model_block, dict):
+        # Thinking matrix form: pick the requested mode, then index by level.
+        if any(str(k).startswith("thinking") for k in model_block):
+            mode = os.environ.get("THINKING_MODE", "thinking_on").strip() or "thinking_on"
+            mode_block = model_block.get(mode)
+            if mode_block is None:
+                sys.exit(
+                    f"ERROR: THINKING_MODE='{mode}' not found in reference YAML "
+                    f"(available: {sorted(model_block)})"
+                )
+            return mode_block.get(num_spec_tokens)
+        # Plain {level: al} mapping.
+        return model_block.get(num_spec_tokens)
+
+    return None
+
+
+def _resolve_al(config_text, ref_yaml):
+    explicit = os.environ.get("SYNTHETIC_ACCEPTANCE_LENGTH", "").strip()
+    if explicit:
+        return float(explicit)
+
+    if not os.path.isfile(ref_yaml):
+        sys.exit(
+            "ERROR: SYNTHETIC_ACCEPTANCE_LENGTH not set and reference YAML not "
+            f"found: {ref_yaml}"
+        )
+
+    import yaml  # local import: only needed on the auto-lookup path
+
+    with open(ref_yaml) as f:
+        data = yaml.safe_load(f)
+
+    key = _yaml_key(os.environ.get("MODEL_PREFIX", ""))
+    model_block = data.get(key)
+    if model_block is None:
+        sys.exit(f'ERROR: model key "{key}" not found in {ref_yaml}')
+
+    nst_env = os.environ.get("NUM_SPEC_TOKENS", "").strip()
+    num_spec_tokens = int(nst_env) if nst_env else _spec_tokens_from_recipe(config_text)
+
+    al = _lookup_al(model_block, num_spec_tokens)
+    if al is None:
+        sys.exit(f"ERROR: num_spec_tokens={num_spec_tokens} not found for {key} in {ref_yaml}")
+
+    _log(
+        f"Auto-resolved AL={al} from {ref_yaml} "
+        f"(model={key}, num_spec_tokens={num_spec_tokens})"
+    )
+    return float(al)
+
+
+def inject(config_file):
+    if os.environ.get("SYNTHETIC_ACCEPTANCE", "false") != "true":
+        return 0
+
+    with open(config_file) as f:
+        content = f.read()
+
+    al = _resolve_al(content, os.path.join(os.path.dirname(__file__), "..", "benchmarks", "speedbench-reference-al.yaml"))
+
+    _log(f"Injecting synthetic acceptance (length={al}) into {config_file}")
+
+    before = [ln.strip() for ln in content.splitlines() if _SPEC_CONFIG_RE.search(ln)]
+    if before:
+        _log("Before:")
+        for ln in before:
+            print(f"  {ln}")
+
+    def _replace(match):
+        spec = json.loads(match.group(1))
+        spec["rejection_sample_method"] = "synthetic"
+        spec["synthetic_acceptance_length"] = al
+        # Compact separators keep the same style as the hand-written recipes.
+        return "speculative-config: '" + json.dumps(spec, separators=(",", ":")) + "'"
+
+    new_content, count = _SPEC_CONFIG_RE.subn(_replace, content)
+
+    if count == 0:
+        _log("WARNING: No speculative-config entries found to modify; leaving recipe unchanged")
+        return 0
+
+    with open(config_file, "w") as f:
+        f.write(new_content)
+    _log(f"Modified {count} speculative-config entries")
+
+    after = [ln.strip() for ln in new_content.splitlines() if _SPEC_CONFIG_RE.search(ln)]
+    if after:
+        _log("After:")
+        for ln in after:
+            print(f"  {ln.strip()}")
+    return 0
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.exit("Usage: inject_synthetic_acceptance.py CONFIG_FILE")
+    return inject(argv[1])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -56,9 +56,14 @@ elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
         # from_config) intermittently failed with FileNotFoundError when a
         # job landed on a node that didn't have the weights. The shared
         # Lustre FS is visible from every node, so there's no placement
-        # lottery. SRT_SLURM_MODEL_PREFIX matches the model.path alias in
-        # our DSV4 recipes.
-        export MODEL_PATH="/mnt/lustre01/models/deepseek-v4-pro"
+        # lottery. Use the CamelCase NVFP4 checkpoint name from Ankur's
+        # staging sheet: the fp4 recipes run the fp4 MoE kernels
+        # (VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE / use_fp4_indexer_cache) and
+        # therefore need the NVFP4-quantized weights, not the BF16 base.
+        # Linux is case-sensitive, so the path must match the on-disk
+        # CamelCase exactly. SRT_SLURM_MODEL_PREFIX is the recipe's
+        # model.path alias key (not a path) and stays as-is.
+        export MODEL_PATH="/mnt/lustre01/models/DeepSeek-V4-Pro-NVFP4"
         export SRT_SLURM_MODEL_PREFIX="deepseek-v4-pro"
     elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/MiniMax-M2.5-NVFP4"

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -49,10 +49,16 @@ elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/kimi-k2.5-nvfp4"
         export SRT_SLURM_MODEL_PREFIX="kimi-k2.5-nvfp4"
     elif [[ $MODEL_PREFIX == "dsv4" && $PRECISION == "fp4" ]]; then
-        # Weights live on compute-node local NVMe (/mnt/numa1) — no Lustre
-        # contention, fast startup. SRT_SLURM_MODEL_PREFIX matches the
-        # model.path alias in our DSV4 recipes.
-        export MODEL_PATH="/mnt/numa1/models/deepseek-v4-pro/"
+        # Lustre-resident weights staged on the GB200 cluster. The
+        # local-NVMe path (/mnt/numa1) was abandoned on main (6/23) because
+        # it isn't staged consistently across all compute nodes, so the
+        # in-job orchestrator's runtime model-path check (runtime.py
+        # from_config) intermittently failed with FileNotFoundError when a
+        # job landed on a node that didn't have the weights. The shared
+        # Lustre FS is visible from every node, so there's no placement
+        # lottery. SRT_SLURM_MODEL_PREFIX matches the model.path alias in
+        # our DSV4 recipes.
+        export MODEL_PATH="/mnt/lustre01/models/deepseek-v4-pro"
         export SRT_SLURM_MODEL_PREFIX="deepseek-v4-pro"
     elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/MiniMax-M2.5-NVFP4"

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -72,6 +72,17 @@ fi
 export SLURM_PARTITION="batch"
 export SLURM_ACCOUNT="benchmark"
 
+# The watchtower (Oracle) gb200 cluster does not cross-mount the runner's
+# working dir to compute nodes. Multi-node jobs whose srt-slurm/outputs and
+# INFMAX_WORKSPACE live under the runner home die in ~1s at the batch step
+# because Slurm can't open --output. dsv4 and minimax must therefore stage
+# those onto a compute-visible shared FS. Other models keep the legacy
+# behavior to avoid regressing paths that already work on their clusters.
+USE_SHARED_FS=0
+if [[ $MODEL_PREFIX == "minimaxm2.5" ]] || [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv4" ]]; then
+    USE_SHARED_FS=1
+fi
+
 NGINX_IMAGE="nginx:1.27.4"
 
 # === Cluster diagnostic probe (minimax only) ===
@@ -202,7 +213,7 @@ SRT_REPO_DIR="srt-slurm"
 # cross-mounted to compute nodes. Put the srt-slurm workspace and staged
 # InferenceX checkout on a writable shared-FS path that compute can see.
 # Per-run-unique paths avoid races between parallel sweep jobs.
-if [[ $MODEL_PREFIX == "minimaxm2.5" ]]; then
+if [[ "$USE_SHARED_FS" == "1" ]]; then
     SHARED_BASE=""
     for cand in \
         /mnt/lustre01/users-public/sa-shared/gha-runs \
@@ -292,7 +303,7 @@ source $HOME/.local/bin/env
 # under a head-node-only path, .venv/bin/python3 becomes a broken
 # symlink on compute. Pin the venv to /usr/bin/python3 — a system
 # path that exists at the same location on both head and compute.
-if [[ $MODEL_PREFIX == "minimaxm2.5" && -x /usr/bin/python3 ]]; then
+if [[ "$USE_SHARED_FS" == "1" && -x /usr/bin/python3 ]]; then
     uv venv --seed --python /usr/bin/python3
 else
     uv venv --seed
@@ -309,10 +320,10 @@ echo "Configs available at: $SRT_REPO_DIR/"
 
 # Create srtslurm.yaml for srtctl (used by both frameworks)
 SRTCTL_ROOT="${GITHUB_WORKSPACE}/srt-slurm"
-# Minimax on watchtower: SRT_REPO_DIR was moved to a shared-FS path
-# above so srtctl's outputs/ directory (which lives under
-# SRTCTL_ROOT) is visible to compute nodes.
-if [[ $MODEL_PREFIX == "minimaxm2.5" ]]; then
+# Shared-FS models (dsv4/minimax) on watchtower: SRT_REPO_DIR was moved
+# to a shared-FS path above so srtctl's outputs/ directory (which lives
+# under SRTCTL_ROOT) is visible to compute nodes.
+if [[ "$USE_SHARED_FS" == "1" ]]; then
     SRTCTL_ROOT="$SRT_REPO_DIR"
 fi
 echo "Creating srtslurm.yaml configuration..."
@@ -354,7 +365,7 @@ export INFMAX_WORKSPACE="$GITHUB_WORKSPACE"
 # can't see. Stage the relevant subset to shared FS and repoint
 # INFMAX_WORKSPACE there. rsync excludes the srt-slurm clone (already
 # on shared FS) and .git (not needed in container) for speed.
-if [[ $MODEL_PREFIX == "minimaxm2.5" ]]; then
+if [[ "$USE_SHARED_FS" == "1" ]]; then
     SHARED_INFMAX_WORKSPACE="${SHARED_BASE}/infmax-workspace-${RUN_KEY}"
     mkdir -p "$SHARED_INFMAX_WORKSPACE" || exit 1
     rsync -a --delete \
@@ -378,6 +389,11 @@ if [[ ! -f "$CONFIG_PATH" ]]; then
     exit 1
 fi
 sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_PATH"
+
+# Inject synthetic acceptance into the recipe's speculative-config when
+# SYNTHETIC_ACCEPTANCE=true (no-op otherwise). Must run after the name
+# override and before srtctl apply so the rendered job picks it up.
+python3 "$GITHUB_WORKSPACE/runners/inject_synthetic_acceptance.py" "$CONFIG_PATH"
 
 if [[ "$FRAMEWORK" == "dynamo-sglang" ]]; then
     SRTCTL_OUTPUT=$(srtctl apply -f "$CONFIG_PATH" --tags "gb200,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)" --setup-script install-torchao.sh 2>&1)

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -56,14 +56,15 @@ elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
         # from_config) intermittently failed with FileNotFoundError when a
         # job landed on a node that didn't have the weights. The shared
         # Lustre FS is visible from every node, so there's no placement
-        # lottery. Use the CamelCase NVFP4 checkpoint name from Ankur's
-        # staging sheet: the fp4 recipes run the fp4 MoE kernels
-        # (VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE / use_fp4_indexer_cache) and
-        # therefore need the NVFP4-quantized weights, not the BF16 base.
-        # Linux is case-sensitive, so the path must match the on-disk
-        # CamelCase exactly. SRT_SLURM_MODEL_PREFIX is the recipe's
-        # model.path alias key (not a path) and stays as-is.
-        export MODEL_PATH="/mnt/lustre01/models/DeepSeek-V4-Pro-NVFP4"
+        # lottery. Use the CamelCase name from Ankur's staging sheet (Linux
+        # is case-sensitive). Use the base DeepSeek-V4-Pro checkpoint, not
+        # the -NVFP4 re-quant: the recipe's served-model identity is plain
+        # deepseek-ai/DeepSeek-V4-Pro and the pinned v0.20.1 container's
+        # deepseek_v4 loader doesn't define the NVFP4 export's extra quant
+        # params (e.g. ffn.experts.w13_input_scale), which KeyErrors at
+        # load. SRT_SLURM_MODEL_PREFIX is the recipe's model.path alias key
+        # (not a path) and stays as-is.
+        export MODEL_PATH="/mnt/lustre01/models/DeepSeek-V4-Pro"
         export SRT_SLURM_MODEL_PREFIX="deepseek-v4-pro"
     elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/MiniMax-M2.5-NVFP4"


### PR DESCRIPTION
## Summary
Adds opt-in synthetic-acceptance injection for multi-node MTP recipes, enabled on a single dsv4 MTP2 agg cell as
the bring-up / e2e test.
- `runners/inject_synthetic_acceptance.py` (new): when `SYNTHETIC_ACCEPTANCE=true`, rewrites each `speculative-config` in the srt-slurm recipe to use synthetic rejection sampling. No-op when the env var is unset/false.
- `runners/launch_gb200-nv.sh`: generalize the watchtower shared-FS staging from minimax-only to a `USE_SHARED_FS` flag (now also dsv4 dynamo-vllm), and invoke the injection after the name override / before `srtctl apply`.
- `.github/configs/nvidia-master.yaml`: enable `SYNTHETIC_ACCEPTANCE` (length 2.27) on the dsv4 gb200 dynamo-vllm mtp2 agg cell only.

## Design
Bring-up approach: keep it opt-in so we can enable support incrementally per fw/model/config and roll back easily. Currently per-recipe via `additional-settings`; promote to a first-class field once enforced everywhere.

## Not in this PR (follow-ups)
- Per-model toggle ("flip once per model"), flag is currently per recipe cell.
- AL auto-resolve from `benchmarks/speedbench-reference-al.yaml`, this cell hardcodes `2.27`; the reference YAML isn't in this repo yet.
