### PR TITLE
[codex] Recover PR 1798 ingest without rerunning sweep

### DIFF
--- a/.github/workflows/recover-pr-1798-ingest.yml
+++ b/.github/workflows/recover-pr-1798-ingest.yml
@@ -1,0 +1,203 @@
+name: Recover PR 1798 ingest
+run-name: "Recover PR #1798 ingest from run 27622347964"
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm:
+                description: "Enter recover-pr-1798 to run the artifact-only recovery"
+                required: true
+                type: string
+
+permissions:
+    actions: read
+    contents: read
+
+jobs:
+    recover-ingest:
+        if: ${{ inputs.confirm == 'recover-pr-1798' }}
+        runs-on: ubuntu-latest
+        env:
+            SOURCE_REPO: SemiAnalysisAI/InferenceX
+            SOURCE_RUN_ID: "27622347964"
+            SOURCE_RUN_ATTEMPT: "2"
+            SOURCE_PR_NUMBER: "1798"
+            SOURCE_HEAD_SHA: ffe21af32e2d7b3fbd568e2f7fc066659d9b16c9
+            TARGET_RUN_ID: "27712344914"
+            TARGET_JOB_ID: "81976315082"
+            ORIGINAL_BASE_SHA: 7b9843d3a6e1fe7a2d92d327e25aae57ed3506c5
+            ORIGINAL_MERGE_SHA: ba5879b126cd6e976518641e5bc88b11976af890
+        steps:
+            - name: Checkout recovery code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 0
+
+            - name: Validate failed target and reusable source run
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+              run: |
+                  target_json=$(gh api "repos/${SOURCE_REPO}/actions/runs/${TARGET_RUN_ID}")
+                  jq -e \
+                    --arg expected_head "$ORIGINAL_MERGE_SHA" \
+                    '.event == "push" and
+                     .status == "completed" and
+                     .conclusion == "failure" and
+                     .path == ".github/workflows/run-sweep.yml" and
+                     .head_sha == $expected_head' \
+                    <<<"$target_json" >/dev/null
+
+                  target_jobs=$(gh api \
+                    "repos/${SOURCE_REPO}/actions/runs/${TARGET_RUN_ID}/jobs?per_page=100")
+                  jq -e \
+                    --argjson expected_job "$TARGET_JOB_ID" \
+                    '.jobs[] |
+                     select(.id == $expected_job and
+                            .name == "setup" and
+                            .conclusion == "failure")' \
+                    <<<"$target_jobs" >/dev/null
+
+                  run_json=$(gh api "repos/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}")
+                  jq -e \
+                    --arg expected_head "$SOURCE_HEAD_SHA" \
+                    --argjson expected_attempt "$SOURCE_RUN_ATTEMPT" \
+                    '.event == "pull_request" and
+                     .status == "completed" and
+                     .conclusion == "success" and
+                     .path == ".github/workflows/run-sweep.yml" and
+                     .head_sha == $expected_head and
+                     .run_attempt == $expected_attempt' \
+                    <<<"$run_json" >/dev/null
+
+                  gh api "repos/${SOURCE_REPO}/pulls/${SOURCE_PR_NUMBER}/commits" \
+                    --paginate --jq '.[].sha' \
+                    | grep -Fxq "$SOURCE_HEAD_SHA"
+
+                  artifacts_json=$(gh api \
+                    "repos/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100")
+                  for required in results_bmk eval_results_all run-stats; do
+                      jq -e --arg name "$required" \
+                        '.artifacts[] | select(.name == $name and (.expired | not))' \
+                        <<<"$artifacts_json" >/dev/null
+                  done
+
+            - name: Reconstruct PR 1798 merge configuration
+              run: |
+                  git checkout --detach "$ORIGINAL_MERGE_SHA"
+                  test "$(git rev-parse "${ORIGINAL_MERGE_SHA}^")" = "$ORIGINAL_BASE_SHA"
+
+                  perl -0pi -e '
+                    $count = s/^- config-keys:\n(?=    - dsr1-fp8-gb300-dynamo-trt\n  description:\n    - "Fix gsm8k)/  - config-keys:\n/m;
+                    END {
+                      die "Expected exactly one PR #1767 indentation repair\n"
+                        unless $count == 1;
+                    }
+                  ' perf-changelog.yaml
+                  grep -A2 '^  - config-keys:$' perf-changelog.yaml \
+                    | grep -q 'dsr1-fp8-gb300-dynamo-trt'
+                  grep -A1 '^- config-keys:$' perf-changelog.yaml \
+                    | grep -q 'glm5-fp4-gb300-dynamo-trt'
+
+                  git add perf-changelog.yaml
+                  fixed_tree=$(git write-tree)
+                  fixed_sha=$(printf '%s\n' \
+                    'Synthetic PR #1798 merge tree without the unrelated PR #1767 indentation repair' \
+                    | git -c user.name='InferenceX Recovery' \
+                          -c user.email='actions@users.noreply.github.com' \
+                          commit-tree "$fixed_tree" -p "$ORIGINAL_BASE_SHA")
+
+                  pip install pydantic
+                  python3 utils/process_changelog.py \
+                    --changelog-file perf-changelog.yaml \
+                    --base-ref "$ORIGINAL_BASE_SHA" \
+                    --head-ref "$fixed_sha" \
+                    > "$RUNNER_TEMP/full-config.json"
+                  jq empty "$RUNNER_TEMP/full-config.json"
+
+                  mkdir -p "$RUNNER_TEMP/changelog-metadata"
+                  jq \
+                    --arg base "$ORIGINAL_BASE_SHA" \
+                    --arg head "$ORIGINAL_MERGE_SHA" \
+                    '.changelog_metadata | .base_ref = $base | .head_ref = $head' \
+                    "$RUNNER_TEMP/full-config.json" \
+                    > "$RUNNER_TEMP/changelog-metadata/changelog_metadata.json"
+
+            - name: Download reusable benchmark artifacts
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+              run: |
+                  artifacts_dir="$RUNNER_TEMP/source-artifacts"
+                  gh run download "$SOURCE_RUN_ID" \
+                    --repo "$SOURCE_REPO" \
+                    -D "$artifacts_dir"
+
+                  rm -rf "$artifacts_dir/changelog-metadata"
+                  for artifact_dir in "$artifacts_dir"/*; do
+                      [ -e "$artifact_dir" ] || continue
+                      name=$(basename "$artifact_dir")
+                      case "$name" in
+                          results_bmk|eval_results_all|run-stats|bmk_*|eval_*|server_logs_*|multinode_server_logs_*|agentic_aggregated)
+                              ;;
+                          *)
+                              rm -rf "$artifact_dir"
+                              ;;
+                      esac
+                  done
+
+                  mkdir -p "$artifacts_dir/reused-ingest-metadata"
+                  jq -n \
+                    --arg source_run_id "$SOURCE_RUN_ID" \
+                    --arg source_run_attempt "$SOURCE_RUN_ATTEMPT" \
+                    --arg source_run_url "https://github.com/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}" \
+                    --arg source_pr_number "$SOURCE_PR_NUMBER" \
+                    --arg source_head_sha "$SOURCE_HEAD_SHA" \
+                    --arg target_run_id "$TARGET_RUN_ID" \
+                    --arg target_job_id "$TARGET_JOB_ID" \
+                    --arg ingest_run_id "$GITHUB_RUN_ID" \
+                    --arg ingest_run_attempt "$GITHUB_RUN_ATTEMPT" \
+                    --arg ingest_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+                    '{
+                      source_run_id: $source_run_id,
+                      source_run_attempt: $source_run_attempt,
+                      source_run_url: $source_run_url,
+                      source_pr_number: $source_pr_number,
+                      source_head_sha: $source_head_sha,
+                      target_run_id: $target_run_id,
+                      target_job_id: $target_job_id,
+                      ingest_run_id: $ingest_run_id,
+                      ingest_run_attempt: $ingest_run_attempt,
+                      ingest_run_url: $ingest_run_url
+                    }' \
+                    > "$artifacts_dir/reused-ingest-metadata/reuse_source_run.json"
+
+            - name: Validate reusable artifacts
+              run: |
+                  python3 utils/validate_reusable_sweep_artifacts.py \
+                    --config-json "$RUNNER_TEMP/full-config.json" \
+                    --artifacts-dir "$RUNNER_TEMP/source-artifacts"
+
+            - name: Upload reusable ingest artifacts
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: reused-ingest-artifacts
+                  path: ${{ runner.temp }}/source-artifacts/*
+
+            - name: Upload PR 1798 changelog metadata
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: changelog-metadata
+                  path: ${{ runner.temp }}/changelog-metadata/changelog_metadata.json
+
+            - name: Trigger database ingest
+              run: |
+                  curl -sSf -X POST \
+                    -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
+                    -H "Accept: application/vnd.github+v3+json" \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
+                    -d '{
+                      "event_type": "ingest-results",
+                      "client_payload": {
+                        "run-id": "${{ github.run_id }}",
+                        "run-attempt": "${{ github.run_attempt }}"
+                      }
+                    }'


### PR DESCRIPTION
## What changed

- adds a manually dispatched, CPU-only recovery workflow for PR #1798
- validates failed push run 27712344914 and setup job 81976315082
- validates and reuses artifacts from successful source run 27622347964, attempt 2
- reconstructs PR #1798 merge metadata without treating its unrelated PR #1767 indentation repair as a changelog deletion
- dispatches the resulting carrier run to InferenceX-app

## Root cause

The push-to-main run failed in setup because PR #1798 corrected the malformed PR #1767 changelog indentation. The changelog processor rejects non-whitespace deletions, so artifact reuse and ingest never ran.

## Safety

- commit and merge message include `[skip-sweep]`
- workflow requires an explicit `recover-pr-1798` confirmation input
- failed target run/job, source run attempt, PR commit, workflow path, conclusion, and required artifacts are validated
- the reconstructed matrix is validated against the downloaded artifacts before dispatch
- no benchmark matrix or GPU runner is referenced

## Validation

- `actionlint .github/workflows/recover-pr-1798-ingest.yml`
- target/source guard script passed locally
- reusable artifact validator passed: 20 benchmark rows and 2 multinode eval jobs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production ingest via repository dispatch and uses a one-off changelog/git reconstruction; mitigated by hard-coded run/SHA checks, artifact validation, and no GPU matrix.
> 
> **Overview**
> Adds a **manually dispatched** GitHub Actions workflow (`recover-pr-1798-ingest.yml`) to finish database ingest for PR #1798 after the post-merge `run-sweep` push failed in **setup**, without rerunning benchmarks on GPU.
> 
> The workflow mirrors the existing PR #1767 recovery pattern but pins **specific** failed push run/job IDs and a successful PR sweep run (attempt 2), and requires typing `recover-pr-1798` to run. It **validates** those runs via the GitHub API (event, workflow path, SHAs, conclusions, non-expired `results_bmk` / `eval_results_all` / `run-stats` artifacts).
> 
> It **reconstructs** the sweep config by building a synthetic tree from the merge commit: a `perl` edit on `perf-changelog.yaml` undoes the unrelated PR #1767 indentation fix so `process_changelog.py` does not treat it as a forbidden deletion, then runs the validator and uploads artifacts plus changelog metadata. Finally it **dispatches** `ingest-results` to `InferenceX-app` with the recovery run id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0a80563cb3d7636f31daa58c8cae8bf51875d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->