### PR TITLE
DSR1-FP4 MI355x SGLang: Add EP configurations

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -1,5 +1,5 @@
 dsr1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi35x
+  image: lmsysorg/sglang:v0.5.13-rocm700-mi35x
   model: amd/DeepSeek-R1-0528-MXFP4-Preview
   model-prefix: dsr1
   runner: mi355x
@@ -11,13 +11,18 @@ dsr1-fp4-mi355x-sglang:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 256 }
+      - { tp: 8, conc-start: 4, conc-end: 256 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
-      - { tp: 8, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 256 }
+      - { tp: 8, conc-start: 4, conc-end: 256 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
+ 
     # Agentic-coding sweep commented out for this image-bump PR — the
     # 10-conc agentic matrix amplifies sweep cost and the bump validation
     # only needs the fixed-seq-len throughput shape. Re-enable once the

--- a/benchmarks/single_node/fixed_seq_len/dsr1_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsr1_fp4_mi355x.sh
@@ -5,6 +5,7 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 check_env_vars \
     MODEL \
     TP \
+	EP_SIZE \
     CONC \
     ISL \
     OSL \
@@ -37,16 +38,21 @@ fi
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    PARALLEL_ARGS+=( --ep-size "$EP_SIZE" )
+fi
+
 set -x
 python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --host=0.0.0.0 --port=$PORT \
+"${PARALLEL_ARGS[@]}" \
 --tensor-parallel-size=$TP \
 --chunked-prefill-size=$PREFILL_SIZE \
 --mem-fraction-static=0.8 \
 --disable-radix-cache \
 --num-continuous-decode-steps=4 \
 --max-prefill-tokens=$PREFILL_SIZE \
---cuda-graph-max-bs=128 \
+--cuda-graph-max-bs=512 \
 --attention-backend aiter \
 --kv-cache-dtype fp8_e4m3 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3919,3 +3919,8 @@
     - "Also update all configs for DSR1 TRTLLM FP8 to reflect latest released image usage"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1767
   
+  - config-keys:
+    - dsr1-fp4-mi355x-sglang
+  description:
+    - "Introduce EP configurations"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1811


### PR DESCRIPTION
This PR does two things for DSR1-FP4 SGLang for MI355x:
1. Adding EP configurations 
2. Update the sglang image to 0.5.13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and CI config only; no production serving or security paths. Main operational impact is longer/more expensive GPU sweeps from higher concurrency and new EP matrix points.
> 
> **Overview**
> Extends **`dsr1-fp4-mi355x-sglang`** in `amd-master.yaml` for DeepSeek-R1 FP4 on MI355X: SGLang image **v0.5.12 → v0.5.13**, fixed-seq-len concurrency sweeps **conc-end 64 → 256** for TP-only points, and new **expert-parallel** search-space rows (**TP4/EP4** and **TP8/EP8**) for both 1k/1k and 8k/1k scenarios.
> 
> **`dsr1_fp4_mi355x.sh`** now requires **`EP_SIZE`**, passes **`--ep-size`** when EP &gt; 1, and raises **`--cuda-graph-max-bs`** from **128 → 512** to match the wider concurrency range.
> 
> Documents the change under **`dsr1-fp4-mi355x-sglang`** in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008eeaa5d8afcadb678599144de5e0bdd17237c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->