### PR TITLE
docs: add supported hardware table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <a href="https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://github.com/SemiAnalysisAI/InferenceX/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
   <a href="https://inferencex.semianalysis.com/"><img alt="Dashboard" src="https://img.shields.io/badge/Performance-Dashboard-blue"></a>
+  <a href="https://deepwiki.com/SemiAnalysisAI/InferenceX"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
   <a href="https://github.com/SemiAnalysisAI/InferenceX"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/SemiAnalysisAI/InferenceX?style=social"></a>
 </p>
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ AI software like SGLang, vLLM, TensorRT-LLM, CUDA, ROCm and achieve this continu
 This pace of software advancement creates a challenge: benchmarks conducted at a fixed point in time quickly go stale and do not represent the performance that can be achieved with the latest software packages.
 
 
+## Officially Supported Hardware
+
+| SKU | Status |
+| --- | --- |
+| GB300 NVL72 | ✅ |
+| GB200 NVL72 | ✅ |
+| MI355X | ✅ |
+| B300 | ✅ |
+| B200 | ✅ |
+| MI325X | ✅ |
+| MI300X | ✅ |
+| H200 | ✅ |
+| H100 | ✅ |
+| MI455 UALoE72 | Coming Soon 🔜 |
+| Vera Rubin NVL72 | Coming Soon 🔜 |
+| Rubin NVL8 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #1 | Coming Soon 🔜 |
+| Chip #2 from Hardware Vendor #1 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #2 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #3 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #4 | Coming Soon 🔜 |
+
+
 ## Acknowledgements & Supporters
 Thank you to Lisa Su and Anush Elangovan for providing the MI355X and CDNA3 GPUs for this free and open-source project. We want to recognize the many AMD contributors for their responsiveness and for debugging, optimizing, and validating performance across AMD GPUs. 
 We’re also grateful to Jensen Huang and Ian Buck for supporting this open source with access to a GB200 NVL72 rack (through OCI) and B200 GPUs. Thank you to the many NVIDIA contributors from the NVIDIA inference team, NVIDIA Dynamo team.

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,6 +3,7 @@
   <a href="https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://github.com/SemiAnalysisAI/InferenceX/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
   <a href="https://inferencex.semianalysis.com/"><img alt="Dashboard" src="https://img.shields.io/badge/Performance-Dashboard-blue"></a>
+  <a href="https://deepwiki.com/SemiAnalysisAI/InferenceX"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
   <a href="https://github.com/SemiAnalysisAI/InferenceX"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/SemiAnalysisAI/InferenceX?style=social"></a>
 </p>
 <div align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,6 +45,29 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 这种软件演进的速度带来了一个挑战：在某个固定时间点进行的基准测试很快就会过时，无法代表使用最新软件包所能达到的性能。
 
 
+## 官方支持硬件
+
+| SKU | 状态 |
+| --- | --- |
+| GB300 NVL72 | ✅ |
+| GB200 NVL72 | ✅ |
+| MI355X | ✅ |
+| B300 | ✅ |
+| B200 | ✅ |
+| MI325X | ✅ |
+| MI300X | ✅ |
+| H200 | ✅ |
+| H100 | ✅ |
+| MI455 UALoE72 | Coming Soon 🔜 |
+| Vera Rubin NVL72 | Coming Soon 🔜 |
+| Rubin NVL8 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #1 | Coming Soon 🔜 |
+| Chip #2 from Hardware Vendor #1 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #2 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #3 | Coming Soon 🔜 |
+| Chip #1 from Hardware Vendor #4 | Coming Soon 🔜 |
+
+
 ## 致谢与支持者
 感谢 Lisa Su 与 Anush Elangovan 为这一免费开源项目提供 MI355X 与 CDNA3 GPU。我们也要感谢众多 AMD 贡献者的积极响应，以及他们在各类 AMD GPU 上进行调试、优化与性能验证所付出的努力。
 我们同样感谢 Jensen Huang 与 Ian Buck 通过提供 GB200 NVL72 机架（经由 OCI）与 B200 GPU 来支持本开源项目。感谢来自 NVIDIA 推理团队与 NVIDIA Dynamo 团队的众多 NVIDIA 贡献者。


### PR DESCRIPTION
Summary:
- Add an Officially Supported Hardware section between Why and Acknowledgements & Supporters.
- Mirror the new section in README_zh.md.

Tests:
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README updates with no runtime, security, or data-handling impact.
> 
> **Overview**
> **README** and **README_zh.md** now include an **Ask DeepWiki** badge in the header badge row, linking to `deepwiki.com/SemiAnalysisAI/InferenceX`.
> 
> Both files add a new **Officially Supported Hardware** section (between *Why?* and acknowledgements) with a SKU/status table: nine platforms marked supported (e.g. GB300/GB200 NVL72, B200/B300, H100/H200, MI300X–MI355X) and several entries labeled **Coming Soon** (MI455 UALoE72, Vera Rubin NVL72, Rubin NVL8, and placeholder vendor chips). The Chinese readme mirrors the same table with localized column headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb72ab70d47b134d55760c5dd34aafce19da3ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->