### PR TITLE
[NV] Update MiniMax-M3 B200 MTP, B300, and B300 MTP vLLM serving settings

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -12604,6 +12604,7 @@ minimaxm3-fp8-b300-vllm:
       # tp2 fits MXFP8 weights (~222 GB/GPU of 288) but KV headroom is thin;
       # 1k1k only, drop if it OOMs at the high end.
       - { tp: 2, ep: 2, conc-start: 16, conc-end: 128 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
     - isl: 8192
       osl: 1024
@@ -12611,6 +12612,8 @@ minimaxm3-fp8-b300-vllm:
       - { tp: 8, conc-start: 1, conc-end: 64 }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 128 }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
 
 # MiniMax-M3 day-zero (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3).
@@ -12676,6 +12679,7 @@ minimaxm3-fp8-b200-vllm-mtp:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
@@ -12683,6 +12687,8 @@ minimaxm3-fp8-b200-vllm-mtp:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
@@ -12710,6 +12716,7 @@ minimaxm3-fp8-b300-vllm-mtp:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
@@ -12717,6 +12724,8 @@ minimaxm3-fp8-b300-vllm-mtp:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
@@ -61,6 +61,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -72,14 +73,6 @@ fi
 
 # use 3 speculative tokens for all configs for now
 NUM_SPEC_TOKENS=3
-
-# Fixed-seq-len runs don't need graphs past the decode step's token count:
-# with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS
-# tokens per step, so capture up to the next power of two >=
-# CONC * (1 + NUM_SPEC_TOKENS), capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -95,7 +88,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
@@ -46,6 +46,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -54,12 +55,6 @@ elif [ "$EP_SIZE" -gt 1 ]; then
 else
   PARALLEL_ARGS="--tensor-parallel-size=$TP"
 fi
-
-# Fixed-seq-len runs don't need graphs past the request concurrency: capture
-# up to the next power of two >= CONC, capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -75,7 +70,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -62,6 +62,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -73,14 +74,6 @@ fi
 
 # use 3 speculative tokens for all configs for now
 NUM_SPEC_TOKENS=3
-
-# Fixed-seq-len runs don't need graphs past the decode step's token count:
-# with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS
-# tokens per step, so capture up to the next power of two >=
-# CONC * (1 + NUM_SPEC_TOKENS), capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -96,7 +89,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3858,9 +3858,17 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
 
 - config-keys:
+    - minimaxm3-fp8-b200-vllm
+  description:
+    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
     - minimaxm3-fp8-b200-vllm-mtp
     - minimaxm3-fp8-b300-vllm
     - minimaxm3-fp8-b300-vllm-mtp
   description:
     - "Extend MiniMax-M3 B200 MTP, B300, and B300 MTP vLLM settings to match B200 (PR #1779): set VLLM_FLOAT32_MATMUL_PRECISION=high, hardcode max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage: DP-attention rows for 1k1k and non-DP-attention + DP-attention rows for 8k1k across all three variants."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1802

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3858,8 +3858,9 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
 
 - config-keys:
-    - minimaxm3-fp8-b200-vllm
+    - minimaxm3-fp8-b200-vllm-mtp
+    - minimaxm3-fp8-b300-vllm
+    - minimaxm3-fp8-b300-vllm-mtp
   description:
-    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
-    - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+    - "Extend MiniMax-M3 B200 MTP, B300, and B300 MTP vLLM settings to match B200 (PR #1779): set VLLM_FLOAT32_MATMUL_PRECISION=high, hardcode max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage: DP-attention rows for 1k1k and non-DP-attention + DP-attention rows for 8k1k across all three variants."


### PR DESCRIPTION
## Summary

Extends the B200 fixes from #1779 to the three remaining MiniMax-M3 Blackwell variants:

- **`minimaxm3_fp8_b200_mtp.sh`** / **`minimaxm3_fp8_b300.sh`** / **`minimaxm3_fp8_b300_mtp.sh`**: set `VLLM_FLOAT32_MATMUL_PRECISION=high`; replace dynamic `CAPTURE_SIZE` computation with hardcoded `--max-cudagraph-capture-size 2048`
- **`nvidia-master.yaml`** — add TP4+EP4 coverage to three config keys:
  - `minimaxm3-fp8-b300-vllm`: add `tp4ep4 dp-attn` for 1k1k; add `tp4ep4` and `tp4ep4 dp-attn` for 8k1k
  - `minimaxm3-fp8-b200-vllm-mtp`: same additions (concs trimmed at high end per MTP convention)
  - `minimaxm3-fp8-b300-vllm-mtp`: same additions as B200 MTP

## Test plan
- [ ] CI sweep on `minimaxm3-fp8-b200-vllm-mtp`
- [ ] CI sweep on `minimaxm3-fp8-b300-vllm`
- [ ] CI sweep on `minimaxm3-fp8-b300-vllm-mtp`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI sweep configuration only; no application runtime or security-sensitive code paths.
> 
> **Overview**
> Brings **MiniMax-M3 B200 MTP**, **B300**, and **B300 MTP** vLLM fixed-seq-len serving in line with the B200 changes from #1779.
> 
> The three benchmark launch scripts now export `VLLM_FLOAT32_MATMUL_PRECISION=high` and pass a fixed `--max-cudagraph-capture-size 2048` instead of computing capture size from concurrency (and spec-token count on MTP).
> 
> `nvidia-master.yaml` gains **TP4+EP4** sweep rows for `minimaxm3-fp8-b300-vllm`, `minimaxm3-fp8-b200-vllm-mtp`, and `minimaxm3-fp8-b300-vllm-mtp`: DP-attention at 1k1k, plus non-DP and DP-attention at 8k1k (with MTP-appropriate concurrency caps). `perf-changelog.yaml` records the same for those config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0bca9658b4ecae2ce8e4b21170c9edd6536b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->