### PR TITLE
Fix sweep reuse after spec changes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -192,76 +192,51 @@ test-config --config-keys dsr1-fp8-h200-sglang --evals-only --all-evals --config
 
 ## PR Eval Modifiers
 
-Apply `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection to every generated fixed-sequence configuration. Each multi-node engine topology gets one eval job that runs every distinct value in its `conc-list` sequentially against the same engine. `evals-only` suppresses throughput jobs while keeping the selected eval subset; combining both runs every eval and no throughput. The primary label still controls canary and fail-fast behavior. Default full sweeps remain eligible for reuse, including their selected eval subset; runs with either modifier are not eligible. See the [eval reuse contract](../../utils/evals/EVALS.md#artifact-reuse).
+Use `all-evals` and/or `evals-only` with one primary sweep label. `all-evals`
+covers every fixed-sequence config; each multi-node topology runs all
+`conc-list` values on one engine. `evals-only` suppresses throughput; together
+they run all evals only. The primary label still controls canary/fail-fast.
+Modifier runs are not reusable; default full sweeps, including default evals,
+are.
 
 ## Reusing an Approved PR Full Sweep
 
-`[skip-sweep]` is a PR-only benchmark opt-out. When it appears in the latest
-PR head commit, `check-changelog` still validates the matrix and the reuse gate
-still runs, but benchmark setup is skipped. Pushes to `main` ignore the marker
-and always enter setup, where they either reuse approved artifacts or run the
-full untrimmed sweep.
+`[skip-sweep]` skips PR benchmark setup only; changelog and reuse checks still
+run. Pushes to `main` ignore it.
 
-If a PR has already run the full untrimmed sweep (`full-sweep-enabled` with a
-sequential canary, `non-canary-full-sweep-enabled` without one, or a
-fail-fast variant — `full-sweep-fail-fast` / `full-sweep-fail-fast-no-canary`), a
-maintainer can avoid running the same sweep again after merge by leaving a PR
-comment before merging:
+After an eligible full sweep (`full-sweep-enabled`,
+`non-canary-full-sweep-enabled`, or either fail-fast variant), an authorized
+maintainer can comment:
 
 ```
 /reuse-sweep-run
 ```
 
-That reuses the latest successful `run-sweep.yml` `pull_request` run whose
-commit is still part of the PR. To select a particular eligible successful
-or failed run, pin the source run explicitly:
+This selects the latest successful `run-sweep.yml` PR run whose commit remains
+in the PR. A run ID can pin an eligible successful or failed run:
 
 ```
 /reuse-sweep-run <run_id>
 ```
 
-Only an explicitly pinned run may have a `failure` conclusion. An unpinned
-command always selects the latest successful eligible run. Pinned failed runs
-must still contain readable, internally consistent artifacts.
-
-The comment is the reuse authorization, so adding it does not trigger or cancel
-a PR sweep. Once the comment is present, later commits pushed to a PR with a
-full-sweep label do not start another benchmark sweep. The synchronize run
-checks that the changelog diff can generate the setup matrix before inspecting
-the authorization and continuing to setup. This catches malformed conflict
-resolutions before reuse can skip setup. Removing and re-adding a sweep label
-explicitly starts a new sweep.
+Failed-run artifacts must still validate. The latest matching comment by an
+`OWNER`, `MEMBER`, or `COLLABORATOR` wins. Comments do not trigger or cancel
+sweeps; later commits skip a new sweep after changelog/matrix validation.
+Remove and re-add the sweep label to force one.
 
 `utils/merge_with_reuse.sh <pr-number>` is the supported merge path for reuse.
-It merges `main`, preserves the current main changelog bytes, canonicalizes an
-appended `XXX` link to the PR URL, pushes a fresh synchronization commit, and
-waits for the PR checks before merging.
+It merges `main`, preserves changelog bytes, fixes an appended `XXX` PR link,
+pushes a synchronization commit, waits for checks, then merges.
 
-On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
-commit, verifies the source run is an eligible `pull_request` `run-sweep.yml`
-run for the same PR, downloads the ingest-relevant artifacts, validates their
-internal consistency, and uploads them as `reused-ingest-artifacts`. The source
-run is authoritative for benchmark, agentic, and eval coverage, so matrix or
-eval-selection policy changes between the PR sweep and merge do not invalidate
-reuse. The normal database ingest then publishes those artifacts with the merge
-run's changelog metadata.
+The main run verifies the source, validates and uploads its ingest artifacts,
+then ingests them with merge-run changelog metadata. Source coverage is
+authoritative, so later matrix/eval policy changes do not invalidate reuse.
+Validation rejects duplicate fixed rows, missing run stats, inconsistent
+agentic artifacts, malformed eval metadata, and raw/aggregate eval mismatches.
+Batched evals use only `completed_eval_concs`.
 
-For evals, raw result artifacts and `eval_results_all` must contain the same
-logical identities. Batched artifacts contribute the points listed in
-`completed_eval_concs`; points listed only as failed are not expected. Missing
-or invalid raw `meta_env.json`, duplicate identities, and raw/aggregate
-disagreement fail validation.
-
-Only comments from `OWNER`, `MEMBER`, or `COLLABORATOR` users authorize reuse.
-The most recent matching comment wins, so a maintainer can supersede an earlier
-pin by leaving a new `/reuse-sweep-run [<run_id>]` comment.
-
-Reuse fails closed: if the comment is present but no full-sweep label
-(`full-sweep-enabled`, `non-canary-full-sweep-enabled`,
-`full-sweep-fail-fast`, or `full-sweep-fail-fast-no-canary`) is present, or if
-the source PR run or artifacts cannot be validated, the push-to-main workflow
-fails instead of falling back to a cluster sweep. Without the comment, the
-push-to-main workflow runs the normal full sweep.
+Reuse fails closed when authorized but ineligible or invalid; without
+authorization, `main` runs the normal full sweep.
 
 ## Validation Architecture
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -192,7 +192,7 @@ test-config --config-keys dsr1-fp8-h200-sglang --evals-only --all-evals --config
 
 ## PR Eval Modifiers
 
-Apply `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection to every generated fixed-sequence configuration. Each multi-node engine topology gets one eval job that runs every distinct value in its `conc-list` sequentially against the same engine. `evals-only` suppresses throughput jobs while keeping the selected eval subset; combining both runs every eval and no throughput. The primary label still controls canary and fail-fast behavior. Runs with either modifier are not eligible for artifact reuse.
+Apply `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection to every generated fixed-sequence configuration. Each multi-node engine topology gets one eval job that runs every distinct value in its `conc-list` sequentially against the same engine. `evals-only` suppresses throughput jobs while keeping the selected eval subset; combining both runs every eval and no throughput. The primary label still controls canary and fail-fast behavior. Default full sweeps remain eligible for reuse, including their selected eval subset; runs with either modifier are not eligible. See the [eval reuse contract](../../utils/evals/EVALS.md#artifact-reuse).
 
 ## Reusing an Approved PR Full Sweep
 
@@ -241,11 +241,16 @@ On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
 commit, verifies the source run is an eligible `pull_request` `run-sweep.yml`
 run for the same PR, downloads the ingest-relevant artifacts, validates their
 internal consistency, and uploads them as `reused-ingest-artifacts`. The source
-run is authoritative, so matrix-generation policy changes between the PR sweep
-and merge do not invalidate reuse. The normal database ingest then publishes
-those artifacts with the merge run's changelog metadata. Duplicate identities,
-malformed eval metadata, and disagreement between raw and aggregate artifacts
-are still rejected.
+run is authoritative for benchmark, agentic, and eval coverage, so matrix or
+eval-selection policy changes between the PR sweep and merge do not invalidate
+reuse. The normal database ingest then publishes those artifacts with the merge
+run's changelog metadata.
+
+For evals, raw result artifacts and `eval_results_all` must contain the same
+logical identities. Batched artifacts contribute the points listed in
+`completed_eval_concs`; points listed only as failed are not expected. Missing
+or invalid raw `meta_env.json`, duplicate identities, and raw/aggregate
+disagreement fail validation.
 
 Only comments from `OWNER`, `MEMBER`, or `COLLABORATOR` users authorize reuse.
 The most recent matching comment wins, so a maintainer can supersede an earlier

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -222,7 +222,7 @@ or failed run, pin the source run explicitly:
 
 Only an explicitly pinned run may have a `failure` conclusion. An unpinned
 command always selects the latest successful eligible run. Pinned failed runs
-must still contain complete artifacts for the merge run's expected matrix.
+must still contain readable, internally consistent artifacts.
 
 The comment is the reuse authorization, so adding it does not trigger or cancel
 a PR sweep. Once the comment is present, later commits pushed to a PR with a
@@ -239,12 +239,13 @@ waits for the PR checks before merging.
 
 On the push-to-main run, `run-sweep.yml` resolves the merged PR from the merge
 commit, verifies the source run is an eligible `pull_request` `run-sweep.yml`
-run for the same PR, downloads the ingest-relevant artifacts, validates that
-fixed-sequence, agentic, and eval-only artifacts exactly match the merge run's
-expected matrix, and uploads them as `reused-ingest-artifacts`. The normal
-database ingest then publishes those artifacts with the merge run's changelog
-metadata. Duplicate fixed-sequence, agentic, eval, or raw eval identities are
-rejected rather than collapsed during that comparison.
+run for the same PR, downloads the ingest-relevant artifacts, validates their
+internal consistency, and uploads them as `reused-ingest-artifacts`. The source
+run is authoritative, so matrix-generation policy changes between the PR sweep
+and merge do not invalidate reuse. The normal database ingest then publishes
+those artifacts with the merge run's changelog metadata. Duplicate identities,
+malformed eval metadata, and disagreement between raw and aggregate artifacts
+are still rejected.
 
 Only comments from `OWNER`, `MEMBER`, or `COLLABORATOR` users authorize reuse.
 The most recent matching comment wins, so a maintainer can supersede an earlier

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -725,11 +725,7 @@ jobs:
 
             - name: Validate reusable artifacts
               run: |
-                  cat <<'CONFIGEOF' > _full_config.json
-                  ${{ needs.setup.outputs.search-space-config }}
-                  CONFIGEOF
                   python3 utils/validate_reusable_sweep_artifacts.py \
-                    --config-json _full_config.json \
                     --artifacts-dir source-artifacts
 
             - name: Upload reusable ingest artifacts

--- a/KLAUD_DEBUG.md
+++ b/KLAUD_DEBUG.md
@@ -212,8 +212,10 @@ match a matrix regenerated from the merge commit. A generator-policy change
 between the PR sweep and merge therefore does not require another GPU sweep.
 
 Raw and aggregate eval identities must still match, as must agentic point/raw
-artifacts and summaries. Malformed metadata, duplicate identities, or
-internally incomplete artifacts still fail reuse.
+artifacts and summaries. Batched eval identities come from
+`completed_eval_concs`, so an explicitly pinned failed run may reuse only the
+points it completed. Missing or invalid metadata, duplicate identities, and
+raw/aggregate disagreement still fail reuse.
 
 ---
 

--- a/KLAUD_DEBUG.md
+++ b/KLAUD_DEBUG.md
@@ -203,6 +203,18 @@ Or check whether any other recipe on main uses the proposed tag — if zero uses
   The old run will be auto-cancelled by `workflow/cancel-sweep-on-merge` (provided the head SHA changed).
 - For a `cancelled` run (not `failure`), use `gh run rerun <id>` without `--failed` to re-run everything.
 
+### 7.1 Reuse after matrix-generation policy changes
+
+Reusable source artifacts are authoritative. The merge-time
+`reuse-ingest-artifacts` job validates that downloaded artifacts are readable,
+non-duplicated, and internally consistent, but it does not require them to
+match a matrix regenerated from the merge commit. A generator-policy change
+between the PR sweep and merge therefore does not require another GPU sweep.
+
+Raw and aggregate eval identities must still match, as must agentic point/raw
+artifacts and summaries. Malformed metadata, duplicate identities, or
+internally incomplete artifacts still fail reuse.
+
 ---
 
 ## 8. gh CLI gotchas

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -21,9 +21,17 @@ Generator eval modes:
 
 The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. `all-evals: true` extends eval-only selection and implies throughput suppression for that entry, so it works either alone or alongside `evals-only: true`.
 
-For PR validation, add `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection for every appended changelog entry without changing throughput. `evals-only` suppresses throughput while keeping the default eval subset. Combining both runs every fixed-sequence eval and no throughput. Runs with either modifier are not eligible for full-sweep artifact reuse.
+For PR validation, add `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection for every appended changelog entry without changing throughput. `evals-only` suppresses throughput while keeping the default eval subset. Combining both runs every fixed-sequence eval and no throughput. Default full sweeps remain eligible for reuse, including their selected eval subset; runs with either modifier are not eligible.
 
 When multiple appended changelog entries reference the same config, benchmark deduplication is scenario-aware: a `fixed-seq-len` entry does not suppress a separate `agentic-coding` entry. Eval deduplication only consumes fixed-sequence coverage, and a broader `all-evals` entry takes precedence over the default eval subset for overlapping configs.
+
+### Artifact reuse
+
+Merge-time reuse treats the source PR run's eval coverage as authoritative. It does not regenerate an expected eval matrix, so eval-selection policy changes between the PR sweep and merge do not require another GPU run.
+
+Reuse downloads both the raw eval result artifacts and `eval_results_all`. Logical identities are derived from each raw artifact's `meta_env.json` and must match the aggregate exactly. Batched artifacts expand from `completed_eval_concs`, so an explicitly pinned failed run can reuse its completed points without requiring failed points. Missing or invalid metadata, duplicate identities, and raw/aggregate disagreement fail validation.
+
+See [Reusing an Approved PR Full Sweep](../../.github/workflows/README.md#reusing-an-approved-pr-full-sweep) for authorization, source-run selection, and merge behavior.
 
 ## Why?
 To verify how model outputs are affected by throughput optimizations.

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -1,43 +1,41 @@
 # Evals
 
-## What?
-Quick graded QnA which measures model performance. Examples of test suites:
-- **gsm8k**: Grade school math questions
-- **gpqa**: Graduate level, Google-Proof multiple choice questions
+Graded QA jobs (`gsm8k`, `gpqa`) catch accuracy regressions from parallelism,
+concurrency, kernels, and other throughput optimizations. They run separately
+from throughput; selection lives in `mark_eval_entries()` in
+`utils/matrix_logic/generate_sweep_configs.py`.
 
-## When?
-Evals run as **separate workflow jobs** from throughput benchmarks. The selection logic is in `mark_eval_entries()` of `utils/matrix_logic/generate_sweep_configs.py`.
+## Selection
 
-**Single-node**: At the highest and median concurrency levels (all TPs), per (model, runner, framework, precision, ISL, OSL, spec-decoding, dp-attn), only for 8k1k.
-
-**Multi-node**: Every distinct parallelism configuration, only for 8k1k. Rows that differ only by concurrency are treated as one configuration. Each eval job runs at `eval-conc`, the highest eligible concurrency across those rows.
+- **Single-node:** 8k1k only; highest and median concurrency for every model,
+  runner, framework, precision, TP, and decoding configuration.
+- **Multi-node:** 8k1k only; one job per parallelism topology at its highest
+  eligible concurrency. Rows differing only by concurrency share a topology.
 
 Generator eval modes:
 
-- Default: run throughput for every generated config and eval-only jobs for the selected subset above.
-- `--no-evals`: generate throughput jobs only.
-- `--evals-only`: generate eval-only jobs for the selected subset above.
-- `--evals-only --all-evals`: expand the eval-only matrix to every generated fixed-sequence config. `--all-evals` alone remains an equivalent shorthand. Agentic configs are excluded. For multi-node configs, each engine topology gets one eval job that runs every distinct value in its `conc-list` sequentially against the same live engine.
+- Default: throughput plus the selected eval subset.
+- `--no-evals`: throughput only.
+- `--evals-only`: selected evals only.
+- `--all-evals`: every fixed-sequence eval only; equivalent to
+  `--evals-only --all-evals`. Multi-node topologies run all `conc-list` values
+  sequentially on one engine. Agentic configs are excluded.
 
-The same modes are available to changelog-triggered sweeps through `evals-only: true` and `all-evals: true`. `all-evals: true` extends eval-only selection and implies throughput suppression for that entry, so it works either alone or alongside `evals-only: true`.
+Changelog entries use `evals-only: true` and `all-evals: true`; `all-evals`
+implies eval-only there. On PRs, the same names are modifier labels:
+`all-evals` expands coverage without suppressing throughput, while `evals-only`
+suppresses it. Modifier runs cannot be reused.
 
-For PR validation, add `all-evals` and/or `evals-only` alongside one primary sweep label. `all-evals` expands eval selection for every appended changelog entry without changing throughput. `evals-only` suppresses throughput while keeping the default eval subset. Combining both runs every fixed-sequence eval and no throughput. Default full sweeps remain eligible for reuse, including their selected eval subset; runs with either modifier are not eligible.
-
-When multiple appended changelog entries reference the same config, benchmark deduplication is scenario-aware: a `fixed-seq-len` entry does not suppress a separate `agentic-coding` entry. Eval deduplication only consumes fixed-sequence coverage, and a broader `all-evals` entry takes precedence over the default eval subset for overlapping configs.
+Deduplication is scenario-aware: fixed-sequence coverage does not suppress
+agentic coverage, and `all-evals` wins over default eval coverage.
 
 ### Artifact reuse
 
-Merge-time reuse treats the source PR run's eval coverage as authoritative. It does not regenerate an expected eval matrix, so eval-selection policy changes between the PR sweep and merge do not require another GPU run.
-
-Reuse downloads both the raw eval result artifacts and `eval_results_all`. Logical identities are derived from each raw artifact's `meta_env.json` and must match the aggregate exactly. Batched artifacts expand from `completed_eval_concs`, so an explicitly pinned failed run can reuse its completed points without requiring failed points. Missing or invalid metadata, duplicate identities, and raw/aggregate disagreement fail validation.
-
-See [Reusing an Approved PR Full Sweep](../../.github/workflows/README.md#reusing-an-approved-pr-full-sweep) for authorization, source-run selection, and merge behavior.
-
-## Why?
-To verify how model outputs are affected by throughput optimizations.
-- TP/Conc might affect model outputs
-- Check kernel implementations for correctness
-- If there was a tradeoff in accuracy for performance
+Default full sweeps may reuse their eval subset. Source coverage is
+authoritative: raw `meta_env.json` identities must match `eval_results_all`,
+and batched evals use `completed_eval_concs`. Policy drift is allowed;
+malformed metadata, duplicates, or raw/aggregate mismatches are not. See
+[workflow reuse](../../.github/workflows/README.md#reusing-an-approved-pr-full-sweep).
 
 ## How?
 `run_eval` in `benchmarks/benchmark_lib.sh` runs EleutherAI/lm-evaluation-harness against the server's OpenAI-compatible endpoint. Concurrency is set via `EVAL_CONCURRENT_REQUESTS` env var (not a CLI flag). Results are collected by `utils/collect_eval_results.py` and published as a summary table.

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -5,16 +5,11 @@ import sys
 from pathlib import Path
 
 from validate_reusable_sweep_artifacts import (
-    actual_benchmark_keys,
     agentic_key,
-    expected_agentic_keys,
-    expected_benchmark_keys,
-    expected_eval_keys,
     main,
     validate_agentic_artifacts,
     validate_eval_artifacts,
     validate_fixed_artifacts,
-    validate_identity_set,
 )
 
 
@@ -27,29 +22,6 @@ def write_eval_aggregate(
     (eval_dir / "agg_eval_all.json").write_text(
         json.dumps(rows or [{"task": "gsm8k"}])
     )
-
-
-def single_eval_entry(
-    conc: int,
-    runner: str = "h100-dgxc-slurm",
-    isl: int = 8192,
-    osl: int = 1024,
-) -> dict:
-    return {
-        "exp-name": "gptoss_8k1k",
-        "runner": runner,
-        "model-prefix": "gptoss",
-        "precision": "fp4",
-        "framework": "vllm",
-        "tp": 2,
-        "ep": 1,
-        "dp-attn": False,
-        "disagg": False,
-        "spec-decoding": "none",
-        "isl": isl,
-        "osl": osl,
-        "conc": conc,
-    }
 
 
 def single_eval_result(
@@ -102,33 +74,6 @@ def write_raw_eval_artifact(
     )
 
 
-def multinode_eval_entry(concs: list[int]) -> dict:
-    return {
-        "exp-name": "gptoss_8k1k",
-        "runner": "gb200",
-        "model-prefix": "gptoss",
-        "precision": "fp8",
-        "framework": "dynamo-sglang",
-        "spec-decoding": "none",
-        "isl": 8192,
-        "osl": 1024,
-        "prefill": {
-            "tp": 4,
-            "ep": 1,
-            "dp-attn": False,
-            "num-worker": 1,
-        },
-        "decode": {
-            "tp": 8,
-            "ep": 1,
-            "dp-attn": True,
-            "num-worker": 2,
-        },
-        "conc": concs,
-        "eval-all-concs": True,
-    }
-
-
 def multinode_eval_result(conc: int) -> dict:
     return {
         "is_multinode": True,
@@ -166,23 +111,6 @@ def write_raw_batched_eval_artifact(
     (artifact_dir / "meta_env.json").write_text(json.dumps(meta))
 
 
-def single_fixed_entry(conc: int) -> dict:
-    return {
-        "runner": "h100",
-        "model-prefix": "gptoss",
-        "framework": "vllm",
-        "precision": "fp8",
-        "spec-decoding": "none",
-        "disagg": False,
-        "isl": 1024,
-        "osl": 1024,
-        "tp": 2,
-        "ep": 1,
-        "dp-attn": False,
-        "conc": conc,
-    }
-
-
 def fixed_result(conc: int) -> dict:
     return {
         "hw": "h100",
@@ -198,20 +126,6 @@ def fixed_result(conc: int) -> dict:
         "dp_attention": False,
         "conc": conc,
         "is_multinode": False,
-    }
-
-
-def single_agentic_entry(conc: int = 16) -> dict:
-    return {
-        "runner": "b200-dgxc",
-        "model-prefix": "dsv4",
-        "framework": "vllm",
-        "precision": "fp4",
-        "tp": 8,
-        "ep": 8,
-        "dp-attn": True,
-        "conc": conc,
-        "offloading": "cpu",
     }
 
 
@@ -232,34 +146,6 @@ def agentic_result(conc: int = 16) -> dict:
 
 
 def test_multinode_agentic_identity_fields_match() -> None:
-    config = {
-        "single_node": {"agentic": []},
-        "multi_node": {
-            "agentic": [
-                {
-                    "runner": "gb200",
-                    "model-prefix": "dsv4",
-                    "framework": "dynamo-sglang",
-                    "precision": "fp8",
-                    "spec-decoding": "none",
-                    "disagg": True,
-                    "prefill": {
-                        "tp": 4,
-                        "ep": 2,
-                        "dp-attn": True,
-                        "num-worker": 2,
-                    },
-                    "decode": {
-                        "tp": 8,
-                        "ep": 4,
-                        "dp-attn": False,
-                        "num-worker": 3,
-                    },
-                    "conc": 64,
-                }
-            ]
-        },
-    }
     row = {
         "hw": "gb200",
         "infmax_model_prefix": "dsv4",
@@ -280,7 +166,24 @@ def test_multinode_agentic_identity_fields_match() -> None:
         "conc": 64,
     }
 
-    assert expected_agentic_keys(config) == {agentic_key(row)}
+    assert agentic_key(row) == (
+        "multi",
+        "gb200",
+        "dsv4",
+        "dynamo-sglang",
+        "fp8",
+        "none",
+        True,
+        4,
+        2,
+        True,
+        2,
+        8,
+        4,
+        False,
+        3,
+        64,
+    )
 
 
 def write_agentic_artifacts(
@@ -307,10 +210,6 @@ def write_agentic_artifacts(
 def test_eval_validation_requires_raw_result_dirs_not_eval_debug_dirs(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "evals": [single_eval_entry(32), single_eval_entry(64)],
-        "multinode_evals": [],
-    }
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(64)],
@@ -320,16 +219,14 @@ def test_eval_validation_requires_raw_result_dirs_not_eval_debug_dirs(
     (tmp_path / "eval_gpu_metrics_gptoss_8k1k_runner").mkdir()
     write_raw_eval_artifact(tmp_path, 32)
 
-    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
+    errors = validate_eval_artifacts(tmp_path)
 
-    assert any("missing" in error for error in errors)
+    assert any("unexpected" in error for error in errors)
 
 
-def test_eval_validation_accepts_all_expected_raw_result_dirs(tmp_path: Path) -> None:
-    config = {
-        "evals": [single_eval_entry(32), single_eval_entry(64)],
-        "multinode_evals": [],
-    }
+def test_eval_validation_accepts_matching_raw_and_aggregate(
+    tmp_path: Path,
+) -> None:
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(64)],
@@ -341,17 +238,10 @@ def test_eval_validation_accepts_all_expected_raw_result_dirs(tmp_path: Path) ->
         physical_runner="h100-dgxc-slurm_01",
     )
 
-    assert validate_eval_artifacts(tmp_path, expected_eval_keys(config)) == []
+    assert validate_eval_artifacts(tmp_path) == []
 
 
 def test_eval_validation_distinguishes_sequence_lengths(tmp_path: Path) -> None:
-    config = {
-        "evals": [
-            single_eval_entry(32, isl=1024),
-            single_eval_entry(32, isl=8192),
-        ],
-        "multinode_evals": [],
-    }
     write_eval_aggregate(
         tmp_path,
         [
@@ -367,12 +257,10 @@ def test_eval_validation_distinguishes_sequence_lengths(tmp_path: Path) -> None:
         isl=8192,
     )
 
-    assert len(expected_eval_keys(config)) == 2
-    assert validate_eval_artifacts(tmp_path, expected_eval_keys(config)) == []
+    assert validate_eval_artifacts(tmp_path) == []
 
 
-def test_eval_validation_rejects_unexpected_result_dir(tmp_path: Path) -> None:
-    config = {"evals": [single_eval_entry(32)], "multinode_evals": []}
+def test_eval_validation_rejects_raw_aggregate_mismatch(tmp_path: Path) -> None:
     write_eval_aggregate(tmp_path, [single_eval_result(32)])
     write_raw_eval_artifact(tmp_path, 32)
     write_raw_eval_artifact(
@@ -381,13 +269,12 @@ def test_eval_validation_rejects_unexpected_result_dir(tmp_path: Path) -> None:
         physical_runner="h100-dgxc-slurm_01",
     )
 
-    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
+    errors = validate_eval_artifacts(tmp_path)
 
-    assert any("unexpected" in error for error in errors)
+    assert any("missing" in error for error in errors)
 
 
 def test_eval_validation_rejects_duplicate_raw_identity(tmp_path: Path) -> None:
-    config = {"evals": [single_eval_entry(32)], "multinode_evals": []}
     write_eval_aggregate(tmp_path, [single_eval_result(32)])
     write_raw_eval_artifact(tmp_path, 32)
     write_raw_eval_artifact(
@@ -396,7 +283,7 @@ def test_eval_validation_rejects_duplicate_raw_identity(tmp_path: Path) -> None:
         physical_runner="h100-dgxc-slurm_01",
     )
 
-    errors = validate_eval_artifacts(tmp_path, expected_eval_keys(config))
+    errors = validate_eval_artifacts(tmp_path)
 
     assert any("duplicate" in error for error in errors)
 
@@ -404,10 +291,6 @@ def test_eval_validation_rejects_duplicate_raw_identity(tmp_path: Path) -> None:
 def test_eval_validation_uses_logical_runner_from_metadata(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "evals": [single_eval_entry(64, "mi300x")],
-        "multinode_evals": [],
-    }
     write_eval_aggregate(tmp_path, [single_eval_result(64, "mi300x")])
     write_raw_eval_artifact(
         tmp_path,
@@ -416,44 +299,30 @@ def test_eval_validation_uses_logical_runner_from_metadata(
         physical_runner="mi300x-amds_04",
     )
 
-    assert validate_eval_artifacts(tmp_path, expected_eval_keys(config)) == []
+    assert validate_eval_artifacts(tmp_path) == []
 
 
 def test_eval_validation_expands_one_batched_multinode_artifact(
     tmp_path: Path,
 ) -> None:
     concs = [4, 16, 64]
-    config = {
-        "evals": [],
-        "multinode_evals": [multinode_eval_entry(concs)],
-    }
     write_eval_aggregate(
         tmp_path,
         [multinode_eval_result(conc) for conc in concs],
     )
     write_raw_batched_eval_artifact(tmp_path, concs)
 
-    expected = expected_eval_keys(config)
-
-    assert len(expected) == 3
-    assert validate_eval_artifacts(tmp_path, expected) == []
+    assert validate_eval_artifacts(tmp_path) == []
 
 
 def test_eval_aggregate_validation_is_exact(tmp_path: Path) -> None:
-    config = {
-        "evals": [single_eval_entry(32)],
-        "multinode_evals": [],
-    }
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(64)],
     )
     write_raw_eval_artifact(tmp_path, 32)
 
-    errors = validate_eval_artifacts(
-        tmp_path,
-        expected_eval_keys(config),
-    )
+    errors = validate_eval_artifacts(tmp_path)
 
     assert any(
         "eval aggregate" in error and "unexpected" in error
@@ -464,20 +333,13 @@ def test_eval_aggregate_validation_is_exact(tmp_path: Path) -> None:
 def test_eval_aggregate_validation_rejects_duplicate_identity(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "evals": [single_eval_entry(32)],
-        "multinode_evals": [],
-    }
     write_eval_aggregate(
         tmp_path,
         [single_eval_result(32), single_eval_result(32)],
     )
     write_raw_eval_artifact(tmp_path, 32)
 
-    errors = validate_eval_artifacts(
-        tmp_path,
-        expected_eval_keys(config),
-    )
+    errors = validate_eval_artifacts(tmp_path)
 
     assert any(
         "eval aggregate" in error and "duplicate" in error
@@ -485,92 +347,47 @@ def test_eval_aggregate_validation_rejects_duplicate_identity(
     )
 
 
-def test_fixed_sequence_validation_is_exact(tmp_path: Path) -> None:
-    config = {
-        "single_node": {
-            "1k1k": [single_fixed_entry(8)],
-            "8k1k": [],
-        },
-        "multi_node": {"1k1k": [], "8k1k": []},
-    }
+def test_fixed_sequence_validation_accepts_unique_source_rows(tmp_path: Path) -> None:
     results = tmp_path / "results_bmk"
     results.mkdir()
     (results / "agg_bmk.json").write_text(
         json.dumps([fixed_result(8), fixed_result(16)])
     )
 
-    errors = validate_identity_set(
-        "fixed-sequence",
-        expected_benchmark_keys(config),
-        actual_benchmark_keys(tmp_path),
-    )
-
-    assert "fixed-sequence artifacts contain 1 unexpected row(s)" in errors
+    assert validate_fixed_artifacts(tmp_path) == []
 
 
 def test_fixed_sequence_validation_rejects_duplicate_identity(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "single_node": {
-            "1k1k": [single_fixed_entry(8)],
-            "8k1k": [],
-        },
-        "multi_node": {"1k1k": [], "8k1k": []},
-    }
     results = tmp_path / "results_bmk"
     results.mkdir()
     (results / "agg_bmk.json").write_text(
         json.dumps([fixed_result(8), fixed_result(8)])
     )
 
-    errors = validate_fixed_artifacts(
-        tmp_path,
-        expected_benchmark_keys(config),
-    )
+    errors = validate_fixed_artifacts(tmp_path)
 
     assert "fixed-sequence artifacts contain 1 duplicate row(s)" in errors
 
 
 def test_agentic_validation_checks_points_raw_and_aggregate(tmp_path: Path) -> None:
-    config = {
-        "single_node": {"agentic": [single_agentic_entry()]},
-        "multi_node": {"agentic": []},
-    }
     write_agentic_artifacts(tmp_path)
 
-    assert (
-        validate_agentic_artifacts(
-            tmp_path,
-            expected_agentic_keys(config),
-        )
-        == []
-    )
+    assert validate_agentic_artifacts(tmp_path) == []
 
 
 def test_agentic_validation_accepts_run_sweep_point_artifacts(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "single_node": {"agentic": [single_agentic_entry()]},
-        "multi_node": {"agentic": []},
-    }
     write_agentic_artifacts(tmp_path, aggregate=False)
 
-    assert (
-        validate_agentic_artifacts(
-            tmp_path,
-            expected_agentic_keys(config),
-        )
-        == []
-    )
+    assert validate_agentic_artifacts(tmp_path) == []
 
 
-def test_agentic_validation_rejects_extra_identity(tmp_path: Path) -> None:
-    config = {
-        "single_node": {"agentic": [single_agentic_entry()]},
-        "multi_node": {"agentic": []},
-    }
+def test_agentic_validation_accepts_additional_source_identity(
+    tmp_path: Path,
+) -> None:
     write_agentic_artifacts(tmp_path)
     extra_dir = tmp_path / "bmk_agentic_extra"
     extra_dir.mkdir()
@@ -579,42 +396,26 @@ def test_agentic_validation_rejects_extra_identity(tmp_path: Path) -> None:
     summary = tmp_path / "agentic_aggregated" / "summary.csv"
     summary.write_text(summary.read_text() + "agentic_extra,SUCCESS\n")
 
-    errors = validate_agentic_artifacts(
-        tmp_path,
-        expected_agentic_keys(config),
-    )
-
-    assert "agentic artifacts contain 1 unexpected row(s)" in errors
+    assert validate_agentic_artifacts(tmp_path) == []
 
 
 def test_agentic_validation_requires_point_and_raw_artifacts(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "single_node": {"agentic": [single_agentic_entry()]},
-        "multi_node": {"agentic": []},
-    }
     aggregate = tmp_path / "results_bmk"
     aggregate.mkdir()
     (aggregate / "agg_bmk.json").write_text(
         json.dumps([agentic_result()])
     )
 
-    errors = validate_agentic_artifacts(
-        tmp_path,
-        expected_agentic_keys(config),
-    )
+    errors = validate_agentic_artifacts(tmp_path)
 
-    assert "agentic artifacts are missing 1 expected row(s)" in errors
+    assert "agentic aggregate artifacts contain 1 unexpected row(s)" in errors
 
 
 def test_agentic_validation_rejects_duplicate_point_identity(
     tmp_path: Path,
 ) -> None:
-    config = {
-        "single_node": {"agentic": [single_agentic_entry()]},
-        "multi_node": {"agentic": []},
-    }
     write_agentic_artifacts(tmp_path, aggregate=False)
     point_dir = (
         tmp_path / "bmk_agentic_dsv4_tp8_conc16_offloadcpu_result"
@@ -624,10 +425,7 @@ def test_agentic_validation_rejects_duplicate_point_identity(
         json.dumps([agentic_result(), agentic_result()])
     )
 
-    errors = validate_agentic_artifacts(
-        tmp_path,
-        expected_agentic_keys(config),
-    )
+    errors = validate_agentic_artifacts(tmp_path)
 
     assert "agentic point artifacts contain 1 duplicate row(s)" in errors
 
@@ -636,14 +434,6 @@ def test_eval_only_main_does_not_require_benchmark_artifacts(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    config = {
-        "single_node": {"1k1k": [], "8k1k": [], "agentic": []},
-        "multi_node": {"1k1k": [], "8k1k": [], "agentic": []},
-        "evals": [single_eval_entry(32)],
-        "multinode_evals": [],
-    }
-    config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps(config))
     write_eval_aggregate(tmp_path, [single_eval_result(32)])
     write_raw_eval_artifact(tmp_path, 32)
     monkeypatch.setattr(
@@ -651,8 +441,6 @@ def test_eval_only_main_does_not_require_benchmark_artifacts(
         "argv",
         [
             "validate_reusable_sweep_artifacts.py",
-            "--config-json",
-            str(config_path),
             "--artifacts-dir",
             str(tmp_path),
         ],

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -100,14 +100,21 @@ def multinode_eval_result(conc: int) -> dict:
 def write_raw_batched_eval_artifact(
     root: Path,
     concs: list[int],
+    *,
+    completed_concs: list[int] | None = None,
+    failed_concs: list[int] | None = None,
 ) -> None:
     artifact_dir = root / "eval_gptoss_8k1k_batch"
     artifact_dir.mkdir()
     meta = multinode_eval_result(concs[0])
     meta["infmax_model_prefix"] = meta.pop("model_prefix")
     meta["eval_concs"] = concs
-    meta["completed_eval_concs"] = concs
-    meta["failed_eval_concs"] = []
+    meta["completed_eval_concs"] = (
+        concs if completed_concs is None else completed_concs
+    )
+    meta["failed_eval_concs"] = (
+        [] if failed_concs is None else failed_concs
+    )
     (artifact_dir / "meta_env.json").write_text(json.dumps(meta))
 
 
@@ -311,6 +318,25 @@ def test_eval_validation_expands_one_batched_multinode_artifact(
         [multinode_eval_result(conc) for conc in concs],
     )
     write_raw_batched_eval_artifact(tmp_path, concs)
+
+    assert validate_eval_artifacts(tmp_path) == []
+
+
+def test_eval_validation_accepts_completed_points_from_failed_batch(
+    tmp_path: Path,
+) -> None:
+    requested_concs = [4, 16, 64]
+    completed_concs = [4, 64]
+    write_eval_aggregate(
+        tmp_path,
+        [multinode_eval_result(conc) for conc in completed_concs],
+    )
+    write_raw_batched_eval_artifact(
+        tmp_path,
+        requested_concs,
+        completed_concs=completed_concs,
+        failed_concs=[16],
+    )
 
     assert validate_eval_artifacts(tmp_path) == []
 

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate reused sweep artifacts against the exact target matrix."""
+"""Validate reused sweep artifacts for internal consistency."""
 
 from __future__ import annotations
 
@@ -10,9 +10,6 @@ import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any, Iterable
-
-
-FIXED_SEQ_KEYS = ("1k1k", "8k1k")
 
 
 def as_bool(value: Any) -> bool:
@@ -44,63 +41,6 @@ def json_rows(paths: Iterable[Path]) -> Iterable[tuple[Path, dict[str, Any]]]:
         for row in rows:
             if isinstance(row, dict):
                 yield path, row
-
-
-def expected_benchmark_keys(config: dict[str, Any]) -> set[tuple[Any, ...]]:
-    """Build expected fixed-sequence identities from process_changelog output."""
-    expected: set[tuple[Any, ...]] = set()
-
-    for seq_key in FIXED_SEQ_KEYS:
-        for entry in config.get("single_node", {}).get(seq_key, []) or []:
-            expected.add(
-                (
-                    "single",
-                    entry["runner"],
-                    entry["model-prefix"],
-                    entry["framework"],
-                    entry["precision"],
-                    entry.get("spec-decoding", "none"),
-                    as_bool(entry.get("disagg", False)),
-                    as_int(entry["isl"]),
-                    as_int(entry["osl"]),
-                    as_int(entry["tp"]),
-                    as_int(entry.get("ep", 1)),
-                    as_bool(entry.get("dp-attn", False)),
-                    as_int(entry["conc"]),
-                )
-            )
-
-        for entry in config.get("multi_node", {}).get(seq_key, []) or []:
-            prefill = entry["prefill"]
-            decode = entry["decode"]
-            decode_workers = as_int(decode.get("num-worker", 0))
-            decode_tp = as_int(decode.get("tp", 0)) if decode_workers > 0 else 0
-            decode_ep = as_int(decode.get("ep", 0)) if decode_workers > 0 else 0
-            for conc in entry["conc"]:
-                expected.add(
-                    (
-                        "multi",
-                        entry["runner"],
-                        entry["model-prefix"],
-                        entry["framework"],
-                        entry["precision"],
-                        entry.get("spec-decoding", "none"),
-                        as_bool(entry.get("disagg", False)),
-                        as_int(entry["isl"]),
-                        as_int(entry["osl"]),
-                        as_int(prefill.get("tp", 0)),
-                        as_int(prefill.get("ep", 1)),
-                        as_bool(prefill.get("dp-attn", False)),
-                        as_int(prefill.get("num-worker", 0)),
-                        decode_tp,
-                        decode_ep,
-                        as_bool(decode.get("dp-attn", False)),
-                        decode_workers,
-                        as_int(conc),
-                    )
-                )
-
-    return expected
 
 
 def benchmark_key(row: dict[str, Any]) -> tuple[Any, ...]:
@@ -158,51 +98,6 @@ def actual_benchmark_key_rows(
 def actual_benchmark_keys(artifacts_dir: Path) -> set[tuple[Any, ...]]:
     """Build the set of actual fixed-sequence identities."""
     return set(actual_benchmark_key_rows(artifacts_dir))
-
-
-def expected_agentic_keys(config: dict[str, Any]) -> set[tuple[Any, ...]]:
-    """Build expected agentic point-result identities."""
-    expected: set[tuple[Any, ...]] = set()
-    for entry in config.get("single_node", {}).get("agentic", []) or []:
-        expected.add(
-            (
-                "single",
-                entry["runner"],
-                entry["model-prefix"],
-                entry["framework"],
-                entry["precision"],
-                as_int(entry["tp"]),
-                as_int(entry.get("ep", 1)),
-                as_bool(entry.get("dp-attn", False)),
-                as_int(entry["conc"]),
-                entry.get("offloading", "none"),
-            )
-        )
-
-    for entry in config.get("multi_node", {}).get("agentic", []) or []:
-        prefill = entry["prefill"]
-        decode = entry["decode"]
-        expected.add(
-            (
-                "multi",
-                entry["runner"],
-                entry["model-prefix"],
-                entry["framework"],
-                entry["precision"],
-                entry.get("spec-decoding", "none"),
-                as_bool(entry.get("disagg", False)),
-                as_int(prefill.get("tp", 0)),
-                as_int(prefill.get("ep", 1)),
-                as_bool(prefill.get("dp-attn", False)),
-                as_int(prefill.get("num-worker", 0)),
-                as_int(decode.get("tp", 0)),
-                as_int(decode.get("ep", 1)),
-                as_bool(decode.get("dp-attn", False)),
-                as_int(decode.get("num-worker", 0)),
-                as_int(entry["conc"]),
-            )
-        )
-    return expected
 
 
 def agentic_key(row: dict[str, Any]) -> tuple[Any, ...]:
@@ -319,26 +214,18 @@ def duplicate_identity_errors(
 
 def validate_fixed_artifacts(
     artifacts_dir: Path,
-    expected: set[tuple[Any, ...]],
 ) -> list[str]:
-    """Validate exact fixed-sequence rows, including duplicates."""
+    """Validate fixed-sequence aggregate rows for duplicate identities."""
     actual_rows = actual_benchmark_key_rows(artifacts_dir)
-    return [
-        *duplicate_identity_errors("fixed-sequence", actual_rows),
-        *validate_identity_set("fixed-sequence", expected, set(actual_rows)),
-    ]
+    return duplicate_identity_errors("fixed-sequence", actual_rows)
 
 
 def validate_agentic_artifacts(
     artifacts_dir: Path,
-    expected: set[tuple[Any, ...]],
 ) -> list[str]:
-    """Validate exact agentic point, raw, and aggregate artifact coverage."""
+    """Validate agentic point, raw, and aggregate artifacts agree."""
     point_rows = agentic_keys_from_paths(agentic_point_files(artifacts_dir))
-    errors = [
-        *duplicate_identity_errors("agentic point", point_rows),
-        *validate_identity_set("agentic", expected, set(point_rows)),
-    ]
+    errors = duplicate_identity_errors("agentic point", point_rows)
 
     results_bmk = artifacts_dir / "results_bmk"
     if results_bmk.is_dir():
@@ -349,7 +236,7 @@ def validate_agentic_artifacts(
         errors.extend(
             validate_identity_set(
                 "agentic aggregate",
-                expected,
+                set(point_rows),
                 set(aggregate_rows),
             )
         )
@@ -376,9 +263,7 @@ def validate_agentic_artifacts(
     aggregate_dir = artifacts_dir / "agentic_aggregated"
     summary_path = aggregate_dir / "summary.csv"
     if aggregate_dir.exists():
-        if not expected:
-            errors.append("unexpected agentic_aggregated artifact")
-        elif not summary_path.is_file():
+        if not summary_path.is_file():
             errors.append("missing agentic_aggregated/summary.csv")
         else:
             with open(summary_path, newline="") as handle:
@@ -408,70 +293,9 @@ def validate_agentic_artifacts(
     return errors
 
 
-def expected_eval_jobs(config: dict[str, Any]) -> int:
-    """Count expected eval-only matrix jobs."""
-    return len(config.get("evals", []) or []) + len(
-        config.get("multinode_evals", []) or []
-    )
-
-
 def normalized_runner(value: Any) -> str:
     """Normalize runner labels that aggregates may uppercase."""
     return str(value or "").lower()
-
-
-def expected_eval_keys(config: dict[str, Any]) -> set[tuple[Any, ...]]:
-    """Build expected eval aggregate identities."""
-    expected: set[tuple[Any, ...]] = set()
-    for entry in config.get("evals", []) or []:
-        expected.add(
-            (
-                "single",
-                normalized_runner(entry["runner"]),
-                entry["model-prefix"],
-                entry["framework"],
-                entry["precision"],
-                entry.get("spec-decoding", "none"),
-                as_int(entry["isl"]),
-                as_int(entry["osl"]),
-                as_int(entry["tp"]),
-                as_int(entry.get("ep", 1)),
-                as_bool(entry.get("dp-attn", False)),
-                as_int(entry["conc"]),
-            )
-        )
-
-    for entry in config.get("multinode_evals", []) or []:
-        prefill = entry["prefill"]
-        decode = entry["decode"]
-        eval_concs = (
-            entry["conc"]
-            if entry.get("eval-all-concs", False)
-            else [entry.get("eval-conc", entry["conc"][0])]
-        )
-        for eval_conc in eval_concs:
-            expected.add(
-                (
-                    "multi",
-                    normalized_runner(entry["runner"]),
-                    entry["model-prefix"],
-                    entry["framework"],
-                    entry["precision"],
-                    entry.get("spec-decoding", "none"),
-                    as_int(entry["isl"]),
-                    as_int(entry["osl"]),
-                    as_int(prefill.get("tp", 0)),
-                    as_int(prefill.get("ep", 1)),
-                    as_bool(prefill.get("dp-attn", False)),
-                    as_int(prefill.get("num-worker", 0)),
-                    as_int(decode.get("tp", 0)),
-                    as_int(decode.get("ep", 1)),
-                    as_bool(decode.get("dp-attn", False)),
-                    as_int(decode.get("num-worker", 0)),
-                    as_int(eval_conc),
-                )
-            )
-    return expected
 
 
 def eval_key(row: dict[str, Any]) -> tuple[Any, ...]:
@@ -571,18 +395,14 @@ def raw_eval_key_rows(
 
 def validate_eval_artifacts(
     artifacts_dir: Path,
-    expected_keys: set[tuple[Any, ...]],
 ) -> list[str]:
-    """Validate exact eval aggregate and raw artifact coverage."""
+    """Validate raw and aggregate eval artifacts agree."""
     raw_rows, errors = raw_eval_key_rows(artifacts_dir)
     errors.extend(duplicate_identity_errors("raw eval", raw_rows))
-    errors.extend(
-        validate_identity_set("raw eval", expected_keys, set(raw_rows))
-    )
 
     aggregate_dir = artifacts_dir / "eval_results_all"
     aggregate_files = list(aggregate_dir.glob("*.json"))
-    if expected_keys:
+    if raw_rows or aggregate_dir.exists():
         if not aggregate_files:
             errors.append("missing eval_results_all aggregate artifact")
         else:
@@ -608,12 +428,10 @@ def validate_eval_artifacts(
             errors.extend(
                 validate_identity_set(
                     "eval aggregate",
-                    expected_keys,
+                    set(raw_rows),
                     set(aggregate_rows),
                 )
             )
-    elif aggregate_dir.exists():
-        errors.append("unexpected eval_results_all aggregate artifact")
 
     return errors
 
@@ -630,35 +448,26 @@ def validate_run_stats(artifacts_dir: Path, required: bool) -> list[str]:
 def main() -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config-json", required=True, type=Path)
     parser.add_argument("--artifacts-dir", required=True, type=Path)
     args = parser.parse_args()
 
-    config = load_json(args.config_json)
-    if not isinstance(config, dict):
-        raise ValueError("config JSON must be an object")
     if not args.artifacts_dir.is_dir():
         raise ValueError(
             f"artifacts directory does not exist: {args.artifacts_dir}"
         )
 
-    expected_bmk = expected_benchmark_keys(config)
-    expected_agentic = expected_agentic_keys(config)
-    expected_eval = expected_eval_keys(config)
+    fixed_rows = actual_benchmark_key_rows(args.artifacts_dir)
+    agentic_rows = agentic_keys_from_paths(
+        agentic_point_files(args.artifacts_dir)
+    )
+    eval_rows, _ = raw_eval_key_rows(args.artifacts_dir)
 
-    errors = validate_fixed_artifacts(args.artifacts_dir, expected_bmk)
-    if expected_bmk and not (args.artifacts_dir / "results_bmk").is_dir():
-        errors.insert(0, "missing results_bmk benchmark aggregate artifact")
-    errors.extend(
-        validate_agentic_artifacts(args.artifacts_dir, expected_agentic)
-    )
-    errors.extend(
-        validate_eval_artifacts(
-            args.artifacts_dir,
-            expected_eval,
-        )
-    )
-    errors.extend(validate_run_stats(args.artifacts_dir, bool(expected_bmk)))
+    errors = validate_fixed_artifacts(args.artifacts_dir)
+    errors.extend(validate_agentic_artifacts(args.artifacts_dir))
+    errors.extend(validate_eval_artifacts(args.artifacts_dir))
+    errors.extend(validate_run_stats(args.artifacts_dir, bool(fixed_rows)))
+    if not fixed_rows and not agentic_rows and not eval_rows:
+        errors.append("no reusable benchmark, agentic, or eval result rows found")
 
     if errors:
         print("Reusable sweep artifact validation failed:", file=sys.stderr)
@@ -668,9 +477,9 @@ def main() -> int:
 
     print(
         "Reusable sweep artifacts validated: "
-        f"{len(expected_bmk)} fixed-sequence row(s), "
-        f"{len(expected_agentic)} agentic row(s), "
-        f"{expected_eval_jobs(config)} eval job(s)."
+        f"{len(set(fixed_rows))} fixed-sequence row(s), "
+        f"{len(set(agentic_rows))} agentic row(s), "
+        f"{len(set(eval_rows))} eval row(s)."
     )
     return 0
 


### PR DESCRIPTION
## Summary

- Treat source-run artifacts as authoritative during reuse.
- Keep internal consistency checks for benchmark, agentic, and eval artifacts.
- Document eval reuse, including completed points from pinned failed batches.

## Validation

- 122 reuse/eval tests passed
- `actionlint` passed for changed workflows
- Historical run `27663808752` replay passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-time ingest validation for reused sweeps: broader reuse when matrix policy shifts, but still fails closed on corrupt or inconsistent artifacts; behavior is covered by updated tests.
> 
> **Overview**
> Merge-time sweep reuse no longer compares downloaded PR artifacts to a matrix regenerated from the merge commit. **`validate_reusable_sweep_artifacts.py`** now only checks that fixed, agentic, and eval artifacts are internally consistent (duplicates, raw vs aggregate agreement, agentic point/raw/summary alignment, **`completed_eval_concs`** for batched evals, run-stats when fixed rows exist).
> 
> The **`reuse-ingest-artifacts`** job in **`run-sweep.yml`** drops the **`--config-json`** / **`search-space-config`** wiring; validation runs on the artifact tree alone.
> 
> Docs (**`.github/workflows/README.md`**, **`utils/evals/EVALS.md`**, **`KLAUD_DEBUG.md`**) state that generator/eval policy drift between PR sweep and merge does not block reuse, while modifier runs and malformed artifacts still do. Tests were refocused on artifact-only rules, including partial reuse from pinned failed batched eval runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504ced86335983b51dc791cfa3cf601b94bf4ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->