### PR TITLE
point to sa-submission-q2-2026 branch instead

### DIFF
--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -85,7 +85,7 @@ elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" && $PRECIS
 elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp8" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR" || exit 1
-    git checkout main
+    git checkout sa-submission-q2-2026
     mkdir -p recipes/vllm/minimax-m3
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3" recipes/vllm/minimax-m3
 else


### PR DESCRIPTION
Point to sa-submission-q2-2026 with DP health check fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line branch pin for one benchmark matrix path; no auth, data, or application logic changes.
> 
> **Overview**
> For **dynamo-vllm** multinode runs of **minimaxm3** at **fp8** on the B300 launcher, the `srt-slurm` clone now checks out **`sa-submission-q2-2026`** instead of **`main`**.
> 
> That matches the default branch used for other B300 `srt-slurm` jobs in the same script and pulls in the **DP health check fix** described for this submission branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa925b9889b502bc1eb1e46af3b144a6a0d909a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->