### PR TITLE
Revert "[Klaud Cold] MI300X MiniMax-M3 EAGLE3 nightly image and FP8 KV cache"

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2901,9 +2901,12 @@ minimaxm3-fp8-mi300x-vllm:
 # Inferact/MiniMax-M3-EAGLE3 draft head (3 speculative tokens). Same TP8-only
 # search space as the non-MTP MI300X entry (gfx942 192 GB is memory-tight, like
 # H100), with the TP8 latency rows started at conc 1 to capture single-request
-# latency — matching the H100/MI355X MTP recipes.
+# latency — matching the H100/MI355X MTP recipes. The shipped ROCm image lacks
+# SupportsEagle3 on the AMD MiniMax-M3 model, so the recipe applies that fix
+# in-place at runtime (functionstackx/vllm#1, upstream vllm-project/vllm#45546;
+# validated green on MI355X) before serving.
 minimaxm3-fp8-mi300x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a
+  image: vllm/vllm-openai-rocm:minimax-m3
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: mi300x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x_mtp.sh
@@ -8,7 +8,9 @@
 # the text-only benchmark, --attention-backend TRITON_ATTN, and
 # --no-enable-prefix-caching. Runs with CUDA graphs (no --enforce-eager);
 # VLLM_USE_BREAKABLE_CUDAGRAPH=0 avoids the M3-decode breakable-cudagraph path.
-# FP8 KV cache reduces memory pressure and increases concurrency headroom.
+# The default BF16 KV cache is retained (unlike
+# the MI355X recipe's FP8 KV cache): gfx942 has no calibrated q/prob scales for
+# ROCm FP8 attention and vLLM's fallback scale of 1.0 corrupts accuracy.
 #
 # Unlike the CUDA recipes, the drafter needs no attention_backend override:
 # the FlashInfer "page size 128 requires GQA/MQA" limitation that forced
@@ -16,9 +18,15 @@
 # Here the whole server runs on TRITON_ATTN (set globally below), which serves
 # the MHA draft fine.
 #
-# Keep the SupportsEagle3 compatibility guard for older images. It exits
-# immediately when the installed AMD MiniMax-M3 model already has the upstream
-# interface and otherwise applies the validated compatibility patch.
+# [AI generated draft test] The shipped vllm/vllm-openai-rocm:minimax-m3 image
+# does NOT implement SupportsEagle3 on the AMD MiniMax-M3 model, so EAGLE3
+# engine init fails with "Model does not support EAGLE3 interface but
+# aux_hidden_state_outputs was requested". This recipe applies that fix
+# (functionstackx/vllm#1 — ported from nvidia/model.py, upstreamed as
+# vllm-project/vllm#45546) in-place to the installed vllm before serving, so we
+# can validate EAGLE3 on real MI300X hardware ahead of an image rebuild. The
+# same patch is validated green on MI355X. It is idempotent and fails the job
+# loudly if the installed amd/model.py has drifted from the expected base.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -167,7 +175,6 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
-    --kv-cache-dtype fp8 \
     --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3958,11 +3958,3 @@
     - "Use FP8 KV cache"
     - "Exclude unprovisioned chi-mi300x-121 from Slurm allocation"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1837
-
-- config-keys:
-    - minimaxm3-fp8-mi300x-vllm-mtp
-  description:
-    - "Update the MI300X MiniMax-M3 EAGLE3 vLLM image to vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a"
-    - "Use FP8 KV cache"
-    - "Exclude unprovisioned chi-mi300x-121 from Slurm allocation"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1839


### PR DESCRIPTION
Reverts SemiAnalysisAI/InferenceX#1839

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Benchmark recipe and image pin changes affect reported MI300X EAGLE3 numbers (KV dtype and container build); the runtime vLLM source patch adds operational fragility if `amd/model.py` drifts.
> 
> **Overview**
> Undoes the MI300X MiniMax-M3 **EAGLE3 (MTP)** benchmark changes from #1839: the ROCm image goes back from the pinned **nightly** to **`vllm/vllm-openai-rocm:minimax-m3`**, and **`minimaxm3_fp8_mi300x_mtp.sh` no longer passes `--kv-cache-dtype fp8`**, keeping the default **BF16 KV** on gfx942 because ROCm FP8 attention lacks calibrated scales and the 1.0 fallback hurts accuracy.
> 
> Config comments now state that this image still lacks **SupportsEagle3** on the AMD MiniMax-M3 model, so the recipe continues to apply the validated **in-place runtime patch** before serve. The **perf-changelog** entry that documented the nightly image bump and FP8 KV for this config is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b98bfaf46c6d1fa35620b778d98db5ab8e49b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->