### PR TITLE
[codex] Make skip-sweep PR-only and fix ingest recovery

### DIFF
--- a/.claude/commands/recover-failed-ingest.md
+++ b/.claude/commands/recover-failed-ingest.md
@@ -1,44 +1,48 @@
 ---
-description: Recover a failed main-branch sweep ingest from validated PR artifacts without rerunning GPU benchmarks
+description: Recover a failed main-branch sweep ingest through the normal artifact-reuse path without rerunning GPU benchmarks
 argument-hint: <failed-run-or-job-url> [source-run-id]
 ---
 
-Recover the official database ingest for a failed InferenceX push-to-main `Run Sweep`
-workflow by reusing artifacts from the corresponding PR sweep. Execute the diagnosis,
-recovery PR, dispatch, and downstream verification end to end.
+Recover the official database ingest for a failed or skipped InferenceX
+push-to-main `Run Sweep` workflow by creating a recovery PR that reuses validated
+artifacts from an earlier PR sweep. Do not add a one-off recovery workflow.
 
 Inputs from `$ARGUMENTS`:
 
-- `failed-run-or-job-url` is required. A run-only URL is accepted only when it has exactly
-  one completed failed job; otherwise require a `/job/<job-id>` URL.
-- `source-run-id` is optional and is only a candidate until every source and artifact check
-  passes.
+- `failed-run-or-job-url` is required.
+- `source-run-id` is optional and remains a candidate until every source,
+  ancestry, matrix, and artifact check passes.
 
 ## Safety rules
 
 - Never rerun the failed target workflow or job.
-- The target must be a completed failed `push` run of
-  `.github/workflows/run-sweep.yml` on `main`.
-- Reuse only a completed PR run of that workflow whose head SHA remains in the merged PR.
-  Unpinned runs must be successful. A specifically supplied failed run is allowed only when
-  exact artifact validation proves the target matrix is complete.
-- Stop if execution-relevant files changed between the source SHA and final PR head.
-- The recovery workflow must contain one `ubuntu-latest` job, only
-  `workflow_dispatch`, and an exact confirmation input. It must not call benchmark reusable
-  workflows or use a matrix. Its GitHub token permissions must be explicitly read-only.
-- Preserve historical `perf-changelog.yaml` bytes. Reconstruct only the target PR's appended
-  entries, with canonical links to that PR.
-- Use a detached temporary worktree for reconstruction. Every `git add`, `write-tree`, and
-  processor command must run through `git -C "$WORKTREE"` or the recovery helper.
-- Never bypass failing or pending checks. Use admin merge only when all checks passed and
-  repository policy is the sole blocker.
-- Put `[skip-sweep]` in the recovery commit and merge subject.
-- Do not add co-author lines, generated-by text, bot branding, or author attribution.
+- The target must be a completed `push` run of
+  `.github/workflows/run-sweep.yml` on `main` whose official ingest did not
+  complete.
+- Reuse only a completed `pull_request` run of `run-sweep.yml`. Unpinned reuse
+  requires success. A specifically pinned failed run is allowed only when exact
+  artifact validation proves the recovery matrix is complete.
+- Stop if execution-relevant config, image, model, runner, launcher, benchmark,
+  or matrix files changed between the source SHA and the final source PR head.
+- Preserve all historical `perf-changelog.yaml` bytes. Append recovery entries
+  only at the end.
+- Keep exactly one full-sweep label on the recovery PR and pin the source run
+  with `/reuse-sweep-run <run_id>` before pushing the changelog change.
+- The final recovery branch head must have the recovery commit as its first
+  parent, the source run SHA as its second parent, and the recovery commit's
+  file tree unchanged.
+- Never rebase, squash, force-push, or otherwise rewrite the recovery branch
+  after attaching the source SHA. Those operations can remove the ancestry that
+  makes the source run reusable.
+- Do not rely on `[skip-sweep]`. Reuse authorization suppresses PR benchmark
+  work, and pushes to `main` ignore that marker.
+- Never bypass failing or pending checks. Use admin merge only when all checks
+  passed and repository policy is the sole blocker.
+- Do not add co-author lines, generated-by text, bot branding, or attribution.
 
-## 1. Inspect the exact target
+## 1. Inspect the target
 
-Install local helper dependencies, then let the tested helper parse the URL, resolve an
-omitted job ID only when unambiguous, validate target invariants, and resolve the merged PR:
+Install helper dependencies and inspect the target:
 
 ```bash
 python -m pip install pydantic pyyaml
@@ -48,7 +52,7 @@ python utils/recover_failed_ingest.py inspect-target \
 
 TARGET_RUN_ID=$(jq -r .run_id /tmp/infx-recovery-target.json)
 TARGET_JOB_ID=$(jq -r .job_id /tmp/infx-recovery-target.json)
-PR=$(jq -r .pr_number /tmp/infx-recovery-target.json)
+ORIGINAL_PR=$(jq -r .pr_number /tmp/infx-recovery-target.json)
 ORIGINAL_MERGE_SHA=$(jq -r .merge_sha /tmp/infx-recovery-target.json)
 
 gh run view "$TARGET_RUN_ID" \
@@ -57,7 +61,25 @@ gh run view "$TARGET_RUN_ID" \
   > "/tmp/infx-target-$TARGET_RUN_ID.log"
 ```
 
-Fetch history and require the merge's first parent:
+`inspect-target` handles completed failed runs. If the target workflow itself
+was `skipped`, inspect it directly with `gh api`, identify the skipped setup or
+reuse job, and resolve the merge SHA to exactly one merged PR:
+
+```bash
+TARGET_RUN_ID=<run-id>
+TARGET_JSON=$(gh api \
+  "repos/SemiAnalysisAI/InferenceX/actions/runs/$TARGET_RUN_ID")
+ORIGINAL_MERGE_SHA=$(jq -r .head_sha <<<"$TARGET_JSON")
+ORIGINAL_PR=$(gh api \
+  "repos/SemiAnalysisAI/InferenceX/commits/$ORIGINAL_MERGE_SHA/pulls" \
+  --jq 'if length == 1 then .[0].number else error("expected one PR") end')
+```
+
+Require event `push`, status `completed`, workflow path
+`.github/workflows/run-sweep.yml`, branch `main`, and a failed or skipped state
+that explains the missing ingest. Record the original PR and root cause.
+
+Fetch history and inspect the exact original changelog delta:
 
 ```bash
 git fetch origin main
@@ -65,42 +87,49 @@ git cat-file -e "${ORIGINAL_MERGE_SHA}^{commit}"
 ORIGINAL_BASE_SHA=$(git rev-parse "${ORIGINAL_MERGE_SHA}^")
 python utils/recover_failed_ingest.py audit-changelog \
   --ref "$ORIGINAL_MERGE_SHA"
-git diff --check "$ORIGINAL_BASE_SHA" "$ORIGINAL_MERGE_SHA" \
-  -- perf-changelog.yaml
+git diff "$ORIGINAL_BASE_SHA" "$ORIGINAL_MERGE_SHA" -- \
+  perf-changelog.yaml
 ```
 
-The audit reads `perf-changelog.yaml` from `ORIGINAL_MERGE_SHA`, never from the current
-checkout. Its `errors` list records repairable historical defects such as a missing final
-newline; duplicate keys or an unparseable schema still abort. Record the failed job's root
-cause and stop unless it is an ingest/reuse failure that can be repaired without GPU work.
+## 2. Select and validate the source run
 
-## 2. Select the source PR sweep
-
-Enumerate every current PR commit and every `run-sweep.yml` PR run for those SHAs. Validate
-the candidate through GitHub's API:
-
-- workflow path, event, status, conclusion, attempt, and source head SHA;
-- source-head membership in the PR commit list;
-- all retained artifacts are unexpired;
-- the candidate produced `results_bmk`, `eval_results_all`, or at least one
-  `bmk_agentic_*` point artifact.
-
-Do not require `results_bmk` or `run-stats` for eval-only or agentic-only matrices. The exact
-matrix validator in step 4 decides which aggregates and point artifacts are required.
-
-Compare the source SHA through the final PR head. Any target-specific config, image, model,
-runner, launcher, benchmark script, or matrix change disqualifies the source.
-
-## 3. Reconstruct in a detached worktree
-
-Read the two prior examples, inspect the historical diff, and create a worktree at the exact
-failed merge:
+Resolve the candidate source run and record:
 
 ```bash
-sed -n '1,260p' .github/workflows/recover-pr-1767-ingest.yml
-sed -n '1,280p' .github/workflows/recover-pr-1798-ingest.yml
-git diff "$ORIGINAL_BASE_SHA" "$ORIGINAL_MERGE_SHA" -- perf-changelog.yaml
+SOURCE_RUN_ID=<validated-run-id>
+SOURCE_JSON=$(gh api \
+  "repos/SemiAnalysisAI/InferenceX/actions/runs/$SOURCE_RUN_ID")
+SOURCE_HEAD_SHA=$(jq -r .head_sha <<<"$SOURCE_JSON")
+SOURCE_RUN_ATTEMPT=$(jq -r .run_attempt <<<"$SOURCE_JSON")
+```
 
+Require:
+
+- event `pull_request`, status `completed`, and path
+  `.github/workflows/run-sweep.yml`;
+- a successful conclusion unless this exact run ID was explicitly supplied;
+- an unexpired benchmark, eval, or agentic result artifact;
+- source-head membership in its original PR commit list.
+
+Find the source PR and fetch its history:
+
+```bash
+SOURCE_PR=$(gh api \
+  "repos/SemiAnalysisAI/InferenceX/commits/$SOURCE_HEAD_SHA/pulls" \
+  --jq 'if length == 1 then .[0].number else error("expected one source PR") end')
+git fetch origin "pull/$SOURCE_PR/head:refs/remotes/origin/source-pr-$SOURCE_PR"
+git cat-file -e "${SOURCE_HEAD_SHA}^{commit}"
+```
+
+Compare `SOURCE_HEAD_SHA` through the final source PR head. Stop if any
+execution-relevant target configuration changed after the source run.
+
+## 3. Reconstruct and validate the intended matrix
+
+Use a detached worktree at the original merge to reconstruct its intended
+changelog entries when historical formatting or links need repair:
+
+```bash
 WORKTREE=$(mktemp -d /tmp/infx-recovery-worktree.XXXXXX)
 rmdir "$WORKTREE"
 python utils/recover_failed_ingest.py create-worktree \
@@ -108,30 +137,115 @@ python utils/recover_failed_ingest.py create-worktree \
   --directory "$WORKTREE"
 ```
 
-Edit only `$WORKTREE/perf-changelog.yaml`. Repair malformed target entries and reverse any
-unrelated historical repair so the resulting file is exactly the base bytes followed by the
-target PR's intended entries. Do not autoformat or deduplicate.
-
-Build the synthetic commit and config through the helper. It stages only inside the detached
-worktree, rejects unrelated changes, enforces exact historical bytes and canonical PR links,
-and verifies that the synthetic commit changes only `perf-changelog.yaml`:
+Edit only `$WORKTREE/perf-changelog.yaml`. Preserve the original base bytes and
+append only the original PR's intended entries with canonical links. Then build
+the historical matrix:
 
 ```bash
 python utils/recover_failed_ingest.py build-config \
   --worktree "$WORKTREE" \
   --base-ref "$ORIGINAL_BASE_SHA" \
   --merge-ref "$ORIGINAL_MERGE_SHA" \
-  --pr-number "$PR" \
-  --config-output /tmp/full-config.json \
-  --metadata-output /tmp/changelog-metadata/changelog_metadata.json
+  --pr-number "$ORIGINAL_PR" \
+  --config-output /tmp/original-full-config.json \
+  --metadata-output /tmp/original-changelog-metadata.json
 ```
 
-Inspect the reported fixed-sequence, agentic, and eval counts before continuing.
+Record the fixed-sequence, agentic, and eval counts. Remove the worktree when
+finished:
 
-## 4. Download and validate exact artifacts
+```bash
+git worktree remove "$WORKTREE"
+```
 
-Download the selected source run to a fresh directory. Remove its changelog metadata and
-retain only ingest-relevant classes:
+## 4. Bootstrap the recovery PR
+
+Create an empty bootstrap branch from current `main`. Opening and labeling the
+PR before it changes `perf-changelog.yaml` avoids starting a sweep before reuse
+is authorized:
+
+```bash
+git fetch origin main
+BRANCH="recovery/reuse-pr-$ORIGINAL_PR"
+git switch -c "$BRANCH" origin/main
+git commit --allow-empty -m "chore: prepare PR $ORIGINAL_PR ingest recovery"
+git push -u origin "$BRANCH"
+
+RECOVERY_PR_URL=$(gh pr create \
+  --repo SemiAnalysisAI/InferenceX \
+  --base main \
+  --head "$BRANCH" \
+  --title "fix: recover PR $ORIGINAL_PR ingest via sweep reuse" \
+  --body "Recover the missing official ingest from source run $SOURCE_RUN_ID.")
+RECOVERY_PR=$(gh pr view "$RECOVERY_PR_URL" \
+  --repo SemiAnalysisAI/InferenceX \
+  --json number --jq .number)
+
+gh pr edit "$RECOVERY_PR" \
+  --repo SemiAnalysisAI/InferenceX \
+  --add-label full-sweep-enabled
+gh pr comment "$RECOVERY_PR" \
+  --repo SemiAnalysisAI/InferenceX \
+  --body "/reuse-sweep-run $SOURCE_RUN_ID"
+```
+
+Keep exactly one of `full-sweep-enabled`,
+`non-canary-full-sweep-enabled`, `full-sweep-fail-fast`, or
+`full-sweep-fail-fast-no-canary`.
+
+## 5. Append the recovery changelog and validate artifacts
+
+Append recovery entries to the end of `perf-changelog.yaml`. Preserve the
+original entries' `config-keys`, `evals-only`, and `scenario-type` shape so the
+recovery PR generates the same logical matrix. Use the new recovery PR URL and
+state clearly that this is an artifact-only ingest recovery.
+
+Commit without `[skip-sweep]`:
+
+```bash
+git add perf-changelog.yaml
+git commit -m "fix: recover PR $ORIGINAL_PR ingest"
+RECOVERY_COMMIT=$(git rev-parse HEAD)
+```
+
+Generate the exact matrix that the merge-to-main run will validate:
+
+```bash
+python utils/validate_perf_changelog.py \
+  --changelog-file perf-changelog.yaml \
+  --base-ref origin/main \
+  --head-ref "$RECOVERY_COMMIT"
+python utils/process_changelog.py \
+  --changelog-file perf-changelog.yaml \
+  --base-ref origin/main \
+  --head-ref "$RECOVERY_COMMIT" \
+  > /tmp/recovery-full-config.json
+```
+
+Download the source run to a fresh directory, remove its
+`changelog-metadata`, and retain only ingest-relevant artifact classes:
+
+```bash
+rm -rf /tmp/source-artifacts
+gh run download "$SOURCE_RUN_ID" \
+  --repo SemiAnalysisAI/InferenceX \
+  -D /tmp/source-artifacts
+rm -rf /tmp/source-artifacts/changelog-metadata
+
+for artifact_dir in /tmp/source-artifacts/*; do
+  [ -e "$artifact_dir" ] || continue
+  name=$(basename "$artifact_dir")
+  case "$name" in
+    results_bmk|eval_results_all|run-stats|bmk_*|eval_*|agentic_*|server_logs_*|multinode_server_logs_*)
+      ;;
+    *)
+      rm -rf "$artifact_dir"
+      ;;
+  esac
+done
+```
+
+The retained classes are:
 
 ```text
 results_bmk
@@ -142,67 +256,124 @@ eval_*
 agentic_*
 server_logs_*
 multinode_server_logs_*
-agentic_aggregated
 ```
 
-Run the authoritative exact validator:
+Validate exact equality against the recovery PR matrix:
 
 ```bash
 python utils/validate_reusable_sweep_artifacts.py \
-  --config-json /tmp/full-config.json \
+  --config-json /tmp/recovery-full-config.json \
   --artifacts-dir /tmp/source-artifacts
 ```
 
-It requires equality for fixed-sequence identities, agentic point/raw/aggregate identities,
-and eval-only raw identities. It also rejects unexpected rows and requires `run-stats` only
-when fixed-sequence collection should have produced it. Stop on any mismatch.
+Stop on any missing, unexpected, or duplicate fixed-sequence, agentic, or eval
+identity.
 
-## 5. Create the guarded recovery workflow
+## 6. Attach the source SHA without changing the tree
 
-Create `workflow/recover-pr-<PR>-ingest` from current `origin/main` and add
-`.github/workflows/recover-pr-<PR>-ingest.yml`, based on the closest prior example.
-Hard-code the validated source run/attempt/SHA, target run/job, PR, original base, and merge
-SHAs. Revalidate those values in the workflow before downloading artifacts.
-
-The workflow must reproduce the locally tested reconstruction, upload
-`reused-ingest-artifacts` and corrected `changelog-metadata`, then dispatch
-`ingest-results` to `SemiAnalysisAI/InferenceX-app`.
-
-Validate it before committing:
+Make the ancestry carrier the final branch commit. `git commit-tree` guarantees
+the required parent order and preserves the recovery tree:
 
 ```bash
-python utils/recover_failed_ingest.py validate-workflow \
-  ".github/workflows/recover-pr-$PR-ingest.yml" \
-  --pr-number "$PR"
-actionlint ".github/workflows/recover-pr-$PR-ingest.yml"
-yq eval '.' ".github/workflows/recover-pr-$PR-ingest.yml" >/dev/null
-git diff --check
+TARGET_PARENT=$(git rev-parse HEAD)
+TARGET_TREE=$(git rev-parse "${TARGET_PARENT}^{tree}")
+ATTACH_SHA=$(
+  printf 'chore: attach reusable sweep run %s\n' "$SOURCE_RUN_ID" |
+    git commit-tree "$TARGET_TREE" \
+      -p "$TARGET_PARENT" \
+      -p "$SOURCE_HEAD_SHA"
+)
+git reset --hard "$ATTACH_SHA"
+
+test "$(git rev-parse HEAD^1)" = "$TARGET_PARENT"
+test "$(git rev-parse HEAD^2)" = "$SOURCE_HEAD_SHA"
+test "$(git rev-parse HEAD^{tree})" = "$(git rev-parse HEAD^1^{tree})"
+test "$(git diff --name-only origin/main...HEAD)" = "perf-changelog.yaml"
+git diff --check origin/main...HEAD
 ```
 
-Commit as `fix: recover PR <PR> ingest [skip-sweep]`, push, and open a PR. The body and a PR
-comment must record the failed target/job, root cause, source run/attempt/SHA, exact counts,
-and CPU-only safeguards. Do not add attribution.
-
-Wait for all checks, then merge with a `[skip-sweep]` subject. Use admin merge only for the
-policy-only case described above.
-
-## 6. Dispatch and verify
-
-Dispatch from `main` with the exact confirmation string:
+Push once the branch is based on the current `main`:
 
 ```bash
-gh workflow run "recover-pr-$PR-ingest.yml" \
+git push origin "$BRANCH"
+```
+
+Do not rebase, squash, amend, or force-push after this point.
+
+## 7. Verify the PR reuse gate
+
+Require GitHub to list `SOURCE_HEAD_SHA` in the recovery PR commit list while
+the Files tab contains only the recovery changelog append:
+
+```bash
+gh api \
+  "repos/SemiAnalysisAI/InferenceX/pulls/$RECOVERY_PR/commits" \
+  --paginate --jq '.[].sha' |
+  grep -Fx "$SOURCE_HEAD_SHA"
+
+gh pr diff "$RECOVERY_PR" \
   --repo SemiAnalysisAI/InferenceX \
-  --ref main \
-  -f confirm="recover-pr-$PR"
+  --name-only
 ```
 
-Require the carrier workflow to succeed and confirm it created no GPU or benchmark jobs.
-Then locate the resulting `repository_dispatch` run in `SemiAnalysisAI/InferenceX-app`.
-Require successful artifact download/flattening, database ingest, run overrides, database
-verification, cache invalidation, and unmapped-entity checks.
+Wait for `check-changelog` and `reuse-sweep-gate` to pass. `setup` and all GPU
+jobs must be skipped:
 
-Post a final recovery PR comment with carrier and downstream run links plus exact counts.
-Remove the temporary worktree with `git worktree remove "$WORKTREE"` and report the recovery
-PR, merge SHA, source attempt, carrier run, downstream run, row counts, and verification
-outcome.
+```bash
+gh pr checks "$RECOVERY_PR" \
+  --repo SemiAnalysisAI/InferenceX \
+  --watch --fail-fast
+```
+
+Also invoke `validate_reusable_run` locally against the recovery PR so source
+ancestry, workflow path, conclusion, and artifacts are checked before merge.
+
+```bash
+GH_TOKEN="$(gh auth token)" \
+SOURCE_RUN_ID="$SOURCE_RUN_ID" \
+RECOVERY_PR="$RECOVERY_PR" \
+python3 - <<'PY'
+import os
+
+from utils import find_reusable_sweep_run as reuse
+
+repo = "SemiAnalysisAI/InferenceX"
+token = os.environ["GH_TOKEN"]
+run_id = int(os.environ["SOURCE_RUN_ID"])
+pr_number = int(os.environ["RECOVERY_PR"])
+run = reuse.github_api(repo, f"/actions/runs/{run_id}", token)
+reuse.validate_reusable_run(
+    repo,
+    "run-sweep.yml",
+    pr_number,
+    run,
+    token,
+    allow_failed=True,
+)
+print(f"Validated reusable run {run_id} for PR #{pr_number}")
+PY
+```
+
+## 8. Merge and verify official ingest
+
+Merge the current branch head without rewriting its commits. If `main` advances
+or the PR conflicts, update from `main` first and recreate the final two-parent
+carrier commit before pushing again.
+
+The push-to-main `Run Sweep` must:
+
+- run `setup` even if the merge message contains `[skip-sweep]`;
+- resolve the recovery PR and pinned source run;
+- set `reuse-enabled=true`;
+- pass `reuse-ingest-artifacts` exact validation;
+- upload recovery changelog metadata;
+- run `trigger-ingest`.
+
+Then locate the resulting `repository_dispatch` run in
+`SemiAnalysisAI/InferenceX-app`. Require successful artifact download,
+flattening, database ingest, run overrides, database verification, cache
+invalidation, and unmapped-entity checks.
+
+Post a final recovery PR comment with the original failed run/job, source
+run/attempt/SHA, recovery merge run, downstream ingest run, exact matrix counts,
+and verification outcome.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -180,6 +180,12 @@ test-config --config-keys *-b200-* --conc 4 8 --config-files .github/configs/nvi
 
 ## Reusing an Approved PR Full Sweep
 
+`[skip-sweep]` is a PR-only benchmark opt-out. When it appears in the latest
+PR head commit, `check-changelog` still validates the matrix and the reuse gate
+still runs, but benchmark setup is skipped. Pushes to `main` ignore the marker
+and always enter setup, where they either reuse approved artifacts or run the
+full untrimmed sweep.
+
 If a PR has already run the full untrimmed sweep (`full-sweep-enabled` with a
 sequential canary, `non-canary-full-sweep-enabled` without one, or a
 fail-fast variant — `full-sweep-fail-fast` / `full-sweep-fail-fast-no-canary`), a

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -47,6 +47,8 @@ jobs:
               github.event.label.name == 'full-sweep-fail-fast' ||
               github.event.label.name == 'full-sweep-fail-fast-no-canary'
             )
+        outputs:
+            skip-pr-sweep: ${{ steps.sweep_policy.outputs.skip-pr-sweep }}
         steps:
             - name: Reject conflicting sweep labels
               env:
@@ -74,6 +76,17 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
+
+            - name: Read PR sweep policy
+              id: sweep_policy
+              env:
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+              run: |
+                  if git log -1 --format=%B "$HEAD_SHA" | grep -Fq '[skip-sweep]'; then
+                      echo "skip-pr-sweep=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "skip-pr-sweep=false" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Validate perf-changelog matrix
               run: |
@@ -142,6 +155,7 @@ jobs:
               (
                 github.event_name == 'pull_request' &&
                 !github.event.pull_request.draft &&
+                needs.check-changelog.outputs.skip-pr-sweep != 'true' &&
                 (
                   contains(github.event.pull_request.labels.*.name, 'sweep-enabled') ||
                   contains(github.event.pull_request.labels.*.name, 'full-sweep-enabled') ||
@@ -159,8 +173,7 @@ jobs:
                 )
               ) ||
               (
-                github.event_name != 'pull_request' &&
-                !contains(github.event.head_commit.message, '[skip-sweep]')
+                github.event_name == 'push'
               )
             )
         outputs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ YAML: kebab-case field names (`model-prefix`, `conc-start`, `dp-attn`). Master c
 
 Bash: source shared utilities via `source benchmark_lib.sh` (`check_env_vars`, `wait_for_server_ready`, `run_benchmark_serving`, `run_eval`, `append_lm_eval_summary`); parameters passed via env vars. **MTP scripts MUST pass `--use-chat-template` to `run_benchmark_serving`** - EAGLE-style spec decoding is trained against chat-formatted inputs; benchmarking against raw prompts silently regresses acceptance rate. Applies to every `*_mtp.sh`.
 
-Git: conventional commit messages. `[skip-sweep]` in commit message skips benchmarks (push-to-main only). Changes to `perf-changelog.yaml` trigger benchmark runs.
+Git: conventional commit messages. `[skip-sweep]` in the latest PR head commit skips that PR's benchmark setup after changelog validation. It is ignored on pushes to `main`. Changes to `perf-changelog.yaml` trigger benchmark runs.
 
 Docs: the README is bilingual — `README.md` (English, default) and `README_zh.md` (Simplified Chinese), with an `English | 中文` switcher under the badges. **Any edit to `README.md` MUST be mirrored in `README_zh.md`, and vice versa** — keep the two in sync (same sections, links, badges, images) and update both in the same PR.
 
@@ -71,7 +71,7 @@ PRs do not run the sweep automatically - `run-sweep.yml` is gated on a label. Pi
 
 **The sweep does not trigger while the PR has merge conflicts.** Even with `sweep-enabled`, `full-sweep-enabled`, `non-canary-full-sweep-enabled`, or `full-sweep-fail-fast` applied, the `run-sweep.yml` workflow will not start until the PR cleanly merges into main — a stale claude/* or update-* branch with a `perf-changelog.yaml` conflict (the common case) will sit in NO_SWEEP / NO_SUCCESS until rebased. Resolution recipe is documented in `KLAUD_DEBUG.md §1.1`: `git merge origin/main`, then `git checkout origin/main -- perf-changelog.yaml`, then re-append the PR's own changelog entry at the tail. Don't 3-way merge `perf-changelog.yaml`; whitespace edits silently re-trigger the deletion check.
 
-Push-to-main always runs the full untrimmed sweep unless `[skip-sweep]` is in the commit message. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the lowest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[min(conc)]`.
+Push-to-main always enters sweep setup: it either reuses approved full-sweep artifacts or runs the full untrimmed sweep. `[skip-sweep]` never suppresses a main-branch sweep. For PR runs, the marker in the latest head commit skips benchmark setup while still allowing changelog validation and reuse authorization checks. Trim logic lives in `trim_conc()` in `utils/process_changelog.py`: single-node entries are grouped by every non-`conc` field and only the lowest-`conc` entry per group is kept; multi-node entries have their `conc` list collapsed to `[min(conc)]`.
 
 ## Common Tasks
 

--- a/utils/changelog_gate_tests/test_recover_failed_ingest.py
+++ b/utils/changelog_gate_tests/test_recover_failed_ingest.py
@@ -17,6 +17,9 @@ from recover_failed_ingest import (
 from validate_perf_changelog import ChangelogValidationError
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
 def block(key: str, link: str) -> bytes:
     return f"""- config-keys:
     - {key}
@@ -307,3 +310,18 @@ def test_synthetic_commit_uses_base_tree_plus_only_changelog(
         "perf-changelog.yaml"
     )
     assert git("show", f"{fixed_sha}:other.txt") == "base"
+
+
+def test_recovery_command_uses_normal_sweep_reuse_path() -> None:
+    command = (
+        REPO_ROOT / ".claude/commands/recover-failed-ingest.md"
+    ).read_text()
+
+    assert "git commit-tree" in command
+    assert '-p "$TARGET_PARENT"' in command
+    assert '-p "$SOURCE_HEAD_SHA"' in command
+    assert "/reuse-sweep-run $SOURCE_RUN_ID" in command
+    assert "full-sweep-enabled" in command
+    assert "Create the guarded recovery workflow" not in command
+    assert "validate-workflow" not in command
+    assert 'gh workflow run "recover-pr-' not in command

--- a/utils/changelog_gate_tests/test_run_sweep_gating.py
+++ b/utils/changelog_gate_tests/test_run_sweep_gating.py
@@ -208,6 +208,9 @@ def run_dag(sc: dict) -> tuple[str, str, str]:
     else:
         check_result = sc.get("check", "success")
     ctx["needs.check-changelog.result"] = check_result
+    ctx["needs.check-changelog.outputs.skip-pr-sweep"] = (
+        "true" if "[skip-sweep]" in sc.get("msg", "") else "false"
+    )
 
     if not _eval(GATE_IF, ctx):
         gate_result, skip = "skipped", ""
@@ -259,12 +262,16 @@ CASES = [
     ("PR-ready-for-review",
      {**_PR, "action": "ready_for_review", "labels": ["full-sweep-enabled"],
       "reuse_auth": False}, ("success", "skipped", "RUN")),
+    ("PR-sync-skip-sweep-tag",
+     {**_PR, "action": "synchronize", "labels": ["full-sweep-enabled"],
+      "msg": "fix: docs [skip-sweep]"},
+     ("success", "success", "SKIP")),
     ("push-additions-no-skip",
      {"event": "push", "msg": "feat: add model"},
      ("skipped", "skipped", "RUN")),
-    ("push-skip-sweep-tag",
+    ("push-skip-sweep-tag-ignored",
      {"event": "push", "msg": "fix: x [skip-sweep]"},
-     ("skipped", "skipped", "SKIP")),
+     ("skipped", "skipped", "RUN")),
 ]
 
 
@@ -347,9 +354,14 @@ def reference_gate(sc: dict) -> tuple[str, str, str]:
         action_ok = action not in ("labeled", "unlabeled") or (
             sc.get("label_name") in SWEEP_LABELS
         )
-        event_ok = (not draft) and bool(labels & SWEEP_LABELS) and action_ok
+        event_ok = (
+            (not draft)
+            and bool(labels & SWEEP_LABELS)
+            and action_ok
+            and "[skip-sweep]" not in sc.get("msg", "")
+        )
     else:
-        event_ok = "[skip-sweep]" not in sc.get("msg", "")
+        event_ok = True
 
     check_clause = check in ("success", "skipped")
     runs = check_clause and reuse_clause and event_ok
@@ -375,11 +387,12 @@ def _all_scenarios() -> list[dict]:
         ["full-sweep-enabled", "sweep-enabled", "documentation", None],  # label.name
         [False, True],                      # reuse authorized
         ["success", "failure"],             # changelog outcome when it runs
+        ["feat: add model", "fix: thing [skip-sweep]"],  # head commit message
     )
     scenarios = [
         {"event": "pull_request", "action": a, "draft": d, "labels": labs,
-         "label_name": ln, "reuse_auth": r, "check": chk}
-        for a, d, labs, ln, r, chk in pr_axes
+         "label_name": ln, "reuse_auth": r, "check": chk, "msg": msg}
+        for a, d, labs, ln, r, chk, msg in pr_axes
     ]
     scenarios += [
         {"event": "push", "msg": msg}
@@ -398,8 +411,8 @@ def test_exhaustive_cross_product() -> None:
     assert not mismatches, mismatches[:10]
     # Sanity: confirm the sweep actually covered the whole input space
     # (4 actions x 2 draft x 9 label-configs x 4 label-names x 2 reuse x
-    # 2 changelog outcomes = 1152 PR cases, plus 2 push cases).
-    assert len(scenarios) == 1154
+    # 2 changelog outcomes x 2 messages = 2304 PR cases, plus 2 push cases).
+    assert len(scenarios) == 2306
 
 
 def test_named_cases_match_reference_spec() -> None:

--- a/utils/changelog_gate_tests/test_validate_perf_changelog.py
+++ b/utils/changelog_gate_tests/test_validate_perf_changelog.py
@@ -273,6 +273,10 @@ def test_run_sweep_checks_changelog_before_reuse_and_setup() -> None:
     assert "Reject conflicting sweep labels" in check_step_names
     assert "Reject conflicting sweep labels" not in setup_step_names
     assert "needs" not in jobs["check-changelog"]
+    assert (
+        jobs["check-changelog"]["outputs"]["skip-pr-sweep"]
+        == "${{ steps.sweep_policy.outputs.skip-pr-sweep }}"
+    )
     assert jobs["reuse-sweep-gate"]["needs"] == "check-changelog"
     assert jobs["setup"]["needs"] == [
         "check-changelog",
@@ -291,6 +295,12 @@ def test_run_sweep_checks_changelog_before_reuse_and_setup() -> None:
     assert "validate_perf_changelog.py" in check_script
     assert "--base-ref" in check_script
     assert "--head-ref" in check_script
+    assert "git log -1 --format=%B" in check_script
+    assert "[skip-sweep]" in check_script
+    setup_if = jobs["setup"]["if"]
+    assert "needs.check-changelog.outputs.skip-pr-sweep != 'true'" in setup_if
+    assert "github.event_name == 'push'" in setup_if
+    assert "github.event.head_commit.message" not in setup_if
 
 
 def test_merge_helper_waits_for_pr_checks_before_merge() -> None:


### PR DESCRIPTION
## Summary

- Rewrite `.claude/commands/recover-failed-ingest.md` to recover through the normal sweep-reuse path.
- Attach the source run SHA as the recovery branch head's second parent while preserving the recovery tree.
- Make `[skip-sweep]` suppress PR benchmark setup only; pushes to `main` always enter setup.
- Keep PR changelog validation and reuse authorization active when `[skip-sweep]` is present.

## Root cause

The old recovery command created a one-off workflow instead of using the repository's validated reuse and ingest path. Separately, `[skip-sweep]` was evaluated on push-to-main squash messages, so helper-generated PR commits could accidentally suppress both normal sweep setup and artifact reuse after merge.

## Validation

- 97 changelog, reuse, recovery, artifact, and gating tests passed.
- Exhaustive gating coverage now checks 2,306 PR/push combinations.
- `actionlint` passed for `run-sweep.yml` and `test-changelog-gate.yml`.
- Workflow YAML parsing and `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when main-branch sweeps and official ingest run after merge; incorrect gating could skip needed benchmarks or block reuse, though exhaustive workflow tests mitigate this.
> 
> **Overview**
> **`[skip-sweep]` is PR-only:** `run-sweep.yml` now reads the marker from the latest PR head commit and exports `skip-pr-sweep` from `check-changelog`, which blocks benchmark `setup` on PRs while changelog validation and reuse authorization still run. **Push to `main` always enters `setup`** (reuse or full sweep); squash merge messages with `[skip-sweep]` no longer suppress main-branch ingest.
> 
> **Failed ingest recovery** is documented to use the normal reuse path: recovery PR with a full-sweep label, `/reuse-sweep-run`, changelog append, artifact validation, and a two-parent `git commit-tree` that attaches the source sweep SHA—**not** a one-off `recover-pr-*` workflow.
> 
> Docs (`AGENTS.md`, workflows README) and gating tests are updated to match (including 2,306 PR/push scenarios).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3e27827843a07523837819b0be2e41b74cd416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->