### PR TITLE
Bump vLLM version for DSV4 B200 disagg

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
@@ -17,7 +17,7 @@ name: "svf-vllm-disagg-b200-low-latency"
 #     absorb cold-cache model loads.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -131,7 +131,7 @@ benchmark:
 
 identity:
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
     vllm: "0.20.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml
@@ -134,4 +134,4 @@ identity:
     image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    vllm: "0.23.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only version bump in a single benchmark recipe; main risk is benchmark/runtime compatibility with the pinned Dynamo wheel, not application code paths.
> 
> **Overview**
> Updates the **DeepSeek V4 B200 disaggregated low-latency** Slurm recipe (`disagg-b200-low-latency.yaml`) from **vLLM v0.20.1 / 0.20.0** to **v0.23.0**.
> 
> The bump is applied consistently on **`model.container`**, **`identity.container.image`**, and **`identity.frameworks.vllm`** so the launched container and recorded benchmark identity match the new stack. No changes to Dynamo wheel, vLLM CLI flags, Slurm layout, or benchmark parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e821fa1545730ab5cadc7e01586ab6da2d601822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->