### PR TITLE
chore: re-trigger MiniMax-M3 B200 vLLM sweep ingest

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3849,3 +3849,10 @@
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
+    - minimaxm3-fp8-b200-vllm
+  description:
+    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779


### PR DESCRIPTION
Duplicate of #1779's perf-changelog entry to force a fresh push-to-main run-sweep on the now-fixed workflow (#1786), backfilling the ingest that #1779's merge run silently skipped (reuse-ingest-artifacts poisoned by the always() gate regression).

Additions-only as required by process_changelog. Sweeps the same config-key (minimaxm3-fp8-b200-vllm).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog duplication with no runtime or config changes; only affects which sweeps CI schedules on merge.
> 
> **Overview**
> This PR **does not change benchmark recipes or master config** — it only **appends a second `perf-changelog.yaml` block** for `minimaxm3-fp8-b200-vllm` that duplicates the entry already recorded for #1779 (same description bullets and `pr-link`).
> 
> That duplicate is intentional: **`process_changelog` treats the changelog diff vs `main` as the sweep selector**, and entries must be **additions-only**. After #1779 merged, the push-to-main sweep **skipped ingest** (workflow `always()` / reuse-ingest-artifacts regression, fixed in #1786). Re-adding the same config-key text forces a **fresh `run-sweep` on merge** so results for MiniMax-M3 B200 vLLM can be ingested without editing the original #1779 block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218823878c3cf073c756d66f0133d4823b11a878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->