### PR TITLE
Integrate GKE TPU v7 runner for Qwen.

### DIFF
--- a/runners/README_TPU.md
+++ b/runners/README_TPU.md
@@ -1,0 +1,127 @@
+# Running InferenceX on Google Cloud TPU v7 (GKE)
+
+This directory contains the automation scripts to benchmark LLM inference performance on Google Cloud's TPU v7 chips using Kubernetes.
+
+## Prerequisites
+
+1.  **GCP Project**: A Google Cloud project with billing enabled (e.g., `cloud-tpu-inference-test`).
+2.  **TPU v7 Quota**: Ensure your project has sufficient quota for `TPU v7` in your target region (e.g., `us-central1`).
+3.  **CLI Tools**: Install and configure [gcloud](https://cloud.google.com/sdk/docs/install) and [kubectl](https://kubernetes.io/docs/tasks/tools/).
+
+---
+
+## 1. Environment Setup
+
+### Create a GKE Cluster with TPU v7
+Run the following command to create a GKE cluster optimized for TPU workloads. Replace `<PROJECT_ID>` and `<REGION>` with your actual values (e.g., region `us-central1` or zone `us-central1-c`).
+
+```bash
+gcloud container clusters create tpu-v7-bench-cluster \
+    --project=<PROJECT_ID> \
+    --region=<REGION> \
+    --release-channel=rapid \
+    --tpu-v7-node-pool \
+    --machine-type=ct7p-hightpu-4vcpu \
+    --num-nodes=1
+```
+
+### Authentication setup
+If you hit authentication issues with the `gke-gcloud-auth-plugin` stating that it cannot find credentials, authenticate your local Application Default Credentials (ADC) first:
+
+```bash
+gcloud auth application-default login
+```
+
+Then authenticate `kubectl` to connect to your GKE cluster:
+```bash
+# Zonal Cluster:
+gcloud container clusters get-credentials <CLUSTER_NAME> --zone=<ZONE>
+
+# Regional Cluster:
+gcloud container clusters get-credentials <CLUSTER_NAME> --region=<REGION>
+```
+
+### Install/Upgrade JobSet Controller
+The TPU runner uses the `JobSet` API to coordinate the inference server and the benchmark client. Install the controller in your cluster:
+
+```bash
+VERSION=v0.12.0 # Use the latest stable version
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/$VERSION/manifests.yaml
+```
+
+Verify that the JobSet controller has successfully booted:
+```bash
+kubectl get pods -n jobset-system
+```
+Wait until the status is `Running` and the ready containers read `1/1` (or `2/2` depending on version).
+
+---
+
+## 2. Running the Benchmark
+
+The `launch_tpu-v7-gke.sh` script automates the entire sweep process (iterating through different sequence lengths and concurrencies).
+
+### Run the Full Sweep
+Execute the launcher script directly to run the complete sweep of sequence lengths and concurrencies:
+
+```bash
+./launch_tpu-v7-gke.sh
+```
+
+### Run a Local Smoke Test (Single Point Validation)
+You can override the sweep parameters from the command line using environment variables without modifying the script files. This is useful for quickly validating the setup:
+
+```bash
+ISL_LIST="1024" OSL_LIST="1024" CONC_LIST="4" TP=8 ./launch_tpu-v7-gke.sh
+```
+
+### Expected Run Timeline
+Here is the step-by-step estimated time required for a full 14-point benchmark sweep (Qwen-397B FP8, TP=8):
+
+| Phase | Duration (Initial Run) | Duration (Subsequent Runs) | Description |
+| :--- | :--- | :--- | :--- |
+| **1. Node Scheduling & Init** | 1 - 3 mins | 1 - 3 mins | GKE allocates TPU nodes and pulls the container image. |
+| **2. Weight Loading** | ~15 mins | **0 seconds** | Downloads 378 GB weights from GCS on first run; reads from host RAM disk thereafter. |
+| **3. JAX Warmup (Compile)** | ~1.5 hours | **~2 mins** | Compiles 70 static shapes from scratch on first run; hits the persistent JAX cache thereafter. |
+| **4. Benchmark Execution** | ~35 - 45 mins | ~35 - 45 mins | Sequentially executes the 14 configurations (2-3 mins per test point). |
+| **5. Host RAM Purging** | 1 - 2 mins | 1 - 2 mins | Clears weight caches from host RAM disk while preserving the JAX compile cache. |
+| **Total Duration** | **~2.5 hours** | **~40 - 55 mins** | Caching reduces subsequent runs to under an hour. |
+
+### Advanced Configuration
+You can override models, images, or TP settings via environment variables:
+
+```bash
+# Example: Testing a different model and TP size
+export TP=4
+export MODEL_NAME="your-custom-model"
+export MODEL_WEIGHTS_PATH="gs://your-bucket/weights/"
+export IMAGE="your-custom-vllm-image"
+
+./launch_tpu-v7-gke.sh
+```
+
+### 🎛️ Single-Node vs. Multi-Node Mode (TP=8)
+By default, running `TP=8` on GKE will schedule the workload entirely on a **single physical host** (`TPU_TOPOLOGY="2x2x1"` / `TPU_REPLICAS=1`) for maximum performance (reaching parity with CDK bare-metal), though it restricts active HBM memory headroom to $32\text{ GB}$ (higher OOM risk under `CONC >= 128`):
+
+```bash
+# Run TP=8 on a single host (Default, maximum performance, tight HBM headroom)
+./launch_tpu-v7-gke.sh
+
+# Run TP=8 across 2 hosts (Multi-Host, maximum HBM headroom, slight network latency)
+TP=8 TPU_REPLICAS=2 TPU_TOPOLOGY=2x2x2 ./launch_tpu-v7-gke.sh
+```
+
+---
+
+## 3. How it Works & Output
+
+1.  **Consolidated Mesh Orchestration**: The script deploys a **single unified Kubernetes JobSet** (`tpu-v7-jobset.yaml.template`) covering the entire sweep space. This avoids repeated GKE cluster node re-allocations and weight downloading, and completely prevents Double-Loading RAM OOMs.
+2.  **Resource Configuration**: The requested TPU chips and GKE TPU topology selector are automatically determined from the `$TP` parameter (e.g., TP=8 maps to 8 chips with topology `2x2x2`).
+3.  **JAX Cache Preservation**: JAX compilation caching is enabled via `JAX_COMPILATION_CACHE_DIR` pointing to `/root/.cache`. By running a targeted Host Purge DaemonSet after the run, we clean up the massive 378 GB weights while preserving the compile cache. Subsequent warmups are cut from 1.5 hours to 2 minutes.
+4.  **Logging-based Data Collection**: Once the sequential benchmark loop completes inside the container, results are dumped to the container's stdout logs. The script downloads these logs via `kubectl logs`, parses the output markers, and reconstructs the 14 individual result JSON files locally.
+5.  **Standardization**: The script automatically calls `utils/process_result.py` to convert the raw metrics into standard InferenceX dashboard JSON format (`results/agg_*.json`).
+    
+    > [!IMPORTANT]
+    > **Local Output Only**: The current TPU GKE runner pipeline **only** generates the local `results/agg_*.json` result files. Automatic telemetry ingestion into the production database (InferenceX dashboard website) is currently **not** supported for GKE TPU runs.
+    > 
+    > **TODO**: Sync results to the iX Neon database automatically.

--- a/runners/launch_tpu-v7-gke.sh
+++ b/runners/launch_tpu-v7-gke.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# InferenceX TPU v7 Runner for GKE
+#
+# This script launches benchmark jobs on a Google Kubernetes Engine (GKE) cluster
+# equipped with TPU v7 chips.
+
+set -e
+
+# --- 1. Basic Configuration ---
+export RUNNER_TYPE="tpu-v7"
+export FRAMEWORK="vllm-tpu"
+export PRECISION="fp8"
+# Recommended image for TPU v7
+export IMAGE="${IMAGE:-us-central1-docker.pkg.dev/cloud-tpu-inference-test/wyzhang/vllm:inferencex_v1.06_04}"
+export MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3.5-397B-A17B-FP8}"
+export MODEL_WEIGHTS_PATH="${MODEL_WEIGHTS_PATH:-gs://sangamjindal/Qwen3.5-397B-A17B-FP8/}"
+
+# Load iX library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../benchmarks/benchmark_lib.sh"
+
+# --- 2. Sweep Parameters ---
+if [ -n "$ISL_LIST" ]; then
+    read -r -a ISL_LIST <<< "$ISL_LIST"
+else
+    ISL_LIST=(1024 8192)
+fi
+
+if [ -n "$OSL_LIST" ]; then
+    read -r -a OSL_LIST <<< "$OSL_LIST"
+else
+    OSL_LIST=(1024)
+fi
+
+if [ -n "$CONC_LIST" ]; then
+    read -r -a CONC_LIST <<< "$CONC_LIST"
+else
+    CONC_LIST=(4 8 16 32 64 128 256)
+fi
+
+# Determine TPU resource configuration based on TP
+export TP="${TP:-8}"
+if [ "$TP" -eq 8 ]; then
+    export TPU_REPLICAS="${TPU_REPLICAS:-1}"
+    export TPU_CHIPS="${TPU_CHIPS:-4}"
+    export TPU_TOPOLOGY="${TPU_TOPOLOGY:-2x2x1}"
+elif [ "$TP" -eq 4 ]; then
+    export TPU_REPLICAS="${TPU_REPLICAS:-1}"
+    export TPU_CHIPS="${TPU_CHIPS:-4}"
+    export TPU_TOPOLOGY="${TPU_TOPOLOGY:-2x2x1}"
+elif [ "$TP" -eq 2 ]; then
+    # Minimum topology for TPU v7 on GKE is 4 chips (2x2x1), so we run TP=2 on it
+    export TPU_REPLICAS="${TPU_REPLICAS:-1}"
+    export TPU_CHIPS="${TPU_CHIPS:-4}"
+    export TPU_TOPOLOGY="${TPU_TOPOLOGY:-2x2x1}"
+else
+    echo "Unsupported TP: $TP. Supported values are 2, 4, 8."
+    exit 1
+fi
+
+# Check for prerequisites
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl is not installed."
+    exit 1
+fi
+
+mkdir -p "${SCRIPT_DIR}/../results"
+
+# --- 3. Compute Sweep Constraints & Format Lists ---
+MAX_ISL=0
+for isl in "${ISL_LIST[@]}"; do
+    if [ "$isl" -gt "$MAX_ISL" ]; then
+        MAX_ISL="$isl"
+    fi
+done
+
+MAX_OSL=0
+for osl in "${OSL_LIST[@]}"; do
+    if [ "$osl" -gt "$MAX_OSL" ]; then
+        MAX_OSL="$osl"
+    fi
+done
+
+# Format lists as space-separated strings for bash arrays in the container
+ISL_LIST_STR="${ISL_LIST[*]}"
+OSL_LIST_STR="${OSL_LIST[*]}"
+CONC_LIST_STR="${CONC_LIST[*]}"
+
+# Create a unique job name
+TIMESTAMP=$(date +%H%M%S)
+export JOB_NAME="ix-tpu-v7-sweep-${TIMESTAMP}"
+
+echo "============================================================"
+echo "LAUNCHING GKE TPU SWEEP JOB: ${JOB_NAME}"
+echo "ISL LIST   : ${ISL_LIST_STR}"
+echo "OSL LIST   : ${OSL_LIST_STR}"
+echo "CONC LIST  : ${CONC_LIST_STR}"
+echo "MAX LENGTH : ${MAX_ISL} + ${MAX_OSL} + 20"
+echo "============================================================"
+
+# Generate Job YAML from template
+TEMPLATE_PATH="${SCRIPT_DIR}/tpu-v7-jobset.yaml.template"
+TEMP_YAML=$(mktemp /tmp/tpu-job.XXXXXX)
+
+sed -e "s|\${JOB_NAME}|${JOB_NAME}|g" \
+    -e "s|\${IMAGE}|${IMAGE}|g" \
+    -e "s|\${ISL_LIST}|${ISL_LIST_STR}|g" \
+    -e "s|\${OSL_LIST}|${OSL_LIST_STR}|g" \
+    -e "s|\${CONC_LIST}|${CONC_LIST_STR}|g" \
+    -e "s|\${MAX_ISL}|${MAX_ISL}|g" \
+    -e "s|\${MAX_OSL}|${MAX_OSL}|g" \
+    -e "s|\${MODEL_NAME}|${MODEL_NAME}|g" \
+    -e "s|\${MODEL_WEIGHTS_PATH}|${MODEL_WEIGHTS_PATH}|g" \
+    -e "s|\${TP}|${TP}|g" \
+    -e "s|\${TPU_REPLICAS}|${TPU_REPLICAS}|g" \
+    -e "s|\${TPU_CHIPS}|${TPU_CHIPS}|g" \
+    -e "s|\${TPU_TOPOLOGY}|${TPU_TOPOLOGY}|g" \
+    "${TEMPLATE_PATH}" > "$TEMP_YAML"
+
+# Submit to GKE
+kubectl apply -f "$TEMP_YAML"
+
+echo "Waiting for TPU Sweep Job to complete (this may take up to 30-40 minutes)..."
+kubectl wait --for=condition=Completed jobset/${JOB_NAME} --timeout=2h
+
+# Find master pod name
+POD_NAME=$(kubectl get pods -l jobset.sigs.k8s.io/jobset-name=${JOB_NAME},batch.kubernetes.io/job-completion-index=0 -o jsonpath='{.items[0].metadata.name}')
+
+echo "Job completed successfully. Pulling stdout results log from pod ${POD_NAME}..."
+kubectl logs "${POD_NAME}" -c sidecar-bench > "${SCRIPT_DIR}/../results/raw_logs.txt"
+
+# Reconstruct JSON files locally using inline python
+python3 -c "
+import os, re, json
+log_path = '${SCRIPT_DIR}/../results/raw_logs.txt'
+out_dir = '${SCRIPT_DIR}/../results/bench_results'
+os.makedirs(out_dir, exist_ok=True)
+with open(log_path, 'r') as f:
+    content = f.read()
+match = re.search(r'=== BENCHMARK_JSON_RESULT_START ===\n(.*)\n=== BENCHMARK_JSON_RESULT_END ===', content, re.DOTALL)
+if match:
+    file_blocks = re.split(r'=== RESULT_FILE: (.*) ===', match.group(1))
+    for i in range(1, len(file_blocks), 2):
+        filename = file_blocks[i].strip()
+        with open(os.path.join(out_dir, filename), 'w') as out_f:
+            json.dump(json.loads(file_blocks[i+1].strip()), out_f, indent=2)
+"
+rm -f "${SCRIPT_DIR}/../results/raw_logs.txt"
+
+# --- 4. Process Loop Result Files ---
+echo "Translating and processing sweep results..."
+for file in "${SCRIPT_DIR}/../results/bench_results"/result_*.json; do
+    if [ -f "$file" ]; then
+        # Parse parameters from filename e.g. result_1024_1024_4.json
+        filename=$(basename "$file")
+        parts="${filename#result_}"
+        parts="${parts%.json}"
+        read -r -a params <<< "${parts//_/ }"
+        isl="${params[0]}"
+        osl="${params[1]}"
+        conc="${params[2]}"
+
+        # Standard job result name
+        target_job_name="ix-tpu-v7-${isl}-${osl}-c${conc}-${TIMESTAMP}"
+        target_path="${SCRIPT_DIR}/../results/${target_job_name}.json"
+
+        # Move to standard destination
+        mv "$file" "$target_path"
+
+        # Process the result file for the global dashboard
+        echo "Processing results for ISL=${isl}, OSL=${osl}, CONC=${conc}..."
+        export RESULT_FILENAME="${target_job_name}"
+        export RUNNER_TYPE="tpu-v7"
+        export FRAMEWORK="vllm"
+        export PRECISION="${PRECISION}"
+        export IMAGE="${IMAGE}"
+        export DISAGG="false"
+        export SPEC_DECODING="none"
+        export MODEL_PREFIX="qwen3.5"
+        export TP="${TP}"
+        export EP_SIZE="${EP_SIZE:-1}"
+        export DP_ATTENTION="${DP_ATTENTION:-false}"
+        export ISL="${isl}"
+        export OSL="${osl}"
+
+        cd "${SCRIPT_DIR}/../results"
+        python3 ../utils/process_result.py
+        cd "${SCRIPT_DIR}"
+    fi
+done
+
+# Clean up local temporary results dir
+rm -rf "${SCRIPT_DIR}/../results/bench_results"
+
+# Cleanup GKE JobSet resources
+echo "Cleaning up GKE resources..."
+kubectl delete -f "$TEMP_YAML"
+rm "$TEMP_YAML"
+
+# --- 5. Clean up Host RAM model cache ---
+# Deploy a temporary daemonset to purge the RAM cache (/dev/shm/vllm_cache) to prevent OOM
+echo "Deploying transient cleanup daemonset to purge host /dev/shm memory cache..."
+CLEANUP_YAML="${SCRIPT_DIR}/../scratch/tpu-disk-cleanup.yaml"
+# Ensure namespace is set to kube-system for critical priority
+sed -i '' 's/namespace: default/namespace: kube-system/g' "$CLEANUP_YAML" 2>/dev/null || sed -i 's/namespace: default/namespace: kube-system/g' "$CLEANUP_YAML"
+kubectl apply -f "$CLEANUP_YAML"
+sleep 15
+kubectl delete -f "$CLEANUP_YAML"
+
+echo "============================================================"
+echo "ALL TPU BENCHMARKS SWEEP COMPLETE & RAM CLEANED."
+echo "Results are in the 'results/' directory."
+echo "============================================================"

--- a/runners/tpu-v7-jobset.yaml.template
+++ b/runners/tpu-v7-jobset.yaml.template
@@ -1,0 +1,525 @@
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: ${JOB_NAME}
+spec:
+  successPolicy:
+    operator: All
+    targetReplicatedJobs:
+      - tpu-worker
+  replicatedJobs:
+    - name: tpu-worker
+      replicas: 1
+      template:
+        spec:
+          parallelism: ${TPU_REPLICAS}
+          completions: ${TPU_REPLICAS}
+          completionMode: Indexed
+          template:
+            spec:
+              containers:
+              - name: vllm-server
+                image: ${IMAGE}
+                imagePullPolicy: Always
+                command: ["/bin/bash", "-c"]
+                args:
+                - |
+                  set -x
+                  # Multi-host JAX configuration
+                  export JAX_COORDINATOR_ADDRESS="${JOB_NAME}-tpu-worker-0-0.${JOB_NAME}"
+                  export JAX_COORDINATOR_PORT=1234
+                  export JAX_PROCESS_COUNT=${TPU_REPLICAS}
+                  export JAX_PROCESS_INDEX=$$JOB_COMPLETION_INDEX
+
+                  # Calculation for model length
+                  model_len=$(( ${MAX_ISL} + ${MAX_OSL} + 20 ))
+                  
+                  # Synchronize weight download, startup, and wait for CoreDNS propagation
+                  python3 <<'EOF'
+                  import os
+                  import socket
+                  import time
+                  from google.cloud import storage
+
+                  # 1. Download weights
+                  dest_dir = '/root/.cache/vllm/assets/model_streamer/98418607'
+                  os.makedirs(dest_dir, exist_ok=True)
+                  client = storage.Client()
+                  bucket_src = client.bucket('sangamjindal')
+                  blobs = list(bucket_src.list_blobs(prefix='Qwen3.5-397B-A17B-FP8/'))
+ 
+                  from concurrent.futures import ThreadPoolExecutor
+ 
+                  def download_blob(blob):
+                      if blob.name.endswith('/'):
+                          return
+                      rel_path = os.path.relpath(blob.name, 'Qwen3.5-397B-A17B-FP8')
+                      dest_path = os.path.join(dest_dir, rel_path)
+                      os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                      if not os.path.exists(dest_path) or os.path.getsize(dest_path) != blob.size:
+                          print(f'Downloading {blob.name} to {dest_path}...')
+                          # Re-create client per thread to prevent connection pool sharing issues
+                          thread_client = storage.Client()
+                          thread_bucket = thread_client.bucket('sangamjindal')
+                          thread_blob = thread_bucket.blob(blob.name)
+                          thread_blob.download_to_filename(dest_path)
+                          print(f'Finished {blob.name}')
+ 
+                  with ThreadPoolExecutor(max_workers=16) as executor:
+                      executor.map(download_blob, blobs)
+
+                  # 2. Socket Barrier Sync & IP Exchange
+                  job_index = os.environ.get('JOB_COMPLETION_INDEX', '0')
+                  port = 12345
+
+                  # Get local IP
+                  hostname = socket.gethostname()
+                  local_ip = socket.gethostbyname(hostname)
+
+                  # Get hostnames from environment
+                  job_name = os.environ.get('JOB_NAME', 'ix-tpu-v7-1024-1024-c4-141658')
+                  host0_dns = f"{job_name}-tpu-worker-0-0.{job_name}"
+                  host1_dns = f"{job_name}-tpu-worker-0-1.{job_name}"
+
+                  process_count = int(os.environ.get('JAX_PROCESS_COUNT', '1'))
+                  if process_count > 1:
+                      if job_index == '0':
+                          # Server (Worker 0)
+                          s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                          s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                          s.bind(('0.0.0.0', port))
+                          s.listen(1)
+                          print(f"Worker 0 listening on port {port}...")
+                          conn, addr = s.accept()
+                          worker1_ip = addr[0]
+                          print(f"Worker 1 connected from {worker1_ip}. Exchanging IPs...")
+                          # Send worker 0 IP to worker 1
+                          conn.sendall(local_ip.encode('utf-8'))
+                          conn.close()
+                          s.close()
+                          
+                          actual_worker0_ip = local_ip
+                          actual_worker1_ip = worker1_ip
+                      else:
+                          # Client (Worker 1)
+                          coordinator_host = os.environ.get('JAX_COORDINATOR_ADDRESS', 'localhost')
+                          print(f"Worker 1 attempting to connect to coordinator {coordinator_host}:{port}...")
+                          while True:
+                              try:
+                                  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                                  s.connect((coordinator_host, port))
+                                  # Receive worker 0's IP
+                                  worker0_ip = s.recv(1024).decode('utf-8')
+                                  print(f"Connected to coordinator at {worker0_ip}. Synchronization complete!")
+                                  s.close()
+                                  break
+                              except Exception as e:
+                                  print(f"Connection to coordinator failed: {e}. Sleeping 2s...")
+                                  time.sleep(2)
+                                  
+                          actual_worker0_ip = worker0_ip
+                          actual_worker1_ip = local_ip
+                  else:
+                      actual_worker0_ip = local_ip
+                      actual_worker1_ip = ""
+
+                  # 3. Wait for DNS propagation
+                  if process_count > 1:
+                      print("Waiting for CoreDNS to propagate correct IP records...")
+                      while True:
+                          try:
+                              resolved_worker0_ip = socket.gethostbyname(host0_dns)
+                              resolved_worker1_ip = socket.gethostbyname(host1_dns)
+                              print(f"DNS Resolution: {host0_dns} -> {resolved_worker0_ip} (expected: {actual_worker0_ip})")
+                              print(f"DNS Resolution: {host1_dns} -> {resolved_worker1_ip} (expected: {actual_worker1_ip})")
+                              
+                              if resolved_worker0_ip == actual_worker0_ip and resolved_worker1_ip == actual_worker1_ip:
+                                  print("CoreDNS records are fully synchronized!")
+                                  break
+                          except Exception as e:
+                              print(f"DNS Resolution error: {e}")
+                              
+                          print("DNS records are stale/missing. Sleeping 5s before retry...")
+                          time.sleep(5)
+
+                  # Write to env file
+                  with open('/tmp/signal/resolved_ips.env', 'w') as f:
+                      f.write(f"export resolved_worker0_ip={actual_worker0_ip}\n")
+                      f.write(f"export resolved_worker1_ip={actual_worker1_ip}\n")
+                  EOF
+
+                  # Hotpatch tpu_inference utils.py to handle non-addressable devices memory stats
+                  python3 <<'EOF'
+                  file_path = '/root/cloud-devkit/tpu-inference/tpu_inference/utils.py'
+                  with open(file_path, 'r') as f:
+                      code = f.read()
+
+                  target = "\n".join([line if line.strip() else "" for line in """\
+                      multihost_backend = envs.TPU_MULTIHOST_BACKEND
+                      if multihost_backend == "ray":
+                          # MemoryStats is only supported for addressable PjRt devices.
+                          # Assume all the devices have similar memory usage for now.
+                          # TODO(ranlihao): find a proper way to get the memory usage of each device.
+                          for device in devices:
+                              try:
+                                  hbm_used = device.memory_stats()["bytes_in_use"]
+                                  hbm_limit = device.memory_stats()["bytes_limit"]
+                                  logger.info(
+                                      "Get memory stats for device %s. Assuming all devices have the same usage.",
+                                      device)
+                                  usage.extend([(hbm_used, hbm_limit)] * len(devices))
+                                  break
+                              except Exception as e:
+                                  logger.warning(
+                                      "Failed to get memory stats for device %s: %s. ", device,
+                                      e)
+                      else:
+                          for device in devices:
+                              hbm_used = device.memory_stats()["bytes_in_use"]
+                              hbm_limit = device.memory_stats()["bytes_limit"]
+                              usage.append((hbm_used, hbm_limit))
+                  """.splitlines()])
+
+                  replacement = "\n".join([line if line.strip() else "" for line in """\
+                      import jax
+                      if jax.process_count() > 1:
+                          local_device = None
+                          local_process_index = jax.process_index()
+                          for d in devices:
+                              if d.process_index == local_process_index:
+                                  local_device = d
+                                  break
+                          if local_device is None:
+                              for d in jax.devices():
+                                  if d.process_index == local_process_index:
+                                      local_device = d
+                                      break
+                          if local_device is not None:
+                              try:
+                                  hbm_used = local_device.memory_stats()["bytes_in_use"]
+                                  hbm_limit = local_device.memory_stats()["bytes_limit"]
+                                  usage.extend([(hbm_used, hbm_limit)] * len(devices))
+                              except Exception:
+                                  usage.extend([(0, 95 * 1024 * 1024 * 1024)] * len(devices))
+                          else:
+                              usage.extend([(0, 95 * 1024 * 1024 * 1024)] * len(devices))
+                      else:
+                          for device in devices:
+                              try:
+                                  hbm_used = device.memory_stats()["bytes_in_use"]
+                                  hbm_limit = device.memory_stats()["bytes_limit"]
+                                  usage.append((hbm_used, hbm_limit))
+                              except Exception:
+                                  usage.append((0, 95 * 1024 * 1024 * 1024))
+                  """.splitlines()])
+
+                  if target in code:
+                      code = code.replace(target, replacement)
+                      with open(file_path, 'w') as f:
+                          f.write(code)
+                      print('utils.py patched successfully!')
+                  else:
+                      print('Error: Target string not found in utils.py!')
+                      with open('/tmp/debug_target.txt', 'w') as f:
+                          f.write(target)
+                      with open('/tmp/debug_code.txt', 'w') as f:
+                          f.write(code)
+                  EOF
+
+                  # Hotpatch tpu_inference layers/common/utils.py to handle multi-host Native JAX setups without Ray
+                  python3 <<'EOF'
+                  file_path = '/root/cloud-devkit/tpu-inference/tpu_inference/layers/common/utils.py'
+                  with open(file_path, 'r') as f:
+                      code = f.read()
+                  target1 = "        if multihost_backend != \"ray\" or (isinstance(t, jax.Array)\n                                          and not t.is_fully_addressable):"
+                  replacement1 = "        if jax.process_count() == 1 or (isinstance(t, jax.Array)\n                                          and not t.is_fully_addressable):"
+                  target2 = "            global_array = jax.make_array_from_callback(\n                t.shape, sharding, lambda index: t[index])"
+                  replacement2 = "            global_array = jax.make_array_from_callback(\n                t.shape, sharding, lambda index: t[index], dtype=t.dtype)"
+                  if target1 in code and target2 in code:
+                      code = code.replace(target1, replacement1).replace(target2, replacement2)
+                      with open(file_path, 'w') as f:
+                          f.write(code)
+                      print('layers/common/utils.py patched successfully!')
+                  else:
+                      print('Error: Target code blocks not found in layers/common/utils.py!')
+                  EOF
+
+                  # Hotpatch tpu_inference worker/tpu_worker.py to dynamically resolve local devices based on JAX process index
+                  python3 <<'EOF'
+                  file_path = '/root/cloud-devkit/tpu-inference/tpu_inference/worker/tpu_worker.py'
+                  with open(file_path, 'r') as f:
+                      code = f.read()
+                  lines = code.splitlines()
+                  patched = False
+                  for i, line in enumerate(lines):
+                      if 'self.devices = jax.devices()[:sharding_config.' in line:
+                          indent = len(line) - len(line.lstrip())
+                          lines[i] = ' ' * indent + 'local_process_index = jax.process_index()'
+                          lines[i+1] = ' ' * indent + 'self.devices = [d for d in jax.devices() if d.process_index == local_process_index][:sharding_config.total_devices]'
+                          patched = True
+                          break
+                  if patched:
+                      code = '\n'.join(lines) + '\n'
+                      with open(file_path, 'w') as f:
+                          f.write(code)
+                      print('tpu_worker.py patched successfully!')
+                  else:
+                      print('Error: Target code line not found in tpu_worker.py!')
+                  EOF
+
+                  # Hotpatch tpu_inference models/vllm/experimental/vision_tower_jit.py to check for StageMissingLayer (text-only models)
+                  python3 <<'EOF'
+                  file_path = '/root/cloud-devkit/tpu-inference/tpu_inference/models/vllm/experimental/vision_tower_jit.py'
+                  with open(file_path, 'r') as f:
+                      code = f.read()
+                  lines = code.splitlines()
+                  patched = False
+                  for i, line in enumerate(lines):
+                      if 'def has_jittable_vision(vllm_model) -> bool:' in line:
+                          lines.insert(i + 2, '    if type(getattr(vllm_model, "visual", None)).__name__ == "StageMissingLayer":')
+                          lines.insert(i + 3, '        return False')
+                          patched = True
+                          break
+                  if patched:
+                      code = '\n'.join(lines) + '\n'
+                      with open(file_path, 'w') as f:
+                          f.write(code)
+                      print('vision_tower_jit.py patched successfully!')
+                  else:
+                      print('Error: Target function signature not found in vision_tower_jit.py!')
+                  EOF
+
+                  # Load the resolved IP variables
+                  source /tmp/signal/resolved_ips.env
+
+                  # Override JAX/TPU env vars using the raw IPs
+                  export JAX_COORDINATOR_ADDRESS="${resolved_worker0_ip}"
+                  if [ -n "${resolved_worker1_ip:-}" ]; then
+                      export TPU_PROCESS_ADDRESSES="${resolved_worker0_ip}:8471,${resolved_worker1_ip}:8471"
+                      export TPU_WORKER_HOSTNAMES="${resolved_worker0_ip},${resolved_worker1_ip}"
+                      export JAX_PROCESS_COUNT=2
+                  else
+                      export TPU_PROCESS_ADDRESSES="${resolved_worker0_ip}:8471"
+                      export TPU_WORKER_HOSTNAMES="${resolved_worker0_ip}"
+                      export JAX_PROCESS_COUNT=1
+                  fi
+                  export JAX_PROCESS_INDEX=$$JOB_COMPLETION_INDEX
+                  export TPU_WORKER_ID=$$JOB_COMPLETION_INDEX
+                  export CLOUD_TPU_TASK_ID=$$JOB_COMPLETION_INDEX
+
+                  # Start vLLM server
+                  vllm serve \
+                    /root/.cache/vllm/assets/model_streamer/98418607 \
+                    --served-model-name ${MODEL_NAME} \
+                    --max-model-len=${model_len} \
+                    --tensor-parallel-size=${TP} \
+                    --max-num-batched-tokens=2048 \
+                    --max-num-seqs=64 \
+                    --no-enable-prefix-caching \
+                    --gpu-memory-utilization=0.90 \
+                    --async-scheduling \
+                    --limit-mm-per-prompt '{"image": 0, "video": 0}' \
+                    --kv-cache-dtype=fp8 \
+                    --mamba-ssm-cache-dtype bfloat16 \
+                    --enable-chunked-prefill \
+                    --enable-expert-parallel \
+                    --language-model-only \
+                    --enable-auto-tool-choice \
+                    --tool-call-parser=qwen3_coder \
+                    --reasoning-parser=qwen3 \
+                    --block-size=256 \
+                    --additional-config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}' \
+                    &
+                  
+                  vllm_pid=$$!
+                  while [ ! -f /tmp/signal/done ]; do
+                    if ! kill -0 $$vllm_pid 2>/dev/null; then
+                      echo "vLLM process died, exiting loop."
+                      touch /tmp/signal/done
+                      break
+                    fi
+                    sleep 5
+                  done
+                  kill -9 $$vllm_pid 2>/dev/null || true
+                  exit 0
+                env:
+                - name: ATTN_BUCKETIZED_NUM_REQS
+                  value: "true"
+                - name: ATTN_CUSTOM_NUM_REQS_BUCKETS
+                  value: "1,2,4,8,16,32,64"
+                - name: ONEHOT_MOE_PERMUTE_THRESHOLD
+                  value: "32768"
+                - name: DP_SCHED_BATCH_PREFILL
+                  value: "1"
+                - name: NEW_MODEL_DESIGN
+                  value: "1"
+                - name: USE_MOE_EP_KERNEL
+                  value: "0"
+                - name: RAGGED_GATED_DELTA_RULE_IMPL
+                  value: "chunked_kernel_p_recurrent_kernel_d"
+                - name: MODEL_IMPL_TYPE
+                  value: "vllm"
+                - name: TPU_BACKEND_TYPE
+                  value: "jax"
+                - name: PJRT_DEVICE
+                  value: "TPU"
+                - name: TPU_PREMAPPED_BUFFER_SIZE
+                  value: "17179869184"
+                - name: TPU_PREMAPPED_BUFFER_TRANSFER_THRESHOLD_BYTES
+                  value: "17179869184"
+                - name: TPU_PROCESS_PORT
+                  value: "8471"
+                - name: JOB_NAME
+                  value: "${JOB_NAME}"
+                - name: JAX_PLATFORMS
+                  value: "tpu,cpu"
+                - name: JAX_COORDINATOR_TIMEOUT
+                  value: "1200"
+                - name: JAX_DISTRIBUTED_TIMEOUT
+                  value: "1200"
+                - name: TPU_SDK_GRPC_TIMEOUT_SEC
+                  value: "1200"
+                - name: TPU_LOG_DIR
+                  value: "/root/.cache/tpu_logs"
+                - name: JAX_COMPILATION_CACHE_DIR
+                  value: "/root/.cache/jax_compilation_cache"
+                resources:
+                  limits:
+                    google.com/tpu: "${TPU_CHIPS}"
+                  requests:
+                    google.com/tpu: "${TPU_CHIPS}"
+                volumeMounts:
+                - mountPath: /tmp/signal
+                  name: shared-signal
+                - mountPath: /root/.cache
+                  name: model-cache
+
+              - name: sidecar-bench
+                image: ${IMAGE}
+                command: ["/bin/bash", "-c"]
+                args:
+                - |
+                    set -e
+                    if [ "$$JOB_COMPLETION_INDEX" -eq 0 ]; then
+                        OUTPUT_DIR=/tmp/bench_results
+                        mkdir -p $$OUTPUT_DIR
+                        
+                        # Wait for the IP file to be generated by the server container
+                        while [ ! -f /tmp/signal/resolved_ips.env ]; do sleep 2; done
+
+                        # Load the resolved IP variables
+                        source /tmp/signal/resolved_ips.env
+
+                        # Probe which worker is running the API server (JAX process 0 ends up on either worker0 or worker1)
+                        TARGET_IP=""
+                        while [ -z "${TARGET_IP}" ]; do
+                            for ip in "${resolved_worker0_ip}" "${resolved_worker1_ip}"; do
+                                if [ -n "${ip}" ] && curl -s -f http://${ip}:8000/health > /dev/null; then
+                                    TARGET_IP="${ip}"
+                                    break
+                                fi
+                            done
+                            if [ -z "${TARGET_IP}" ]; then
+                                echo "Waiting for API server to start on any worker IP..."
+                                sleep 5
+                            fi
+                        done
+
+                        echo "API server successfully detected on ${TARGET_IP}:8000"
+
+                        # Parse list variables into bash arrays
+                        read -r -a isls <<< "$$ISL_LIST"
+                        read -r -a osls <<< "$$OSL_LIST"
+                        read -r -a concs <<< "$$CONC_LIST"
+
+                        # Sequential internal loop sweep
+                        for isl in "$${isls[@]}"; do
+                            for osl in "$${osls[@]}"; do
+                                for conc in "$${concs[@]}"; do
+                                    echo "============================================================"
+                                    echo "RUNNING BENCHMARK IN LOOP: ISL=$$isl, OSL=$$osl, CONC=$$conc"
+                                    echo "============================================================"
+                                    python3 /root/cloud-devkit/InferenceX/utils/bench_serving/benchmark_serving.py \
+                                      --host "$${TARGET_IP}" \
+                                      --model "${MODEL_NAME}" \
+                                      --port "8000" \
+                                      --dataset-name random \
+                                      --random-input-len "$$isl" \
+                                      --random-output-len "$$osl" \
+                                      --random-range-ratio "0.8" \
+                                      --num-prompts "$$(( conc * 10 ))" \
+                                      --max-concurrency "$$conc" \
+                                      --save-result \
+                                      --result-dir "$$OUTPUT_DIR" \
+                                      --result-filename "result_$${isl}_$${osl}_$${conc}.json" \
+                                      --ignore-eos
+                                done
+                            done
+                        done
+
+                        touch /tmp/signal/done
+                        echo "All benchmarks complete on master. Dumping logs for output parser..."
+                        
+                        echo "=== BENCHMARK_JSON_RESULT_START ==="
+                        for file in $$OUTPUT_DIR/result_*.json; do
+                            if [ -f "$$file" ]; then
+                                echo "=== RESULT_FILE: $$(basename $$file) ==="
+                                cat "$$file"
+                                echo ""
+                            fi
+                        done
+                        echo "=== BENCHMARK_JSON_RESULT_END ==="
+                        sleep 5
+                    else
+                        echo "Worker pod (rank $$JOB_COMPLETION_INDEX) waiting for completion..."
+                        while [ ! -f /tmp/signal/resolved_ips.env ]; do sleep 2; done
+                        source /tmp/signal/resolved_ips.env
+
+                        # Wait until Worker 0's JAX port is OPEN for the first time
+                        echo "Waiting for Worker 0 JAX port to open..."
+                        while ! timeout 2 bash -c "cat < /dev/null > /dev/tcp/\${resolved_worker0_ip}/8471" 2>/dev/null; do
+                            sleep 2
+                        done
+                        echo "Worker 0 JAX port is open. Monitoring for shutdown..."
+
+                        # Loop and check if Worker 0 (master) is still responsive on port 8471 (JAX)
+                        while true; do
+                            if ! timeout 2 bash -c "cat < /dev/null > /dev/tcp/\${resolved_worker0_ip}/8471" 2>/dev/null; then
+                                echo "Worker 0 JAX port closed. Master pod has completed. Shutting down..."
+                                touch /tmp/signal/done
+                                break
+                            fi
+                            sleep 5
+                        done
+                        echo "Worker pod shutting down."
+                    fi
+                volumeMounts:
+                - mountPath: /tmp/signal
+                  name: shared-signal
+                - mountPath: /root/.cache
+                  name: model-cache
+                env:
+                - name: JOB_COMPLETION_INDEX
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['batch.kubernetes.io/job-completion-index']
+                - name: ISL_LIST
+                  value: "${ISL_LIST}"
+                - name: OSL_LIST
+                  value: "${OSL_LIST}"
+                - name: CONC_LIST
+                  value: "${CONC_LIST}"
+              
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: "tpu7x"
+                cloud.google.com/gke-tpu-topology: "${TPU_TOPOLOGY}"
+              restartPolicy: Never
+              volumes:
+              - emptyDir: {}
+                name: shared-signal
+              - name: model-cache
+                hostPath:
+                  path: /dev/shm/vllm_cache
+                  type: DirectoryOrCreate

--- a/scratch/tpu-disk-cleanup.yaml
+++ b/scratch/tpu-disk-cleanup.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tpu-disk-cleanup
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: tpu-disk-cleanup
+  template:
+    metadata:
+      labels:
+        name: tpu-disk-cleanup
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: "tpu7x"
+      containers:
+      - name: cleanup
+        image: alpine
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          privileged: true
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          echo "=== DISK USAGE ==="
+          df -h /host
+          
+          echo "=== CONTAINERS ==="
+          chroot /host crictl ps -a
+          
+          echo "=== CLEANING CONTAINERS ==="
+          # Remove all exited containers
+          EXITED_CONTAINERS=$(chroot /host crictl ps -a --state Exited -q)
+          if [ -n "$EXITED_CONTAINERS" ]; then
+              chroot /host crictl rm $EXITED_CONTAINERS
+          fi
+          
+          echo "=== CLEANING IMAGES ==="
+          chroot /host crictl rmi --prune || true
+          
+          echo "=== CLEANING SHM, VAR_TMP & STATEFUL_PARTITION MODEL CACHE (PRESERVING JAX CACHE) ==="
+          find /host/dev/shm/vllm_cache/ -mindepth 1 -maxdepth 1 ! -name 'jax_compilation_cache' -exec rm -rf {} +
+          rm -rf /host/var/tmp/vllm_cache/*
+          rm -rf /host/mnt/stateful_partition/vllm_cache/*
+          echo "Model weights cache cleared, JAX compilation cache preserved!"
+          
+          echo "=== DISK USAGE AFTER CLEANUP ==="
+          df -h /host
+          
+          # Keep container running for a bit so we can inspect logs
+          sleep 120
+        volumeMounts:
+        - mountPath: /host
+          name: host-root
+      volumes:
+      - hostPath:
+          path: /
+        name: host-root


### PR DESCRIPTION
### Summary                                                                                                                      
This PR integrates the GKE TPU v7 runner for the `Qwen3.5-397B-A17B-FP8` sweep benchmark.                                                                                      

- Flexible Topology Overrides & Single-Host Default:
       * Made `TPU_REPLICAS`, `TPU_CHIPS`, and `TPU_TOPOLOGY` overridable via environment variables.
       * Set single-host (`TPU_REPLICAS=1` / `TPU_TOPOLOGY="2x2x1"`) as the default configuration for `TP=8` to eliminate inter-host  network latency, matching CDK execution speed. 
-  Documented options in `runners/README_TPU.md`.

### Testing
Staged code was validated end-to-end via GKE single-point smoke test (`ISL=1024, OSL=1024, CONC=4`), running successfully, parsing results correctly, and purging memory without issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cluster automation uses hostNetwork, privileged node cleanup, and runtime patches inside the inference image; failures could affect TPU node disk/RAM or produce misleading benchmarks, but scope is offline benchmarking rather than production serving.
> 
> **Overview**
> Adds a **GKE TPU v7** benchmark path for **Qwen3.5-397B FP8** sweeps: `launch_tpu-v7-gke.sh` drives a single **JobSet** (`tpu-v7-jobset.yaml.template`) over ISL/OSL/concurrency grids, then pulls sidecar logs, rebuilds per-point JSON, and runs existing `process_result.py` into local `results/agg_*.json` (no Neon upload yet).
> 
> The JobSet runs **vLLM on TPU** plus a **benchmark sidecar** on one sweep: GCS weight fetch, multi-host IP/DNS coordination, in-container **hotpatches** for native JAX multi-host, sequential `benchmark_serving.py`, and stdout markers for result extraction. **TP=8** defaults to **single-host** (`TPU_REPLICAS=1`, topology `2x2x1`) with env overrides for multi-node (`TPU_REPLICAS=2`, `2x2x2`); `README_TPU.md` documents cluster/JobSet setup, timelines, and smoke overrides.
> 
> After the job, the launcher deletes the JobSet and applies a short-lived **privileged DaemonSet** (`scratch/tpu-disk-cleanup.yaml`) on TPU nodes to drop huge host RAM model caches under `/dev/shm/vllm_cache` while keeping the JAX compile cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59509b41adf39de39a95686fbd04a44ee8f23e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->