### PR TITLE
fix: recover PR 1797 ingest [skip-sweep]

### DIFF
--- a/.github/workflows/recover-pr-1797-ingest.yml
+++ b/.github/workflows/recover-pr-1797-ingest.yml
@@ -1,0 +1,265 @@
+name: Recover PR 1797 ingest
+run-name: "Recover PR #1797 ingest from run 27591355916 attempt 6"
+
+on:
+    workflow_dispatch:
+        inputs:
+            confirm:
+                description: "Enter recover-pr-1797 to run the artifact-only recovery"
+                required: true
+                type: string
+
+permissions:
+    actions: read
+    contents: read
+
+jobs:
+    recover-ingest:
+        if: ${{ inputs.confirm == 'recover-pr-1797' }}
+        runs-on: ubuntu-latest
+        env:
+            SOURCE_REPO: SemiAnalysisAI/InferenceX
+            SOURCE_RUN_ID: "27591355916"
+            SOURCE_RUN_ATTEMPT: "6"
+            SOURCE_PR_NUMBER: "1797"
+            SOURCE_HEAD_SHA: 29e08b95e557d6d6408861d3397c393d9d501865
+            FINAL_PR_HEAD_SHA: 392878acc0f9e5e6f0c0750dc56c864cdfc2b293
+            TARGET_RUN_ID: "27845906617"
+            TARGET_SETUP_JOB_ID: "82414939448"
+            ORIGINAL_BASE_SHA: 6633e17c2e4b8eaad1db8995415d47f5436f9e3b
+            ORIGINAL_MERGE_SHA: 1ae2b9c6cfc022d77a13463fbdebea5f4acc7a98
+            EXPECTED_FIXED_ROWS: "25"
+            EXPECTED_AGENTIC_ROWS: "0"
+            EXPECTED_EVAL_JOBS: "2"
+        steps:
+            - name: Checkout recovery code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 0
+
+            - name: Validate skipped target and reusable source run
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+              run: |
+                  target_json=$(gh api "repos/${SOURCE_REPO}/actions/runs/${TARGET_RUN_ID}")
+                  jq -e \
+                    --arg expected_head "$ORIGINAL_MERGE_SHA" \
+                    '.event == "push" and
+                     .status == "completed" and
+                     .conclusion == "skipped" and
+                     .path == ".github/workflows/run-sweep.yml" and
+                     .head_branch == "main" and
+                     .head_sha == $expected_head and
+                     .run_attempt == 1' \
+                    <<<"$target_json" >/dev/null
+
+                  target_jobs=$(gh api \
+                    "repos/${SOURCE_REPO}/actions/runs/${TARGET_RUN_ID}/jobs?filter=all&per_page=100")
+                  jq -e \
+                    --argjson expected_job "$TARGET_SETUP_JOB_ID" \
+                    '.jobs[] |
+                     select(.id == $expected_job and
+                            .name == "setup" and
+                            .status == "completed" and
+                            .conclusion == "skipped")' \
+                    <<<"$target_jobs" >/dev/null
+
+                  pr_json=$(gh api "repos/${SOURCE_REPO}/pulls/${SOURCE_PR_NUMBER}")
+                  jq -e \
+                    --arg expected_merge "$ORIGINAL_MERGE_SHA" \
+                    --arg expected_head "$FINAL_PR_HEAD_SHA" \
+                    '.merged_at != null and
+                     .merge_commit_sha == $expected_merge and
+                     .head.sha == $expected_head and
+                     .base.ref == "main"' \
+                    <<<"$pr_json" >/dev/null
+
+                  pr_commits=$(gh api \
+                    "repos/${SOURCE_REPO}/pulls/${SOURCE_PR_NUMBER}/commits" \
+                    --paginate --jq '.[].sha')
+                  grep -Fxq "$SOURCE_HEAD_SHA" <<<"$pr_commits"
+                  grep -Fxq "$FINAL_PR_HEAD_SHA" <<<"$pr_commits"
+
+                  run_json=$(gh api "repos/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}")
+                  jq -e \
+                    --arg expected_head "$SOURCE_HEAD_SHA" \
+                    --argjson expected_attempt "$SOURCE_RUN_ATTEMPT" \
+                    '.event == "pull_request" and
+                     .status == "completed" and
+                     .conclusion == "success" and
+                     .path == ".github/workflows/run-sweep.yml" and
+                     .head_sha == $expected_head and
+                     .run_attempt == $expected_attempt' \
+                    <<<"$run_json" >/dev/null
+
+                  artifacts_json=$(gh api \
+                    "repos/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100")
+                  jq -e '
+                    def retained:
+                      .name == "results_bmk" or
+                      .name == "eval_results_all" or
+                      .name == "run-stats" or
+                      (.name | startswith("bmk_")) or
+                      (.name | startswith("eval_")) or
+                      (.name | startswith("agentic_")) or
+                      (.name | startswith("server_logs_")) or
+                      (.name | startswith("multinode_server_logs_"));
+                    [.artifacts[] | select(retained and .expired)] | length == 0
+                  ' <<<"$artifacts_json" >/dev/null
+                  for required in results_bmk eval_results_all run-stats; do
+                      jq -e --arg name "$required" \
+                        '.artifacts[] | select(.name == $name and (.expired | not))' \
+                        <<<"$artifacts_json" >/dev/null
+                  done
+
+            - name: Reconstruct PR 1797 merge configuration
+              run: |
+                  python3 -m pip install pydantic pyyaml
+
+                  git fetch origin "pull/${SOURCE_PR_NUMBER}/head"
+                  git cat-file -e "${SOURCE_HEAD_SHA}^{commit}"
+                  git cat-file -e "${FINAL_PR_HEAD_SHA}^{commit}"
+                  git cat-file -e "${ORIGINAL_MERGE_SHA}^{commit}"
+                  test "$(git rev-parse "${ORIGINAL_MERGE_SHA}^")" = "$ORIGINAL_BASE_SHA"
+
+                  python3 - <<'PY'
+                  import subprocess
+                  import yaml
+
+                  source = "29e08b95e557d6d6408861d3397c393d9d501865"
+                  final = "392878acc0f9e5e6f0c0750dc56c864cdfc2b293"
+
+                  def blob(ref, path):
+                      return subprocess.check_output(["git", "show", f"{ref}:{path}"])
+
+                  def yaml_key(ref, path, key):
+                      return yaml.safe_load(blob(ref, path))[key]
+
+                  checks = (
+                      (".github/configs/nvidia-master.yaml", "kimik2.5-fp4-gb200-dynamo-trt"),
+                      (".github/configs/runners.yaml", "gb200-nv"),
+                  )
+                  for path, key in checks:
+                      if yaml_key(source, path, key) != yaml_key(final, path, key):
+                          raise SystemExit(f"{path}:{key} changed after the source sweep")
+
+                  launcher = "runners/launch_gb200-nv.sh"
+                  if blob(source, launcher) != blob(final, launcher):
+                      raise SystemExit(f"{launcher} changed after the source sweep")
+                  PY
+
+                  audit_json=$(python3 utils/recover_failed_ingest.py \
+                    audit-changelog --ref "$ORIGINAL_MERGE_SHA")
+                  jq -e '.errors | length == 0' <<<"$audit_json" >/dev/null
+
+                  worktree="$RUNNER_TEMP/recovery-worktree"
+                  python3 utils/recover_failed_ingest.py create-worktree \
+                    --ref "$ORIGINAL_MERGE_SHA" \
+                    --directory "$worktree"
+                  python3 utils/recover_failed_ingest.py build-config \
+                    --worktree "$worktree" \
+                    --base-ref "$ORIGINAL_BASE_SHA" \
+                    --merge-ref "$ORIGINAL_MERGE_SHA" \
+                    --pr-number "$SOURCE_PR_NUMBER" \
+                    --config-output "$RUNNER_TEMP/full-config.json" \
+                    --metadata-output \
+                      "$RUNNER_TEMP/changelog-metadata/changelog_metadata.json" \
+                    | tee "$RUNNER_TEMP/reconstruction.json"
+                  git worktree remove "$worktree"
+
+                  jq -e \
+                    --argjson fixed "$EXPECTED_FIXED_ROWS" \
+                    --argjson agentic "$EXPECTED_AGENTIC_ROWS" \
+                    --argjson evals "$EXPECTED_EVAL_JOBS" \
+                    '.appended_entries == 1 and
+                     .fixed_rows == $fixed and
+                     .agentic_rows == $agentic and
+                     .eval_jobs == $evals' \
+                    "$RUNNER_TEMP/reconstruction.json" >/dev/null
+
+            - name: Download reusable benchmark artifacts
+              env:
+                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
+              run: |
+                  artifacts_dir="$RUNNER_TEMP/source-artifacts"
+                  gh run download "$SOURCE_RUN_ID" \
+                    --repo "$SOURCE_REPO" \
+                    -D "$artifacts_dir"
+
+                  rm -rf "$artifacts_dir/changelog-metadata"
+                  for artifact_dir in "$artifacts_dir"/*; do
+                      [ -e "$artifact_dir" ] || continue
+                      name=$(basename "$artifact_dir")
+                      case "$name" in
+                          results_bmk|eval_results_all|run-stats|bmk_*|eval_*|agentic_*|server_logs_*|multinode_server_logs_*)
+                              ;;
+                          *)
+                              rm -rf "$artifact_dir"
+                              ;;
+                      esac
+                  done
+
+                  mkdir -p "$artifacts_dir/reused-ingest-metadata"
+                  jq -n \
+                    --arg source_run_id "$SOURCE_RUN_ID" \
+                    --arg source_run_attempt "$SOURCE_RUN_ATTEMPT" \
+                    --arg source_run_url "https://github.com/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}" \
+                    --arg source_pr_number "$SOURCE_PR_NUMBER" \
+                    --arg source_head_sha "$SOURCE_HEAD_SHA" \
+                    --arg target_run_id "$TARGET_RUN_ID" \
+                    --arg target_setup_job_id "$TARGET_SETUP_JOB_ID" \
+                    --arg target_conclusion "skipped" \
+                    --arg original_base_sha "$ORIGINAL_BASE_SHA" \
+                    --arg original_merge_sha "$ORIGINAL_MERGE_SHA" \
+                    --arg ingest_run_id "$GITHUB_RUN_ID" \
+                    --arg ingest_run_attempt "$GITHUB_RUN_ATTEMPT" \
+                    --arg ingest_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+                    '{
+                      source_run_id: $source_run_id,
+                      source_run_attempt: $source_run_attempt,
+                      source_run_url: $source_run_url,
+                      source_pr_number: $source_pr_number,
+                      source_head_sha: $source_head_sha,
+                      target_run_id: $target_run_id,
+                      target_setup_job_id: $target_setup_job_id,
+                      target_conclusion: $target_conclusion,
+                      original_base_sha: $original_base_sha,
+                      original_merge_sha: $original_merge_sha,
+                      ingest_run_id: $ingest_run_id,
+                      ingest_run_attempt: $ingest_run_attempt,
+                      ingest_run_url: $ingest_run_url
+                    }' \
+                    > "$artifacts_dir/reused-ingest-metadata/reuse_source_run.json"
+
+            - name: Validate reusable artifacts
+              run: |
+                  python3 utils/validate_reusable_sweep_artifacts.py \
+                    --config-json "$RUNNER_TEMP/full-config.json" \
+                    --artifacts-dir "$RUNNER_TEMP/source-artifacts" \
+                    | tee -a "$GITHUB_STEP_SUMMARY"
+
+            - name: Upload reusable ingest artifacts
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: reused-ingest-artifacts
+                  path: ${{ runner.temp }}/source-artifacts/*
+
+            - name: Upload PR 1797 changelog metadata
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: changelog-metadata
+                  path: ${{ runner.temp }}/changelog-metadata/changelog_metadata.json
+
+            - name: Trigger database ingest
+              run: |
+                  curl -sSf -X POST \
+                    -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
+                    -H "Accept: application/vnd.github+v3+json" \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
+                    -d '{
+                      "event_type": "ingest-results",
+                      "client_payload": {
+                        "run-id": "${{ github.run_id }}",
+                        "run-attempt": "${{ github.run_attempt }}"
+                      }
+                    }'


### PR DESCRIPTION
## Summary

- Add a one-shot, CPU-only workflow to recover the official ingest for PR #1797.
- Reuse the already validated artifacts from source run 27591355916, attempt 6.
- Reconstruct the original merge matrix and changelog metadata without rerunning GPU benchmarks.

## Root cause

The push-to-main [run 27845906617](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27845906617) completed as `skipped`. Its squash commit message inherited `[skip-sweep]` from the reuse refresh commits, so `setup` never ran and the merge workflow never downloaded or ingested the reusable artifacts.

## Validated source

- Source: [run 27591355916](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27591355916), attempt 6
- Source SHA: `29e08b95e557d6d6408861d3397c393d9d501865`
- Final PR head: `392878acc0f9e5e6f0c0750dc56c864cdfc2b293`
- Original merge: `1ae2b9c6cfc022d77a13463fbdebea5f4acc7a98`
- Exact matrix: 25 fixed-sequence rows, 0 agentic rows, 2 eval jobs

The Kimi configuration, `gb200-nv` runner definition, and GB200 launcher are unchanged between the source SHA and final PR head. The downloaded aggregate and raw eval artifacts pass exact identity validation against the reconstructed merge matrix.

## Safeguards

- `workflow_dispatch` only, guarded by the exact `recover-pr-1797` confirmation
- one `ubuntu-latest` job with explicit read-only GitHub token permissions
- no matrix, benchmark reusable workflow, or GPU runner
- detached historical worktree reconstruction
- hard-coded target, source, PR, base, merge, attempt, and SHA validation
- exact artifact validation before upload and database dispatch

## Validation

- `python3 utils/recover_failed_ingest.py validate-workflow ...`
- `actionlint .github/workflows/recover-pr-1797-ingest.yml`
- `yq eval '.' .github/workflows/recover-pr-1797-ingest.yml`
- `git diff --check`
- 30 focused recovery and reusable-artifact tests
- local exact artifact validation: 25 fixed-sequence rows and 2 eval jobs
