### PR TITLE
chore(runners): add TensorWave MI300X docker runners (mi300x-tw)

### DIFF
--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -104,10 +104,15 @@ mi300x:
 - 'mi300x-amds_06'
 - 'mi300x-amds_07'
 - 'mi300x-amds_08'
+- 'mi300x-tw_00'
+- 'mi300x-tw_01'
 mi300x-disagg:
 - 'mi300x-amds_06'
 - 'mi300x-amds_07'
 - 'mi300x-amds_08'
+mi300x-tw:
+- 'mi300x-tw_00'
+- 'mi300x-tw_01'
 mi325x:
 - 'mi325x-amds_00'
 - 'mi325x-amds_01'

--- a/runners/launch_mi300x-tw.sh
+++ b/runners/launch_mi300x-tw.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# TensorWave MI300X (tw018, tw032) — docker runners, NOT slurm.
+# Unlike the amds/325x/355x fleets (salloc + enroot squash on a Slurm worker),
+# these are standalone docker nodes: the benchmark image runs directly via
+# `docker run` on the same host the GitHub Actions runner lives on. Storage is
+# node-local (single ~14T root, no shared/NFS mount), so the HF cache lives
+# under the runner user's home and weights download on first use.
+
+# The runner user (cam) is not in the docker group, but has passwordless sudo.
+# Prefer rootless `docker` when available, fall back to `sudo docker`.
+DOCKER="docker"
+if ! docker ps >/dev/null 2>&1; then
+    DOCKER="sudo docker"
+fi
+
+export HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-$HOME/hf_hub_cache/}"
+export PORT=8888
+
+server_name="bmk-server"
+
+# Route spec-decoding=mtp configs to the _mtp benchmark script (e.g.
+# minimaxm3_fp8_mi300x_mtp.sh), matching the h100/h200 docker launchers.
+SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+
+# Variables the benchmark scripts (and benchmark_lib.sh) read. The slurm
+# launchers get these for free via `srun --export=ALL`; docker needs each named
+# explicitly so its value is pulled from the job environment.
+PASS_ENV=(
+    HF_TOKEN HF_HUB_CACHE
+    MODEL TP CONC MAX_MODEL_LEN ISL OSL RANDOM_RANGE_RATIO
+    CONTEXT_LENGTH ATTN_BACKEND DP_ATTENTION EP EP_SIZE
+    DRAFT_MODEL NUM_SPEC_TOKENS SPEC_DECODING
+    OFFLOADING OFFLOAD_ARGS PARALLEL_ARGS MAX_PREFILL_TOKENS
+    FUSE_ROPE_KVCACHE NF TOTAL_CPU_DRAM_GB
+    FRAMEWORK PRECISION EXP_NAME DISAGG
+    RESULT_DIR RESULT_FILENAME RUNNER_TYPE RUN_EVAL EVAL_ONLY
+    EVAL_CONTEXT_ARGS EVAL_MAX_MODEL_LEN
+    PROFILE SGLANG_TORCH_PROFILER_DIR VLLM_TORCH_PROFILER_DIR VLLM_RPC_TIMEOUT
+)
+ENV_FLAGS=()
+for v in "${PASS_ENV[@]}"; do
+    ENV_FLAGS+=(-e "$v")
+done
+ENV_FLAGS+=(-e PORT="$PORT" -e PYTHONPYCACHEPREFIX=/tmp/pycache/)
+
+mkdir -p "$HF_HUB_CACHE_MOUNT"
+
+set -x
+
+# numa_balancing hurts MI300X throughput; disable it like the older AMD docker
+# launchers did (passwordless sudo is available on these nodes).
+sudo sh -c 'echo 0 > /proc/sys/kernel/numa_balancing' || true
+
+$DOCKER run --rm --ipc=host --shm-size=16g --network=host --name=$server_name \
+--privileged --cap-add=CAP_SYS_ADMIN --device=/dev/kfd --device=/dev/dri --device=/dev/mem \
+--cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+-v "$HF_HUB_CACHE_MOUNT":"$HF_HUB_CACHE" \
+-v "$GITHUB_WORKSPACE":/workspace/ -w /workspace/ \
+"${ENV_FLAGS[@]}" \
+--entrypoint=/bin/bash \
+"$IMAGE" \
+benchmarks/single_node/${SCENARIO_SUBDIR}"${EXP_NAME%%_*}_${PRECISION}_mi300x${SPEC_SUFFIX}.sh"


### PR DESCRIPTION
## What

Onboards the two TensorWave MI300X nodes that were just handed off (**tw018** / `64.139.222.218` → `mi300x-tw_00`, **tw032** / `64.139.222.212` → `mi300x-tw_01`) as self-hosted GitHub Actions runners, following [`utils/runner_setup/RUNNER_SETUP.md`](../blob/main/utils/runner_setup/RUNNER_SETUP.md).

These are **docker nodes, not Slurm** — different from every current AMD fleet (amds/325x/355x), which run `salloc` + `enroot` squash on a Slurm worker. So they need a `docker run`-based launch script, in the spirit of the docker nodes we used to run (the deleted `launch_mi300x-amd.sh` / `launch_mi300x-cr.sh`, and the still-present NVIDIA `launch_h100-cr.sh`).

## Changes

- **`runners/launch_mi300x-tw.sh`** (new) — ROCm `docker run` launcher:
  - GPUs via `--device=/dev/kfd --device=/dev/dri --device=/dev/mem` + `--privileged`/`SYS_PTRACE`/`seccomp=unconfined` (standard AMD docker flags).
  - Auto-selects `sudo docker`: the runner user (`cam`) isn't in the `docker` group but has passwordless sudo (verified on both nodes). Falls back to plain `docker` if a future setup adds the group.
  - Node-local HF cache under `$HOME/hf_hub_cache/` — these nodes have a single ~14T local root and **no shared/NFS mount**, so weights download on first use (stage them ahead of time for big models).
  - Disables `numa_balancing` (AMD throughput tuning), like the old AMD docker launchers.
  - Explicit env passthrough array (docker has no `--export=ALL` equivalent) covering everything the `*_mi300x.sh` scripts + `benchmark_lib.sh` read.
  - Dispatches to `benchmarks/single_node/${SCENARIO_SUBDIR}<model>_<prec>_mi300x[_mtp].sh` (SCENARIO_SUBDIR + SPEC_SUFFIX, parity with the h100/b200 launchers).
- **`.github/configs/runners.yaml`** — register `mi300x-tw_00` (tw018) and `mi300x-tw_01` (tw032) in the `mi300x` group, plus a dedicated `mi300x-tw` subfleet (mirrors the `b200-dgxc`/`h200-dgxc` dual-listing).

## Validation

- `bash -n` on the launch script ✅
- YAML parses; both nodes present in `mi300x` and `mi300x-tw` ✅
- Launch-script-name invariant holds (`mi300x-tw_NN` → `launch_mi300x-tw.sh` exists) ✅
- `utils/matrix_logic/test_generate_sweep_configs.py` — 91 passed ✅
- Both nodes: confirmed gfx942 (MI300X), 192 CPUs, Docker 29.1.3, passwordless sudo, `sudo docker` works ✅

## On-node registration — DONE ✅

Runners are registered and live (runner v2.335.1), one per node, started under `tmux` (session `github-actions`) via `start_runners.sh`:

```
mi300x-tw_00  status=online  busy=false  labels=[self-hosted,Linux,X64,mi300x,mi300x-tw,mi300x-tw_00]   # tw018
mi300x-tw_01  status=online  busy=false  labels=[self-hosted,Linux,X64,mi300x,mi300x-tw,mi300x-tw_01]   # tw032
```

Notes / follow-ups:
- Runners run via `./run.sh` in tmux (not systemd) — **they don't survive a reboot**; re-run `start_runners.sh` after node maintenance (standard for this fleet).
- Optionally add `cam` to the `docker` group on both nodes to drop the `sudo` in the launcher.
- Big-model weights will download to `~/hf_hub_cache` on first run unless pre-staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)