### PR TITLE
fix(ci): skip gated no-op runs when resolving unpinned /reuse-sweep-run

### DIFF
--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -181,12 +181,18 @@ def find_latest_successful_pr_run(
             "status": "completed",
         },
     )
-    # GitHub returns runs newest-first.
+    # GitHub returns runs newest-first.  Skip gated no-op runs (synchronize
+    # events suppressed by a /reuse-sweep-run comment) which complete as
+    # "success" but produce no benchmark or eval artifacts.
     for run in runs:
         if run.get("conclusion") != "success":
             continue
-        if str(run.get("head_sha") or "") in valid_shas:
-            return run
+        if str(run.get("head_sha") or "") not in valid_shas:
+            continue
+        names = artifact_names(repo, int(run["id"]), token)
+        if "results_bmk" not in names and "eval_results_all" not in names:
+            continue
+        return run
     return None
 
 

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -119,6 +119,7 @@ def test_find_latest_successful_pr_run_skips_newer_failed_run(monkeypatch) -> No
         return [failed_run, successful_run]
 
     monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
 
     assert (
         reuse.find_latest_successful_pr_run(
@@ -129,6 +130,40 @@ def test_find_latest_successful_pr_run_skips_newer_failed_run(monkeypatch) -> No
             "token",
         )
         == successful_run
+    )
+
+
+def test_find_latest_successful_pr_run_skips_gated_noop_run(monkeypatch) -> None:
+    gated_run = {
+        "id": 333,
+        "conclusion": "success",
+        "head_sha": "def456",
+    }
+    real_run = {
+        "id": 222,
+        "conclusion": "success",
+        "head_sha": "abc123",
+    }
+
+    def fake_paginated_github_api(repo, path, token, item_key, params=None):
+        assert path == "/actions/workflows/run-sweep.yml/runs"
+        return [gated_run, real_run]
+
+    artifacts_by_run = {333: set(), 222: {"results_bmk"}}
+    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
+    monkeypatch.setattr(
+        reuse, "artifact_names", lambda repo, run_id, token: artifacts_by_run[run_id]
+    )
+
+    assert (
+        reuse.find_latest_successful_pr_run(
+            "SemiAnalysisAI/InferenceX",
+            "run-sweep.yml",
+            "feature-branch",
+            {"abc123", "def456"},
+            "token",
+        )
+        == real_run
     )
 
 


### PR DESCRIPTION
## Summary

- `find_latest_successful_pr_run` now checks artifact names before selecting a candidate run
- Gated synchronize runs (suppressed by `/reuse-sweep-run` authorization from #1769) complete as `success` with zero artifacts — these are now skipped in favor of the actual sweep run

## Root cause

After #1769 merged, gated synchronize runs produce no artifacts but report `conclusion: success`. The unpinned `/reuse-sweep-run` path picks the latest successful run newest-first, so the gated no-op run was selected over the real sweep run. The push-to-main reuse then failed with "no results_bmk or eval_results_all artifact".

Incident: [runs/27588885351](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27588885351/job/81565213983) latched onto gated run `27588869506` (0 artifacts) instead of sweep run `27528759942` (122 artifacts).

## Validation

- `python -m pytest utils/test_find_reusable_sweep_run.py -v` (21 passed)
- New test: `test_find_latest_successful_pr_run_skips_gated_noop_run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to CI reuse selection logic with targeted tests; no auth, data, or production runtime impact.
> 
> **Overview**
> Unpinned **`/reuse-sweep-run`** on push-to-main uses **`find_latest_successful_pr_run`** to pick the newest successful PR sweep. Gated synchronize runs (skipped sweeps after maintainer authorization) still finish as **`success`** with **no artifacts**, so they were chosen over real sweep runs and reuse failed later.
> 
> **`find_latest_successful_pr_run`** now calls **`artifact_names`** for each candidate and only accepts runs that include **`results_bmk`** or **`eval_results_all`**, aligned with **`validate_reusable_run`**.
> 
> Tests mock artifacts for the existing “skip failed run” case and add **`test_find_latest_successful_pr_run_skips_gated_noop_run`** for the gated no-op scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7d0b3f9b8614dfc017123845298a4cb0744c2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->