### PR TITLE
[Klaud Cold] MI325X MiniMax-M3 nightly image and FP8 KV cache

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2928,11 +2928,10 @@ minimaxm3-fp8-mi300x-vllm-mtp:
       - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
       - { tp: 8, ep: 8, conc-start: 128, conc-end: 256, spec-decoding: mtp }
 
-# MiniMax-M3 MXFP8 MI325X day-zero recipe. Reuse the dedicated ROCm image
-# and serving flags validated on MI355X, with the H200 search space: TP4 and
-# TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention.
+# MiniMax-M3 MXFP8 MI325X recipe, with the H200 search space: TP4 and TP8
+# latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention.
 minimaxm3-fp8-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:minimax-m3
+  image: vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: mi325x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi325x.sh
@@ -53,6 +53,7 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
+    --kv-cache-dtype fp8 \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3950,3 +3950,11 @@
     - "Update ISL=8192 search-space: TP8-only from conc=4-64, DPA from conc=128-1024 (previously conc=1-64 and DPA conc=64-512)"
     - "Update Applied TBO on high concurrencies"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1717
+
+- config-keys:
+    - minimaxm3-fp8-mi325x-vllm
+  description:
+    - "Update the MI325X MiniMax-M3 vLLM image to vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a"
+    - "Use FP8 KV cache"
+    - "Exclude chi-mi325x-pod2-120, which lacks the required populated /raid/hf-hub-cache"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1836

--- a/runners/launch_mi325x-amds.sh
+++ b/runners/launch_mi325x-amds.sh
@@ -13,7 +13,8 @@ SPEC_SUFFIX=$([[ "${SPEC_DECODING:-}" == "mtp" ]] && printf '_mtp' || printf '')
 
 set -x
 
-JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+# pod2-120 lacks the populated /raid/hf-hub-cache required by the launcher.
+JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --exclude=chi-mi325x-pod2-120.ord.vultr.cpe.ice.amd.com --gres=gpu:$TP --cpus-per-task=256 --time=480 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job" >&2


### PR DESCRIPTION
## What changed

- pin `minimaxm3-fp8-mi325x-vllm` to `vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a`
- launch the MI325X MiniMax-M3 server with `--kv-cache-dtype fp8`
- exclude `chi-mi325x-pod2-120`, which lacks the populated model cache required by the launcher
- append an MI325X-only performance changelog entry

## Why

Use the updated ROCm vLLM build and reduce KV-cache memory use for the MI325X MiniMax-M3 sweep. The node exclusion prevents Pyxis mount failures on the incomplete node.

## Validation

- Bash syntax validation
- targeted MI325X MiniMax-M3 full-sweep config generation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark serving (FP8 KV) and container pin, which can shift throughput/memory vs prior MI325X runs; Slurm exclude only affects which nodes run jobs.
> 
> **Overview**
> Updates the **MI325X MiniMax-M3 MXFP8** vLLM benchmark recipe to a pinned ROCm nightly (`vllm/vllm-openai-rocm:nightly-b53b1c7…`) instead of `vllm/vllm-openai-rocm:minimax-m3`, and starts the server with **`--kv-cache-dtype fp8`** in `minimaxm3_fp8_mi325x.sh` to cut KV memory use on the sweep.
> 
> **MI325X job allocation** now excludes `chi-mi325x-pod2-120` in `launch_mi325x-amds.sh` because that node lacks the populated `/raid/hf-hub-cache` the launcher expects. A **`perf-changelog.yaml`** entry documents the image bump, FP8 KV, and node exclusion for `minimaxm3-fp8-mi325x-vllm`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdb37df3f86c77ce5918651e85a33436d1e158ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->