### PR TITLE
fix UCX_ settings to fix nixl handshake failure

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tep8-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tp8-marlin-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tp8-marlin-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p2d-dep2-dep4-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p2d-dep2-dep4-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-dep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-dep8-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-tep8-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p2d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p2d-dep2-tep8-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/3p2d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/3p2d-dep2-tep8-1k1k.yaml
@@ -28,13 +28,11 @@ backend:
   connector: null
 
   prefill_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   decode_environment:
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/1p2d-dep2-dep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/1p2d-dep2-dep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/2p2d-dep2-dep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/2p2d-dep2-dep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/2p2d-dep2-tep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/2p2d-dep2-tep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/3p2d-dep2-dep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/3p2d-dep2-dep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/3p2d-dep2-tep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/3p2d-dep2-tep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/4p2d-dep2-dep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/4p2d-dep2-dep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/4p3d-dep2-dep4-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/4p3d-dep2-dep4-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/5p2d-dep2-tep8-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/5p2d-dep2-tep8-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/5p2d-dep2-tp8-marlin-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/8k1k/5p2d-dep2-tp8-marlin-8k1k.yaml
@@ -29,13 +29,11 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    UCX_NET_DEVICES: "all"
-    UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"
+    UCX_TLS: "cuda_copy,rc"
 
   vllm_config:
     prefill:

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -85,7 +85,7 @@ elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm2.5" && $PRECIS
 elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp8" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR" || exit 1
-    git checkout main
+    git checkout sa-submission-q2-2026
     mkdir -p recipes/vllm/minimax-m3
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3" recipes/vllm/minimax-m3
 else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark YAML env vars and an srt-slurm git branch for one model/framework combo; no application or auth logic is touched.
> 
> **Overview**
> Updates **MiniMax-M3 B300 FP8** disaggregated vLLM Slurm recipes so **Nixl** KV transfer can complete its UCX handshake instead of failing with the previous broad TLS/device settings.
> 
> On every affected `1k1k` and `8k1k` recipe, **prefill** and **decode** `backend` environments drop `UCX_NET_DEVICES: "all"` and replace `UCX_TLS: "rc,cuda_ipc,cuda_copy,sm,self,tcp"` with **`UCX_TLS: "cuda_copy,rc"`**, matching the cluster’s mounted UCX stack used for these jobs.
> 
> For **dynamo-vllm** + **minimaxm3** + **fp8**, `launch_b300-nv.sh` now checks out **`sa-submission-q2-2026`** on `srt-slurm` instead of **`main`** before copying the in-repo MiniMax-M3 recipes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63214b5514476a6041aff2db1456cfb767351176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->