### PR TITLE
chore(runners): register mi325x-amds_09 for sweep scheduling

### DIFF
--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -118,6 +118,7 @@ mi325x:
 - 'mi325x-amds_06'
 - 'mi325x-amds_07'
 - 'mi325x-amds_08'
+- 'mi325x-amds_09'
 mi325x-disagg:
 - 'mi325x-amds_00'
 - 'mi325x-amds_01'


### PR DESCRIPTION
Adds the 10th mi325x runner (`mi325x-amds_09`) to the `mi325x` SKU list in `runners.yaml` so it receives sweep jobs.

The mi325x runner fleet was expanded to **10** runners (`mi325x-amds_00`…`_09`), all registered and **online** under the `gharunner-mi325x` service account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI runner inventory change with no application or security impact; only affects which nodes are eligible for `mi325x` sweeps.
> 
> **Overview**
> Registers the new **`mi325x-amds_09`** node under the **`mi325x`** runner type in `runners.yaml`, so sweep and benchmark workflows that target `runner: mi325x` can schedule jobs on the expanded 10-node fleet.
> 
> No other SKU lists (e.g. **`mi325x-disagg`**) are updated in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf306a3b1d5500ada437b77f6424edd2ca66f302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->