### PR TITLE
[Klaud Cold] docs: add Meta to trusted-by operators (OpenAI, Meta, Microsoft, Oracle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #  InferenceX™, Open Source Continuous Inference Standard and Research Platform 
-## Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Microsoft, Oracle, etc, & ML Community such as PyTorch Foundation, vLLM, SGLang, Tri Dao
+## Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Meta, Microsoft, Oracle, etc, & ML Community such as PyTorch Foundation, vLLM, SGLang, Tri Dao
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/SemiAnalysisAI/InferenceX/pulls)

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,5 @@
 #  InferenceX™，开源持续推理标准与研究平台
-## 受到 OpenAI、Microsoft、Oracle 等万亿美元级 Token 工厂运营商，以及 PyTorch 基金会、vLLM、SGLang、Tri Dao 等机器学习社区的信赖
+## 受到 OpenAI、Meta、Microsoft、Oracle 等万亿美元级 Token 工厂运营商，以及 PyTorch 基金会、vLLM、SGLang、Tri Dao 等机器学习社区的信赖
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/SemiAnalysisAI/InferenceX/pulls)


### PR DESCRIPTION
## What

Add **Meta** to the "Trusted by Operators of Trillion Dollar Token Factories" tagline: `OpenAI, Microsoft, Oracle` → `OpenAI, Meta, Microsoft, Oracle`.

Mirrored in both `README.md` and `README_zh.md` (`OpenAI、Meta、Microsoft、Oracle`) per the bilingual-README rule. Docs-only, one-line change each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README marketing copy only; no runtime, security, or data impact.
> 
> **Overview**
> Updates the **Trusted by Operators of Trillion Dollar Token Factories** subtitle in `README.md` and `README_zh.md` to include **Meta** in the operator list (`OpenAI, Meta, Microsoft, Oracle` / Chinese equivalent).
> 
> Documentation-only; no code or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d867ffebf08ffd292c00bc5c1678add7c34242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->