### PR TITLE
[Klaud Cold] MI300X MiniMax-M3 nightly image and FP8 KV cache

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2876,12 +2876,10 @@ minimaxm3-fp4-mi355x-atom:
       - { tp: 4, conc-start: 1, conc-end: 256 }
       - { tp: 8, conc-start: 1, conc-end: 2 }
 
-# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image and
-# MI355X serving shape, but retain the default BF16 KV cache because this
-# checkpoint lacks calibrated ROCm FP8 attention scales. Use the TP8-only H100
-# search space: TP8 for latency and TP8+EP8 (TEP) at high concurrency.
+# MiniMax-M3 MXFP8 MI300X recipe. Use the TP8-only H100 search space: TP8 for
+# latency and TP8+EP8 (TEP) at high concurrency.
 minimaxm3-fp8-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:minimax-m3
+  image: vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: mi300x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_mi300x.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
 # MiniMax-M3 MXFP8 MI300X (gfx942) single-node vLLM recipe.
-# Reuses the dedicated ROCm image and the MI355X serving shape. Block size 128
-# is mandatory for MSA sparse attention. Keep the default BF16 KV cache on
-# gfx942: the checkpoint has no calibrated q/prob scales for ROCm FP8
-# attention, and vLLM's fallback scale of 1.0 corrupts model accuracy.
+# Block size 128 is mandatory for MSA sparse attention. Use FP8 KV cache to
+# reduce memory pressure and increase the available concurrency headroom.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -55,6 +53,7 @@ set -x
 vllm serve "$MODEL" --port "$PORT" \
     "${PARALLEL_ARGS[@]}" \
     --block-size 128 \
+    --kv-cache-dtype fp8 \
     --no-enable-prefix-caching \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3980,4 +3980,4 @@
     - "Update the MI300X MiniMax-M3 vLLM image to vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a"
     - "Use FP8 KV cache"
     - "Exclude unprovisioned chi-mi300x-121 from Slurm allocation"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1858

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -3972,3 +3972,12 @@
     - "Use FP8 KV cache"
     - "Remove the runtime SupportsEagle3 source patch now included in the pinned nightly"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1843
+
+- config-keys:
+    - minimaxm3-fp8-mi300x-vllm
+  description:
+    - "Reopen #1837 to run and ingest the MI300X MiniMax-M3 STP sweep from main"
+    - "Update the MI300X MiniMax-M3 vLLM image to vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a"
+    - "Use FP8 KV cache"
+    - "Exclude unprovisioned chi-mi300x-121 from Slurm allocation"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -15,7 +15,8 @@ set -x
 
 # Exclude known-bad nodes; let Slurm pick from anything else:
 #   chi-mi300x-049: persistent /nvme_home disk-full
-JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+#   chi-mi300x-121: missing required Enroot and RAID storage provisioning
+JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049,chi-mi300x-121 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"


### PR DESCRIPTION
## Reopen notice

This is a reopening/replacement of #1837. The original PR changes are intentionally identical; this PR exists so the MI300X STP result runs from `main` and is ingested into the official frontend.

The branch currently retains the exact #1837 configuration already present on `main` and appends a fresh changelog trigger. After the dedicated revert PR merges, this PR’s diff will expose the original #1837 image, FP8 KV-cache, and node-exclusion changes again.

## Changes

- pin MI300X MiniMax-M3 STP to `vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a`
- use FP8 KV cache
- exclude unprovisioned `chi-mi300x-121`
- append a fresh performance changelog trigger

## Validation

- generated the targeted MI300X MiniMax-M3 vLLM sweep configuration successfully
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching from BF16 to FP8 KV cache changes serving memory and may affect benchmark accuracy relative to the prior MI300X recipe rationale; image and node-exclusion changes are lower risk.
> 
> **Overview**
> Updates the **MI300X MiniMax-M3 MXFP8** STP benchmark so it can be re-run from `main` and ingested (reopen of #1837), with a fresh **perf-changelog** entry.
> 
> **`minimaxm3-fp8-mi300x-vllm`** now pins **`vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a`** instead of the `minimax-m3` image. Config comments no longer call out a mandatory BF16 KV cache on gfx942.
> 
> The single-node recipe **`minimaxm3_fp8_mi300x.sh`** passes **`--kv-cache-dtype fp8`** to `vllm serve`, reversing the prior stance that BF16 KV was required when ROCm FP8 attention scales were missing.
> 
> **`launch_mi300x-amds.sh`** excludes **`chi-mi300x-121`** from Slurm allocation (unprovisioned Enroot/RAID), alongside the existing **`chi-mi300x-049`** exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fd137652fa902453655ab55c417f5c1eed49d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->