### PR TITLE
docs: link supporter quotes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,4 @@ We’re also grateful to Jensen Huang and Ian Buck for supporting this open sour
 We also want to recognize the SGLang, vLLM, and TensorRT-LLM maintainers for building a world-class software stack and open sourcing it to the entire world.
 Finally, we’re grateful to Crusoe, CoreWeave, Nebius, TensorWave, Oracle and TogetherAI for supporting open-source innovation through compute resources, enabling this.
 
-"As we build systems at unprecedented scale, it's critical for the ML community to have open, transparent benchmarks that reflect how inference really performs across hardware and software. InferenceX™'s head-to-head benchmarks cut through the noise and provide a living picture of token throughput, performance per dollar, and tokens per Megawatt. This kind of open source effort strengthens the entire ecosystem and helps everyone, from researchers to operators of frontier datacenters, make smarter decisions." - Peter Hoeschele, VP of Infrastructure and Industrial Compute, OpenAI Stargate
-
-"The gap between theoretical peak and real-world inference throughput is often determined by systems software: inference engine, distributed strategies, and low-level kernels. InferenceX™ is valuable because it benchmarks the latest software showing how optimizations actually play out across various hardware. Open, reproducible results like these help the whole community move faster.” - Tri Dao, Chief Scientist of Together AI & Inventor of Flash Attention
-
-“The industry needs many public, reproducible benchmarks of inference performance. We’re excited to collaborate with InferenceX™ from the vLLM team. More diverse workloads and scenarios that everyone can trust and reference will help the ecosystem move forward. Fair, transparent measurements drive progress across every layer of the stack, from model architectures to inference engines to hardware.” – Simon Mo, vLLM Project Co-Lead
-
+Full list of supporters & quotes: https://inferencex.semianalysis.com/quotes

--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ We also want to recognize the SGLang, vLLM, and TensorRT-LLM maintainers for bui
 Finally, we’re grateful to Crusoe, CoreWeave, Nebius, TensorWave, Oracle and TogetherAI for supporting open-source innovation through compute resources, enabling this.
 
 Full list of supporters & quotes: https://inferencex.semianalysis.com/quotes
+
+<img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/dcbda40c-4a6e-43a3-aca2-c830d3f2fb8d" />
+

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,3 +52,7 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 最后，我们衷心感谢 Crusoe、CoreWeave、Nebius、TensorWave、Oracle 与 TogetherAI 通过提供计算资源支持开源创新，使这一切成为可能。
 
 完整支持者名单与引言：https://inferencex.semianalysis.com/quotes
+
+<img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/589bfdda-905d-425f-94dc-f2551746dd9d" />
+
+

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,8 +51,4 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 我们还要感谢 SGLang、vLLM 与 TensorRT-LLM 的维护者们，他们打造了世界一流的软件栈，并将其开源给全世界。
 最后，我们衷心感谢 Crusoe、CoreWeave、Nebius、TensorWave、Oracle 与 TogetherAI 通过提供计算资源支持开源创新，使这一切成为可能。
 
-“当我们以前所未有的规模构建系统时，对机器学习社区而言，拥有开放、透明、能够反映推理在各类软硬件上真实表现的基准测试至关重要。InferenceX™ 的正面对比基准测试拨开了纷繁的噪音，为 Token 吞吐量、单位美元性能以及每兆瓦 Token 数提供了一幅鲜活的画面。这类开源工作增强了整个生态系统的实力，帮助从研究人员到前沿数据中心运营商的每一个人做出更明智的决策。” —— Peter Hoeschele，OpenAI Stargate 基础设施与工业计算副总裁
-
-“理论峰值与真实世界推理吞吐量之间的差距，往往由系统软件决定：推理引擎、分布式策略以及底层核函式。InferenceX™ 的价值在于，它对最新软件进行基准测试，展示这些优化在各类硬件上的实际效果。这类开放、可复现的结果有助于整个社区更快地前进。” —— Tri Dao，Together AI 首席科学家、Flash Attention 发明者
-
-“业界需要许多公开、可复现的推理性能基准测试。我们很高兴能代表 vLLM 团队与 InferenceX™ 展开合作。让所有人都能信赖并引用的、更加多样化的工作负载与场景，将帮助生态系统不断向前发展。公平、透明的测量推动着从模型架构到推理引擎再到硬件的每一层栈的进步。” —— Simon Mo，vLLM 项目联合负责人
+完整支持者名单与引言：https://inferencex.semianalysis.com/quotes


### PR DESCRIPTION
Summary: Replace the README supporter quote block with a link to the full supporters and quotes page, and mirror the update in README_zh.md.

Tests: git diff --check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no code, auth, or runtime behavior changes.
> 
> **Overview**
> The **Acknowledgements & Supporters** section in `README.md` and `README_zh.md` no longer embeds long inline quotes from supporters (e.g. Peter Hoeschele, Tri Dao, Simon Mo). Those blocks are replaced by a single link to the full supporters and quotes page (`https://inferencex.semianalysis.com/quotes`), with localized link text in the Chinese README.
> 
> Each README also adds a wide supporter graphic image in place of the removed quote text (English and Chinese use different image assets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757268992cb810612313960ed6cbe768c00f73de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->