### PR TITLE
fix(ci): bound multinode pre-run Slurm cleanup drain loop (unblocks NVIDIA sweeps) / 修复(CI)：限制多节点运行前 Slurm 清理排空循环（解除 NVIDIA 扫描阻塞）

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -172,9 +172,22 @@ jobs:
         run: &slurm-cleanup |
           if command -v squeue >/dev/null 2>&1; then
             echo "[Slurm] Cleaning up jobs with name: ${{ runner.name }} ..."
-            scancel --name="${{ runner.name }}" || true
-            while [ -n "$(squeue --name='${{ runner.name }}' --noheader --format='%i')" ]; do
-              squeue --name="${{ runner.name }}"
+            timeout 30 scancel --name="${{ runner.name }}" 2>/dev/null || true
+            # Bound the drain: on the NVIDIA clusters squeue/scancel hang (zombie
+            # job scancel can't reap, or unresponsive slurmctld), wedging this
+            # step for 15-20min+ and failing every dsr1 multinode leg (gb300-nv,
+            # gb200, b200; CoreWeave is unaffected). timeout-wrap every slurm call
+            # so a hang in the while-condition can't block, and force-KILL +
+            # proceed after 120s rather than looping forever.
+            _drain_deadline=$((SECONDS + 120))
+            while [ -n "$(timeout 30 squeue --name='${{ runner.name }}' --noheader --format='%i' 2>/dev/null)" ]; do
+              if [ "$SECONDS" -ge "$_drain_deadline" ]; then
+                echo "[Slurm] drain exceeded 120s; force-cancelling (KILL) and proceeding"
+                timeout 30 scancel --signal=KILL --name="${{ runner.name }}" 2>/dev/null || true
+                sleep 5
+                break
+              fi
+              timeout 30 squeue --name="${{ runner.name }}" 2>/dev/null || true
               sleep 5
             done
           fi

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -172,18 +172,25 @@ jobs:
         run: &slurm-cleanup |
           if command -v squeue >/dev/null 2>&1; then
             echo "[Slurm] Cleaning up jobs with name: ${{ runner.name }} ..."
-            timeout 30 scancel --name="${{ runner.name }}" 2>/dev/null || true
-            # Bound the drain: on the NVIDIA clusters squeue/scancel hang (zombie
-            # job scancel can't reap, or unresponsive slurmctld), wedging this
-            # step for 15-20min+ and failing every dsr1 multinode leg (gb300-nv,
-            # gb200, b200; CoreWeave is unaffected). timeout-wrap every slurm call
-            # so a hang in the while-condition can't block, and force-KILL +
-            # proceed after 120s rather than looping forever.
-            _drain_deadline=$((SECONDS + 120))
+            # scancel can legitimately run a while: it triggers the node epilog,
+            # which may be a slow/complex script. Give it 5min before giving up
+            # (30s was too short — it could kill an epilog that was still working).
+            timeout 300 scancel --name="${{ runner.name }}" 2>/dev/null || true
+            # Bound the drain: on the NVIDIA clusters squeue/scancel intermittently
+            # HANG (unresponsive slurmctld / munge / network — NOT a stuck job),
+            # wedging this step for 15-20min+ (observed up to 8h) and failing dsr1
+            # multinode legs on gb300-nv, gb200, b200 (CoreWeave unaffected). Proven
+            # live 2026-06-22: gb300-nv_2 answered squeue in 37ms, then the same
+            # runner's cleanup squeue hung >6min only 14min later; gb300-nv_0 hung
+            # concurrently. So: timeout-wrap every slurm call (a hung squeue returns
+            # empty -> the while-condition is false -> loop exits and we proceed),
+            # and cap the whole drain at 5min with a force-KILL instead of looping
+            # forever. A real not-yet-cleared job still gets the full 5min to drain.
+            _drain_deadline=$((SECONDS + 300))
             while [ -n "$(timeout 30 squeue --name='${{ runner.name }}' --noheader --format='%i' 2>/dev/null)" ]; do
               if [ "$SECONDS" -ge "$_drain_deadline" ]; then
-                echo "[Slurm] drain exceeded 120s; force-cancelling (KILL) and proceeding"
-                timeout 30 scancel --signal=KILL --name="${{ runner.name }}" 2>/dev/null || true
+                echo "[Slurm] drain exceeded 5min; force-cancelling (KILL) and proceeding"
+                timeout 60 scancel --signal=KILL --name="${{ runner.name }}" 2>/dev/null || true
                 sleep 5
                 break
               fi


### PR DESCRIPTION
## Problem
`benchmark-multinode-tmpl.yml`'s **"Slurm cleanup (pre-run)"** step drains jobs named after the runner with **no timeout**:
```
scancel --name=$runner || true
while [ -n "$(squeue --name=$runner ...)" ]; do squeue ...; sleep 5; done
```
On the **NVIDIA clusters**, `squeue`/`scancel` hang (a zombie `scancel` can't reap, or an unresponsive `slurmctld`), so the `while`-condition's `$(squeue ...)` blocks and the step wedges **15–20 min+**, failing every dsr1 multinode leg. Observed across **5 wedged sweep runs** on `gb300-nv`, `gb200`, `b200`. **CoreWeave (`gb300-cw`) is unaffected**, so it's NVIDIA-slurm-specific — and the reusable template resolves from `main` for `pull_request`, so a branch-level fix can't apply (must land here).

## Fix
- `timeout 30`-wrap every `scancel`/`squeue` so a hung call can't block the loop condition.
- Add a **120 s deadline → force-`KILL` + proceed** instead of looping forever.

Legs then reach launch (`sbatch` works on these clusters — `glm5-gb300-dynamo-trt` succeeds), unblocking measured-power sweeps for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow shell changes with no application, auth, or data-path impact; worst case is leaving a Slurm job uncleared after forced proceed.
> 
> **Overview**
> The **Slurm cleanup (pre-run)** step in `benchmark-multinode-tmpl.yml` (same YAML anchor as post-run cleanup) no longer blocks indefinitely when NVIDIA-cluster `squeue`/`scancel` hang.
> 
> **`scancel`** is now wrapped in **`timeout 300`** so slow node epilogs can finish without hanging forever. The drain **`while`** loop uses **`timeout 30`** on every **`squeue`** (and periodic status **`squeue`**) so a stuck call returns empty instead of wedging the step. A **5-minute** overall drain deadline triggers **`scancel --signal=KILL`** and exits the loop so benchmarks can proceed to **`sbatch`** even when Slurm control plane calls are unresponsive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a040f5ad909601abff62756ba76a720ba5a5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## 中文说明
修复 `benchmark-multinode-tmpl.yml` 中运行前 Slurm 清理步骤的无超时排空循环问题。在 NVIDIA 集群上，`squeue`/`scancel` 挂起导致步骤阻塞 15-20 分钟以上，影响 `gb300-nv`、`gb200`、`b200` 上所有 dsr1 多节点任务。修复方案：为排空循环添加超时限制和清理逻辑，解除 NVIDIA 扫描阻塞。CoreWeave (`gb300-cw`) 不受影响。
