### PR TITLE
[WIP][NV] Use Marlin for MiniMax M3 TP-only configs

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
@@ -45,7 +45,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 if [ "${EVAL_ONLY}" = "true" ]; then

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
@@ -68,7 +68,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 # use 3 speculative tokens for all configs for now

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
@@ -53,7 +53,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 if [ "${EVAL_ONLY}" = "true" ]; then

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -69,7 +69,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 # use 3 speculative tokens for all configs for now

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3879,3 +3879,12 @@
     - "Align MiniMax-M3 B200/B300 EAGLE3 MTP serving with the MiniMax-M2.5 FP8 serving settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and using max cudagraph capture size 2048."
     - "Add TP4+EP4 MTP coverage: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1784
+
+- config-keys:
+    - minimaxm3-fp8-b200-vllm
+    - minimaxm3-fp8-b300-vllm
+    - minimaxm3-fp8-b200-vllm-mtp
+    - minimaxm3-fp8-b300-vllm-mtp
+  description:
+    - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3887,4 +3887,4 @@
     - minimaxm3-fp8-b300-vllm-mtp
   description:
     - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1807
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1809

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3887,4 +3887,4 @@
     - minimaxm3-fp8-b300-vllm-mtp
   description:
     - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1807


### PR DESCRIPTION
Stacked on #1781 and #1784.

Adds `--moe-backend marlin` for MiniMax-M3 B200/B300 TP-only vLLM launch paths when expert parallelism is disabled.

Validation:
- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh`
- `git diff --check`
- PyYAML parse for `perf-changelog.yaml` and `.github/configs/nvidia-master.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only vLLM serve flags for a specific MoE backend when expert parallelism is off; no auth, data, or core application logic changes.
> 
> **Overview**
> For **MiniMax-M3 MXFP8** B200/B300 vLLM fixed-sequence recipes, the TP-only launch path (`DP_ATTENTION` false and `EP_SIZE` 1) now passes **`--moe-backend marlin`** alongside `--tensor-parallel-size=$TP`. DP-attention and expert-parallel branches are unchanged.
> 
> The same `PARALLEL_ARGS` tweak is applied to the **non-MTP** and **EAGLE3 MTP** scripts (`minimaxm3_fp8_b200.sh`, `minimaxm3_fp8_b300.sh`, and their `_mtp` siblings). **`perf-changelog.yaml`** records the change for `minimaxm3-fp8-b200-vllm`, `minimaxm3-fp8-b300-vllm`, and the matching MTP config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c5fe0411fc7fb0ec37de2c72a4e8741b0e37f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->