### PR TITLE
[Klaud Cold] docs: add Chinese README (README_zh.md) + language switcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ Bash: source shared utilities via `source benchmark_lib.sh` (`check_env_vars`, `
 
 Git: conventional commit messages. `[skip-sweep]` in commit message skips benchmarks (push-to-main only). Changes to `perf-changelog.yaml` trigger benchmark runs.
 
+Docs: the README is bilingual — `README.md` (English, default) and `README_zh.md` (Simplified Chinese), with an `English | 中文` switcher under the badges. **Any edit to `README.md` MUST be mirrored in `README_zh.md`, and vice versa** — keep the two in sync (same sections, links, badges, images) and update both in the same PR.
+
 ### Pull Request Sweep Labels
 
 PRs do not run the sweep automatically - `run-sweep.yml` is gated on a label. Pick exactly one; setting multiple sweep labels is rejected by the workflow's `setup` job.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<div align="center">
+
+**English** | [中文](./README_zh.md)
+
+</div>
+
 #  InferenceX™, Open Source Continuous Inference Standard and Research Platform 
 ## Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Microsoft, Oracle, etc, & ML Community such as PyTorch Foundation, vLLM, SGLang, Tri Dao
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<div align="center">
-
-**English** | [中文](./README_zh.md)
-
-</div>
-
 #  InferenceX™, Open Source Continuous Inference Standard and Research Platform 
 ## Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Microsoft, Oracle, etc, & ML Community such as PyTorch Foundation, vLLM, SGLang, Tri Dao
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/SemiAnalysisAI/InferenceX/pulls)
 [![GitHub Stars](https://img.shields.io/github/stars/SemiAnalysisAI/InferenceX?style=social)](https://github.com/SemiAnalysisAI/InferenceX)
+
+<div align="center">
+
+**English** | [中文](./README_zh.md)
+
+</div>
 
 InferenceX™ (formerly InferenceMAX) is an inference performance research platform dedicated to continually analyzing & benchmarking the world’s most popular open-source inference frameworks used by major token factories and models to track real performance in real time. As these software stacks improve, InferenceX™ captures that progress in near real-time, providing a live indicator of inference performance progress. A [open sourced](https://github.com/SemiAnalysisAI/InferenceX-app) live dashboard  is available for free publicly at https://inferencex.com/. 
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,15 +1,15 @@
-<div align="center">
-
-[English](./README.md) | **中文**
-
-</div>
-
 #  InferenceX™，开源持续推理标准与研究平台
 ## 受到 OpenAI、Microsoft、Oracle 等万亿美元级 Token 工厂运营商，以及 PyTorch 基金会、vLLM、SGLang、Tri Dao 等机器学习社区的信赖
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/SemiAnalysisAI/InferenceX/pulls)
 [![GitHub Stars](https://img.shields.io/github/stars/SemiAnalysisAI/InferenceX?style=social)](https://github.com/SemiAnalysisAI/InferenceX)
+
+<div align="center">
+
+[English](./README.md) | **中文**
+
+</div>
 
 InferenceX™（前身为 InferenceMAX）是一个推理性能研究平台，致力于持续分析与基准测试全球最受欢迎的开源推理框架——这些框架被各大 Token 工厂与模型广泛采用，以实时追踪其真实性能。随着这些软件栈不断改进，InferenceX™ 会以近乎实时的方式捕捉这些进展，提供一个反映推理性能进步的实时指标。我们在 https://inferencex.com/ 上免费公开提供了一个[开源](https://github.com/SemiAnalysisAI/InferenceX-app)的实时仪表盘。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,50 @@
+<div align="center">
+
+[English](./README.md) | **中文**
+
+</div>
+
+#  InferenceX™，开源持续推理标准与研究平台
+## 受到 OpenAI、Microsoft、Oracle 等万亿美元级 Token 工厂运营商，以及 PyTorch 基金会、vLLM、SGLang、Tri Dao 等机器学习社区的信赖
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/SemiAnalysisAI/InferenceX/pulls)
+[![GitHub Stars](https://img.shields.io/github/stars/SemiAnalysisAI/InferenceX?style=social)](https://github.com/SemiAnalysisAI/InferenceX)
+
+InferenceX™（前身为 InferenceMAX）是一个推理性能研究平台，致力于持续分析与基准测试全球最受欢迎的开源推理框架——这些框架被各大 Token 工厂与模型广泛采用，以实时追踪其真实性能。随着这些软件栈不断改进，InferenceX™ 会以近乎实时的方式捕捉这些进展，提供一个反映推理性能进步的实时指标。我们在 https://inferencex.com/ 上免费公开提供了一个[开源](https://github.com/SemiAnalysisAI/InferenceX-app)的实时仪表盘。
+
+> [!IMPORTANT]
+> 只有 [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX) 仓库才包含官方的 InferenceX™ 结果，所有其他派生（fork）与仓库均为非官方。非官方仓库的基准测试设置以及机器/云环境的质量可能存在差异，从而导致基准测试结果欠佳。非官方仓库必须明确标注为“非官方（Unofficial）”。
+> 派生仓库不得移除本免责声明。
+
+[InferenceXv2 完整文章解读](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
+[InferenceXv1 完整文章解读](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)
+
+
+<img width="1150" height="665" alt="image" src="https://github.com/user-attachments/assets/1e9738d4-6fb2-4cd7-a3e9-e6b2e03faed1" />
+<img width="1098" height="655" alt="image" src="https://github.com/user-attachments/assets/5b363271-69b9-4bd2-b85d-b33b9c16f50f" />
+
+
+## 为什么？
+
+InferenceX™ 是一个开源、采用 Apache 2.0 许可证的自动化基准测试平台，其设计目标是与软件生态本身同样快速地演进，以应对这一挑战。
+
+LLM 推理性能由两大支柱驱动：硬件与软件。硬件创新每年通过发布新的 GPU/XPU 与新系统带来阶跃式的性能提升，而软件则每天都在演进，在这些阶跃之上持续带来性能增益。速度即护城河 🚀
+
+SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过内核级优化、分布式推理策略以及调度创新来实现这种持续的性能改进，在相隔可能仅数天的增量版本中不断推升性能的帕累托前沿。
+
+这种软件演进的速度带来了一个挑战：在某个固定时间点进行的基准测试很快就会过时，无法代表使用最新软件包所能达到的性能。
+
+
+## 致谢与支持者
+感谢 Lisa Su 与 Anush Elangovan 为这一免费开源项目提供 MI355X 与 CDNA3 GPU。我们也要感谢众多 AMD 贡献者的积极响应，以及他们在各类 AMD GPU 上进行调试、优化与性能验证所付出的努力。
+我们同样感谢 Jensen Huang 与 Ian Buck 通过提供 GB200 NVL72 机架（经由 OCI）与 B200 GPU 来支持本开源项目。感谢来自 NVIDIA 推理团队与 NVIDIA Dynamo 团队的众多 NVIDIA 贡献者。
+
+我们还要感谢 SGLang、vLLM 与 TensorRT-LLM 的维护者们，他们打造了世界一流的软件栈，并将其开源给全世界。
+最后，我们衷心感谢 Crusoe、CoreWeave、Nebius、TensorWave、Oracle 与 TogetherAI 通过提供计算资源支持开源创新，使这一切成为可能。
+
+“当我们以前所未有的规模构建系统时，对机器学习社区而言，拥有开放、透明、能够反映推理在各类软硬件上真实表现的基准测试至关重要。InferenceX™ 的正面对比基准测试拨开了纷繁的噪音，为 Token 吞吐量、单位美元性能以及每兆瓦 Token 数提供了一幅鲜活的画面。这类开源工作增强了整个生态系统的实力，帮助从研究人员到前沿数据中心运营商的每一个人做出更明智的决策。” —— Peter Hoeschele，OpenAI Stargate 基础设施与工业计算副总裁
+
+“理论峰值与真实世界推理吞吐量之间的差距，往往由系统软件决定：推理引擎、分布式策略以及底层内核。InferenceX™ 的价值在于，它对最新软件进行基准测试，展示这些优化在各类硬件上的实际效果。这类开放、可复现的结果有助于整个社区更快地前进。” —— Tri Dao，Together AI 首席科学家、Flash Attention 发明者
+
+“业界需要许多公开、可复现的推理性能基准测试。我们很高兴能代表 vLLM 团队与 InferenceX™ 展开合作。让所有人都能信赖并引用的、更加多样化的工作负载与场景，将帮助生态系统不断向前发展。公平、透明的测量推动着从模型架构到推理引擎再到硬件的每一层栈的进步。” —— Simon Mo，vLLM 项目联合负责人


### PR DESCRIPTION
## What

Adds a Simplified Chinese translation of the project README and a language switcher so readers can toggle between English and 中文.

- **`README_zh.md`** (new) — full Simplified Chinese translation of `README.md` (title, tagline, intro, the `[!IMPORTANT]` official-repo disclaimer, "Why?", and the Acknowledgements & Supporters quotes). Badges, images, and external links are preserved as-is.
- **`README.md`** — adds a centered language switcher at the very top:

  ```
  **English** | [中文](./README_zh.md)
  ```

  `README_zh.md` carries the mirror switcher (`[English](./README.md) | **中文**`).

## Notes

- The GitHub alert keyword (`> [!IMPORTANT]`) is kept in English so GitHub still renders the callout; only its body is translated.
- Brand/product names (InferenceX™, OpenAI, vLLM, etc.) and URLs are left untranslated.
- Docs-only change — no code, configs, or benchmark recipes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on benchmarks, configs, or runtime code.
> 
> **Overview**
> Introduces **Simplified Chinese** documentation alongside the English README and documents the bilingual workflow for contributors.
> 
> A new **`README_zh.md`** mirrors the main README (intro, official-repo disclaimer, “Why?”, acknowledgements, badges, images, and links). **`README.md`** gains a centered **`English | 中文`** switcher under the badges; the Chinese file links back with **`[English](./README.md) | 中文`**.
> 
> **`AGENTS.md`** now states that **`README.md` and `README_zh.md` must stay in sync**—any edit to one should be mirrored in the other in the same PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9684b44a69e1c119e452d4cb9ead7dc331b9deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->