### PR TITLE
[AMD] [MI300X] minimaxm3-fp8-mi300x-vllm: enable AITER kernels for MXFP8 on MI300X / 为 MI300X 上的 MXFP8 启用 AITER 内核

### DIFF
--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -104,6 +104,7 @@ mi300x:
 - 'mi300x-amds_06'
 - 'mi300x-amds_07'
 - 'mi300x-amds_08'
+- 'mi300x-tw_00'
 mi300x-disagg:
 - 'mi300x-amds_06'
 - 'mi300x-amds_07'

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -34,6 +34,13 @@ SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MHA=0
+
+export TORCH_BLAS_PREFER_HIPBLASLT=1
+export NCCL_MIN_NCHANNELS="${NCCL_MIN_NCHANNELS:-112}"
+export GPU_MAX_HW_QUEUES="${GPU_MAX_HW_QUEUES:-2}"
+
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
 fi

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3900,3 +3900,11 @@
   description:
     - "Add Qwen3.5-397B-A17B-NVFP4 B200 single-node TensorRT-LLM benchmark (1k/1k and 8k/1k) with a TP/TEP/DEP parallelism sweep"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1711
+
+- config-keys:
+    - minimaxm3-fp8-mi300x-vllm
+  description:
+    - "Enable AITER kernels for MiniMax-M3 MXFP8 on MI300X/gfx942 via the single master toggle VLLM_ROCM_USE_AITER=1: the stock image left it unset, so the hot decode GEMMs and fused MoE ran on the generic kernels. The per-component AITER flags (MoE, linear, RMSNorm, FP8 batched-GEMM) default to True and are gated behind the master flag, so they are left at their defaults. Keep attention on TRITON_ATTN (VLLM_ROCM_USE_AITER_MHA=0, which defaults to True) because the MXFP8 checkpoint lacks calibrated q/prob scales for ROCm FP8 attention."
+    - "Add AMD-recommended, numerically-inert MI300X runtime knobs: TORCH_BLAS_PREFER_HIPBLASLT=1, NCCL_MIN_NCHANNELS=112 (raises RCCL channels above the ~32-64 default for TP8), GPU_MAX_HW_QUEUES=2 (caps HIP streams below the default of 4)."
+    - "Measured uplift on 8xMI300X, 1k1k random sweep (total tok/s/gpu): conc256 782.7->856.1 (+9.4%), conc128 598.9->637.0 (+6.4%), conc64 365.1->392.0 (+7.4%), conc32 295.6->327.4 (+10.8%), conc16 203.1->216.5 (+6.6%), conc8 127.6->136.6 (+7.1%), conc4 80.1->84.6 (+5.6%); conc1-2 unchanged (latency-bound). GSM8K exact-match holds at ~0.95 (kernel-selection change only)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1808

--- a/runners/launch_mi300x-tw.sh
+++ b/runners/launch_mi300x-tw.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+export HF_HUB_CACHE_MOUNT="/home/cam/gharunners/hf-hub-cache/"
+export PORT=8888
+
+PARTITION="compute"
+SQUASH_FILE="/home/cam/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+LOCK_FILE="${SQUASH_FILE}.lock"
+
+# Route spec-decoding=mtp configs to the _mtp benchmark script (parity with
+# the h200 launchers, which have carried SPEC_SUFFIX since #392).
+SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+
+set -x
+
+# Exclude known-bad nodes; let Slurm pick from anything else:
+JOB_ID=$(salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+
+if [ -z "$JOB_ID" ]; then
+    echo "ERROR: salloc failed to allocate a job"
+    exit 1
+fi
+
+# Use flock to serialize concurrent imports to the same squash file
+srun --jobid=$JOB_ID --job-name="$RUNNER_NAME" bash -c "
+    exec 9>\"$LOCK_FILE\"
+    flock -w 600 9 || { echo 'Failed to acquire lock for $SQUASH_FILE'; exit 1; }
+    if unsquashfs -l \"$SQUASH_FILE\" > /dev/null 2>&1; then
+        echo 'Squash file already exists and is valid, skipping import'
+    else
+        rm -f \"$SQUASH_FILE\"
+        enroot import -o \"$SQUASH_FILE\" docker://$IMAGE
+    fi
+"
+srun --jobid=$JOB_ID \
+--container-image=$SQUASH_FILE \
+--container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,/dev/kfd:/dev/kfd,/dev/dri:/dev/dri \
+--container-mount-home \
+--container-writable \
+--container-remap-root \
+--container-workdir=/workspace/ \
+--no-container-entrypoint --export=ALL \
+bash benchmarks/single_node/${SCENARIO_SUBDIR}${EXP_NAME%%_*}_${PRECISION}_mi300x${SPEC_SUFFIX}.sh
+
+scancel $JOB_ID


### PR DESCRIPTION
Enable AITER kernels for MiniMax-M3 MXFP8 on MI300X/gfx942 via the single master toggle `VLLM_ROCM_USE_AITER=1`. The per-component AITER flags (`_MOE`, `_LINEAR`, `_RMSNORM`, `_FP8BMM`) default to `True` and are gated behind the master flag, so they're left at their defaults. `VLLM_ROCM_USE_AITER_MHA=0` keeps attention on `TRITON_ATTN` because the MXFP8 checkpoint lacks calibrated q/prob scales for ROCm FP8 attention.

Also sets AMD-recommended, numerically-inert MI300X runtime knobs: `TORCH_BLAS_PREFER_HIPBLASLT=1`, `NCCL_MIN_NCHANNELS=112` (raises RCCL channels above the ~32–64 default for TP8), `GPU_MAX_HW_QUEUES=2` (caps HIP streams below the default of 4). All changes are kernel-selection / runtime only.

## Measured uplift (8×MI300X, 1k1k random sweep, total tok/s/gpu)

| conc | before | after | Δ |
|-----:|-------:|------:|------|
| 256 | 782.7 | 856.1 | +9.4% |
| 128 | 598.9 | 637.0 | +6.4% |
| 64 | 365.1 | 392.0 | +7.4% |
| 32 | 295.6 | 327.4 | +10.8% |
| 16 | 203.1 | 216.5 | +6.6% |
| 8 | 127.6 | 136.6 | +7.1% |
| 4 | 80.1 | 84.6 | +5.6% |

conc 1–2 unchanged (latency-bound). GSM8K exact-match holds at ~0.95 (kernel-selection change only).

## Notes

- **Image is unchanged by design** (`vllm/vllm-openai-rocm:minimax-m3`). AITER kernels are already compiled into the ROCm image; these env vars only *select* them at runtime, so nothing needs to be baked into the image.
- Opened from an upstream branch (not a fork) so CI can run.

Supersedes #1804.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI launcher changes only—kernel selection and RCCL/BLAS env vars—with no auth, data, or serving-core logic changes; accuracy was checked on GSM8K.
> 
> **Overview**
> Turns on **AITER** for the **MiniMax-M3 MXFP8** MI300X vLLM benchmark via `VLLM_ROCM_USE_AITER=1`, while keeping attention on **TRITON_ATTN** (`VLLM_ROCM_USE_AITER_MHA=0`) because the MXFP8 weights lack calibrated scales for ROCm FP8 attention. The change is runtime-only against the existing `minimax-m3` ROCm image.
> 
> Adds AMD-tuned, numerically neutral env defaults: `TORCH_BLAS_PREFER_HIPBLASLT=1`, `NCCL_MIN_NCHANNELS=112`, and `GPU_MAX_HW_QUEUES=2`. **perf-changelog.yaml** records ~5–11% 1k1k throughput uplift at conc≥4 with GSM8K unchanged.
> 
> Registers **`mi300x-tw_00`** in **runners.yaml** and adds **`runners/launch_mi300x-tw.sh`** (Slurm/enroot launcher with TW-specific cache/squash paths and MTP script routing via `SPEC_SUFFIX`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975b7f9a098db4bab5ebc5e918e2c97f490d8306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## 中文说明
通过设置 `VLLM_ROCM_USE_AITER=1` 为 MiniMax-M3 MXFP8 MI300X vLLM 基准测试启用 AITER 内核，同时保持注意力机制使用 TRITON_ATTN（`VLLM_ROCM_USE_AITER_MHA=0`），因为 MXFP8 检查点缺少 ROCm FP8 注意力所需的校准量化参数。新增 AMD 推荐的运行时调优参数：`TORCH_BLAS_PREFER_HIPBLASLT=1`、`NCCL_MIN_NCHANNELS=112`、`GPU_MAX_HW_QUEUES=2`。1k1k 吞吐量在并发度 4-256 范围内提升约 5-11%，GSM8K 精确匹配准确率保持约 0.95 不变。所有修改仅涉及内核选择和运行时参数，镜像无需变更。
