### PR TITLE
[codex] Add all-evals matrix expansion mode

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -53,6 +53,8 @@ If neither `--single-node` nor `--multi-node` is specified, both types are gener
 
 By default, throughput runs for every generated config and eval-only jobs run for the selected 8k1k subset. `--no-evals` disables eval jobs, `--evals-only` emits only that selected subset, and adding `--all-evals` expands it to every fixed-sequence config. `--all-evals` alone is an equivalent eval-only shorthand; it cannot be combined with `--no-evals`.
 
+`--step-size` must be greater than 1 and applies to concurrency ranges. Explicit `conc-list` values are emitted directly and are filtered by `--min-conc` / `--max-conc` when provided; when both bounds are set, `--min-conc` must not exceed `--max-conc`.
+
 ### Examples
 
 **Generate all single-node and multi-node configurations (default):**

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,7 +36,7 @@ The `full-sweep` command generates benchmark configurations with optional filter
 usage: generate_sweep_configs.py full-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
-    [--no-evals | --evals-only | --all-evals]
+    [--no-evals | --evals-only] [--all-evals]
     [--model-prefix MODEL_PREFIX [MODEL_PREFIX ...]]
     [--precision PRECISION [PRECISION ...]]
     [--framework FRAMEWORK [FRAMEWORK ...]]
@@ -51,7 +51,7 @@ usage: generate_sweep_configs.py full-sweep
 
 If neither `--single-node` nor `--multi-node` is specified, both types are generated.
 
-Eval modes are mutually exclusive. By default, throughput runs for every generated config and eval-only jobs run for the selected 8k1k subset. `--no-evals` disables eval jobs, `--evals-only` emits only that selected subset, and `--all-evals` emits every fixed-sequence config as an eval-only job.
+By default, throughput runs for every generated config and eval-only jobs run for the selected 8k1k subset. `--no-evals` disables eval jobs, `--evals-only` emits only that selected subset, and adding `--all-evals` expands it to every fixed-sequence config. `--all-evals` alone is an equivalent eval-only shorthand; it cannot be combined with `--no-evals`.
 
 ### Examples
 
@@ -98,7 +98,7 @@ The `runner-model-sweep` command validates that all runner nodes of a specific t
 usage: generate_sweep_configs.py runner-model-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
-    [--no-evals | --evals-only | --all-evals]
+    [--no-evals | --evals-only] [--all-evals]
     --runner-type RUNNER_TYPE
     [--runner-node-filter RUNNER_NODE_FILTER]
     [--single-node] [--multi-node]
@@ -139,7 +139,7 @@ The `test-config` command generates the full sweep for one or more specific conf
 usage: generate_sweep_configs.py test-config
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
-    [--no-evals | --evals-only | --all-evals]
+    [--no-evals | --evals-only] [--all-evals]
     --config-keys CONFIG_KEYS [CONFIG_KEYS ...]
     [--conc CONC [CONC ...]]
 ```
@@ -185,7 +185,7 @@ test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvi
 
 **Run eval-only jobs for every generated fixed-sequence config:**
 ```
-test-config --config-keys dsr1-fp8-h200-sglang --all-evals --config-files .github/configs/nvidia-master.yaml
+test-config --config-keys dsr1-fp8-h200-sglang --evals-only --all-evals --config-files .github/configs/nvidia-master.yaml
 ```
 
 ## Reusing an Approved PR Full Sweep

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,6 +36,7 @@ The `full-sweep` command generates benchmark configurations with optional filter
 usage: generate_sweep_configs.py full-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
+    [--no-evals | --evals-only | --all-evals]
     [--model-prefix MODEL_PREFIX [MODEL_PREFIX ...]]
     [--precision PRECISION [PRECISION ...]]
     [--framework FRAMEWORK [FRAMEWORK ...]]
@@ -49,6 +50,8 @@ usage: generate_sweep_configs.py full-sweep
 ```
 
 If neither `--single-node` nor `--multi-node` is specified, both types are generated.
+
+Eval modes are mutually exclusive. By default, throughput runs for every generated config and eval-only jobs run for the selected 8k1k subset. `--no-evals` disables eval jobs, `--evals-only` emits only that selected subset, and `--all-evals` emits every fixed-sequence config as an eval-only job.
 
 ### Examples
 
@@ -95,6 +98,7 @@ The `runner-model-sweep` command validates that all runner nodes of a specific t
 usage: generate_sweep_configs.py runner-model-sweep
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
+    [--no-evals | --evals-only | --all-evals]
     --runner-type RUNNER_TYPE
     [--runner-node-filter RUNNER_NODE_FILTER]
     [--single-node] [--multi-node]
@@ -135,6 +139,7 @@ The `test-config` command generates the full sweep for one or more specific conf
 usage: generate_sweep_configs.py test-config
     --config-files CONFIG_FILES [CONFIG_FILES ...]
     [--runner-config RUNNER_CONFIG]
+    [--no-evals | --evals-only | --all-evals]
     --config-keys CONFIG_KEYS [CONFIG_KEYS ...]
     [--conc CONC [CONC ...]]
 ```
@@ -176,6 +181,11 @@ test-config --config-keys dsr1-fp4-b200-sglang gptoss* --config-files .github/co
 **Override concurrency for targeted testing:**
 ```
 test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvidia-master.yaml
+```
+
+**Run eval-only jobs for every generated fixed-sequence config:**
+```
+test-config --config-keys dsr1-fp8-h200-sglang --all-evals --config-files .github/configs/nvidia-master.yaml
 ```
 
 ## Reusing an Approved PR Full Sweep

--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -12,6 +12,7 @@ on:
       - "utils/find_reusable_sweep_run.py"
       - "utils/test_find_reusable_sweep_run.py"
       - "utils/process_changelog.py"
+      - "utils/test_process_changelog.py"
       - "utils/prepare_perf_changelog_merge.py"
       - "utils/recover_failed_ingest.py"
       - "utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py"
@@ -62,4 +63,5 @@ jobs:
             utils/changelog_gate_tests/test_recover_failed_ingest.py \
             utils/test_validate_reusable_sweep_artifacts.py \
             utils/changelog_gate_tests/test_run_sweep_gating.py \
+            utils/test_process_changelog.py \
             -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Update the image tag in the relevant `.github/configs/*-master.yaml` and/or `ben
 
 Optional accuracy checks ensuring inference optimizations do not degrade outputs. See `utils/evals/EVALS.md` for the full reference.
 
-Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals run by default on the 8k1k subset. Workflow jobs run separately from throughput jobs in `EVAL_ONLY=true` mode. Flags on `generate_sweep_configs.py`: `--no-evals` to skip, `--evals-only` for the selected eval subset only, and `--all-evals` for eval-only jobs across every generated fixed-sequence config. Changelog entries support mutually exclusive `evals-only: true` and `all-evals: true` modes. Aggregated output produced by `utils/collect_eval_results.py`.
+Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals run by default on the 8k1k subset. Workflow jobs run separately from throughput jobs in `EVAL_ONLY=true` mode. Flags on `generate_sweep_configs.py`: `--no-evals` to skip, `--evals-only` for the selected eval subset only, and `--all-evals` to expand eval-only selection across every generated fixed-sequence config. `--all-evals` composes with `--evals-only` and remains a standalone shorthand. Changelog `all-evals: true` has the same layered behavior and suppresses throughput jobs for that entry. Aggregated output produced by `utils/collect_eval_results.py`.
 
 ## Key Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Update the image tag in the relevant `.github/configs/*-master.yaml` and/or `ben
 
 Optional accuracy checks ensuring inference optimizations do not degrade outputs. See `utils/evals/EVALS.md` for the full reference.
 
-Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals run by default on the 8k1k subset. Workflow jobs run separately from throughput jobs in `EVAL_ONLY=true` mode. Flags on `generate_sweep_configs.py full-sweep`: `--no-evals` to skip, `--evals-only` for the eval subset only. Aggregated output produced by `utils/collect_eval_results.py`.
+Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generate_sweep_configs.py`; evals run by default on the 8k1k subset. Workflow jobs run separately from throughput jobs in `EVAL_ONLY=true` mode. Flags on `generate_sweep_configs.py`: `--no-evals` to skip, `--evals-only` for the selected eval subset only, and `--all-evals` for eval-only jobs across every generated fixed-sequence config. Changelog entries support mutually exclusive `evals-only: true` and `all-evals: true` modes. Aggregated output produced by `utils/collect_eval_results.py`.
 
 ## Key Files
 

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -21,6 +21,8 @@ Generator eval modes:
 
 The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. `all-evals: true` extends eval-only selection and implies throughput suppression for that entry, so it works either alone or alongside `evals-only: true`.
 
+When multiple appended changelog entries reference the same config, benchmark deduplication is scenario-aware: a `fixed-seq-len` entry does not suppress a separate `agentic-coding` entry. Eval deduplication only consumes fixed-sequence coverage, and a broader `all-evals` entry takes precedence over the default eval subset for overlapping configs.
+
 ## Why?
 To verify how model outputs are affected by throughput optimizations.
 - TP/Conc might affect model outputs

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -17,9 +17,9 @@ Generator eval modes:
 - Default: run throughput for every generated config and eval-only jobs for the selected subset above.
 - `--no-evals`: generate throughput jobs only.
 - `--evals-only`: generate eval-only jobs for the selected subset above.
-- `--all-evals`: generate eval-only jobs for every generated fixed-sequence config. Agentic configs are excluded. Multi-node jobs use the upper median of each entry's full concurrency list as `eval-conc`.
+- `--evals-only --all-evals`: expand the eval-only matrix to every generated fixed-sequence config. `--all-evals` alone remains an equivalent shorthand. Agentic configs are excluded. Existing `eval-conc` choices from the default policy are preserved; newly added multi-node jobs use the upper median of each entry's full concurrency list.
 
-The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. These changelog fields are mutually exclusive and both suppress throughput jobs for that entry.
+The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. `all-evals: true` extends eval-only selection and implies throughput suppression for that entry, so it works either alone or alongside `evals-only: true`.
 
 ## Why?
 To verify how model outputs are affected by throughput optimizations.

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -12,6 +12,15 @@ Evals run as **separate workflow jobs** from throughput benchmarks. The selectio
 
 **Multi-node**: One entry per (model, runner, framework, precision, spec-decoding, prefill-dp-attn, decode-dp-attn) with the highest max eligible concurrency, only for 8k1k. The eval job runs at `eval-conc`, the upper median of that config's eligible concurrency list.
 
+Generator eval modes:
+
+- Default: run throughput for every generated config and eval-only jobs for the selected subset above.
+- `--no-evals`: generate throughput jobs only.
+- `--evals-only`: generate eval-only jobs for the selected subset above.
+- `--all-evals`: generate eval-only jobs for every generated fixed-sequence config. Agentic configs are excluded. Multi-node jobs use the upper median of each entry's full concurrency list as `eval-conc`.
+
+The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. These changelog fields are mutually exclusive and both suppress throughput jobs for that entry.
+
 ## Why?
 To verify how model outputs are affected by throughput optimizations.
 - TP/Conc might affect model outputs

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -133,6 +133,27 @@ def mark_eval_entries(matrix_values: list[dict]) -> list[dict]:
     return matrix_values
 
 
+def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
+    """Mark every fixed-sequence entry for eval-only execution.
+
+    Agentic entries are left untouched because they do not support lm-eval.
+    Multi-node entries use the upper median of their concurrency list for the
+    eval request concurrency.
+    """
+    for entry in matrix_values:
+        if entry.get(Fields.SCENARIO_TYPE.value) == 'agentic-coding':
+            continue
+
+        entry[Fields.RUN_EVAL.value] = True
+        if Fields.PREFILL.value in entry:
+            conc = entry[Fields.CONC.value]
+            conc_values = conc if isinstance(conc, list) else [conc]
+            sorted_concs = sorted(conc_values)
+            entry[Fields.EVAL_CONC.value] = sorted_concs[len(sorted_concs) // 2]
+
+    return matrix_values
+
+
 def generate_full_sweep(args, all_config_data, runner_data):
     """Generate full sweep configurations with optional filtering.
 
@@ -940,6 +961,11 @@ def main():
         action='store_true',
         help='When specified, run ONLY the eval subset (excludes non-eval configs).'
     )
+    eval_group.add_argument(
+        '--all-evals',
+        action='store_true',
+        help='When specified, run ONLY evals for every generated fixed-sequence config.'
+    )
     parent_parser.add_argument(
         '--runner-node-filter',
         required=False,
@@ -1152,13 +1178,16 @@ def main():
     else:
         parser.error(f"Unknown command: {args.command}")
         
-    # Handle eval options (mutually exclusive: --no-evals or --evals-only)
-    if not args.no_evals:
+    # Handle mutually exclusive eval modes.
+    if args.all_evals:
+        matrix_values = mark_all_eval_entries(matrix_values)
+    elif not args.no_evals:
         matrix_values = mark_eval_entries(matrix_values)
-        if args.evals_only:
-            matrix_values = [e for e in matrix_values if e.get(Fields.RUN_EVAL.value, False)]
-            for e in matrix_values:
-                e[Fields.EVAL_ONLY.value] = True
+
+    if args.evals_only or args.all_evals:
+        matrix_values = [e for e in matrix_values if e.get(Fields.RUN_EVAL.value, False)]
+        for entry in matrix_values:
+            entry[Fields.EVAL_ONLY.value] = True
 
     print(json.dumps(matrix_values))
     return matrix_values

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -134,18 +134,22 @@ def mark_eval_entries(matrix_values: list[dict]) -> list[dict]:
 
 
 def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
-    """Mark every fixed-sequence entry for eval-only execution.
+    """Expand eval selection to every fixed-sequence entry.
 
     Agentic entries are left untouched because they do not support lm-eval.
     Multi-node entries use the upper median of their concurrency list for the
-    eval request concurrency.
+    eval request concurrency unless the default eval policy already selected
+    an eval concurrency.
     """
     for entry in matrix_values:
         if entry.get(Fields.SCENARIO_TYPE.value) == 'agentic-coding':
             continue
 
         entry[Fields.RUN_EVAL.value] = True
-        if Fields.PREFILL.value in entry:
+        if (
+            Fields.PREFILL.value in entry
+            and Fields.EVAL_CONC.value not in entry
+        ):
             conc = entry[Fields.CONC.value]
             conc_values = conc if isinstance(conc, list) else [conc]
             sorted_concs = sorted(conc_values)
@@ -961,10 +965,13 @@ def main():
         action='store_true',
         help='When specified, run ONLY the eval subset (excludes non-eval configs).'
     )
-    eval_group.add_argument(
+    parent_parser.add_argument(
         '--all-evals',
         action='store_true',
-        help='When specified, run ONLY evals for every generated fixed-sequence config.'
+        help=(
+            'Expand eval selection to every generated fixed-sequence config. '
+            'Can be combined with --evals-only; used alone, it also emits eval-only jobs.'
+        )
     )
     parent_parser.add_argument(
         '--runner-node-filter',
@@ -1162,6 +1169,8 @@ def main():
 
     args = parser.parse_args()
     apply_node_type_defaults(args)
+    if args.no_evals and args.all_evals:
+        parser.error("--all-evals cannot be combined with --no-evals")
 
     # Load and validate configuration files (validation happens by default in load functions)
     all_config_data = load_config_files(args.config_files)
@@ -1178,11 +1187,11 @@ def main():
     else:
         parser.error(f"Unknown command: {args.command}")
         
-    # Handle mutually exclusive eval modes.
-    if args.all_evals:
-        matrix_values = mark_all_eval_entries(matrix_values)
-    elif not args.no_evals:
+    # Apply the existing eval policy first, then expand it when requested.
+    if not args.no_evals:
         matrix_values = mark_eval_entries(matrix_values)
+        if args.all_evals:
+            matrix_values = mark_all_eval_entries(matrix_values)
 
     if args.evals_only or args.all_evals:
         matrix_values = [e for e in matrix_values if e.get(Fields.RUN_EVAL.value, False)]

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -148,7 +148,7 @@ def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
         entry[Fields.RUN_EVAL.value] = True
         if (
             Fields.PREFILL.value in entry
-            and Fields.EVAL_CONC.value not in entry
+            and entry.get(Fields.EVAL_CONC.value) is None
         ):
             conc = entry[Fields.CONC.value]
             conc_values = conc if isinstance(conc, list) else [conc]
@@ -168,6 +168,15 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
     Assumes all_config_data has been validated by validate_master_config().
     """
+    if args.step_size <= 1:
+        raise ValueError("step_size must be greater than 1")
+    if (
+        args.min_conc is not None
+        and args.max_conc is not None
+        and args.min_conc > args.max_conc
+    ):
+        raise ValueError("min_conc must be less than or equal to max_conc")
+
     # Validate runner types if specified
     if args.runner_type:
         valid_runner_types = set(runner_data.keys())
@@ -322,8 +331,6 @@ def generate_full_sweep(args, all_config_data, runner_data):
                 else:
                     # Single-node configuration
                     tp = bmk[Fields.TP.value]
-                    conc_start = bmk[Fields.CONC_START.value]
-                    conc_end = bmk[Fields.CONC_END.value]
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
@@ -343,31 +350,68 @@ def generate_full_sweep(args, all_config_data, runner_data):
                         if ep is not None and ep > args.max_ep:
                             ep = args.max_ep
 
-                    # Apply min-conc filter if specified
-                    # If conc_end < min_conc, skip this config entirely
-                    if args.min_conc is not None:
-                        if args.min_conc <= 0:
-                            continue  # Skip if min_conc is not positive
-                        if conc_end < args.min_conc:
-                            continue  # Skip if entire range is below min_conc
-                        conc_start = max(conc_start, args.min_conc)
+                    conc_list = bmk.get(Fields.CONC_LIST.value)
+                    if conc_list:
+                        conc_values = list(conc_list)
 
-                    # Apply max-conc filter if specified
-                    # If conc_start > max_conc, use max_conc as both start and end (if valid)
-                    if args.max_conc is not None:
-                        if args.max_conc <= 0:
-                            continue  # Skip if max_conc is not positive
-                        if conc_start > args.max_conc:
-                            conc_start = args.max_conc
-                            conc_end = args.max_conc
-                        else:
-                            conc_end = min(conc_end, args.max_conc)
+                        if args.min_conc is not None:
+                            if args.min_conc <= 0:
+                                continue
+                            conc_values = [
+                                conc for conc in conc_values
+                                if conc >= args.min_conc
+                            ]
+                            if not conc_values:
+                                continue
+
+                        if args.max_conc is not None:
+                            if args.max_conc <= 0:
+                                continue
+                            filtered_conc = [
+                                conc for conc in conc_values
+                                if conc <= args.max_conc
+                            ]
+                            conc_values = (
+                                filtered_conc
+                                if filtered_conc
+                                else [args.max_conc]
+                            )
+                    else:
+                        conc_start = bmk[Fields.CONC_START.value]
+                        conc_end = bmk[Fields.CONC_END.value]
+
+                        # If conc_end < min_conc, skip this config entirely.
+                        if args.min_conc is not None:
+                            if args.min_conc <= 0:
+                                continue
+                            if conc_end < args.min_conc:
+                                continue
+                            conc_start = max(conc_start, args.min_conc)
+
+                        # If conc_start > max_conc, use max_conc directly.
+                        if args.max_conc is not None:
+                            if args.max_conc <= 0:
+                                continue
+                            if conc_start > args.max_conc:
+                                conc_start = args.max_conc
+                                conc_end = args.max_conc
+                            else:
+                                conc_end = min(conc_end, args.max_conc)
+
+                        conc_values = []
+                        conc = conc_start
+                        while conc <= conc_end:
+                            conc_values.append(conc)
+                            if conc == conc_end:
+                                break
+                            conc *= args.step_size
+                            if conc > conc_end:
+                                conc = conc_end
 
                     seq_len_str = seq_len_to_str(isl, osl)
                     runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
 
-                    conc = conc_start
-                    while conc <= conc_end:
+                    for conc in conc_values:
                         for runner_value in runners_for_entry:
                             entry = {
                                 Fields.IMAGE.value: image,
@@ -396,12 +440,6 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
                             validate_matrix_entry(entry, is_multinode)
                             matrix_values.append(entry)
-
-                        if conc == conc_end:
-                            break
-                        conc *= args.step_size
-                        if conc > conc_end:
-                            conc = conc_end
 
         # ---- Agentic-coding scenarios ----
         agentic_configs = scenarios.get(Fields.AGENTIC_CODING.value, []) if (scenario_filter is None or 'agentic-coding' in scenario_filter) else []
@@ -1169,6 +1207,15 @@ def main():
 
     args = parser.parse_args()
     apply_node_type_defaults(args)
+    if args.command == 'full-sweep' and args.step_size <= 1:
+        parser.error("--step-size must be greater than 1")
+    if (
+        args.command == 'full-sweep'
+        and args.min_conc is not None
+        and args.max_conc is not None
+        and args.min_conc > args.max_conc
+    ):
+        parser.error("--min-conc must be less than or equal to --max-conc")
     if args.no_evals and args.all_evals:
         parser.error("--all-evals cannot be combined with --no-evals")
 

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -10,6 +10,7 @@ from generate_sweep_configs import (
     generate_runner_model_sweep_config,
     generate_test_config_sweep,
     mark_eval_entries,
+    mark_all_eval_entries,
     apply_node_type_defaults,
     expand_config_keys,
 )
@@ -390,6 +391,69 @@ class TestMarkEvalEntries:
         non_prefill = [x for x in result if 'prefill' not in x]
         assert not all(x['run-eval'] for x in non_prefill), \
             "mark_eval_entries must not mark all entries — would break e2e splitting"
+
+
+class TestMarkAllEvalEntries:
+    """Tests for the all-evals selection policy."""
+
+    def test_marks_all_fixed_sequence_entries_without_policy_filters(self):
+        entries = [
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 1024, 'osl': 1024, 'tp': 2, 'conc': 1,
+                'spec-decoding': 'none', 'dp-attn': False, 'run-eval': False,
+            },
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 8192, 'osl': 1024, 'tp': 2, 'conc': 8,
+                'spec-decoding': 'none', 'dp-attn': False, 'run-eval': False,
+            },
+        ]
+
+        result = mark_all_eval_entries(entries)
+
+        assert all(entry['run-eval'] for entry in result)
+
+    def test_marks_every_multinode_entry_and_sets_upper_median_eval_conc(self):
+        entries = [
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 1024, 'osl': 1024, 'spec-decoding': 'none',
+                'prefill': {'dp-attn': False},
+                'decode': {'dp-attn': False},
+                'conc': [1, 4, 8, 16],
+                'run-eval': False,
+            },
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 8192, 'osl': 1024, 'spec-decoding': 'none',
+                'prefill': {'dp-attn': True},
+                'decode': {'dp-attn': False},
+                'conc': [32],
+                'run-eval': False,
+            },
+        ]
+
+        result = mark_all_eval_entries(entries)
+
+        assert all(entry['run-eval'] for entry in result)
+        assert result[0]['eval-conc'] == 8
+        assert result[1]['eval-conc'] == 32
+
+    def test_skips_agentic_entries(self):
+        entries = [
+            {
+                'scenario-type': 'agentic-coding',
+                'model': 'm',
+                'runner': 'r',
+                'conc': 64,
+            }
+        ]
+
+        result = mark_all_eval_entries(entries)
+
+        assert 'run-eval' not in result[0]
+        assert 'eval-conc' not in result[0]
 
 
 # =============================================================================
@@ -1543,6 +1607,61 @@ class TestArgumentDefaults:
         # Verify the explicit value
         assert args.runner_config == 'custom/path/runners.yaml'
 
+    def test_all_evals_cli_marks_every_fixed_sequence_entry(
+        self,
+        monkeypatch,
+        sample_single_node_config,
+        sample_runner_config,
+    ):
+        """--all-evals should bypass the default 8k1k/min-conc policy."""
+        import sys
+        import generate_sweep_configs
+
+        monkeypatch.setattr(
+            generate_sweep_configs,
+            'load_config_files',
+            lambda _: sample_single_node_config,
+        )
+        monkeypatch.setattr(
+            generate_sweep_configs,
+            'load_runner_file',
+            lambda _: sample_runner_config,
+        )
+        monkeypatch.setattr(sys, 'argv', [
+            'generate_sweep_configs.py',
+            'test-config',
+            '--config-files', 'dummy.yaml',
+            '--config-keys', 'dsr1-fp8-mi300x-sglang',
+            '--all-evals',
+        ])
+
+        result = generate_sweep_configs.main()
+
+        assert len(result) == 10
+        assert {(entry['isl'], entry['osl']) for entry in result} == {
+            (1024, 1024),
+            (8192, 1024),
+        }
+        assert min(entry['conc'] for entry in result) == 4
+        assert all(entry['run-eval'] is True for entry in result)
+        assert all(entry['eval-only'] is True for entry in result)
+
+    def test_eval_modes_are_mutually_exclusive(self, monkeypatch):
+        import sys
+        import generate_sweep_configs
+
+        monkeypatch.setattr(sys, 'argv', [
+            'generate_sweep_configs.py',
+            'test-config',
+            '--config-files', 'dummy.yaml',
+            '--config-keys', 'dummy',
+            '--evals-only',
+            '--all-evals',
+        ])
+
+        with pytest.raises(SystemExit):
+            generate_sweep_configs.main()
+
 
 # =============================================================================
 # Mixed-mode fixtures
@@ -1934,7 +2053,8 @@ def _split_e2e_configs(data):
 
 class TestE2EConfigSplitting:
     """Verify the e2e-tests.yml config splitting logic handles all flag
-    combinations correctly: default, --no-evals, and --evals-only."""
+    combinations correctly: default, --no-evals, --evals-only, and
+    --all-evals."""
 
     @pytest.fixture
     def mixed_entries(self):
@@ -1987,6 +2107,20 @@ class TestE2EConfigSplitting:
         single, multi, evals = _split_e2e_configs(data)
         assert len(single) == 0, "evals-only should not trigger benchmarks"
         assert len(evals) == 2
+
+    def test_all_evals_routes_every_fixed_sequence_entry_to_evals(self):
+        data = [
+            {'exp-name': 'a', 'isl': 1024, 'conc': 4, 'tp': 2,
+             'run-eval': True, 'eval-only': True},
+            {'exp-name': 'b', 'isl': 8192, 'conc': 8, 'tp': 2,
+             'run-eval': True, 'eval-only': True},
+        ]
+
+        single, multi, evals = _split_e2e_configs(data)
+
+        assert single == []
+        assert multi == []
+        assert evals == data
 
     def test_empty_config(self):
         """Empty input produces empty outputs."""

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -457,6 +457,23 @@ class TestMarkAllEvalEntries:
         assert result[0]['run-eval'] is True
         assert result[0]['eval-conc'] == 32
 
+    def test_replaces_null_eval_conc(self):
+        entries = [
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 1024, 'osl': 1024, 'spec-decoding': 'none',
+                'prefill': {'dp-attn': False},
+                'decode': {'dp-attn': False},
+                'conc': [4, 8, 16],
+                'run-eval': False,
+                'eval-conc': None,
+            },
+        ]
+
+        result = mark_all_eval_entries(entries)
+
+        assert result[0]['eval-conc'] == 8
+
     def test_skips_agentic_entries(self):
         entries = [
             {
@@ -1193,7 +1210,7 @@ class TestEdgeCases:
                             "isl": 1024,
                             "osl": 1024,
                             "search-space": [
-                                {"tp": 8, "conc-start": 4, "conc-end": 16}
+                                {"tp": 8, "conc-list": [4, 16, 64]}
                             ]
                         }
                     ]
@@ -1206,9 +1223,76 @@ class TestEdgeCases:
             sample_runner_config
         )
         conc_values = [entry["conc"] for entry in result]
-        assert 4 in conc_values
-        assert 8 in conc_values
-        assert 16 in conc_values
+        assert conc_values == [4, 16, 64]
+
+    def test_conc_list_in_single_node_honors_filters(
+        self,
+        sample_runner_config,
+        full_sweep_args_single_node,
+    ):
+        config = {
+            "test-config": {
+                "image": "test-image",
+                "model": "test-model",
+                "model-prefix": "test",
+                "precision": "fp8",
+                "framework": "sglang",
+                "runner": "mi300x",
+                "multinode": False,
+                "scenarios": {
+                    "fixed-seq-len": [
+                        {
+                            "isl": 1024,
+                            "osl": 1024,
+                            "search-space": [
+                                {"tp": 8, "conc-list": [4, 16, 64]}
+                            ],
+                        }
+                    ]
+                },
+            }
+        }
+        full_sweep_args_single_node.min_conc = 8
+        full_sweep_args_single_node.max_conc = 32
+
+        result = generate_full_sweep(
+            full_sweep_args_single_node,
+            config,
+            sample_runner_config,
+        )
+
+        assert [entry["conc"] for entry in result] == [16]
+
+    def test_step_size_must_advance(
+        self,
+        sample_single_node_config,
+        sample_runner_config,
+        full_sweep_args_single_node,
+    ):
+        full_sweep_args_single_node.step_size = 1
+
+        with pytest.raises(ValueError, match="greater than 1"):
+            generate_full_sweep(
+                full_sweep_args_single_node,
+                sample_single_node_config,
+                sample_runner_config,
+            )
+
+    def test_min_conc_cannot_exceed_max_conc(
+        self,
+        sample_single_node_config,
+        sample_runner_config,
+        full_sweep_args_single_node,
+    ):
+        full_sweep_args_single_node.min_conc = 16
+        full_sweep_args_single_node.max_conc = 8
+
+        with pytest.raises(ValueError, match="less than or equal"):
+            generate_full_sweep(
+                full_sweep_args_single_node,
+                sample_single_node_config,
+                sample_runner_config,
+            )
 
     def test_disagg_defaults_to_false(self, sample_runner_config, full_sweep_args_single_node):
         """disagg should default to False when not specified."""

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -440,6 +440,23 @@ class TestMarkAllEvalEntries:
         assert result[0]['eval-conc'] == 8
         assert result[1]['eval-conc'] == 32
 
+    def test_preserves_eval_conc_selected_by_default_policy(self):
+        entries = [
+            {
+                'model': 'm', 'runner': 'r', 'framework': 'f', 'precision': 'fp8',
+                'isl': 8192, 'osl': 1024, 'spec-decoding': 'none',
+                'prefill': {'dp-attn': False},
+                'decode': {'dp-attn': False},
+                'conc': [1, 4, 8, 16, 32],
+                'run-eval': False,
+            },
+        ]
+
+        result = mark_all_eval_entries(mark_eval_entries(entries))
+
+        assert result[0]['run-eval'] is True
+        assert result[0]['eval-conc'] == 32
+
     def test_skips_agentic_entries(self):
         entries = [
             {
@@ -1646,7 +1663,41 @@ class TestArgumentDefaults:
         assert all(entry['run-eval'] is True for entry in result)
         assert all(entry['eval-only'] is True for entry in result)
 
-    def test_eval_modes_are_mutually_exclusive(self, monkeypatch):
+    def test_all_evals_composes_with_evals_only(
+        self,
+        monkeypatch,
+        sample_single_node_config,
+        sample_runner_config,
+    ):
+        import sys
+        import generate_sweep_configs
+
+        monkeypatch.setattr(
+            generate_sweep_configs,
+            'load_config_files',
+            lambda _: sample_single_node_config,
+        )
+        monkeypatch.setattr(
+            generate_sweep_configs,
+            'load_runner_file',
+            lambda _: sample_runner_config,
+        )
+        monkeypatch.setattr(sys, 'argv', [
+            'generate_sweep_configs.py',
+            'test-config',
+            '--config-files', 'dummy.yaml',
+            '--config-keys', 'dsr1-fp8-mi300x-sglang',
+            '--evals-only',
+            '--all-evals',
+        ])
+
+        result = generate_sweep_configs.main()
+
+        assert len(result) == 10
+        assert all(entry['run-eval'] is True for entry in result)
+        assert all(entry['eval-only'] is True for entry in result)
+
+    def test_all_evals_cannot_combine_with_no_evals(self, monkeypatch):
         import sys
         import generate_sweep_configs
 
@@ -1655,7 +1706,7 @@ class TestArgumentDefaults:
             'test-config',
             '--config-files', 'dummy.yaml',
             '--config-keys', 'dummy',
-            '--evals-only',
+            '--no-evals',
             '--all-evals',
         ])
 

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -491,6 +491,20 @@ class TestSingleNodeSearchSpaceEntry:
             })
         assert "must be <=" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("conc_start", "conc_end"),
+        [(0, 4), (-1, 4), (1, 0)],
+    )
+    def test_conc_range_values_must_be_positive(self, conc_start, conc_end):
+        with pytest.raises(Exception) as exc_info:
+            SingleNodeSearchSpaceEntry(**{
+                "tp": 4,
+                "conc-start": conc_start,
+                "conc-end": conc_end,
+            })
+
+        assert "must be greater than 0" in str(exc_info.value)
+
     def test_conc_list_values_must_be_positive(self):
         """conc-list values must be > 0."""
         with pytest.raises(Exception) as exc_info:
@@ -837,6 +851,16 @@ class TestChangelogEntry:
 
         assert entry.evals_only is True
         assert entry.all_evals is True
+
+    @pytest.mark.parametrize("scenario_type", [[], ["unsupported"]])
+    def test_scenario_type_must_be_nonempty_and_supported(self, scenario_type):
+        with pytest.raises(ValueError):
+            ChangelogEntry.model_validate({
+                "config-keys": ["test-config"],
+                "description": ["Invalid scenario filter"],
+                "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+                "scenario-type": scenario_type,
+            })
 
 
 # =============================================================================

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -826,15 +826,17 @@ class TestChangelogEntry:
         assert entry.all_evals is True
         assert entry.evals_only is False
 
-    def test_eval_only_modes_are_mutually_exclusive(self):
-        with pytest.raises(ValueError, match="mutually exclusive"):
-            ChangelogEntry.model_validate({
-                "config-keys": ["test-config"],
-                "description": ["Invalid duplicate eval modes"],
-                "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
-                "evals-only": True,
-                "all-evals": True,
-            })
+    def test_all_evals_can_extend_evals_only(self):
+        entry = ChangelogEntry.model_validate({
+            "config-keys": ["test-config"],
+            "description": ["Run the expanded eval-only matrix"],
+            "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+            "evals-only": True,
+            "all-evals": True,
+        })
+
+        assert entry.evals_only is True
+        assert entry.all_evals is True
 
 
 # =============================================================================

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -13,6 +13,7 @@ from validation import (
     MultiNodeSeqLenConfig,
     SingleNodeMasterConfigEntry,
     MultiNodeMasterConfigEntry,
+    ChangelogEntry,
     validate_matrix_entry,
     validate_master_config,
     validate_runner_config,
@@ -805,6 +806,35 @@ class TestValidateRunnerConfig:
         assert "h200" in result
         assert "mi300x" in result
         assert "gb200" in result
+
+
+# =============================================================================
+# Test changelog entry validation
+# =============================================================================
+
+class TestChangelogEntry:
+    """Tests for changelog eval mode validation."""
+
+    def test_all_evals_is_supported(self):
+        entry = ChangelogEntry.model_validate({
+            "config-keys": ["test-config"],
+            "description": ["Run every eval config"],
+            "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+            "all-evals": True,
+        })
+
+        assert entry.all_evals is True
+        assert entry.evals_only is False
+
+    def test_eval_only_modes_are_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            ChangelogEntry.model_validate({
+                "config-keys": ["test-config"],
+                "description": ["Invalid duplicate eval modes"],
+                "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+                "evals-only": True,
+                "all-evals": True,
+            })
 
 
 # =============================================================================

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -492,12 +492,6 @@ class ChangelogEntry(BaseModel):
         description="Restrict to specific scenario types (e.g., ['fixed-seq-len', 'agentic-coding'])"
     )
 
-    @model_validator(mode="after")
-    def validate_eval_modes(self):
-        if self.evals_only and self.all_evals:
-            raise ValueError("'evals-only' and 'all-evals' are mutually exclusive")
-        return self
-
 
 class ChangelogMetadata(BaseModel):
     """Pydantic model for validating changelog metadata structure."""

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -486,10 +486,17 @@ class ChangelogEntry(BaseModel):
     description: list[str] = Field(min_length=1)
     pr_link: str = Field(alias="pr-link")
     evals_only: bool = Field(alias="evals-only", default=False)
+    all_evals: bool = Field(alias="all-evals", default=False)
     scenario_type: Optional[List[str]] = Field(
         alias="scenario-type", default=None,
         description="Restrict to specific scenario types (e.g., ['fixed-seq-len', 'agentic-coding'])"
     )
+
+    @model_validator(mode="after")
+    def validate_eval_modes(self):
+        if self.evals_only and self.all_evals:
+            raise ValueError("'evals-only' and 'all-evals' are mutually exclusive")
+        return self
 
 
 class ChangelogMetadata(BaseModel):

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -252,6 +252,12 @@ def _validate_conc_fields(self):
                 "must be provided together."
             )
 
+        if self.conc_start <= 0 or self.conc_end <= 0:
+            raise ValueError(
+                f"Input '{Fields.CONC_START.value}' and "
+                f"'{Fields.CONC_END.value}' must be greater than 0."
+            )
+
         if self.conc_start > self.conc_end:
             raise ValueError(
                 f"'{Fields.CONC_START.value}' ({self.conc_start}) must be <= "
@@ -487,8 +493,8 @@ class ChangelogEntry(BaseModel):
     pr_link: str = Field(alias="pr-link")
     evals_only: bool = Field(alias="evals-only", default=False)
     all_evals: bool = Field(alias="all-evals", default=False)
-    scenario_type: Optional[List[str]] = Field(
-        alias="scenario-type", default=None,
+    scenario_type: Optional[List[Literal["fixed-seq-len", "agentic-coding"]]] = Field(
+        alias="scenario-type", default=None, min_length=1,
         description="Restrict to specific scenario types (e.g., ['fixed-seq-len', 'agentic-coding'])"
     )
 

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -13,6 +13,8 @@ from matrix_logic.validation import (
     load_config_files,
 )
 
+SCENARIO_TYPES = ("fixed-seq-len", "agentic-coding")
+
 
 def get_added_lines(base_ref: str, head_ref: str, filepath: str) -> str:
     result = subprocess.run(
@@ -85,7 +87,7 @@ def trim_conc(entries: list[dict]) -> list[dict]:
 def get_config_keys_from_master(
     config_keys: list[str], master_config: dict
 ) -> list[str]:
-    resolved_keys = set()
+    resolved_keys = {}
     for key in config_keys:
         if "*" in key:
             pattern = re.compile(re.escape(key).replace(r"\*", ".*"))
@@ -94,11 +96,12 @@ def get_config_keys_from_master(
                 raise ValueError(
                     f"No config keys matched the wildcard pattern '{key}' in master configs."
                 )
-            resolved_keys.update(matched_keys)
+            for matched_key in matched_keys:
+                resolved_keys.setdefault(matched_key, None)
         elif key not in master_config:
             raise ValueError(f"Config key '{key}' not found in master configs.")
         else:
-            resolved_keys.add(key)
+            resolved_keys.setdefault(key, None)
     return list(resolved_keys)
 
 
@@ -134,10 +137,9 @@ def main():
 
     all_benchmark_results = []
     all_eval_results = []
-    # Deduplicate repeated configs separately for benchmarks and evals.
-    # Eval-only modes should not prevent a regular entry from generating
-    # benchmarks for the same config, and vice versa.
-    benchmark_configs_seen = set()
+    # Track benchmark coverage per scenario so overlapping changelog entries
+    # with disjoint scenario filters do not suppress each other.
+    benchmark_scenarios_seen = defaultdict(set)
     eval_configs_seen = set()
 
     master_config = load_config_files(MASTER_CONFIGS)
@@ -154,11 +156,24 @@ def main():
     resolved_entries.sort(key=lambda item: not item[0].all_evals)
 
     for entry, all_configs in resolved_entries:
+        entry_scenarios = tuple(entry.scenario_type or SCENARIO_TYPES)
+
         if not entry.evals_only and not entry.all_evals:
             # Generate benchmark entries (no evals)
-            benchmark_configs = [c for c in all_configs if c not in benchmark_configs_seen]
-            if benchmark_configs:
-                benchmark_configs_seen.update(benchmark_configs)
+            benchmark_groups = defaultdict(list)
+            for config in all_configs:
+                unseen_scenarios = tuple(
+                    scenario for scenario in SCENARIO_TYPES
+                    if (
+                        scenario in entry_scenarios
+                        and scenario not in benchmark_scenarios_seen[config]
+                    )
+                )
+                if unseen_scenarios:
+                    benchmark_scenarios_seen[config].update(unseen_scenarios)
+                    benchmark_groups[unseen_scenarios].append(config)
+
+            for scenarios, benchmark_configs in benchmark_groups.items():
                 base_cmd = [
                     "python3",
                     GENERATE_SWEEPS_PY_SCRIPT,
@@ -169,8 +184,8 @@ def main():
                     *MASTER_CONFIGS,
                     "--no-evals",
                 ]
-                if entry.scenario_type:
-                    base_cmd.extend(["--scenario-type", *entry.scenario_type])
+                if scenarios != SCENARIO_TYPES:
+                    base_cmd.extend(["--scenario-type", *scenarios])
                 try:
                     result = subprocess.run(
                         base_cmd,
@@ -183,7 +198,11 @@ def main():
                     raise
                 all_benchmark_results.extend(json.loads(result.stdout))
 
-        # Generate eval entries separately
+        # Evals only apply to fixed-sequence scenarios. Do not mark a config as
+        # seen when an agentic-only entry generates no eval matrix.
+        if "fixed-seq-len" not in entry_scenarios:
+            continue
+
         eval_configs = [c for c in all_configs if c not in eval_configs_seen]
         if eval_configs:
             eval_configs_seen.update(eval_configs)
@@ -199,9 +218,9 @@ def main():
                 "--config-files",
                 *MASTER_CONFIGS,
                 *eval_flags,
+                "--scenario-type",
+                "fixed-seq-len",
             ]
-            if entry.scenario_type:
-                base_cmd.extend(["--scenario-type", *entry.scenario_type])
             try:
                 eval_result = subprocess.run(
                     base_cmd,

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -187,7 +187,9 @@ def main():
         eval_configs = [c for c in all_configs if c not in eval_configs_seen]
         if eval_configs:
             eval_configs_seen.update(eval_configs)
-            eval_mode = "--all-evals" if entry.all_evals else "--evals-only"
+            eval_flags = ["--evals-only"]
+            if entry.all_evals:
+                eval_flags.append("--all-evals")
             base_cmd = [
                 "python3",
                 GENERATE_SWEEPS_PY_SCRIPT,
@@ -196,7 +198,7 @@ def main():
                 *eval_configs,
                 "--config-files",
                 *MASTER_CONFIGS,
-                eval_mode,
+                *eval_flags,
             ]
             if entry.scenario_type:
                 base_cmd.extend(["--scenario-type", *entry.scenario_type])

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -135,18 +135,26 @@ def main():
     all_benchmark_results = []
     all_eval_results = []
     # Deduplicate repeated configs separately for benchmarks and evals.
-    # An evals-only entry should not prevent a later regular entry from
-    # generating benchmarks for the same config, and vice versa.
+    # Eval-only modes should not prevent a regular entry from generating
+    # benchmarks for the same config, and vice versa.
     benchmark_configs_seen = set()
     eval_configs_seen = set()
 
+    master_config = load_config_files(MASTER_CONFIGS)
+    resolved_entries = []
     for entry_data in changelog_data:
         entry = ChangelogEntry.model_validate(entry_data)
         all_configs = get_config_keys_from_master(
-            entry.config_keys, load_config_files(MASTER_CONFIGS)
+            entry.config_keys, master_config
         )
+        resolved_entries.append((entry, all_configs))
 
-        if not entry.evals_only:
+    # Process all-evals entries first so their broader eval matrix wins when
+    # the same config appears in multiple changelog entries.
+    resolved_entries.sort(key=lambda item: not item[0].all_evals)
+
+    for entry, all_configs in resolved_entries:
+        if not entry.evals_only and not entry.all_evals:
             # Generate benchmark entries (no evals)
             benchmark_configs = [c for c in all_configs if c not in benchmark_configs_seen]
             if benchmark_configs:
@@ -179,6 +187,7 @@ def main():
         eval_configs = [c for c in all_configs if c not in eval_configs_seen]
         if eval_configs:
             eval_configs_seen.update(eval_configs)
+            eval_mode = "--all-evals" if entry.all_evals else "--evals-only"
             base_cmd = [
                 "python3",
                 GENERATE_SWEEPS_PY_SCRIPT,
@@ -187,7 +196,7 @@ def main():
                 *eval_configs,
                 "--config-files",
                 *MASTER_CONFIGS,
-                "--evals-only",
+                eval_mode,
             ]
             if entry.scenario_type:
                 base_cmd.extend(["--scenario-type", *entry.scenario_type])

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -8,6 +8,28 @@ from types import SimpleNamespace
 import process_changelog
 
 
+def _scenario_values(command):
+    if "--scenario-type" not in command:
+        return []
+    index = command.index("--scenario-type") + 1
+    return command[index:]
+
+
+def test_config_key_expansion_is_deterministic_and_deduplicated():
+    master_config = {
+        "config-b": {},
+        "config-a": {},
+        "other": {},
+    }
+
+    result = process_changelog.get_config_keys_from_master(
+        ["config-*", "config-a"],
+        master_config,
+    )
+
+    assert result == ["config-b", "config-a"]
+
+
 def test_all_evals_skips_benchmarks_and_uses_all_evals_generator_flag(
     monkeypatch,
     capsys,
@@ -51,6 +73,7 @@ def test_all_evals_skips_benchmarks_and_uses_all_evals_generator_flag(
     assert "--all-evals" in commands[0]
     assert "--evals-only" in commands[0]
     assert "--no-evals" not in commands[0]
+    assert _scenario_values(commands[0]) == ["fixed-seq-len"]
 
     output = json.loads(capsys.readouterr().out)
     assert output["changelog_metadata"]["entries"][0]["all-evals"] is True
@@ -98,6 +121,7 @@ def test_regular_changelog_entry_keeps_benchmark_and_subset_eval_commands(
     assert "--no-evals" in commands[0]
     assert "--evals-only" in commands[1]
     assert "--all-evals" not in commands[1]
+    assert _scenario_values(commands[1]) == ["fixed-seq-len"]
     json.loads(capsys.readouterr().out)
 
 
@@ -150,4 +174,119 @@ def test_all_evals_takes_precedence_for_duplicate_configs(
     assert "--all-evals" in commands[0]
     assert "--evals-only" in commands[0]
     assert "--no-evals" in commands[1]
+    json.loads(capsys.readouterr().out)
+
+
+def test_disjoint_scenario_entries_for_same_config_are_not_deduplicated(
+    monkeypatch,
+    capsys,
+):
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Fixed sequence jobs
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  scenario-type:
+    - fixed-seq-len
+
+- config-keys:
+    - test-config
+  description:
+    - Agentic jobs
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  scenario-type:
+    - agentic-coding
+"""
+    commands = []
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    assert len(commands) == 3
+    assert "--no-evals" in commands[0]
+    assert _scenario_values(commands[0]) == ["fixed-seq-len"]
+    assert "--evals-only" in commands[1]
+    assert _scenario_values(commands[1]) == ["fixed-seq-len"]
+    assert "--no-evals" in commands[2]
+    assert _scenario_values(commands[2]) == ["agentic-coding"]
+    json.loads(capsys.readouterr().out)
+
+
+def test_agentic_only_all_evals_does_not_suppress_later_fixed_evals(
+    monkeypatch,
+    capsys,
+):
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Agentic-only all-evals entry
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  scenario-type:
+    - agentic-coding
+  all-evals: true
+
+- config-keys:
+    - test-config
+  description:
+    - Fixed sequence jobs
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  scenario-type:
+    - fixed-seq-len
+"""
+    commands = []
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    assert len(commands) == 2
+    assert "--no-evals" in commands[0]
+    assert "--evals-only" in commands[1]
+    assert "--all-evals" not in commands[1]
+    assert _scenario_values(commands[1]) == ["fixed-seq-len"]
     json.loads(capsys.readouterr().out)

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -49,7 +49,7 @@ def test_all_evals_skips_benchmarks_and_uses_all_evals_generator_flag(
 
     assert len(commands) == 1
     assert "--all-evals" in commands[0]
-    assert "--evals-only" not in commands[0]
+    assert "--evals-only" in commands[0]
     assert "--no-evals" not in commands[0]
 
     output = json.loads(capsys.readouterr().out)
@@ -148,6 +148,6 @@ def test_all_evals_takes_precedence_for_duplicate_configs(
 
     assert len(commands) == 2
     assert "--all-evals" in commands[0]
+    assert "--evals-only" in commands[0]
     assert "--no-evals" in commands[1]
-    assert all("--evals-only" not in command for command in commands)
     json.loads(capsys.readouterr().out)

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -1,0 +1,153 @@
+"""Tests for changelog-driven sweep generation."""
+
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import process_changelog
+
+
+def test_all_evals_skips_benchmarks_and_uses_all_evals_generator_flag(
+    monkeypatch,
+    capsys,
+):
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Run every eval configuration
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  all-evals: true
+"""
+    commands = []
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    assert len(commands) == 1
+    assert "--all-evals" in commands[0]
+    assert "--evals-only" not in commands[0]
+    assert "--no-evals" not in commands[0]
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["changelog_metadata"]["entries"][0]["all-evals"] is True
+
+
+def test_regular_changelog_entry_keeps_benchmark_and_subset_eval_commands(
+    monkeypatch,
+    capsys,
+):
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Run benchmarks and selected evals
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+"""
+    commands = []
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    assert len(commands) == 2
+    assert "--no-evals" in commands[0]
+    assert "--evals-only" in commands[1]
+    assert "--all-evals" not in commands[1]
+    json.loads(capsys.readouterr().out)
+
+
+def test_all_evals_takes_precedence_for_duplicate_configs(
+    monkeypatch,
+    capsys,
+):
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Regular benchmark entry appears first
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+
+- config-keys:
+    - test-config
+  description:
+    - Expand the same config to all evals
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+  all-evals: true
+"""
+    commands = []
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    assert len(commands) == 2
+    assert "--all-evals" in commands[0]
+    assert "--no-evals" in commands[1]
+    assert all("--evals-only" not in command for command in commands)
+    json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Description

Add an `all-evals` expansion mode for generated and changelog-triggered accuracy matrices.

### CLI behavior

- `--evals-only` keeps the existing policy-selected eval subset.
- `--evals-only --all-evals` expands that eval-only matrix to every generated fixed-sequence config.
- Standalone `--all-evals` is an equivalent shorthand for the combined form.
- `--no-evals --all-evals` is rejected.
- Agentic configs remain excluded because they do not support lm-eval.
- The existing eval policy runs first, so selected multi-node entries retain their previous `eval-conc`; newly expanded multi-node entries use the upper median configured concurrency.

The mode works for single-node and disaggregated multi-node configs. Multi-node entries preserve their prefill/decode topology and `disagg` metadata and route through the existing eval-only multi-node workflow.

### Changelog behavior

`perf-changelog.yaml` accepts the same layered form:

```yaml
- config-keys:
    - dsr1-fp8-h200-dynamo-trt
  description:
    - "Run the complete eval matrix"
  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
  evals-only: true
  all-evals: true
```

`all-evals: true` also works without explicitly setting `evals-only: true`. Either form suppresses throughput jobs for that changelog entry.

For overlapping changelog entries:

- Broader `all-evals` coverage takes precedence over the default eval subset.
- Eval-only entries do not suppress throughput from regular entries.
- Benchmark deduplication is scenario-aware, so fixed-sequence and agentic entries for the same config both run.
- Agentic-only entries do not consume fixed-sequence eval coverage.
- Wildcard expansion is deterministic and preserves master-config order.

### Edge-case hardening

The full-catalog audit found and fixed several existing paths exposed by `all-evals`:

- `full-sweep` now supports valid single-node `conc-list` search spaces instead of assuming every entry has `conc-start` / `conc-end`.
- A null multi-node `eval-conc` is replaced with a valid configured concurrency.
- `--step-size <= 1` is rejected instead of allowing a non-advancing concurrency loop.
- Contradictory `--min-conc` / `--max-conc` bounds are rejected instead of generating values below the requested minimum.
- Master-config concurrency ranges must be positive.
- Changelog `scenario-type` must be non-empty and use supported values.
- `utils/test_process_changelog.py` is now included in the changelog-gate workflow and path filters.

Documentation is updated in `AGENTS.md`, `.github/workflows/README.md`, and `utils/evals/EVALS.md`.

## User Impact

- Default eval selection is unchanged.
- Existing `--evals-only` output is unchanged.
- `--all-evals` can be used alone or layered on `--evals-only`.
- Single-node and disaggregated multi-node fixed-sequence configs can run their complete eval matrices.
- `perf-changelog.yaml` can request the same behavior without emitting throughput jobs for that entry.

## Validation

- `uv run --with pytest --with pydantic --with pyyaml python -m pytest utils/matrix_logic/ utils/test_process_changelog.py -q`
  - 181 passed.
- Exact `.github/workflows/test-changelog-gate.yml` pytest file list
  - 101 passed.
- `git diff --check`
- Python bytecode compilation for the modified generator, validation, and changelog modules.
- Full NVIDIA + AMD catalog invariant check:
  - 4,214 generated entries with `--no-evals`.
  - 3,812 fixed-sequence entries with `--all-evals`: 3,085 single-node and 727 multi-node.
  - Standalone `--all-evals` and `--evals-only --all-evals` were byte-identical.
  - `full-sweep` and `test-config --config-keys '*'` were byte-identical.
  - The existing 542-entry default eval subset remained contained in the expanded matrix with its prior `eval-conc` values.
- Disposable committed `perf-changelog.yaml` delta using both flags for `dsr1-fp8-h200-dynamo-trt`:
  - 36 H200 disaggregated `multinode_evals` jobs.
  - Both `1k1k` and `8k1k`, STP and MTP.
  - Zero throughput jobs.
  - Every `eval-conc` belonged to its configured concurrency list.
  - Both flags were preserved in changelog metadata.
- [H200 workflow smoke run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27810149624):
  - Dispatched against `codex/all-evals` using standalone `--all-evals`.
  - Separate STP and MTP disaggregated eval-only jobs entered both H200 launchers.
  - Intentionally cancelled after routing and launcher entry were confirmed; both jobs completed Slurm cleanup.
  - This is matrix/launcher validation, not a completed accuracy result.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other

## Checklist

- [x] I have tested my changes locally.
- [x] I have updated documentation.
- [x] No container image or master benchmark config changed, so no `perf-changelog.yaml` entry is required.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI/changelog builds benchmark and eval matrices (larger eval fan-out when enabled), but default eval selection is unchanged and behavior is heavily covered by new tests.
> 
> **Overview**
> Introduces an **`all-evals`** expansion mode on `generate_sweep_configs.py` (and matching **`all-evals: true`** changelog fields) so eval-only workflows can cover **every generated fixed-sequence config**, not just the default 8k1k subset. **`--evals-only --all-evals`** and standalone **`--all-evals`** both emit eval-only jobs; **`--no-evals`** conflicts with **`--all-evals`**. Agentic scenarios stay excluded; multi-node entries get **`eval-conc`** from the upper median when not already set by the default eval policy.
> 
> **`process_changelog.py`** now mirrors that contract: **`all-evals`** entries skip throughput generation, invoke the generator with **`--evals-only`** / **`--all-evals`**, process **`all-evals`** entries first for overlapping configs, and dedupe benchmarks **per scenario** so fixed-seq and agentic changelog lines do not block each other.
> 
> **`full-sweep`** single-node generation gains explicit **`conc-list`** support with **`--min-conc` / `--max-conc`** filtering and validation that **`--step-size` > 1** and min ≤ max. Schema validation requires positive **`conc-start` / `conc-end`**.
> 
> Docs (**`.github/workflows/README.md`**, **`AGENTS.md`**, **`utils/evals/EVALS.md`**) and tests (generator, validation, changelog processing, changelog-gate CI) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d17d4d68f4679a482741e53f5917c6a7c62778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
