### PR TITLE
[Klaud Cold] docs: split [2026/03] News into Qwen3.5 397B Day-0 + other model adds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 - **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
-- **[2026/03]** Added Kimi K2.5 (same architecture as Kimi 2.7-Code), Qwen3.5-397B, GLM5 (same arch as GLM5.1), and MiniMax M2.5 (same arch as MiniMax M2.7) [dashboard](https://inferencex.semianalysis.com/)
+- **[2026/03]** 🔥 Qwen3.5 397B: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/)
+- **[2026/03]** Added Kimi K2.5 (same architecture as Kimi 2.7-Code), GLM5 (same arch as GLM5.1), and MiniMax M2.5 (same arch as MiniMax M2.7) [dashboard](https://inferencex.semianalysis.com/)
 - **[2026/02]** GB300 NVL72: added to InferenceX & continuously benchmarked [SGLang Maintainer Lmsys Blog](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
 - **[2026/02]** 🔥 InferenceX v2 launch — NVIDIA Blackwell vs AMD vs Hopper [article](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
 - **[2025/10]** 🔥 InferenceX (formerly InferenceMAX) v1 launch [article](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,8 @@
 
 - **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试 [文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
-- **[2026/03]** 新增 Kimi K2.5（与 Kimi 2.7-Code 架构相同）、Qwen3.5-397B、GLM5（与 GLM5.1 架构相同）、MiniMax M2.5（与 MiniMax M2.7 架构相同）[仪表盘](https://inferencex.semianalysis.com/)
+- **[2026/03]** 🔥 Qwen3.5 397B：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/)
+- **[2026/03]** 新增 Kimi K2.5（与 Kimi 2.7-Code 架构相同）、GLM5（与 GLM5.1 架构相同）、MiniMax M2.5（与 MiniMax M2.7 架构相同）[仪表盘](https://inferencex.semianalysis.com/)
 - **[2026/02]** GB300 NVL72：已加入 InferenceX 并持续进行基准测试 [SGLang 维护者 LMSYS 博客](https://www.lmsys.org/blog/2026-02-20-gb300-inferencex/)
 - **[2026/02]** 🔥 InferenceX v2 发布——NVIDIA Blackwell 对比 AMD 对比 Hopper [文章](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs)
 - **[2025/10]** 🔥 InferenceX（前身为 InferenceMAX）v1 发布 [文章](https://newsletter.semianalysis.com/p/inferencemax-open-source-inference)


### PR DESCRIPTION
## What

Split the single **[2026/03]** News bullet into two, in both `README.md` and `README_zh.md` (bilingual sync per `AGENTS.md`):

- **[2026/03]** 🔥 Qwen3.5 397B: continuous benchmarks live since Day 0 — [dashboard](https://inferencex.semianalysis.com/)
- **[2026/03]** Added Kimi K2.5 (same architecture as Kimi 2.7-Code), GLM5 (same arch as GLM5.1), and MiniMax M2.5 (same arch as MiniMax M2.7) — [dashboard](https://inferencex.semianalysis.com/)

Qwen3.5 397B gets its own 🔥 Day-0 line; Kimi K2.5 / GLM5 / MiniMax M2.5 stay in the "Added" line. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only News list edits with no runtime, benchmark, or config changes.
> 
> **Overview**
> The **[2026/03]** News section is split from one bullet into two in **`README.md`** and **`README_zh.md`**, keeping English and Chinese in sync.
> 
> **Qwen3.5 397B** now has its own 🔥 Day-0 continuous-benchmark line (same pattern as MiniMax M3 and DeepSeek V4). **Kimi K2.5**, **GLM5**, and **MiniMax M2.5** remain on a separate “Added” bullet with architecture notes; Qwen is no longer listed there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb2be1817c8a283c4fc07b3e4ecbfacb6c7539d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->