### PR TITLE
fix(runners): mi325x launcher squash + hf cache on node-local /raid

### DIFF
--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -118,6 +118,7 @@ mi325x:
 - 'mi325x-amds_06'
 - 'mi325x-amds_07'
 - 'mi325x-amds_08'
+- 'mi325x-amds_09'
 mi325x-disagg:
 - 'mi325x-amds_00'
 - 'mi325x-amds_01'

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HF_HUB_CACHE_MOUNT="/local-nvme/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/raid/hf-hub-cache/"
 
 PARTITION="compute"
-SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+SQUASH_FILE="/raid/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 LOCK_FILE="${SQUASH_FILE}.lock"
 
 # Route spec-decoding=mtp configs to the _mtp benchmark script (parity with


### PR DESCRIPTION
## What

Fix two hardcoded paths in `runners/launch_mi325x-amds.sh` that don't exist / aren't writable on the current mi325x fleet.

```diff
-export HF_HUB_CACHE_MOUNT="/local-nvme/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/raid/hf-hub-cache/"
-SQUASH_FILE="/nfsdata/sa/gharunner/gharunners/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+SQUASH_FILE="/raid/squash/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
```

## Why

1. **Squash path** was under `/nfsdata/sa/gharunner/...` — tied to the old `gharunner` user (runners now run as `gharunner-mi325x`, uid 10020, which can't write that `0750 gharunner:gharunner` dir) and on a mount that only exists on the controller, not the compute nodes where pyxis/enroot read+write the `.sqsh`.
2. **HF cache** pointed at `/local-nvme/hf-hub-cache/`, but the reprovisioned nodes expose the cache at `/raid/hf-hub-cache` (`/local-nvme/hf-hub-cache` does not exist on them).

`/raid` is the local NVMe RAID0 present at the same mount point on every mi325x compute node, satisfying the "exists identically on every compute node" requirement for CI paths. Squash imports stay on fast local storage and work for any runner user (`/raid/squash` is `1777`). Matches the mi300x launcher (`/raid/hf-hub-cache`) and the node-local squash pattern of the mi355x launcher.

## Ops
- `/raid/squash` (`1777`) created on all mi325x compute nodes; the one node without `/raid` (pod2-120, k8s/ZFS) has `/raid/squash` symlinked to its `/nvme` pool.
- Validated end-to-end via an e2e dispatch on this branch against the 10 `mi325x-amds` runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner configuration and launcher path fixes only; no application auth, data, or inference logic changes.
> 
> **Overview**
> Updates **`launch_mi325x-amds.sh`** so CI jobs use paths that exist and are writable on reprovisioned mi325x compute nodes: **`HF_HUB_CACHE_MOUNT`** moves from `/local-nvme/hf-hub-cache/` to **`/raid/hf-hub-cache/`**, and **`SQUASH_FILE`** moves from the controller-only `/nfsdata/sa/gharunner/...` tree to **`/raid/squash/`** (aligned with mi300x HF cache and mi355x-style local squash).
> 
> Registers **`mi325x-amds_09`** in **`.github/configs/runners.yaml`** under the `mi325x` runner pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbe512c67edb26a63807d4a5920cc75261c093a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->