### PR TITLE
[AMD] perf-changelog: duplicate dsv4-fp4-mi355x-sglang TP4 fixed-seq-len entry

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3839,13 +3839,6 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762
 
 - config-keys:
-    - dsv4-fp4-mi355x-sglang
-  description:
-    - "Switch fixed-seq-len search space from TP8 to TP4 for both isl=1024 and isl=8192 scenarios"
-    - "Expand isl=8192 coverage: add TP4 dp-attn sweep (conc 32–2048) and TP4 TP-only sweep (conc 1–32)"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762
-
-- config-keys:
     - dsv4-fp4-gb300-dynamo-trt
     - dsv4-fp4-gb300-dynamo-trt-mtp
   description:
@@ -3870,3 +3863,10 @@
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "Switch fixed-seq-len search space from TP8 to TP4 for both isl=1024 and isl=8192 scenarios"
+    - "Expand isl=8192 coverage: add TP4 dp-attn sweep (conc 32–2048) and TP4 TP-only sweep (conc 1–32)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3837,7 +3837,14 @@
     - "Switch fixed-seq-len search space from TP8 to TP4 for both isl=1024 and isl=8192 scenarios"
     - "Expand isl=8192 coverage: add TP4 dp-attn sweep (conc 32–2048) and TP4 TP-only sweep (conc 1–32)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762
-  
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang
+  description:
+    - "Switch fixed-seq-len search space from TP8 to TP4 for both isl=1024 and isl=8192 scenarios"
+    - "Expand isl=8192 coverage: add TP4 dp-attn sweep (conc 32–2048) and TP4 TP-only sweep (conc 1–32)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762
+
 - config-keys:
     - dsv4-fp4-gb300-dynamo-trt
     - dsv4-fp4-gb300-dynamo-trt-mtp

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3837,7 +3837,7 @@
     - "Switch fixed-seq-len search space from TP8 to TP4 for both isl=1024 and isl=8192 scenarios"
     - "Expand isl=8192 coverage: add TP4 dp-attn sweep (conc 32–2048) and TP4 TP-only sweep (conc 1–32)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1762
-
+  
 - config-keys:
     - dsv4-fp4-gb300-dynamo-trt
     - dsv4-fp4-gb300-dynamo-trt-mtp


### PR DESCRIPTION
## Summary

Duplicates the `perf-changelog.yaml` entry for `dsv4-fp4-mi355x-sglang` originally added in #1768. The duplicate entry is identical in content (config-keys, description, and pr-link).

## Test plan

- [ ] N/A — changelog-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only duplication with no runtime or benchmark config changes; the only downside is redundant history if both entries remain.
> 
> **Overview**
> Adds a **second** `perf-changelog.yaml` block for `dsv4-fp4-mi355x-sglang` that matches the entry already recorded for PR #1762 (TP4 fixed-seq-len search space and expanded 8k1k sweeps). **No new config-keys, descriptions, or pr-links**—only a duplicate changelog row inserted near the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb817cd360fbb431ead3fa7793ef21927932cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->