### PR TITLE
[Klaud Cold][DNM][test] verify bilingual PR recipe-reminder fires

### DIFF
--- a/benchmarks/recipe-reminder-test.md
+++ b/benchmarks/recipe-reminder-test.md
@@ -1,0 +1,7 @@
+# Recipe Reminder Test
+
+Throwaway file to trigger the **PR Recipe Reminder** workflow
+(`.github/workflows/pr-recipe-reminder.yml`), which watches `benchmarks/**`.
+
+This PR is **Do Not Merge** — it only exists to verify the bilingual
+(English + 中文) reminder comment posts correctly. Close after verifying.


### PR DESCRIPTION
Throwaway PR to test the **PR Recipe Reminder** workflow now that it's bilingual (#1847).

Touches `benchmarks/**` (which the reminder watches) but **not** `perf-changelog.yaml`, so it triggers the reminder **without** kicking off any GPU sweep.

**Do Not Merge** — close after confirming the reminder comment posts in both English and 中文.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `benchmarks/` for CI smoke testing; no runtime or security impact.
> 
> **Overview**
> This PR **does not change product behavior** — it adds `benchmarks/recipe-reminder-test.md`, a throwaway doc that exists only to touch `benchmarks/**` and fire `.github/workflows/pr-recipe-reminder.yml`.
> 
> The intent is to confirm the reminder posts correctly in **English and 中文** after the bilingual update (#1847), without modifying `perf-changelog.yaml` or starting a GPU sweep. **Do not merge**; close once the workflow comment looks right.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683cdc6b440014c17bcae473b83afe18a4fb537d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->