### PR TITLE
[Klaud Cold] docs: add News section + Introduction header to README (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## News
 
 - **[2026/06]** 🔥 MiniMax-M3 Day 0 benchmarks live on InferenceX ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
-- **[2026/04]** 🔥 DeepSeek V4 1.6T Day 0 → Day 43 performance over time across GB300 NVL72, MI355X, B200, and Huawei ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)).
+- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)).
 - **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked ([SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
 - **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper ([article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)).
 - **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch ([article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 - **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
+- **[2026/03]** Added Kimi K2.5 (same architecture as Kimi 2.7-Code), Qwen3.5-397B, GLM5 (same arch as GLM5.1), and MiniMax M2.5 (same arch as MiniMax M2.7) [dashboard](https://inferencex.semianalysis.com/)
 - **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked [SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
 - **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper [article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
 - **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch [article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 ## News
 
-- **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
-- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)).
-- **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked ([SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
-- **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper ([article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)).
-- **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch ([article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)).
+- **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
+- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
+- **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked [SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
+- **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper [article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
+- **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch [article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)
 
 ## Introduction
 
@@ -26,10 +26,6 @@ InferenceX™ (formerly InferenceMAX) is an inference performance research platf
 > [!IMPORTANT]
 > Only [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX) repo contains the Official InferenceX™ result, all other forks & repos are Unofficial. The benchmark setup & quality of machines/clouds in unofficial repos may be differ leading to subpar benchmarking. Unofficial must be explicitly labelled as Unofficial.
 > Forks may not remove this disclaimer
-
-[Full Article Write Up for InferenceXv2](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
-[Full Article Write Up for InferenceXv1](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)
-
 
 <img width="1150" height="665" alt="image" src="https://github.com/user-attachments/assets/1e9738d4-6fb2-4cd7-a3e9-e6b2e03faed1" />
 <img width="1098" height="655" alt="image" src="https://github.com/user-attachments/assets/5b363271-69b9-4bd2-b85d-b33b9c16f50f" />

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 
 </div>
 
+## News
+
+- **[2026/06]** 🔥 MiniMax-M3 Day 0 benchmarks live on InferenceX ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
+- **[2026/04]** 🔥 DeepSeek V4 1.6T Day 0 → Day 43 performance over time across GB300 NVL72, MI355X, B200, and Huawei ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)).
+- **[2026/02]** GB300 NVL72: up to 25x inference performance with SGLang on InferenceX ([blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
+- **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper ([article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)).
+- **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch ([article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)).
+
+## Introduction
+
 InferenceX™ (formerly InferenceMAX) is an inference performance research platform dedicated to continually analyzing & benchmarking the world’s most popular open-source inference frameworks used by major token factories and models to track real performance in real time. As these software stacks improve, InferenceX™ captures that progress in near real-time, providing a live indicator of inference performance progress. A [open sourced](https://github.com/SemiAnalysisAI/InferenceX-app) live dashboard  is available for free publicly at https://inferencex.com/. 
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 - **[2026/06]** 🔥 MiniMax-M3 Day 0 benchmarks live on InferenceX ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
 - **[2026/04]** 🔥 DeepSeek V4 1.6T Day 0 → Day 43 performance over time across GB300 NVL72, MI355X, B200, and Huawei ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)).
-- **[2026/02]** GB300 NVL72: up to 25x inference performance with SGLang on InferenceX ([blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
+- **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked ([SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
 - **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper ([article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)).
 - **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch ([article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## News
 
-- **[2026/06]** 🔥 MiniMax-M3 Day 0 benchmarks live on InferenceX ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
+- **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 ([dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)).
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 ([article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)).
 - **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked ([SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)).
 - **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper ([article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)).

--- a/README_zh.md
+++ b/README_zh.md
@@ -11,6 +11,16 @@
 
 </div>
 
+## 新闻
+
+- **[2026/06]** 🔥 MiniMax-M3 Day 0 基准测试已在 InferenceX 上线（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
+- **[2026/04]** 🔥 DeepSeek V4 1.6T 从 Day 0 到 Day 43 的性能演进，覆盖 GB300 NVL72、MI355X、B200 与华为（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)）。
+- **[2026/02]** GB300 NVL72：在 InferenceX 上以 SGLang 实现高达 25 倍的推理性能（[博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
+- **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper（[文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)）。
+- **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布（[文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)）。
+
+## 简介
+
 InferenceX™（前身为 InferenceMAX）是一个推理性能研究平台，致力于持续分析与基准测试全球最受欢迎的开源推理框架——这些框架被各大 Token 工厂与模型广泛采用，以实时追踪其真实性能。随着这些软件栈不断改进，InferenceX™ 会以近乎实时的方式捕捉这些进展，提供一个反映推理性能进步的实时指标。我们在 https://inferencex.com/ 上免费公开提供了一个[开源](https://github.com/SemiAnalysisAI/InferenceX-app)的实时仪表盘。
 
 > [!IMPORTANT]

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,7 +14,7 @@
 ## 新闻
 
 - **[2026/06]** 🔥 MiniMax-M3 Day 0 基准测试已在 InferenceX 上线（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
-- **[2026/04]** 🔥 DeepSeek V4 1.6T 从 Day 0 到 Day 43 的性能演进，覆盖 GB300 NVL72、MI355X、B200 与华为（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)）。
+- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)）。
 - **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试（[SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
 - **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper（[文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)）。
 - **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布（[文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)）。

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,6 +15,7 @@
 
 - **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试 [文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
+- **[2026/03]** 新增 Kimi K2.5（与 Kimi 2.7-Code 架构相同）、Qwen3.5-397B、GLM5（与 GLM5.1 架构相同）、MiniMax M2.5（与 MiniMax M2.7 架构相同）[仪表盘](https://inferencex.semianalysis.com/)
 - **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试 [SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
 - **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper [文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
 - **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布 [文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@
 
 - **[2026/06]** 🔥 MiniMax-M3 Day 0 基准测试已在 InferenceX 上线（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
 - **[2026/04]** 🔥 DeepSeek V4 1.6T 从 Day 0 到 Day 43 的性能演进，覆盖 GB300 NVL72、MI355X、B200 与华为（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)）。
-- **[2026/02]** GB300 NVL72：在 InferenceX 上以 SGLang 实现高达 25 倍的推理性能（[博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
+- **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试（[SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
 - **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper（[文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)）。
 - **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布（[文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)）。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,11 +13,11 @@
 
 ## 新闻
 
-- **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
-- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)）。
-- **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试（[SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
-- **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper（[文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)）。
-- **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布（[文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)）。
+- **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
+- **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试 [文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
+- **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试 [SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
+- **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper [文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
+- **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布 [文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)
 
 ## 简介
 
@@ -26,10 +26,6 @@ InferenceX™（前身为 InferenceMAX）是一个推理性能研究平台，致
 > [!IMPORTANT]
 > 只有 [SemiAnalysisAI/InferenceX](https://github.com/SemiAnalysisAI/InferenceX) 仓库才包含官方的 InferenceX™ 结果，所有其他派生（fork）与仓库均为非官方。非官方仓库的基准测试设置以及机器/云环境的质量可能存在差异，从而导致基准测试结果欠佳。非官方仓库必须明确标注为“非官方（Unofficial）”。
 > 派生仓库不得移除本免责声明。
-
-[InferenceXv2 完整文章解读](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
-[InferenceXv1 完整文章解读](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)
-
 
 <img width="1150" height="665" alt="image" src="https://github.com/user-attachments/assets/1e9738d4-6fb2-4cd7-a3e9-e6b2e03faed1" />
 <img width="1098" height="655" alt="image" src="https://github.com/user-attachments/assets/5b363271-69b9-4bd2-b85d-b33b9c16f50f" />

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,7 +13,7 @@
 
 ## 新闻
 
-- **[2026/06]** 🔥 MiniMax-M3 Day 0 基准测试已在 InferenceX 上线（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
+- **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试（[仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)）。
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试（[文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)）。
 - **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试（[SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)）。
 - **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper（[文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)）。


### PR DESCRIPTION
## What

Add a **News** section (between the language switcher and the intro paragraph) and wrap the existing intro in an **Introduction** / **简介** header — in **both** `README.md` and `README_zh.md` (bilingual sync per `AGENTS.md`). Also remove the now-redundant standalone "Full Article Write Up for InferenceXv1/v2" links (covered by News).

News items (newest first; bullets render as bare `[label](link)`, no wrapping parens):

| Date | Item | Links |
|---|---|---|
| 2026/06 | 🔥 MiniMax M3: continuous benchmarks live since Day 0 | [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch) |
| 2026/04 | 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 | [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch) |
| 2026/03 | Added Kimi K2.5 (Kimi 2.7-Code arch), Qwen3.5-397B, GLM5 (GLM5.1 arch), MiniMax M2.5 (MiniMax M2.7 arch) | [dashboard](https://inferencex.semianalysis.com/) |
| 2026/02 | GB300 NVL72: added to InferenceX & continuously benchmarked | [SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/) |
| 2026/02 | 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper | [article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs) |
| 2025/10 | 🔥 InferenceX (formerly InferenceMAX) v1 launch | [article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference) |

## Notes

- **DeepSeek V4 Day 0 is dated 2026/04**, not 2026/02 — Day 0 support landed in April 2026 (per SemiAnalysis).
- **GB300 NVL72** has no SemiAnalysis newsletter; linked the official LMSYS InferenceX GB300 blog (2026-02-20).
- Docs-only change; `README.md` and `README_zh.md` kept fully in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only README changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Documentation-only README refresh** in `README.md` and `README_zh.md`, kept in sync per project docs rules.
> 
> Adds a **News** / **新闻** section (newest first) with dated bullets for launches and benchmarks—MiniMax M3, DeepSeek V4 Pro, March 2026 model additions, GB300 NVL72, InferenceX v2/v1—with links to dashboards, SemiAnalysis articles, and the LMSYS GB300 post.
> 
> Wraps the existing opening paragraph under **Introduction** / **简介**, and **removes** the standalone “Full Article Write Up for InferenceXv1/v2” lines now covered by the News entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit babf8c2ad0a3a403d893d7270f4759ba7b025b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


