### PR TITLE
job.slurm: opt-in model auto-download fallback (SGLang path) / job.slurm：可选的模型自动下载回退机制（SGLang 路径）

### DIFF
--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -203,14 +203,77 @@ else
         fi
     }
 
-    if check_model_path "$MODEL_DIR/$MODEL_NAME" "$MODEL_DIR"; then
-        MODEL_PATH="$MODEL_DIR/$MODEL_NAME"
-        echo "Selected MODEL_PATH: $MODEL_PATH (available on all nodes)"
-    else
-        echo "FATAL ERROR: Model '$MODEL_NAME' not found on ALL allocated nodes in:"
-        echo "  - $MODEL_DIR/$MODEL_NAME"
-        exit 1
+    # Opt-in auto-download fallback. Fetches the HuggingFace repo into the
+    # shared model store once, atomically, when the model is missing. The store
+    # ($MODEL_DIR) is a shared mount visible on every allocated node, so a single
+    # download on the batch host populates all of them. flock serializes
+    # concurrent matrix jobs targeting the same path; the download lands in a
+    # temp dir and is published with an atomic rename so a crashed/partial fetch
+    # never satisfies the existence check.
+    autodownload_model() {
+        local model_dir=$1
+        local model_name=$2
+        local repo_id="${MODEL:-$model_name}"
+        local dst="$model_dir/$model_name"
+        local lock="$model_dir/.$model_name.download.lock"
+        local tmp="$model_dir/.$model_name.tmp.$$"
+
+        if [[ "$repo_id" != */* ]]; then
+            echo "[autodownload] MODEL='$repo_id' is not an 'org/name' repo id; cannot download. Set MODEL=<org/name>." >&2
+            return 1
+        fi
+
+        echo "[autodownload] Model missing; fetching '$repo_id' -> $dst"
+        mkdir -p "$model_dir" || { echo "[autodownload] cannot create $model_dir" >&2; return 1; }
+
+        # Some lean runtime images ship without the HF CLI.
+        if ! command -v hf >/dev/null 2>&1; then
+            local pip_install=(python3 -m pip install -q)
+            python3 -m pip install --help 2>/dev/null | grep -q -- "--break-system-packages" \
+                && pip_install+=(--break-system-packages)
+            "${pip_install[@]}" "huggingface_hub[cli]>=0.25.0" || {
+                echo "[autodownload] failed to install huggingface_hub CLI" >&2; return 1; }
+        fi
+
+        exec 200>"$lock"
+        flock 200
+        if [[ -d "$dst" ]]; then
+            echo "[autodownload] Another job already staged $dst; skipping."
+            flock -u 200
+            return 0
+        fi
+        rm -rf "$tmp"
+        if hf download "$repo_id" --local-dir "$tmp"; then
+            mv "$tmp" "$dst"
+            echo "[autodownload] Published $dst"
+            flock -u 200
+            return 0
+        fi
+        echo "[autodownload] hf download failed for '$repo_id'" >&2
+        rm -rf "$tmp"
+        flock -u 200
+        return 1
+    }
+
+    if ! check_model_path "$MODEL_DIR/$MODEL_NAME" "$MODEL_DIR"; then
+        # Default (MODEL_AUTODOWNLOAD unset/false): hard-fail so a mis-staged
+        # model is caught immediately. When enabled, fetch from HuggingFace and
+        # re-check before giving up.
+        if [[ "${MODEL_AUTODOWNLOAD:-false}" == "true" || "${MODEL_AUTODOWNLOAD:-0}" == "1" ]]; then
+            autodownload_model "$MODEL_DIR" "$MODEL_NAME"
+            if ! check_model_path "$MODEL_DIR/$MODEL_NAME" "$MODEL_DIR"; then
+                echo "FATAL ERROR: Model '$MODEL_NAME' still not found on all nodes after auto-download"
+                exit 1
+            fi
+        else
+            echo "FATAL ERROR: Model '$MODEL_NAME' not found on ALL allocated nodes in:"
+            echo "  - $MODEL_DIR/$MODEL_NAME"
+            echo "  (set MODEL_AUTODOWNLOAD=1 to fetch '${MODEL:-<org/name>}' from HuggingFace automatically)"
+            exit 1
+        fi
     fi
+    MODEL_PATH="$MODEL_DIR/$MODEL_NAME"
+    echo "Selected MODEL_PATH: $MODEL_PATH (available on all nodes)"
     echo "Final MODEL_PATH: $MODEL_PATH"
 fi
 


### PR DESCRIPTION
## Problem

For the SGLang / disagg engine, `job.slurm` validates the model with a hard existence check across all allocated nodes:

```
if check_model_path "$MODEL_DIR/$MODEL_NAME" "$MODEL_DIR"; then ... else
    echo "FATAL ERROR: Model '$MODEL_NAME' not found on ALL allocated nodes ..."
    exit 1
fi
```

If the weights were never pre-staged to `$MODEL_DIR/$MODEL_NAME` (`/it-share/data/<name>` on mia1), the whole sweep aborts before the server ever launches. This is what failed run [#27834600324](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27834600324) (PR #1856, `MiniMax-M3-MXFP4`): every multi-node job died with `FATAL ERROR: Model 'MiniMax-M3-MXFP4' not found on ALL allocated nodes`. The model simply wasn't on the store yet — there is currently no path that stages it, only manual pre-download.

## Change

Add an **opt-in** auto-download fallback to the SGLang branch of `job.slurm`:

- **Default behavior is unchanged.** Without `MODEL_AUTODOWNLOAD`, the launcher still hard-fails fast, so a mis-staged model is caught immediately.
- When `MODEL_AUTODOWNLOAD=1` (or `true`) and the model is missing, it fetches the HF repo (`$MODEL`, e.g. `amd/MiniMax-M3-MXFP4`) into the shared store, then re-checks before giving up.
- **Concurrency-safe:** `flock` serializes concurrent matrix jobs targeting the same path; the download lands in a temp dir and is published with an atomic `mv`, so a partial/crashed fetch never satisfies the `-d` existence check.
- Installs `huggingface_hub[cli]` on demand for lean images; validates that `$MODEL` is an `org/name` repo id before attempting.

Scoped to the SGLang path only (where the failure occurred). The vLLM path already searches multiple locations + HF-cache snapshots; it could get the same treatment in a follow-up if desired.

## How to use (e.g. to unblock PR #1856)

Set `MODEL_AUTODOWNLOAD=1` in the launcher/workflow env for the model, then re-trigger. The model store ($MODEL_DIR) is a shared mount on all allocated nodes, so a single download on the batch host populates every node.

## Validation plan / open questions for reviewers

This needs a real CI run to confirm two things I can't verify offline — recommend validating with a `full-sweep-fail-fast` (or `sweep-enabled`) label so the first job proves it out and aborts the matrix if not:

1. **Egress:** do the `compute`-partition nodes have outbound access to `huggingface.co`? (github.com works for checkout; HF may be firewalled separately.)
2. **Free space:** ~227G for `MiniMax-M3-MXFP4` on the CI `/it-share/data`.

`amd/MiniMax-M3-MXFP4` is public (no HF token needed), and `bash -n` passes on the edited script.

Design note: kept this **opt-in** to avoid silently turning every missing-model FATAL into a multi-hundred-GB download. Happy to flip it to default-on (or add a size guard) if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 中文说明
为 SGLang 路径的 `job.slurm` 新增可选的模型自动下载回退机制。默认行为不变——模型缺失时仍快速失败。当设置 `MODEL_AUTODOWNLOAD=1` 且模型不存在时，自动从 HuggingFace 下载到共享存储目录。下载过程支持 `flock` 并发锁和原子 `mv` 发布，确保并发安全，避免部分下载被误用。仅作用于 SGLang 路径（即出现故障的路径），vLLM 路径已有多位置搜索机制，可后续跟进。
