### PR TITLE
Revert "[Klaud Cold] MI300X MiniMax-M3 nightly image and FP8 KV cache"

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2876,10 +2876,12 @@ minimaxm3-fp4-mi355x-atom:
       - { tp: 4, conc-start: 1, conc-end: 256 }
       - { tp: 8, conc-start: 1, conc-end: 2 }
 
-# MiniMax-M3 MXFP8 MI300X recipe. Use the TP8-only H100 search space: TP8 for
-# latency and TP8+EP8 (TEP) at high concurrency.
+# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image and
+# MI355X serving shape, but retain the default BF16 KV cache because this
+# checkpoint lacks calibrated ROCm FP8 attention scales. Use the TP8-only H100
+# search space: TP8 for latency and TP8+EP8 (TEP) at high concurrency.
 minimaxm3-fp8-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a
+  image: vllm/vllm-openai-rocm:minimax-m3
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: mi300x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 # MiniMax-M3 MXFP8 MI300X (gfx942) single-node vLLM recipe.
-# Block size 128 is mandatory for MSA sparse attention. Use FP8 KV cache to
-# reduce memory pressure and increase the available concurrency headroom.
+# Reuses the dedicated ROCm image and the MI355X serving shape. Block size 128
+# is mandatory for MSA sparse attention. Keep the default BF16 KV cache on
+# gfx942: the checkpoint has no calibrated q/prob scales for ROCm FP8
+# attention, and vLLM's fallback scale of 1.0 corrupts model accuracy.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -53,7 +55,6 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
-    --kv-cache-dtype fp8 \
     --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3950,20 +3950,11 @@
     - "Update ISL=8192 search-space: TP8-only from conc=4-64, DPA from conc=128-1024 (previously conc=1-64 and DPA conc=64-512)"
     - "Update Applied TBO on high concurrencies"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1717
-
 - config-keys:
     - minimaxm3-fp4-mi355x-atom
   description:
     - "Expand search space for minimaxm3-fp4-mi355x-atom: add TP2 and TP8 configurations, extend concurrency range to 256 for ISL1024 and ISL8192, and add TP8 conc=1-2 for ISL8192."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1825
-
-- config-keys:
-    - minimaxm3-fp8-mi300x-vllm
-  description:
-    - "Update the MI300X MiniMax-M3 vLLM image to vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a"
-    - "Use FP8 KV cache"
-    - "Exclude unprovisioned chi-mi300x-121 from Slurm allocation"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1837
 
 - config-keys:
     - minimaxm3-fp8-mi300x-vllm-mtp

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -15,8 +15,7 @@ set -x
 
 # Exclude known-bad nodes; let Slurm pick from anything else:
 #   chi-mi300x-049: persistent /nvme_home disk-full
-#   chi-mi300x-121: missing required Enroot and RAID storage provisioning
-JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049,chi-mi300x-121 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
Reverts #1837.

## What changed

- restore the MI300X MiniMax-M3 STP image to `vllm/vllm-openai-rocm:minimax-m3`
- restore the default BF16 KV cache
- restore the prior MI300X Slurm exclusion list
- remove the #1837 performance changelog entry while preserving later entries

## Why

The #1837 merge commit contained `[skip-sweep]`, so its post-merge `main` workflow skipped the benchmark, collection, and ingestion jobs. This revert allows the change to be reopened and merged through a clean official workflow.

## Validation

- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh`
- generated targeted MI300X MiniMax-M3 vLLM sweep configuration successfully
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and launcher config only; restores known-good serving settings and widens the MI300X node pool with no auth or data-path changes.
> 
> **Overview**
> Reverts **#1837** so the MI300X MiniMax-M3 MXFP8 vLLM recipe matches the prior day-zero setup and can land again through a normal post-merge workflow (the original merge used `[skip-sweep]`).
> 
> **`minimaxm3-fp8-mi300x-vllm`** again pins **`vllm/vllm-openai-rocm:minimax-m3`** instead of the ROCm nightly, and config comments call out **default BF16 KV cache** on gfx942 because the checkpoint lacks calibrated ROCm FP8 attention scales.
> 
> **`minimaxm3_fp8_mi300x.sh`** drops **`--kv-cache-dtype fp8`** from `vllm serve` for the same accuracy reason (vLLM’s 1.0 fallback corrupts outputs).
> 
> **`launch_mi300x-amds.sh`** stops excluding **`chi-mi300x-121`** from Slurm allocation. **`perf-changelog.yaml`** removes the #1837 entry for this config while leaving later changelog rows intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d8a5127b511070f6bd66a8b3ffa512cc1b25c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->