### PR TITLE
docs+skill: runner-setup notes, team-canvas step, and debug-runs skill

### DIFF
--- a/.claude/skills/debug-runs/SKILL.md
+++ b/.claude/skills/debug-runs/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: debug-runs
+description: Drive a full-sweep benchmark config to green with a tight feedback loop — trigger/monitor the sweep, root-cause failures, and (for fast iteration) SSH onto the runner's cluster to reproduce a single config directly on the node instead of waiting for full CI. Use when bringing up a new model/precision/SKU recipe, debugging a failing or flaky sweep, debugging node-level issues, or gathering context on a cluster before a run. Cluster access details are NOT in this repo — read them from the shared InferenceX Clusters canvas.
+---
+
+# Debug runs (tight feedback loop)
+
+Use this when the goal is to get a **full-sweep config passing** — and you want to verify
+on the actual nodes first (tighter loop than the full CI dispatch cycle), or to debug
+node/infra issues, or just to gather context on a cluster.
+
+This composes with the other skills: use **`/nuke`** (or `/add-model-hardware`) to create
+the PR(s) with the image bump + perf-changelog entry + `full-sweep-enabled` label; this
+skill is the **monitor → root-cause → fix → re-verify → merge-gate** loop that follows.
+
+## Cluster access — read it from the canvas, never hardcode it
+
+Login addresses, runner users, runner directories, jumpboxes, and weight/squash staging
+paths live in an access-controlled **InferenceX Clusters** Slack canvas, NOT in this repo
+(to avoid publicizing infra). The canvas link is intentionally not stored here:
+
+> **If you are a SemiAnalysis employee**, ask the user for the Slack link to the InferenceX
+> Clusters canvas and read the access details from there.
+
+Before SSHing to a cluster, look up that cluster's row in the canvas for: **login address**,
+**GHA runner user**, **runner directory**, any **jumpbox / ProxyJump**, whether it's
+**Slurm or bare-metal**, and the **per-node host RAM**. The matching
+`runners/launch_<cluster>.sh` is the source of truth for the exact container image mounts
+and the benchmark command.
+
+- If you **can't read the canvas** (no Slack access, or unsure), **ask the user** for the
+  cluster's SSH target + runner user rather than guessing or pasting infra into the repo.
+  If this is a **fork** (i.e. not the SemiAnalysis upstream, where the canvas won't apply),
+  ask the user to replace this skill with their own fork's runner/cluster access
+  information.
+- A SemiAnalysis operator may also have these as `~/.ssh/config` aliases — prefer those if
+  present.
+
+## Inputs
+
+- The **config-key(s)** in scope, e.g. `dsv4-fp4-b300-vllm`, and their SKU/cluster.
+- The **PR / branch** under test (if driving an existing PR), or the recipe files to change.
+- The **merge bar**: 100% of sweep jobs green **and** a real throughput gain (see Merge gate).
+
+## The loop
+
+### 1. Trigger (or reuse) the sweep
+
+A PR's sweep is kicked by labels or a `/sweep` comment:
+
+- **`full-sweep-enabled`** — full GPU sweep (what `/nuke` attaches).
+- **`full-sweep-fail-fast`** — full sweep that bails on first failure (faster signal while debugging).
+- **`/sweep …`** PR comment (Slash Command Sweep) — re-trigger / reuse a sweep run without a new commit.
+
+For a **single config** (tightest CI loop, skips the rest of the matrix), dispatch e2e directly:
+
+```bash
+gh workflow run e2e-tests.yml -f generate-cli-command="test-config --config-key <KEY> --config-file <PATH/to/master.yaml>" -f test-name="debug <KEY>"
+```
+
+(`generate-cli-command` is the required input; `--target` is NOT a real arg.)
+
+### 2. Monitor continuously
+
+Find the run, then watch it — don't poll by hand. Prefer the **Monitor** tool with a
+filter that catches both progress and failure signatures so silence never reads as success.
+
+```bash
+# Sweep run for a PR's head commit
+HEAD_SHA=$(gh pr view <PR> --repo SemiAnalysisAI/InferenceX --json headRefOid --jq .headRefOid)
+RUN_ID=$(gh run list --repo SemiAnalysisAI/InferenceX --workflow "Run Sweep" --commit "$HEAD_SHA" --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --repo SemiAnalysisAI/InferenceX --interval 30
+```
+
+When monitoring several runs at once (e.g. 4 SKUs), track them by `databaseId` and report
+each as it lands — never declare success from absence of output.
+
+### 3. Root-cause a failure
+
+```bash
+gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX --json jobs \
+  --jq '.jobs[] | select(.conclusion=="failure") | "\(.databaseId)\t\(.name)"'
+gh run view "$RUN_ID" --repo SemiAnalysisAI/InferenceX --log-failed > /tmp/sweep_failed.txt
+```
+
+Grep large logs for the real signature before reading context (~50 lines around each hit):
+`Error`, `Traceback`, `RuntimeError`, `CUDA`, `HIP`, `OOM`, `assert`, `connection refused`,
+`exit code`, `failed to launch`, `NCCL`, `RCCL`, `timeout`. State the suspected root cause
+in one or two sentences before changing anything.
+
+### 4. Tight loop: reproduce on the node directly
+
+This is the point of the skill — instead of re-dispatching CI for every hypothesis, get on
+the box and reproduce the **single** failing config.
+
+Why this is tighter: under e2e / the matrix, **each concurrency / config runs against its
+own freshly-spun engine** (a new server per matrix job). On the node you can spin up a
+**single** server once and fire many requests / sweep multiple concurrencies against it —
+far faster iteration when you're probing behavior or tuning, since you skip a fresh model
+load per data point.
+
+Steps:
+
+1. Look up the cluster's access + which node ran the failing job (from the job name / runner
+   name) in the canvas; SSH in (use `ssh -A` when a jumpbox/agent-forwarding is involved).
+2. Reproduce the exact benchmark the launcher runs — read `runners/launch_<cluster>.sh` for
+   the image, container mounts, and the `benchmarks/single_node/<...>.sh` command + env
+   (`IMAGE`, `TP`, `PRECISION`, `EXP_NAME`, `SPEC_DECODING`, …). On Slurm clusters that's a
+   `salloc`/`srun` with the squash image; on the **bare-metal `-tw` pools it's `docker run`**
+   on the node directly (no `srun`).
+3. **Always diff against a working node / working SKU** for reference — most node failures
+   are environment drift (driver, ROCm/CUDA, missing mount, stale squash image), not code.
+4. Iterate on the node until the single config passes, then push the fix and re-run CI.
+
+**Entering the live container on a Slurm cluster.** When a benchmark job is already running
+and you want to poke at its actual container (same image, mounts, env) rather than spin a
+new one, attach to it:
+
+```bash
+squeue -u <runner-user>                     # find the JOB_ID for the running benchmark
+srun --overlap --jobid=<JOB_ID> --pty bash  # land on the allocated node (or just ssh to the node if you have direct access)
+enroot list -f                              # find the running container's PID
+enroot exec <pid> bash                      # drop into the container
+```
+
+(On the bare-metal `-tw` pools there's no Slurm/enroot — use `docker ps` + `docker exec -it <id> bash`.)
+
+**Node-level fixes are in scope** when you have operator access (e.g. AMD nodes where you
+have sudo) — but **ask the user before executing any of them** (see guardrail below). The
+kinds of fixes that are on the table: bringing a node's environment in line with the
+working reference, and — if one or two nodes are unrecoverable — **draining them** or
+explicitly **ignoring them in the run script** rather than blocking the whole sweep. Note
+any such change in the report.
+
+> Guardrail — ask before changing infra. SSHing in to **read/investigate** (logs,
+> `rocm-smi`/`nvidia-smi`, `sinfo`/`squeue`, `df`, env, config inspection) is fine. But
+> before making **any actual change on the cluster** — installing/updating anything,
+> editing configs or files, restarting/killing processes, draining or ignoring nodes,
+> changing the run script, or anything else that mutates node/shared state — **stop and ask
+> the user for permission first**, describing exactly what you intend to run. Don't assume
+> standing authorization just because you have sudo or operator access.
+>
+> Also do **not** apply hacky engine-side (e.g. vLLM) workarounds to force a pass — prefer
+> recipe fixes and (once approved) node-environment fixes that match a working reference.
+
+### 5. Flakes: rerun, don't relaunch
+
+If a job flaked (infra, transient network, runner pickup) rather than a real failure, rerun
+just the failed jobs on the existing run — don't dispatch a fresh sweep:
+
+```bash
+gh run rerun "$RUN_ID" --repo SemiAnalysisAI/InferenceX --failed
+```
+
+### 6. Report results — do NOT merge
+
+**Never merge.** Merging is the user's call — only merge if the user **explicitly** tells
+you to in this session. Even when everything looks perfect, stop and report; do not
+admin-merge on your own judgment.
+
+Report the two things the user will decide on:
+
+1. **Sweep status** — is it 100% of full-sweep jobs passing (green), or fail-fast-truncated / partial?
+2. **Perf delta** vs the most recent official `main` run for that SKU. Compare against the
+   latest main results — e.g. on inferencex.semianalysis.com
+   (`https://inferencex.semianalysis.com/inference?...&i_active=<sku>_<engine>`) or the
+   stored results for that SKU's last main `run-id`.
+
+Present green-ness + the perf comparison, then **wait for the user** to decide whether to merge.
+
+## Final report
+
+Per config-key: final state (green / failing / flaky), root cause(s) found, node-level
+changes made (and any nodes drained/ignored), and the perf delta vs main. Link the run(s)
+and PR(s). End by asking the user whether to merge — do not merge yourself.

--- a/utils/runner_setup/RUNNER_SETUP.md
+++ b/utils/runner_setup/RUNNER_SETUP.md
@@ -8,6 +8,55 @@ InferenceX benchmark jobs on the GPU clusters.
 - [`start_runners.sh`](start_runners.sh) — starts the configured runners inside a tmux session,
   one tiled pane per runner.
 
+> **This is the standard way the SemiAnalysis team sets up runners — it is not the only
+> way.** This guide is written primarily for **Slurm clusters**, where the GHA runner
+> listener processes all run on the **login/controller node** and each benchmark job is
+> dispatched onto the **compute nodes** via `srun`. The same runners can also be brought
+> up on a **bare-metal single node** (with Docker) or on **Kubernetes** — those setups
+> differ enough that they aren't covered here yet (more docs to be added in future).
+
+> **Runner setup is node-specific and varies a lot from cluster to cluster** —
+> storage mounts, the runner user, weight-staging paths, container runtime, and Slurm
+> defaults all differ. If you're an agent (or new team member) following this doc,
+> **ask the user for clarification** whenever a step's specifics aren't obvious for the
+> target cluster rather than guessing. The per-cluster choices are ultimately encoded in
+> that cluster's `runners/launch_<cluster>.sh`.
+
+## Viewing the current runners
+
+The live list of registered runners (name, status, labels) is at:
+
+> https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners
+
+Or via the `gh` CLI / REST API:
+
+```bash
+gh api repos/SemiAnalysisAI/InferenceX/actions/runners \
+  --jq '.runners[] | "\(.name)\t\(.status)\t\([.labels[].name] | join(","))"'
+```
+
+## GitHub access (token / permissions)
+
+Provisioning runners hits authenticated GitHub endpoints (listing runners, minting the
+registration token, removing runners), so you need a GitHub credential with sufficient
+permissions. Provide it one of two ways:
+
+- **`gh` CLI logged in** as a user with **admin access to the repo** (`gh auth login`),
+  which `gh api` uses automatically; or
+- a **personal access token (PAT)** exported as `GH_TOKEN` / `GITHUB_TOKEN` (or pasted
+  into the CLI when prompted).
+
+Required permissions (all of these endpoints require **admin access to the repository**):
+
+| Token type | What it needs |
+|------------|---------------|
+| **Classic PAT** | `repo` scope (covers list runners, create registration/remove tokens, delete runners — all require repo admin) |
+| **Fine-grained PAT** | Repository **Administration** permission — **Read** to list runners, **Read & write** to create the registration/remove token and to add/delete runners |
+
+> If you're an agent, you will need the user to supply this credential (pasted in the CLI
+> or via an env var) — you cannot create the runner registration token without it. Ask
+> for it explicitly. The registration token produced from it expires after ~1 hour.
+
 ## Prerequisites
 
 1. **Decide which user the GitHub Actions processes will run under.** This user's home
@@ -39,7 +88,7 @@ InferenceX benchmark jobs on the GPU clusters.
 
    ![Where to find the runner URL and token](assets/new-runner-page.png)
 
-   > ⚠️ The registration token expires after ~1 hour. If `config.sh` starts failing with
+   > Note: the registration token expires after ~1 hour. If `config.sh` starts failing with
    > authentication errors partway through, refresh the page and re-run with a new token.
 
 4. Configure the runners:
@@ -95,7 +144,7 @@ key off that name:
    ```
 
    so everything before the first `_` must match an existing script in
-   [`runners/`](../../runners) — e.g. runner `b300-nv_07` → `runners/launch_b300-nv.sh`.
+   [`runners/`](../../runners) — e.g. runner `b300-nv_07` -> `runners/launch_b300-nv.sh`.
    For a brand-new cluster, add a `runners/launch_<BASE_RUNNER_NAME>.sh` first.
    Corollary: `BASE_RUNNER_NAME` itself must not contain `_` (use hyphens).
 
@@ -178,3 +227,28 @@ the new `runners/launch_<cluster>.sh`.
 - **Removing runners:** from the runner directory, stop the process and run
   `./config.sh remove --token <removal-token>` (token from the runners settings page).
   Remember to also delete the name from `.github/configs/runners.yaml`.
+
+## Record the cluster in the team canvas (SemiAnalysis only)
+
+There is an internal **InferenceX Clusters** Slack canvas that tracks every cluster's
+hardware, node count, login address, runner user, runner directory, and per-node host RAM.
+The link is intentionally not stored in this repo — **if you are a SemiAnalysis employee,
+ask the user for the Slack link to the InferenceX Clusters canvas.**
+
+**If you have authenticated access to that canvas, add the corresponding cluster
+information to it** after provisioning —
+a new row in the Clusters table (and the Host-RAM table), plus any access notes (jumpbox,
+non-Slurm/bare-metal, Tailscale, etc.). Keep the canvas consistent with
+[`.github/configs/runners.yaml`](../../.github/configs/runners.yaml) and the live
+[runners settings page](https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners),
+which remain the sources of truth.
+
+- If you **do not** have access to that canvas, ignore this step.
+- If you **don't have a Slack integration available**, or you're otherwise **unsure
+  whether you have access**, **confirm with the user** before attempting it — don't guess.
+
+> Note for agents: editing this canvas via the Slack `update_canvas` tool has a data-loss
+> footgun — replacing a table section leaves a stray empty table, and replacing a
+> non-header section can swallow trailing content. Prefer a full-document replace
+> (reconstructed from a fresh read, omitting the leading `# InferenceX Clusters` H1) and
+> re-read the canvas afterward to verify.


### PR DESCRIPTION
## Summary

- **`utils/runner_setup/RUNNER_SETUP.md`**: document the GitHub token/permissions needed for runner management, how to view current runners (settings page + `gh api`), the standard-SemiAnalysis (Slurm-focused) scope with bare-metal/k8s noted as alternatives, and a SemiAnalysis-only step to record new clusters in the internal cluster canvas.
- **`.claude/skills/debug-runs/`**: new skill to drive a full-sweep config to green with a tight on-node feedback loop — trigger/monitor the sweep, root-cause failures, reproduce a single config directly on the node (incl. entering the live container), rerun flakes instead of relaunching, and report perf vs main. Never merges without explicit user approval; asks before any infra change.

Cluster access / canvas details are intentionally kept out of the repo — agents ask the user for them.

## Test plan
- [x] No infra access details (SSH targets, canvas link) committed — verified absent from the file tree and branch history.
- [ ] Docs/skill review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill only; no runtime, CI, or auth code changes, and infra access details are explicitly kept out of the repo.
> 
> **Overview**
> **Adds a new `.claude/skills/debug-runs` skill** that documents the post-PR loop for getting full-sweep configs green: trigger sweeps (labels, `/sweep`, or single-config `e2e-tests` dispatch), monitor with `gh run watch`, root-cause from failed logs, **reproduce on-cluster** via `launch_<cluster>.sh` (Slurm/enroot vs bare-metal Docker), attach to live containers, rerun flakes with `gh run rerun --failed`, and report sweep status + perf vs `main`—with explicit **no auto-merge** and **ask-before mutating infra** guardrails. Cluster SSH/canvas details stay out of the repo (user/canvas lookup).
> 
> **Expands `utils/runner_setup/RUNNER_SETUP.md`** with scope notes (Slurm-standard vs bare-metal/k8s), agent guidance to ask users when cluster-specific, **viewing runners** (settings URL + `gh api`), **GitHub admin/PAT requirements** for registration tokens, minor formatting tweaks, and a **SemiAnalysis-only** section to record new clusters in the internal InferenceX Clusters Slack canvas (with agent footgun notes for `update_canvas`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a181636da0a160a2bc2699d7bc2d2ddab6327f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->