### PR TITLE
[codex] Fix reusable eval artifact validation

### DIFF
--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -68,16 +68,10 @@ jobs:
         run: |
           expect_rejected() {
               local label="$1"
-              local expected="$2"
-              shift 2
+              shift
               local output
               if output="$("$@" 2>&1)"; then
                   echo "::error::${label} was unexpectedly accepted"
-                  return 1
-              fi
-              if ! grep -Fq -- "$expected" <<<"$output"; then
-                  echo "::error::${label} failed for the wrong reason; expected output containing: ${expected}"
-                  printf '%s\n' "$output"
                   return 1
               fi
               echo "${label} was rejected as expected"
@@ -90,54 +84,40 @@ jobs:
             --head-ref d99c824b1c4f0b1b007631191657e458ef2a332c
 
           expect_rejected "PR #1767 malformed merge state" \
-            "trailing whitespace" \
             python utils/validate_perf_changelog.py \
               --changelog-file perf-changelog.yaml \
               --base-ref 7b9843d3a6e1fe7a2d92d327e25aae57ed3506c5^ \
               --head-ref 7b9843d3a6e1fe7a2d92d327e25aae57ed3506c5 \
               --pr-number 1767
 
-          git fetch --no-tags origin \
-            "+refs/pull/1798/head:refs/remotes/origin/pr-1798-head"
           expect_rejected "PR #1798 invalid merge state" \
-            "trailing whitespace" \
             python utils/validate_perf_changelog.py \
               --changelog-file perf-changelog.yaml \
-              --base-ref "refs/remotes/origin/pr-1798-head^1" \
-              --head-ref refs/remotes/origin/pr-1798-head \
+              --base-ref 8aaff9fbb645ae9df9ba7593fa63273f839b62fb^1 \
+              --head-ref 8aaff9fbb645ae9df9ba7593fa63273f839b62fb \
               --pr-number 1798
 
       - name: Validate the associated pull request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PRS="$(
-              gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --state open \
-                --head "$GITHUB_REF_NAME" \
-                --json number,baseRefName,headRefOid
+          PR_INFO="$(
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+                --jq '
+                  [.[] | select(.state == "open")]
+                  | first
+                  | if . == null then "" else ([.number, .base.ref] | @tsv) end
+                '
           )"
-          PR_COUNT="$(jq 'length' <<<"$PRS")"
 
-          if [ "$PR_COUNT" -eq 0 ]; then
-              echo "::notice::No open pull request found for branch ${GITHUB_REF_NAME}; skipping PR-diff validation"
+          if [ -z "$PR_INFO" ]; then
+              echo "::notice::No open pull request is associated with ${GITHUB_SHA}; skipping PR-diff validation"
               exit 0
           fi
-          if [ "$PR_COUNT" -ne 1 ]; then
-              echo "::error::Expected exactly one open pull request for branch ${GITHUB_REF_NAME}; found ${PR_COUNT}"
-              jq -r '.[] | "  #\(.number) base=\(.baseRefName) head=\(.headRefOid)"' <<<"$PRS"
-              exit 1
-          fi
 
-          PR_NUMBER="$(jq -r '.[0].number' <<<"$PRS")"
-          BASE_BRANCH="$(jq -r '.[0].baseRefName' <<<"$PRS")"
-          PR_HEAD_SHA="$(jq -r '.[0].headRefOid' <<<"$PRS")"
-          if [ "$PR_HEAD_SHA" != "$GITHUB_SHA" ]; then
-              echo "::error::PR #${PR_NUMBER} head ${PR_HEAD_SHA} does not match pushed SHA ${GITHUB_SHA}"
-              exit 1
-          fi
-
+          IFS=$'\t' read -r PR_NUMBER BASE_BRANCH <<<"$PR_INFO"
           git fetch --no-tags origin \
             "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
 

--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -68,10 +68,16 @@ jobs:
         run: |
           expect_rejected() {
               local label="$1"
-              shift
+              local expected="$2"
+              shift 2
               local output
               if output="$("$@" 2>&1)"; then
                   echo "::error::${label} was unexpectedly accepted"
+                  return 1
+              fi
+              if ! grep -Fq -- "$expected" <<<"$output"; then
+                  echo "::error::${label} failed for the wrong reason; expected output containing: ${expected}"
+                  printf '%s\n' "$output"
                   return 1
               fi
               echo "${label} was rejected as expected"
@@ -84,40 +90,54 @@ jobs:
             --head-ref d99c824b1c4f0b1b007631191657e458ef2a332c
 
           expect_rejected "PR #1767 malformed merge state" \
+            "trailing whitespace" \
             python utils/validate_perf_changelog.py \
               --changelog-file perf-changelog.yaml \
               --base-ref 7b9843d3a6e1fe7a2d92d327e25aae57ed3506c5^ \
               --head-ref 7b9843d3a6e1fe7a2d92d327e25aae57ed3506c5 \
               --pr-number 1767
 
+          git fetch --no-tags origin \
+            "+refs/pull/1798/head:refs/remotes/origin/pr-1798-head"
           expect_rejected "PR #1798 invalid merge state" \
+            "trailing whitespace" \
             python utils/validate_perf_changelog.py \
               --changelog-file perf-changelog.yaml \
-              --base-ref 8aaff9fbb645ae9df9ba7593fa63273f839b62fb^1 \
-              --head-ref 8aaff9fbb645ae9df9ba7593fa63273f839b62fb \
+              --base-ref "refs/remotes/origin/pr-1798-head^1" \
+              --head-ref refs/remotes/origin/pr-1798-head \
               --pr-number 1798
 
       - name: Validate the associated pull request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PR_INFO="$(
-              gh api \
-                -H "Accept: application/vnd.github+json" \
-                "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-                --jq '
-                  [.[] | select(.state == "open")]
-                  | first
-                  | if . == null then "" else ([.number, .base.ref] | @tsv) end
-                '
+          PRS="$(
+              gh pr list \
+                --repo "$GITHUB_REPOSITORY" \
+                --state open \
+                --head "$GITHUB_REF_NAME" \
+                --json number,baseRefName,headRefOid
           )"
+          PR_COUNT="$(jq 'length' <<<"$PRS")"
 
-          if [ -z "$PR_INFO" ]; then
-              echo "::notice::No open pull request is associated with ${GITHUB_SHA}; skipping PR-diff validation"
+          if [ "$PR_COUNT" -eq 0 ]; then
+              echo "::notice::No open pull request found for branch ${GITHUB_REF_NAME}; skipping PR-diff validation"
               exit 0
           fi
+          if [ "$PR_COUNT" -ne 1 ]; then
+              echo "::error::Expected exactly one open pull request for branch ${GITHUB_REF_NAME}; found ${PR_COUNT}"
+              jq -r '.[] | "  #\(.number) base=\(.baseRefName) head=\(.headRefOid)"' <<<"$PRS"
+              exit 1
+          fi
 
-          IFS=$'\t' read -r PR_NUMBER BASE_BRANCH <<<"$PR_INFO"
+          PR_NUMBER="$(jq -r '.[0].number' <<<"$PRS")"
+          BASE_BRANCH="$(jq -r '.[0].baseRefName' <<<"$PRS")"
+          PR_HEAD_SHA="$(jq -r '.[0].headRefOid' <<<"$PRS")"
+          if [ "$PR_HEAD_SHA" != "$GITHUB_SHA" ]; then
+              echo "::error::PR #${PR_NUMBER} head ${PR_HEAD_SHA} does not match pushed SHA ${GITHUB_SHA}"
+              exit 1
+          fi
+
           git fetch --no-tags origin \
             "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
 

--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -121,6 +121,13 @@ jobs:
           git fetch --no-tags origin \
             "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
 
+          if git diff --quiet \
+            "origin/${BASE_BRANCH}...${GITHUB_SHA}" \
+            -- perf-changelog.yaml; then
+              echo "::notice::PR #${PR_NUMBER} does not change perf-changelog.yaml; skipping PR-diff validation"
+              exit 0
+          fi
+
           python utils/validate_perf_changelog.py \
             --changelog-file perf-changelog.yaml \
             --base-ref "origin/${BASE_BRANCH}" \

--- a/utils/changelog_gate_tests/test_validate_perf_changelog.py
+++ b/utils/changelog_gate_tests/test_validate_perf_changelog.py
@@ -271,46 +271,6 @@ def test_changelog_gate_skips_prs_without_changelog_changes() -> None:
     assert "skipping PR-diff validation" in script
 
 
-def test_changelog_gate_resolves_the_exact_branch_head_pr() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    workflow = yaml.load(
-        (repo_root / ".github/workflows/test-changelog-gate.yml").read_text(),
-        Loader=yaml.BaseLoader,
-    )
-    steps = workflow["jobs"]["test-changelog"]["steps"]
-    validate_step = next(
-        step
-        for step in steps
-        if step.get("name") == "Validate the associated pull request"
-    )
-    script = validate_step["run"]
-
-    assert "gh pr list" in script
-    assert 'GITHUB_REF_NAME' in script
-    assert "PR_COUNT" in script
-    assert "PR_HEAD_SHA" in script
-    assert "does not match pushed SHA" in script
-
-
-def test_historical_rejections_must_match_the_expected_reason() -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    workflow = yaml.load(
-        (repo_root / ".github/workflows/test-changelog-gate.yml").read_text(),
-        Loader=yaml.BaseLoader,
-    )
-    steps = workflow["jobs"]["test-changelog"]["steps"]
-    historical_step = next(
-        step
-        for step in steps
-        if step.get("name") == "Test historical push validation"
-    )
-    script = historical_step["run"]
-
-    assert "grep -Fq" in script
-    assert "refs/pull/1798/head" in script
-    assert script.count('"trailing whitespace"') == 2
-
-
 def test_merge_helper_waits_for_changelog_check_before_merge() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     script = (repo_root / "utils/merge_with_reuse.sh").read_text()

--- a/utils/changelog_gate_tests/test_validate_perf_changelog.py
+++ b/utils/changelog_gate_tests/test_validate_perf_changelog.py
@@ -252,6 +252,25 @@ def test_run_sweep_checks_changelog_before_reuse_and_setup() -> None:
     )
 
 
+def test_changelog_gate_skips_prs_without_changelog_changes() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = yaml.load(
+        (repo_root / ".github/workflows/test-changelog-gate.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    steps = workflow["jobs"]["test-changelog"]["steps"]
+    validate_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Validate the associated pull request"
+    )
+    script = validate_step["run"]
+
+    assert "git diff --quiet" in script
+    assert "-- perf-changelog.yaml" in script
+    assert "skipping PR-diff validation" in script
+
+
 def test_merge_helper_waits_for_changelog_check_before_merge() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     script = (repo_root / "utils/merge_with_reuse.sh").read_text()

--- a/utils/changelog_gate_tests/test_validate_perf_changelog.py
+++ b/utils/changelog_gate_tests/test_validate_perf_changelog.py
@@ -271,6 +271,46 @@ def test_changelog_gate_skips_prs_without_changelog_changes() -> None:
     assert "skipping PR-diff validation" in script
 
 
+def test_changelog_gate_resolves_the_exact_branch_head_pr() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = yaml.load(
+        (repo_root / ".github/workflows/test-changelog-gate.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    steps = workflow["jobs"]["test-changelog"]["steps"]
+    validate_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Validate the associated pull request"
+    )
+    script = validate_step["run"]
+
+    assert "gh pr list" in script
+    assert 'GITHUB_REF_NAME' in script
+    assert "PR_COUNT" in script
+    assert "PR_HEAD_SHA" in script
+    assert "does not match pushed SHA" in script
+
+
+def test_historical_rejections_must_match_the_expected_reason() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = yaml.load(
+        (repo_root / ".github/workflows/test-changelog-gate.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    steps = workflow["jobs"]["test-changelog"]["steps"]
+    historical_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Test historical push validation"
+    )
+    script = historical_step["run"]
+
+    assert "grep -Fq" in script
+    assert "refs/pull/1798/head" in script
+    assert script.count('"trailing whitespace"') == 2
+
+
 def test_merge_helper_waits_for_changelog_check_before_merge() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     script = (repo_root / "utils/merge_with_reuse.sh").read_text()

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -9,7 +9,6 @@ from validate_reusable_sweep_artifacts import (
     agentic_key,
     expected_agentic_keys,
     expected_benchmark_keys,
-    expected_eval_artifact_prefixes,
     expected_eval_keys,
     main,
     validate_agentic_artifacts,
@@ -30,10 +29,13 @@ def write_eval_aggregate(
     )
 
 
-def single_eval_entry(conc: int) -> dict:
+def single_eval_entry(
+    conc: int,
+    runner: str = "h100-dgxc-slurm",
+) -> dict:
     return {
         "exp-name": "gptoss_8k1k",
-        "runner": "h100-dgxc-slurm",
+        "runner": runner,
         "model-prefix": "gptoss",
         "precision": "fp4",
         "framework": "vllm",
@@ -46,10 +48,13 @@ def single_eval_entry(conc: int) -> dict:
     }
 
 
-def single_eval_result(conc: int) -> dict:
+def single_eval_result(
+    conc: int,
+    runner: str = "h100-dgxc-slurm",
+) -> dict:
     return {
         "is_multinode": False,
-        "hw": "H100-DGXC-SLURM",
+        "hw": runner.upper(),
         "model_prefix": "gptoss",
         "framework": "vllm",
         "precision": "fp4",
@@ -60,6 +65,29 @@ def single_eval_result(conc: int) -> dict:
         "conc": conc,
         "task": "gsm8k",
     }
+
+
+def single_eval_meta(
+    conc: int,
+    runner: str = "h100-dgxc-slurm",
+) -> dict:
+    row = single_eval_result(conc, runner)
+    row["infmax_model_prefix"] = row.pop("model_prefix")
+    return row
+
+
+def write_raw_eval_artifact(
+    root: Path,
+    conc: int,
+    *,
+    logical_runner: str = "h100-dgxc-slurm",
+    physical_runner: str = "h100-dgxc-slurm_00",
+) -> None:
+    artifact_dir = root / f"eval_result_conc{conc}_{physical_runner}"
+    artifact_dir.mkdir()
+    (artifact_dir / "meta_env.json").write_text(
+        json.dumps(single_eval_meta(conc, logical_runner))
+    )
 
 
 def single_fixed_entry(conc: int) -> dict:
@@ -207,17 +235,18 @@ def test_eval_validation_requires_raw_result_dirs_not_eval_debug_dirs(
         "evals": [single_eval_entry(32), single_eval_entry(64)],
         "multinode_evals": [],
     }
-    prefixes = expected_eval_artifact_prefixes(config)
-    write_eval_aggregate(tmp_path)
+    write_eval_aggregate(
+        tmp_path,
+        [single_eval_result(32), single_eval_result(64)],
+    )
 
     (tmp_path / "eval_server_logs_gptoss_8k1k_runner").mkdir()
     (tmp_path / "eval_gpu_metrics_gptoss_8k1k_runner").mkdir()
-    (tmp_path / f"{prefixes[0]}00").mkdir()
+    write_raw_eval_artifact(tmp_path, 32)
 
-    errors = validate_eval_artifacts(tmp_path, prefixes)
+    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
 
-    assert "missing 1 expected raw eval result artifact dir(s)" in errors
-    assert f"  missing eval artifact prefix: {prefixes[1]}" in errors
+    assert any("missing" in error for error in errors)
 
 
 def test_eval_validation_accepts_all_expected_raw_result_dirs(tmp_path: Path) -> None:
@@ -225,36 +254,66 @@ def test_eval_validation_accepts_all_expected_raw_result_dirs(tmp_path: Path) ->
         "evals": [single_eval_entry(32), single_eval_entry(64)],
         "multinode_evals": [],
     }
-    prefixes = expected_eval_artifact_prefixes(config)
-    write_eval_aggregate(tmp_path)
-    for index, prefix in enumerate(prefixes):
-        (tmp_path / f"{prefix}{index:02d}").mkdir()
+    write_eval_aggregate(
+        tmp_path,
+        [single_eval_result(32), single_eval_result(64)],
+    )
+    write_raw_eval_artifact(tmp_path, 32)
+    write_raw_eval_artifact(
+        tmp_path,
+        64,
+        physical_runner="h100-dgxc-slurm_01",
+    )
 
-    assert validate_eval_artifacts(tmp_path, prefixes) == []
+    assert validate_eval_artifacts(tmp_path, expected_eval_keys(config)) == []
 
 
 def test_eval_validation_rejects_unexpected_result_dir(tmp_path: Path) -> None:
     config = {"evals": [single_eval_entry(32)], "multinode_evals": []}
-    prefixes = expected_eval_artifact_prefixes(config)
-    write_eval_aggregate(tmp_path)
-    (tmp_path / f"{prefixes[0]}00").mkdir()
-    (tmp_path / "eval_unrelated_config").mkdir()
+    write_eval_aggregate(tmp_path, [single_eval_result(32)])
+    write_raw_eval_artifact(tmp_path, 32)
+    write_raw_eval_artifact(
+        tmp_path,
+        64,
+        physical_runner="h100-dgxc-slurm_01",
+    )
 
-    errors = validate_eval_artifacts(tmp_path, prefixes)
+    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
 
-    assert "found 1 unexpected raw eval artifact dir(s)" in errors
+    assert any("unexpected" in error for error in errors)
 
 
 def test_eval_validation_rejects_duplicate_raw_identity(tmp_path: Path) -> None:
     config = {"evals": [single_eval_entry(32)], "multinode_evals": []}
-    prefixes = expected_eval_artifact_prefixes(config)
-    write_eval_aggregate(tmp_path)
-    (tmp_path / f"{prefixes[0]}00").mkdir()
-    (tmp_path / f"{prefixes[0]}01").mkdir()
+    write_eval_aggregate(tmp_path, [single_eval_result(32)])
+    write_raw_eval_artifact(tmp_path, 32)
+    write_raw_eval_artifact(
+        tmp_path,
+        32,
+        physical_runner="h100-dgxc-slurm_01",
+    )
 
-    errors = validate_eval_artifacts(tmp_path, prefixes)
+    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
 
-    assert any("matched 2 raw result artifact dirs" in error for error in errors)
+    assert any("duplicate" in error for error in errors)
+
+
+def test_eval_validation_uses_logical_runner_from_metadata(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "evals": [single_eval_entry(64, "mi300x")],
+        "multinode_evals": [],
+    }
+    write_eval_aggregate(tmp_path, [single_eval_result(64, "mi300x")])
+    write_raw_eval_artifact(
+        tmp_path,
+        64,
+        logical_runner="mi300x",
+        physical_runner="mi300x-amds_04",
+    )
+
+    assert validate_eval_artifacts(tmp_path, expected_eval_keys(config)) == []
 
 
 def test_eval_aggregate_validation_is_exact(tmp_path: Path) -> None:
@@ -262,20 +321,21 @@ def test_eval_aggregate_validation_is_exact(tmp_path: Path) -> None:
         "evals": [single_eval_entry(32)],
         "multinode_evals": [],
     }
-    prefixes = expected_eval_artifact_prefixes(config)
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(64)],
     )
-    (tmp_path / f"{prefixes[0]}00").mkdir()
+    write_raw_eval_artifact(tmp_path, 32)
 
     errors = validate_eval_artifacts(
         tmp_path,
-        prefixes,
         expected_eval_keys(config),
     )
 
-    assert "eval aggregate artifacts contain 1 unexpected row(s)" in errors
+    assert any(
+        "eval aggregate" in error and "unexpected" in error
+        for error in errors
+    )
 
 
 def test_eval_aggregate_validation_rejects_duplicate_identity(
@@ -285,20 +345,21 @@ def test_eval_aggregate_validation_rejects_duplicate_identity(
         "evals": [single_eval_entry(32)],
         "multinode_evals": [],
     }
-    prefixes = expected_eval_artifact_prefixes(config)
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(32)],
     )
-    (tmp_path / f"{prefixes[0]}00").mkdir()
+    write_raw_eval_artifact(tmp_path, 32)
 
     errors = validate_eval_artifacts(
         tmp_path,
-        prefixes,
         expected_eval_keys(config),
     )
 
-    assert "eval aggregate artifacts contain 1 duplicate row(s)" in errors
+    assert any(
+        "eval aggregate" in error and "duplicate" in error
+        for error in errors
+    )
 
 
 def test_fixed_sequence_validation_is_exact(tmp_path: Path) -> None:
@@ -460,9 +521,8 @@ def test_eval_only_main_does_not_require_benchmark_artifacts(
     }
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps(config))
-    prefixes = expected_eval_artifact_prefixes(config)
     write_eval_aggregate(tmp_path, [single_eval_result(32)])
-    (tmp_path / f"{prefixes[0]}00").mkdir()
+    write_raw_eval_artifact(tmp_path, 32)
     monkeypatch.setattr(
         sys,
         "argv",

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -30,11 +30,6 @@ def as_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def bool_str(value: Any) -> str:
-    """Render booleans as GitHub Actions does in filenames."""
-    return "true" if as_bool(value) else "false"
-
-
 def load_json(path: Path) -> Any:
     """Load a JSON file."""
     with open(path) as handle:
@@ -475,7 +470,7 @@ def eval_key(row: dict[str, Any]) -> tuple[Any, ...]:
         return (
             "multi",
             normalized_runner(row.get("hw")),
-            row.get("model_prefix"),
+            row.get("model_prefix", row.get("infmax_model_prefix")),
             row.get("framework"),
             row.get("precision"),
             row.get("spec_decoding", "none"),
@@ -492,7 +487,7 @@ def eval_key(row: dict[str, Any]) -> tuple[Any, ...]:
     return (
         "single",
         normalized_runner(row.get("hw")),
-        row.get("model_prefix"),
+        row.get("model_prefix", row.get("infmax_model_prefix")),
         row.get("framework"),
         row.get("precision"),
         row.get("spec_decoding", "none"),
@@ -503,111 +498,64 @@ def eval_key(row: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def expected_eval_artifact_prefixes(config: dict[str, Any]) -> list[str]:
-    """Build expected raw eval result artifact prefixes from matrix entries."""
-    prefixes: list[str] = []
-    for entry in config.get("evals", []) or []:
-        exp_name = entry["exp-name"]
-        prefixes.append(
-            f"eval_{exp_name}_{exp_name}_{entry['precision']}_{entry['framework']}_"
-            f"tp{as_int(entry['tp'])}-ep{as_int(entry.get('ep', 1))}-"
-            f"dpa{bool_str(entry.get('dp-attn', False))}_"
-            f"disagg-{bool_str(entry.get('disagg', False))}_"
-            f"spec-{entry.get('spec-decoding', 'none')}_conc{as_int(entry['conc'])}_"
-            f"{entry['runner']}_"
-        )
-
-    for entry in config.get("multinode_evals", []) or []:
-        exp_name = entry["exp-name"]
-        prefill = entry["prefill"]
-        decode = entry["decode"]
-        conc = "x".join(str(as_int(value)) for value in entry["conc"])
-        prefixes.append(
-            f"eval_{exp_name}_{exp_name}_{entry['precision']}_{entry['framework']}_"
-            f"prefill-tp{as_int(prefill['tp'])}-ep{as_int(prefill.get('ep', 1))}-"
-            f"dp{bool_str(prefill.get('dp-attn', False))}-"
-            f"nw{as_int(prefill.get('num-worker', 0))}_"
-            f"decode-tp{as_int(decode.get('tp', 0))}-ep{as_int(decode.get('ep', 0))}-"
-            f"dp{bool_str(decode.get('dp-attn', False))}-"
-            f"nw{as_int(decode.get('num-worker', 0))}_"
-            f"disagg-{bool_str(entry.get('disagg', False))}_"
-            f"spec-{entry.get('spec-decoding', 'none')}_conc{conc}_"
-            f"{entry['runner']}_"
-        )
-    return prefixes
-
-
-def raw_eval_artifact_names(artifacts_dir: Path) -> set[str]:
-    """Return eval result artifacts, excluding aggregate and debug artifacts."""
-    return {
-        path.name
+def raw_eval_artifact_dirs(artifacts_dir: Path) -> list[Path]:
+    """Return raw eval result artifacts, excluding aggregate and debug artifacts."""
+    return sorted(
+        path
         for path in artifacts_dir.iterdir()
         if path.is_dir()
         and path.name.startswith("eval_")
         and path.name != "eval_results_all"
         and not path.name.startswith("eval_server_logs_")
         and not path.name.startswith("eval_gpu_metrics_")
-    }
+    )
+
+
+def raw_eval_key_rows(
+    artifacts_dir: Path,
+) -> tuple[list[tuple[Any, ...]], list[str]]:
+    """Build logical eval identities from each raw artifact's metadata."""
+    rows: list[tuple[Any, ...]] = []
+    errors: list[str] = []
+    for artifact_dir in raw_eval_artifact_dirs(artifacts_dir):
+        meta_path = artifact_dir / "meta_env.json"
+        if not meta_path.is_file():
+            errors.append(
+                f"raw eval artifact {artifact_dir.name!r} is missing meta_env.json"
+            )
+            continue
+        try:
+            meta = load_json(meta_path)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(
+                f"raw eval artifact {artifact_dir.name!r} has invalid "
+                f"meta_env.json: {exc}"
+            )
+            continue
+        if not isinstance(meta, dict):
+            errors.append(
+                f"raw eval artifact {artifact_dir.name!r} has non-object "
+                "meta_env.json"
+            )
+            continue
+        rows.append(eval_key(meta))
+    return rows, errors
 
 
 def validate_eval_artifacts(
     artifacts_dir: Path,
-    expected_prefixes: list[str],
-    expected_aggregate_keys: set[tuple[Any, ...]] | None = None,
+    expected_keys: set[tuple[Any, ...]],
 ) -> list[str]:
     """Validate exact eval aggregate and raw artifact coverage."""
-    errors: list[str] = []
-    expected = set(expected_prefixes)
-    duplicate_prefixes = [
-        prefix
-        for prefix, count in Counter(expected_prefixes).items()
-        if count > 1
-    ]
-    for prefix in sorted(duplicate_prefixes):
-        errors.append(f"duplicate expected eval artifact prefix: {prefix}")
-
-    actual_names = raw_eval_artifact_names(artifacts_dir)
-    matched: dict[str, list[str]] = {
-        prefix: [] for prefix in expected
-    }
-    unexpected: set[str] = set()
-
-    for name in actual_names:
-        matches = {prefix for prefix in expected if name.startswith(prefix)}
-        if len(matches) == 1:
-            matched[next(iter(matches))].append(name)
-        elif not matches:
-            unexpected.add(name)
-        else:
-            errors.append(
-                f"eval artifact {name!r} matches multiple expected identities"
-            )
-
-    missing = {
-        prefix for prefix, names in matched.items() if not names
-    }
-    if missing:
-        errors.append(f"missing {len(missing)} expected raw eval result artifact dir(s)")
-        for prefix in sorted(missing)[:20]:
-            errors.append(f"  missing eval artifact prefix: {prefix}")
-        if len(missing) > 20:
-            errors.append(f"  ... and {len(missing) - 20} more")
-    if unexpected:
-        errors.append(f"found {len(unexpected)} unexpected raw eval artifact dir(s)")
-        for name in sorted(unexpected)[:20]:
-            errors.append(f"  unexpected eval artifact: {name}")
-        if len(unexpected) > 20:
-            errors.append(f"  ... and {len(unexpected) - 20} more")
-    for prefix, names in sorted(matched.items()):
-        if len(names) > 1:
-            errors.append(
-                f"eval artifact prefix {prefix!r} matched "
-                f"{len(names)} raw result artifact dirs"
-            )
+    raw_rows, errors = raw_eval_key_rows(artifacts_dir)
+    errors.extend(duplicate_identity_errors("raw eval", raw_rows))
+    errors.extend(
+        validate_identity_set("raw eval", expected_keys, set(raw_rows))
+    )
 
     aggregate_dir = artifacts_dir / "eval_results_all"
     aggregate_files = list(aggregate_dir.glob("*.json"))
-    if expected:
+    if expected_keys:
         if not aggregate_files:
             errors.append("missing eval_results_all aggregate artifact")
         else:
@@ -624,20 +572,19 @@ def validate_eval_artifacts(
                     )
             if row_count == 0:
                 errors.append("eval_results_all contains no rows")
-            if expected_aggregate_keys is not None:
-                errors.extend(
-                    duplicate_identity_errors(
-                        "eval aggregate",
-                        aggregate_rows,
-                    )
+            errors.extend(
+                duplicate_identity_errors(
+                    "eval aggregate",
+                    aggregate_rows,
                 )
-                errors.extend(
-                    validate_identity_set(
-                        "eval aggregate",
-                        expected_aggregate_keys,
-                        set(aggregate_rows),
-                    )
+            )
+            errors.extend(
+                validate_identity_set(
+                    "eval aggregate",
+                    expected_keys,
+                    set(aggregate_rows),
                 )
+            )
     elif aggregate_dir.exists():
         errors.append("unexpected eval_results_all aggregate artifact")
 
@@ -670,8 +617,7 @@ def main() -> int:
 
     expected_bmk = expected_benchmark_keys(config)
     expected_agentic = expected_agentic_keys(config)
-    expected_eval_prefixes = expected_eval_artifact_prefixes(config)
-    expected_eval_aggregate = expected_eval_keys(config)
+    expected_eval = expected_eval_keys(config)
 
     errors = validate_fixed_artifacts(args.artifacts_dir, expected_bmk)
     if expected_bmk and not (args.artifacts_dir / "results_bmk").is_dir():
@@ -682,8 +628,7 @@ def main() -> int:
     errors.extend(
         validate_eval_artifacts(
             args.artifacts_dir,
-            expected_eval_prefixes,
-            expected_eval_aggregate,
+            expected_eval,
         )
     )
     errors.extend(validate_run_stats(args.artifacts_dir, bool(expected_bmk)))


### PR DESCRIPTION
## Summary

- validate raw eval artifacts from their `meta_env.json` logical matrix identity
- decouple reuse validation from physical GitHub runner names
- add a regression for logical `mi300x` jobs running on `mi300x-amds_04`
- keep failure tests focused on behavior instead of exact diagnostic strings
- skip the test workflow's PR changelog validation when `perf-changelog.yaml` is unchanged

## Root cause

Merge run [27798519988](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27798519988) reused a successful PR sweep, but job [82263580083](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27798519988/job/82263580083) rejected its eval artifacts. The validator built expected artifact prefixes with the logical config runner (`mi300x`), while artifact names contain the physical runner (`mi300x-amds_01` or `mi300x-amds_04`). Valid artifacts were therefore reported as both missing and unexpected.

The initial PR check also failed after all tests passed because `test-changelog-gate.yml` unconditionally validated the associated PR's changelog diff. This PR does not modify `perf-changelog.yaml`, so the validator correctly reported that the file had no changes. The workflow now skips only that final validation when the PR has no changelog diff.

## Impact

Merge-time ingest can now reuse successful eval artifacts from pooled self-hosted runners without depending on runner-name formatting. Missing, unexpected, and duplicate eval identities are still rejected using the artifact metadata. Changelog-changing PRs retain full append-only validation.

## Validation

- `uv run --with pytest --with pydantic --with pyyaml python -m pytest utils/changelog_gate_tests/test_validate_perf_changelog.py utils/test_find_reusable_sweep_run.py utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py utils/changelog_gate_tests/test_recover_failed_ingest.py utils/test_validate_reusable_sweep_artifacts.py utils/changelog_gate_tests/test_run_sweep_gating.py -v` (97 passed)
- `uv run --with pytest --with pydantic --with pyyaml python -m pytest utils/matrix_logic/ -v` (156 passed)
- `actionlint .github/workflows/test-changelog-gate.yml`
- replayed validation against downloaded artifacts from source run `27794193288` (passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge/reuse artifact gating and CI changelog checks for sweep workflows; incorrect logic could allow bad reuse or skip needed validation, but scope is limited to eval artifact matching and optional PR changelog diff.
> 
> **Overview**
> Fixes merge-time reuse rejecting valid eval artifacts when directory names use **physical** runner labels (e.g. `mi300x-amds_04`) while the matrix expects **logical** runners (`mi300x`).
> 
> **Reusable sweep eval validation** no longer matches expected `eval_*` directory prefixes. It reads each raw eval dir’s `meta_env.json`, builds the same logical identity as aggregates (`expected_eval_keys` / `eval_key`), and still enforces exact coverage for raw dirs and `eval_results_all` (missing, unexpected, duplicates). `eval_key` also accepts `infmax_model_prefix` when `model_prefix` is absent.
> 
> **Test changelog workflow** skips the associated-PR `validate_perf_changelog.py` step when the PR diff does not touch `perf-changelog.yaml`, so infra-only PRs are not failed for “no changelog changes.”
> 
> Tests were updated with `meta_env.json`-based fixtures (including logical `mi300x` on physical `mi300x-amds_04`), looser assertions on error text, and a workflow regression for the changelog skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44421d2bcf383524c67aadf6ce642a39899c787f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->