### PR TITLE
[NV] Use Marlin for MiniMax M3 TP-only configs

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -12618,6 +12618,7 @@ minimaxm3-fp8-b300-vllm:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
       # tp2 fits MXFP8 weights (~222 GB/GPU of 288) but KV headroom is thin;
       # 1k1k only, drop if it OOMs at the high end.
       - { tp: 2, ep: 2, conc-start: 16, conc-end: 128 }
@@ -12628,6 +12629,8 @@ minimaxm3-fp8-b300-vllm:
       - { tp: 8, conc-start: 1, conc-end: 64 }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
       - { tp: 4, conc-start: 1, conc-end: 128 }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
 
 # MiniMax-M3 day-zero (https://recipes.vllm.ai/MiniMaxAI/MiniMax-M3).

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -12693,6 +12693,7 @@ minimaxm3-fp8-b200-vllm-mtp:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
@@ -12700,6 +12701,8 @@ minimaxm3-fp8-b200-vllm-mtp:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
@@ -12727,6 +12730,7 @@ minimaxm3-fp8-b300-vllm-mtp:
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
@@ -12734,6 +12738,8 @@ minimaxm3-fp8-b300-vllm-mtp:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
+      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 128, spec-decoding: mtp }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh
@@ -45,7 +45,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 if [ "${EVAL_ONLY}" = "true" ]; then

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
@@ -61,6 +61,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -72,14 +73,6 @@ fi
 
 # use 3 speculative tokens for all configs for now
 NUM_SPEC_TOKENS=3
-
-# Fixed-seq-len runs don't need graphs past the decode step's token count:
-# with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS
-# tokens per step, so capture up to the next power of two >=
-# CONC * (1 + NUM_SPEC_TOKENS), capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -95,7 +88,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh
@@ -68,7 +68,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 # use 3 speculative tokens for all configs for now

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
@@ -53,7 +53,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 if [ "${EVAL_ONLY}" = "true" ]; then

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh
@@ -46,6 +46,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -54,12 +55,6 @@ elif [ "$EP_SIZE" -gt 1 ]; then
 else
   PARALLEL_ARGS="--tensor-parallel-size=$TP"
 fi
-
-# Fixed-seq-len runs don't need graphs past the request concurrency: capture
-# up to the next power of two >= CONC, capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -75,7 +70,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -62,6 +62,7 @@ SERVER_LOG=/workspace/server.log
 # 444 GB of MXFP8 weights off shared FS; engine startup can exceed the
 # default 600s readiness window.
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_FLOAT32_MATMUL_PRECISION=high
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -73,14 +74,6 @@ fi
 
 # use 3 speculative tokens for all configs for now
 NUM_SPEC_TOKENS=3
-
-# Fixed-seq-len runs don't need graphs past the decode step's token count:
-# with spec decoding every running request contributes 1 + NUM_SPEC_TOKENS
-# tokens per step, so capture up to the next power of two >=
-# CONC * (1 + NUM_SPEC_TOKENS), capped at vLLM's 2048 ceiling.
-CAPTURE_SIZE=4
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) )); do CAPTURE_SIZE=$((CAPTURE_SIZE * 2)); done
-(( CAPTURE_SIZE > 2048 )) && CAPTURE_SIZE=2048
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -96,7 +89,7 @@ $PARALLEL_ARGS \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
 --language-model-only \
---max-cudagraph-capture-size $CAPTURE_SIZE \
+--max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh
@@ -69,7 +69,7 @@ if [ "${DP_ATTENTION}" = "true" ]; then
 elif [ "$EP_SIZE" -gt 1 ]; then
   PARALLEL_ARGS="--tensor-parallel-size=$TP --enable-expert-parallel"
 else
-  PARALLEL_ARGS="--tensor-parallel-size=$TP"
+  PARALLEL_ARGS="--tensor-parallel-size=$TP --moe-backend marlin"
 fi
 
 # use 3 speculative tokens for all configs for now

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3858,6 +3858,13 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
 
 - config-keys:
+    - minimaxm3-fp8-b200-vllm
+  description:
+    - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
     - kimik2.5-int4-mi355x-vllm
   description:
     - "Replace triton w4a16 MoE with FlyDSL w4a16 MoE"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3879,3 +3879,12 @@
     - "Align MiniMax-M3 B200/B300 EAGLE3 MTP serving with the MiniMax-M2.5 FP8 serving settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and using max cudagraph capture size 2048."
     - "Add TP4+EP4 MTP coverage: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1784
+
+- config-keys:
+    - minimaxm3-fp8-b200-vllm
+    - minimaxm3-fp8-b300-vllm
+    - minimaxm3-fp8-b200-vllm-mtp
+    - minimaxm3-fp8-b300-vllm-mtp
+  description:
+    - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3849,3 +3849,11 @@
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
+    - minimaxm3-fp8-b200-vllm-mtp
+    - minimaxm3-fp8-b300-vllm-mtp
+  description:
+    - "Align MiniMax-M3 B200/B300 EAGLE3 MTP serving with the MiniMax-M2.5 FP8 serving settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and using max cudagraph capture size 2048."
+    - "Add TP4+EP4 MTP coverage: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3887,4 +3887,4 @@
     - minimaxm3-fp8-b300-vllm-mtp
   description:
     - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1807
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1809

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3849,3 +3849,10 @@
     - "Align MiniMax-M3 B200 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 B200 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage for MiniMax-M3 B200: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1779
+
+- config-keys:
+    - minimaxm3-fp8-b300-vllm
+  description:
+    - "Align MiniMax-M3 B300 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
+    - "Add TP4+EP4 coverage for MiniMax-M3 B300: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
+  pr-link: TODO

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3887,4 +3887,4 @@
     - minimaxm3-fp8-b300-vllm-mtp
   description:
     - "Use the Marlin MoE backend for MiniMax-M3 B200/B300 TP-only vLLM configurations by adding --moe-backend marlin when expert parallelism is disabled."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1807

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3855,4 +3855,4 @@
   description:
     - "Align MiniMax-M3 B300 vLLM fixed-sequence serving with MiniMax-M2.5 FP8 settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and restoring max cudagraph capture size 2048."
     - "Add TP4+EP4 coverage for MiniMax-M3 B300: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
-  pr-link: TODO
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1781

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3856,4 +3856,4 @@
   description:
     - "Align MiniMax-M3 B200/B300 EAGLE3 MTP serving with the MiniMax-M2.5 FP8 serving settings by setting VLLM_FLOAT32_MATMUL_PRECISION=high and using max cudagraph capture size 2048."
     - "Add TP4+EP4 MTP coverage: DP-attention rows for 1k1k/8k1k and the missing non-DP-attention row for 8k1k."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1784


### PR DESCRIPTION
Stacked on #1781 and #1784.

Adds `--moe-backend marlin` for MiniMax-M3 B200/B300 TP-only vLLM launch paths when expert parallelism is disabled.

Validation:
- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b200_mtp.sh benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_b300_mtp.sh`
- `git diff --check`
- PyYAML parse for `perf-changelog.yaml` and `.github/configs/nvidia-master.yaml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only vLLM serve flag change on a narrow parallelism branch; no auth, data, or production runtime impact.
> 
> **Overview**
> For **MiniMax-M3 MXFP8** B200/B300 fixed-sequence vLLM recipes (standard and EAGLE3 MTP), the TP-only launch path now passes **`--moe-backend marlin`** when expert parallelism is off (`EP_SIZE` ≤ 1 and DP attention is false). DP-attention and TP+EP branches are unchanged.
> 
> **`perf-changelog.yaml`** records this for `minimaxm3-fp8-b200-vllm`, `minimaxm3-fp8-b300-vllm`, and the matching MTP config keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ddf2cd9b66c45275be1e6d001b779d69e103b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->