### PR TITLE
ci: add CODEOWNER sign-off verification workflow

### DIFF
--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -1,0 +1,223 @@
+name: CODEOWNER Sign-off Verify
+
+# Independently re-verifies a CODEOWNER reviewer sign-off comment.
+#
+# A reviewer marks a PR ready by posting the sign-off checklist comment that
+# starts with "As a PR reviewer and CODEOWNER" (see e.g.
+# https://github.com/SemiAnalysisAI/InferenceX/pull/1792#issuecomment-4781799476).
+# When that happens on a non-draft, open PR, this workflow asks Claude to
+# independently confirm the three claims that actually gate a merge:
+#   1. PR validation has at least one fully-green run.
+#   2. Evals pass on that same green run.
+#   3. The single-node recipe(s) are linked in the sign-off comment AND the
+#      linked recipe PR/commit contains all of the reproduction information that
+#      is in this InferenceX PR.
+# If any of those are not to standard, Claude posts a single comment that
+# @-mentions the reviewer who signed off and explains exactly what is wrong.
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+concurrency:
+  group: codeowner-signoff-verify-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Gate: only proceed for the sign-off checklist comment on an OPEN, non-draft
+  # PR. Resolves an immutable head SHA (TOCTOU-safe) and surfaces the comment
+  # metadata the verifier needs.
+  # ---------------------------------------------------------------------------
+  gate:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'As a PR reviewer and CODEOWNER')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      proceed: ${{ steps.resolve.outputs.proceed }}
+      pr-number: ${{ steps.resolve.outputs.pr-number }}
+      head-sha: ${{ steps.resolve.outputs.head-sha }}
+      comment-author: ${{ steps.resolve.outputs.comment-author }}
+      comment-id: ${{ steps.resolve.outputs.comment-id }}
+    steps:
+      - name: Resolve PR state and sign-off metadata
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.issue.number;
+            const commentAuthor = context.payload.comment.user.login;
+            const commentId = context.payload.comment.id;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+
+            // "PRs marked ready" => open and not a draft.
+            const ready = pr.state === 'open' && pr.draft === false;
+            if (!ready) {
+              core.info(`PR #${prNumber} is not a ready PR (state=${pr.state}, draft=${pr.draft}); skipping.`);
+            }
+
+            core.setOutput('proceed', ready ? 'true' : 'false');
+            core.setOutput('pr-number', String(prNumber));
+            core.setOutput('head-sha', pr.head.sha);
+            core.setOutput('comment-author', commentAuthor);
+            core.setOutput('comment-id', String(commentId));
+
+  verify:
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate.outputs.head-sha }}
+          token: ${{ secrets.CLAUDE_PAT }}
+
+      - name: Setup MCP Server
+        run: |
+          pip3 install -r .claude/requirements-mcp.txt
+          mkdir -p /tmp/inferencemax-mcp
+
+      - name: Verify sign-off with Claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_PAT }}
+          INFERENCEMAX_ROOT: ${{ github.workspace }}
+          BASH_DEFAULT_TIMEOUT_MS: "1800000"
+          BASH_MAX_TIMEOUT_MS: "3600000"
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.CLAUDE_PAT }}
+          track_progress: true
+          allowed_bots: ''
+          additional_permissions: |
+            actions: read
+          settings: |
+            {"fastMode": true}
+
+          claude_args: |
+            --model 'claude-opus-4-6'
+            --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
+            --allowedTools "Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ needs.gate.outputs.pr-number }}
+            PR HEAD SHA: ${{ needs.gate.outputs.head-sha }}
+            SIGN-OFF COMMENT ID: ${{ needs.gate.outputs.comment-id }}
+            SIGN-OFF AUTHOR: ${{ needs.gate.outputs.comment-author }}
+
+            You are an automated merge-gate auditor for InferenceX.
+
+            A CODEOWNER (`${{ needs.gate.outputs.comment-author }}`) just posted the reviewer
+            sign-off checklist comment that marks PR #${{ needs.gate.outputs.pr-number }} as
+            ready to merge. Your job is to INDEPENDENTLY verify the three claims below. Do not
+            trust the reviewer's checkmarks — re-derive every conclusion from CI runs, the PR
+            diff, and the linked recipe yourself. Be rigorous and specific.
+
+            Read the sign-off comment first so you have its exact contents, especially the
+            "Additional detail section":
+            ```bash
+            gh api repos/${{ github.repository }}/issues/comments/${{ needs.gate.outputs.comment-id }} --jq .body
+            ```
+
+            Get the PR metadata and the full diff (this is the "InferenceX PR recipe" you will
+            compare against later):
+            ```bash
+            gh pr view ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }} --json title,headRefName,headRefOid,files,body
+            gh pr diff ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }}
+            ```
+
+            ## Check 1 — PR validation has at least one fully-green run
+            "PR validation" is an `e2e-tests.yml` run executed for this PR (usually kicked off
+            by a `/sweep` comment, which replies with a `Run:` link, or by workflow_dispatch).
+            - Find validation runs tied to this PR's head SHA `${{ needs.gate.outputs.head-sha }}`.
+              Use the head SHA, not just the branch — stale runs on older commits do NOT count.
+              ```bash
+              gh run list --repo ${{ github.repository }} --workflow e2e-tests.yml --limit 30 \
+                --json databaseId,headSha,status,conclusion,event,createdAt,url
+              ```
+              Also scan the PR's comments for `/sweep` replies containing `Run:` links and
+              cross-reference those run IDs.
+            - A run counts as GREEN only if `status == completed` and `conclusion == success`.
+              Inspect its jobs to confirm there are no failed/cancelled benchmark jobs:
+              ```bash
+              gh run view <RUN_ID> --repo ${{ github.repository }} --json jobs,conclusion,status,headSha
+              ```
+            - PASS if at least one such green run exists on the current head SHA. Otherwise FAIL
+              and record which runs you found and why none qualified (failed jobs, wrong SHA,
+              still running, cancelled by infra, etc.).
+
+            ## Check 2 — Evals pass on that green run
+            Using the green run from Check 1 (the SAME run):
+            - Confirm the eval jobs actually ran (e.g. `test-sweep-evals` / `collect-evals`) and
+              concluded `success`. A green run that ran NO evals does NOT satisfy this check.
+            - Download and inspect the eval results to confirm the numbers are real and passing,
+              not empty or erroring:
+              ```bash
+              gh run download <RUN_ID> --repo ${{ github.repository }} -p 'eval_results_*' -D ./evals || \
+              gh run download <RUN_ID> --repo ${{ github.repository }} -p 'eval_*' -D ./evals
+              find ./evals -name '*.json' | head
+              ```
+              Read the aggregated eval JSON / the run's "Eval Summary" step summary and confirm
+              accuracy is present and meets the expected bar for the model. FAIL if eval jobs are
+              missing, skipped, failed, or the results are empty/below bar — say exactly which.
+
+            ## Check 3 — Recipe linked AND complete
+            The InferenceX "recipe" for this PR = the files it changes under `benchmarks/`
+            (especially `benchmarks/single_node/**/*.sh`) plus its entry in
+            `.github/configs/*-master.yaml`. The merge standard is: the community must be able to
+            reproduce this benchmark from a public recipe.
+            - (a) LINK PRESENT: The sign-off comment's "Additional detail section" MUST contain a
+              link to the corresponding recipe — a PR/commit in
+              `https://github.com/vllm-project/recipes` or
+              `https://github.com/sgl-project/sglang` (cookbook under `docs_new`), or the
+              published recipe page (`https://recipes.vllm.ai/` or
+              `https://docs.sglang.io/cookbook/...`). If no such link is present, FAIL.
+            - (b) RECIPE COMPLETE: Fetch the linked recipe (use the `fetch` MCP tool or WebFetch;
+              for a recipe PR, read its diff via `gh pr diff` against that repo if accessible)
+              and verify it includes ALL of the reproduction-critical information present in this
+              InferenceX PR's recipe. At minimum cross-check: model, hardware/SKU, inference
+              engine + image tag/version, parallelism (TP/EP/DP/PP), quantization, kv-cache
+              dtype, key server launch flags, required env vars, and benchmark settings
+              (concurrency, sequence lengths / ISL-OSL). FAIL and list every detail that is in
+              the InferenceX PR but missing from the linked recipe.
+            - Note: a bare "recipes are already similar to the official ones" claim WITHOUT a
+              link does not pass this workflow's standard — a link is required.
+
+            ## Verdict and output
+            Decide PASS only if Checks 1, 2, and 3 ALL pass. Post EXACTLY ONE summary comment on
+            PR #${{ needs.gate.outputs.pr-number }} using `gh pr comment`. Start the comment with
+            the hidden marker so reruns are identifiable:
+            `<!-- codeowner-signoff-verify sha=${{ needs.gate.outputs.head-sha }} -->`
+
+            Before posting, list the PR's comments and, if a prior verification comment with this
+            marker already exists for THIS head SHA, do not post a duplicate — update your
+            assessment only if the conclusion changed.
+
+            - If everything is to standard: post a brief confirmation (2-3 sentences) noting the
+              green run URL, that evals pass, and that the recipe link is present and complete.
+              Do NOT @-mention anyone on a pass.
+            - If anything is NOT to standard: the FIRST line of the comment body (after the
+              marker) must @-mention the sign-off author as `@${{ needs.gate.outputs.comment-author }}`.
+              Then list, grouped under "❌ PR validation", "❌ Evals", and "❌ Recipe", each
+              concrete problem with links (run URLs, the recipe link, specific missing fields).
+              Be precise and actionable — tell them exactly what to fix before this PR can merge.
+
+            Use only facts you verified. If a required artifact or run is inaccessible, say so
+            explicitly rather than assuming pass.

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -41,13 +41,19 @@ jobs:
   # command for fetching the exact sign-off body.
   # ---------------------------------------------------------------------------
   gate:
+    # Only trusted reviewers can trigger this (a CODEOWNER sign-off only means
+    # something from a member/collaborator anyway). This also limits the blast
+    # radius of any prompt-injection via PR-supplied content.
     if: |
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER')) ||
+       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.body || '', 'As a PR reviewer and CODEOWNER')) ||
+       contains(github.event.review.body || '', 'As a PR reviewer and CODEOWNER') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER'))
+       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,11 +128,16 @@ jobs:
       issues: write
       actions: read
     steps:
-      - name: Checkout repository
+      # SECURITY: this is a privileged job (write perms + secrets) triggered by
+      # comment events, so it must NOT check out untrusted PR head code — the
+      # setup step and the MCP server would then execute attacker-controlled
+      # files. Check out the trusted default branch; all PR content is read
+      # read-only via the GitHub API (gh / MCP), never from the working tree.
+      - name: Checkout repository (trusted default branch only)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.gate.outputs.head-sha }}
+          ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.CLAUDE_PAT }}
 
       - name: Setup MCP Server
@@ -184,6 +195,13 @@ jobs:
             gh pr view ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }} --json title,headRefName,headRefOid,files,body
             gh pr diff ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }}
             ```
+            Anchor everything to the pinned head SHA `${{ needs.gate.outputs.head-sha }}` (the
+            commit that was signed off). First confirm the PR tip has not moved since the gate
+            ran: if `headRefOid` from the command above differs from the pinned SHA, the head
+            advanced mid-verification — assess the recipe at the PINNED SHA (e.g.
+            `gh api repos/${{ github.repository }}/commits/${{ needs.gate.outputs.head-sha }}` and
+            the files at that SHA), and note in your comment that a fresh sign-off is needed for
+            the new commit. This keeps Check 3 (recipe) consistent with Checks 1-2.
 
             ## Check 1 — A passing sweep + evals ran on a commit IN this PR
             The merge standard (and InferenceX's own reuse gate) requires a green full sweep —

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -185,94 +185,59 @@ jobs:
             gh pr diff ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }}
             ```
 
-            ## Check 1 — PR validation has at least one fully-green full-sweep run
-            "PR validation" is a `run-sweep.yml` run (it shows up named "Run Sweep - <PR title>").
-            It is triggered automatically on push/synchronize when the PR carries a sweep label
-            (`full-sweep-enabled`, `non-canary-full-sweep-enabled`, `full-sweep-fail-fast`, or
-            `full-sweep-fail-fast-no-canary`). It runs the benchmark + eval jobs. (Older PRs may
-            instead have an `e2e-tests.yml` run kicked off by a `/sweep` comment — treat that as
-            equivalent.)
+            ## Check 1 — A passing sweep + evals ran on a commit IN this PR
+            The merge standard (and InferenceX's own reuse gate) requires a green full sweep —
+            including evals — on a commit that is CURRENTLY part of this PR. A sweep that ran on a
+            commit later rebased/force-pushed out does NOT count: at merge, `merge_with_reuse.sh`
+            → `validate_reusable_run` (in `utils/find_reusable_sweep_run.py`) rejects any source
+            whose `head_sha` is not in `GET /pulls/<n>/commits`. So the whole question collapses
+            to one fact: does a commit still in this PR carry green, executed sweep/eval checks?
 
-            IMPORTANT — artifact reuse is normal and valid, BUT it must anchor to a real
-            executed sweep on a commit that is still in this PR. After an eligible full sweep, a
-            maintainer comments `/reuse-sweep-run [run_id]` to reuse those artifacts. When that
-            happens, the run on the CURRENT head SHA is a "reuse" run: `check-changelog` /
-            `reuse-sweep-gate` run, but every benchmark and eval job is `skipped`. That is not a
-            failure by itself — but you MUST confirm the reuse points at a concrete green executed
-            sweep whose commit is part of this PR. A reuse that anchors to nothing, or to a commit
-            that has been force-pushed/rebased out of the PR, does NOT count as validation.
-
-            Key definitions:
-            - EXECUTED run: a `run-sweep.yml` run whose benchmark + eval jobs actually RAN
-              (conclusion `success`), not `skipped`. A run where only `check-changelog` /
-              `reuse-sweep-gate` ran and all `single-node */eval */collect-evals` are `skipped` is
-              a SKIP/REUSE run, never the authoritative run.
-            - IN-PR commit: a commit whose SHA literally appears in the PR's commit list. This is
-              the SAME check InferenceX's own reuse gate runs at merge time
-              (`validate_reusable_run` in `utils/find_reusable_sweep_run.py` requires the source
-              run's `head_sha` to be in `GET /pulls/<n>/commits`). If the validated commit was
-              rebased/force-pushed out, it is NOT in this list and `merge_with_reuse.sh` will fail
-              closed — so your verdict here exactly predicts whether the reuse can be promoted:
+            The cleanest way to answer is the check-runs attached to each in-PR commit — you do
+            NOT need to list `run-sweep.yml` runs or parse reuse logs.
+            - Get the PR's current commit SHAs:
               ```bash
               gh api repos/${{ github.repository }}/pulls/${{ needs.gate.outputs.pr-number }}/commits \
-                --paginate --jq '.[].sha'   # the authoritative run's head_sha MUST appear here
+                --paginate --jq '.[].sha'
               ```
-              (A `main`-merge that adds a commit keeps the original SHAs in this list, so it stays
-              valid; only a rebase/force-push that drops the validated SHA breaks it.)
+            - For each of those SHAs, list its check-runs and look at the sweep/eval jobs:
+              ```bash
+              gh api repos/${{ github.repository }}/commits/<sha>/check-runs --paginate \
+                --jq '.check_runs[] | {name, conclusion}'
+              ```
+              The per-config benchmark/eval check-runs are named like `single-node 1k1k /`,
+              `single-node 8k1k /`, and `eval /`. A commit satisfies validation only if the actual
+              executed jobs — the `eval /` AND `single-node */` check-runs — have conclusion
+              `success`. `skipped` does NOT count (it means a skip/reuse run that executed nothing
+              on that commit); `failure` does not count.
+              IMPORTANT: do NOT rely on `collect-evals` — it is an aggregator that can report
+              `success` even when every underlying `eval /` job was `skipped` (it just aggregated
+              an empty set). Always key off the per-config `eval /` and `single-node */` jobs.
+            - PASS if ANY commit currently in the PR has green (success, non-skipped) `single-node */`
+              AND `eval /` check-runs. Remember the run id behind a passing `eval /` check (its
+              `details_url` contains `/actions/runs/<run_id>/...`) — Check 2 needs it.
+            - Otherwise FAIL. State the ROOT ISSUE plainly and keep it actionable:
+              "No passing sweep/eval was found on any commit in this PR."
+              Do NOT write a confusing message like "it technically passed but the commit isn't in
+              the PR" — a sweep that ran on a rebased-out commit is irrelevant to the reviewer, so
+              don't lead with it. The fix the author needs is simply: run (or re-anchor via
+              `/reuse-sweep-run`) a passing full sweep on a commit currently in this PR. You may
+              add an offending run/SHA as a short supporting detail AFTER the root-issue line.
 
-            Procedure:
-            - List this PR's full-sweep runs by branch (the authoritative run may be on an earlier
-              in-PR commit, not the head SHA):
-              ```bash
-              gh run list --repo ${{ github.repository }} --workflow run-sweep.yml \
-                --branch <headRefName> --limit 30 \
-                --json databaseId,headSha,status,conclusion,event,createdAt,url
-              ```
-            - Inspect the head-SHA run's jobs:
-              ```bash
-              gh run view <RUN_ID> --repo ${{ github.repository }} --json jobs,conclusion,status,headSha
-              ```
-              If it is an EXECUTED green run on the head SHA, Check 1 passes.
-            - If the head-SHA run is a SKIP/REUSE run, read what it anchored to from the
-              `reuse-sweep-gate` job log (it prints `skip-pr-sweep`, `reuse-source-run-id`,
-              `reuse-source-head-sha`):
-              ```bash
-              gh run view <HEAD_RUN_ID> --repo ${{ github.repository }} --log \
-                | grep -E 'skip-pr-sweep|reuse-source-run-id|reuse-source-head-sha'
-              ```
-              Also check PR comments for `/reuse-sweep-run [run_id]` (latest by an
-              OWNER/MEMBER/COLLABORATOR wins; may pin a run id). The AUTHORITATIVE run is that
-              anchored source run. If `reuse-source-run-id` is EMPTY (skip with no anchor) and no
-              pinned run is supplied, there is NO validation — FAIL.
-            - Validate the AUTHORITATIVE run: it must be an EXECUTED green run, AND its head SHA
-              must be an IN-PR commit (must appear in `GET /pulls/<n>/commits`, per above). An
-              executed green run on a diverged/orphaned commit does NOT satisfy validation — and
-              InferenceX's merge gate would reject it for the same reason.
-            - PASS only if such a run exists (executed green, in-PR, evals run — see Check 2).
-              Otherwise FAIL and state precisely why: e.g. "all runs on the PR's commits are
-              skip/failed; head reuse anchored to empty source; the only executed green sweep
-              (<run-url>, sha <x>) is rebased out of the PR, so reuse cannot be promoted
-              (merge_with_reuse.sh would fail)."
-
-            ## Check 2 — Evals pass on the authoritative run
-            Using the AUTHORITATIVE run from Check 1 (the run that actually executed the sweep —
-            for a reused PR this is the source full-sweep run, NOT the skipped reuse run on the
-            head SHA):
-            - Confirm the eval jobs actually ran (e.g. `eval /` / `collect-evals`) and concluded
-              `success`. If the authoritative run's eval jobs are skipped or failed, FAIL.
-            - Download and inspect the eval results to confirm the numbers are real and passing,
-              not empty or erroring:
+            ## Check 2 — Evals actually pass (accuracy), on that in-PR commit's run
+            For the commit that passed Check 1, confirm the eval numbers are real and meet the bar
+            — not just that the job is green:
+            - Take the run id behind the passing `eval /` / `collect-evals` check-run (from its
+              `details_url`) and download its eval results:
               ```bash
               gh run download <RUN_ID> --repo ${{ github.repository }} -p 'eval_results_*' -D ./evals || \
               gh run download <RUN_ID> --repo ${{ github.repository }} -p 'eval_*' -D ./evals
               find ./evals -name '*.json' | head
               ```
-              Read the aggregated eval JSON / the run's "Eval Summary" step summary and confirm
-              accuracy is present and meets the expected bar for the model. Also confirm the
-              authoritative run used the same inference-engine image as this PR's config (a reuse
-              is only valid if the validated artifacts match the merged recipe). FAIL if eval jobs
-              are missing, failed, the results are empty/below bar, or the image differs — say
-              exactly which.
+            - Read the aggregated eval JSON / the run's "Eval Summary" step summary and confirm
+              accuracy is present and meets the expected bar for the model, and that the run used
+              the same inference-engine image as this PR's config. FAIL if evals are
+              skipped/failed/empty/below bar, or the image differs — say exactly which.
 
             ## Check 3 — Recipe linked AND complete
             The InferenceX "recipe" for this PR = the files it changes under `benchmarks/`
@@ -312,8 +277,11 @@ jobs:
             - If anything is NOT to standard: the FIRST line of the comment body (after the
               marker) must @-mention the sign-off author as `@${{ needs.gate.outputs.signoff-author }}`.
               Then list, grouped under "PR validation", "Evals", and "Recipe", each concrete
-              problem with links (run URLs, the recipe link, specific missing fields). Be
-              precise and actionable — tell them exactly what to fix before this PR can merge.
+              problem. Lead each item with the ROOT ISSUE in plain language (e.g. for validation,
+              "No passing sweep/eval was found on any commit in this PR"), then add supporting
+              detail/links (run URLs, the recipe link, specific missing fields) AFTER. Be precise
+              and actionable — tell them exactly what to fix before this PR can merge. Avoid
+              confusing nuance the reviewer can't act on.
 
             Do not use emojis anywhere in the comment. Use only facts you verified. If a required
             artifact or run is inaccessible, say so explicitly rather than assuming pass.

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -207,13 +207,18 @@ jobs:
               (conclusion `success`), not `skipped`. A run where only `check-changelog` /
               `reuse-sweep-gate` ran and all `single-node */eval */collect-evals` are `skipped` is
               a SKIP/REUSE run, never the authoritative run.
-            - IN-PR commit: a commit that is an ancestor of the current head SHA. Verify with the
-              compare API — `ahead`/`identical` means in-PR; `diverged` or `behind` means it was
-              rebased/force-pushed out and does NOT count:
+            - IN-PR commit: a commit whose SHA literally appears in the PR's commit list. This is
+              the SAME check InferenceX's own reuse gate runs at merge time
+              (`validate_reusable_run` in `utils/find_reusable_sweep_run.py` requires the source
+              run's `head_sha` to be in `GET /pulls/<n>/commits`). If the validated commit was
+              rebased/force-pushed out, it is NOT in this list and `merge_with_reuse.sh` will fail
+              closed — so your verdict here exactly predicts whether the reuse can be promoted:
               ```bash
-              gh api repos/${{ github.repository }}/compare/<candidate-sha>...${{ needs.gate.outputs.head-sha }} \
-                --jq '{status,ahead_by,behind_by}'   # require status ahead|identical, behind_by 0
+              gh api repos/${{ github.repository }}/pulls/${{ needs.gate.outputs.pr-number }}/commits \
+                --paginate --jq '.[].sha'   # the authoritative run's head_sha MUST appear here
               ```
+              (A `main`-merge that adds a commit keeps the original SHAs in this list, so it stays
+              valid; only a rebase/force-push that drops the validated SHA breaks it.)
 
             Procedure:
             - List this PR's full-sweep runs by branch (the authoritative run may be on an earlier
@@ -240,12 +245,14 @@ jobs:
               anchored source run. If `reuse-source-run-id` is EMPTY (skip with no anchor) and no
               pinned run is supplied, there is NO validation — FAIL.
             - Validate the AUTHORITATIVE run: it must be an EXECUTED green run, AND its head SHA
-              must be an IN-PR commit (compare check above). An executed green run that is on a
-              diverged/orphaned commit does NOT satisfy validation.
+              must be an IN-PR commit (must appear in `GET /pulls/<n>/commits`, per above). An
+              executed green run on a diverged/orphaned commit does NOT satisfy validation — and
+              InferenceX's merge gate would reject it for the same reason.
             - PASS only if such a run exists (executed green, in-PR, evals run — see Check 2).
-              Otherwise FAIL and state precisely why: e.g. "all runs on the 3 PR commits are
+              Otherwise FAIL and state precisely why: e.g. "all runs on the PR's commits are
               skip/failed; head reuse anchored to empty source; the only executed green sweep
-              (<run-url>, sha <x>) is diverged out of the PR."
+              (<run-url>, sha <x>) is rebased out of the PR, so reuse cannot be promoted
+              (merge_with_reuse.sh would fail)."
 
             ## Check 2 — Evals pass on the authoritative run
             Using the AUTHORITATIVE run from Check 1 (the run that actually executed the sweep —

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -193,39 +193,59 @@ jobs:
             instead have an `e2e-tests.yml` run kicked off by a `/sweep` comment — treat that as
             equivalent.)
 
-            IMPORTANT — artifact reuse is normal and valid. After an eligible full sweep, a
+            IMPORTANT — artifact reuse is normal and valid, BUT it must anchor to a real
+            executed sweep on a commit that is still in this PR. After an eligible full sweep, a
             maintainer comments `/reuse-sweep-run [run_id]` to reuse those artifacts. When that
-            happens, the run on the CURRENT head SHA is a "reuse" run: `reuse-sweep-gate` /
-            `check-changelog` run, but every benchmark and eval job is `skipped`. That is NOT a
-            failure — it means the authoritative validation lives in an earlier full-sweep run
-            whose commit is still in this PR. You must trace back to that source run.
+            happens, the run on the CURRENT head SHA is a "reuse" run: `check-changelog` /
+            `reuse-sweep-gate` run, but every benchmark and eval job is `skipped`. That is not a
+            failure by itself — but you MUST confirm the reuse points at a concrete green executed
+            sweep whose commit is part of this PR. A reuse that anchors to nothing, or to a commit
+            that has been force-pushed/rebased out of the PR, does NOT count as validation.
+
+            Key definitions:
+            - EXECUTED run: a `run-sweep.yml` run whose benchmark + eval jobs actually RAN
+              (conclusion `success`), not `skipped`. A run where only `check-changelog` /
+              `reuse-sweep-gate` ran and all `single-node */eval */collect-evals` are `skipped` is
+              a SKIP/REUSE run, never the authoritative run.
+            - IN-PR commit: a commit that is an ancestor of the current head SHA. Verify with the
+              compare API — `ahead`/`identical` means in-PR; `diverged` or `behind` means it was
+              rebased/force-pushed out and does NOT count:
+              ```bash
+              gh api repos/${{ github.repository }}/compare/<candidate-sha>...${{ needs.gate.outputs.head-sha }} \
+                --jq '{status,ahead_by,behind_by}'   # require status ahead|identical, behind_by 0
+              ```
 
             Procedure:
-            - List this PR's full-sweep runs (by branch, since the authoritative run may be on an
-              earlier in-PR commit, not the head SHA):
+            - List this PR's full-sweep runs by branch (the authoritative run may be on an earlier
+              in-PR commit, not the head SHA):
               ```bash
               gh run list --repo ${{ github.repository }} --workflow run-sweep.yml \
                 --branch <headRefName> --limit 30 \
                 --json databaseId,headSha,status,conclusion,event,createdAt,url
               ```
-              Also scan the PR comments for `/reuse-sweep-run [run_id]` (the latest such comment
-              by an OWNER/MEMBER/COLLABORATOR wins; it may pin a specific run id) and for `/sweep`
-              replies containing `Run:` links. Cross-reference those run IDs.
-            - Determine the AUTHORITATIVE run — the run that actually executed the sweep:
+            - Inspect the head-SHA run's jobs:
               ```bash
               gh run view <RUN_ID> --repo ${{ github.repository }} --json jobs,conclusion,status,headSha
               ```
-              If the head-SHA run only has `check-changelog` / `reuse-sweep-gate` and all
-              benchmark/eval jobs are `skipped`, it is a reuse run — follow it to the source full
-              sweep (the pinned `/reuse-sweep-run <id>`, else the latest successful `run-sweep.yml`
-              PR run whose commit is still in the PR). The authoritative run is that source run.
-            - A run counts as GREEN only if `status == completed` and `conclusion == success` and
-              its benchmark jobs actually ran (not all skipped). Confirm the authoritative run's
-              head SHA is a commit that is part of this PR.
-            - PASS if a green authoritative full-sweep run exists (directly on the head SHA, or
-              reused from an earlier in-PR commit). Otherwise FAIL and record which runs you found
-              and why none qualified (failed jobs, not part of the PR, still running, cancelled by
-              infra, reuse pointing at a non-green/non-existent source, etc.).
+              If it is an EXECUTED green run on the head SHA, Check 1 passes.
+            - If the head-SHA run is a SKIP/REUSE run, read what it anchored to from the
+              `reuse-sweep-gate` job log (it prints `skip-pr-sweep`, `reuse-source-run-id`,
+              `reuse-source-head-sha`):
+              ```bash
+              gh run view <HEAD_RUN_ID> --repo ${{ github.repository }} --log \
+                | grep -E 'skip-pr-sweep|reuse-source-run-id|reuse-source-head-sha'
+              ```
+              Also check PR comments for `/reuse-sweep-run [run_id]` (latest by an
+              OWNER/MEMBER/COLLABORATOR wins; may pin a run id). The AUTHORITATIVE run is that
+              anchored source run. If `reuse-source-run-id` is EMPTY (skip with no anchor) and no
+              pinned run is supplied, there is NO validation — FAIL.
+            - Validate the AUTHORITATIVE run: it must be an EXECUTED green run, AND its head SHA
+              must be an IN-PR commit (compare check above). An executed green run that is on a
+              diverged/orphaned commit does NOT satisfy validation.
+            - PASS only if such a run exists (executed green, in-PR, evals run — see Check 2).
+              Otherwise FAIL and state precisely why: e.g. "all runs on the 3 PR commits are
+              skip/failed; head reuse anchored to empty source; the only executed green sweep
+              (<run-url>, sha <x>) is diverged out of the PR."
 
             ## Check 2 — Evals pass on the authoritative run
             Using the AUTHORITATIVE run from Check 1 (the run that actually executed the sweep —

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -257,9 +257,9 @@ jobs:
               Do NOT @-mention anyone on a pass.
             - If anything is NOT to standard: the FIRST line of the comment body (after the
               marker) must @-mention the sign-off author as `@${{ needs.gate.outputs.signoff-author }}`.
-              Then list, grouped under "❌ PR validation", "❌ Evals", and "❌ Recipe", each
-              concrete problem with links (run URLs, the recipe link, specific missing fields).
-              Be precise and actionable — tell them exactly what to fix before this PR can merge.
+              Then list, grouped under "PR validation", "Evals", and "Recipe", each concrete
+              problem with links (run URLs, the recipe link, specific missing fields). Be
+              precise and actionable — tell them exactly what to fix before this PR can merge.
 
-            Use only facts you verified. If a required artifact or run is inaccessible, say so
-            explicitly rather than assuming pass.
+            Do not use emojis anywhere in the comment. Use only facts you verified. If a required
+            artifact or run is inaccessible, say so explicitly rather than assuming pass.

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -185,30 +185,54 @@ jobs:
             gh pr diff ${{ needs.gate.outputs.pr-number }} --repo ${{ github.repository }}
             ```
 
-            ## Check 1 — PR validation has at least one fully-green run
-            "PR validation" is an `e2e-tests.yml` run executed for this PR (usually kicked off
-            by a `/sweep` comment, which replies with a `Run:` link, or by workflow_dispatch).
-            - Find validation runs tied to this PR's head SHA `${{ needs.gate.outputs.head-sha }}`.
-              Use the head SHA, not just the branch — stale runs on older commits do NOT count.
+            ## Check 1 — PR validation has at least one fully-green full-sweep run
+            "PR validation" is a `run-sweep.yml` run (it shows up named "Run Sweep - <PR title>").
+            It is triggered automatically on push/synchronize when the PR carries a sweep label
+            (`full-sweep-enabled`, `non-canary-full-sweep-enabled`, `full-sweep-fail-fast`, or
+            `full-sweep-fail-fast-no-canary`). It runs the benchmark + eval jobs. (Older PRs may
+            instead have an `e2e-tests.yml` run kicked off by a `/sweep` comment — treat that as
+            equivalent.)
+
+            IMPORTANT — artifact reuse is normal and valid. After an eligible full sweep, a
+            maintainer comments `/reuse-sweep-run [run_id]` to reuse those artifacts. When that
+            happens, the run on the CURRENT head SHA is a "reuse" run: `reuse-sweep-gate` /
+            `check-changelog` run, but every benchmark and eval job is `skipped`. That is NOT a
+            failure — it means the authoritative validation lives in an earlier full-sweep run
+            whose commit is still in this PR. You must trace back to that source run.
+
+            Procedure:
+            - List this PR's full-sweep runs (by branch, since the authoritative run may be on an
+              earlier in-PR commit, not the head SHA):
               ```bash
-              gh run list --repo ${{ github.repository }} --workflow e2e-tests.yml --limit 30 \
+              gh run list --repo ${{ github.repository }} --workflow run-sweep.yml \
+                --branch <headRefName> --limit 30 \
                 --json databaseId,headSha,status,conclusion,event,createdAt,url
               ```
-              Also scan the PR's comments for `/sweep` replies containing `Run:` links and
-              cross-reference those run IDs.
-            - A run counts as GREEN only if `status == completed` and `conclusion == success`.
-              Inspect its jobs to confirm there are no failed/cancelled benchmark jobs:
+              Also scan the PR comments for `/reuse-sweep-run [run_id]` (the latest such comment
+              by an OWNER/MEMBER/COLLABORATOR wins; it may pin a specific run id) and for `/sweep`
+              replies containing `Run:` links. Cross-reference those run IDs.
+            - Determine the AUTHORITATIVE run — the run that actually executed the sweep:
               ```bash
               gh run view <RUN_ID> --repo ${{ github.repository }} --json jobs,conclusion,status,headSha
               ```
-            - PASS if at least one such green run exists on the current head SHA. Otherwise FAIL
-              and record which runs you found and why none qualified (failed jobs, wrong SHA,
-              still running, cancelled by infra, etc.).
+              If the head-SHA run only has `check-changelog` / `reuse-sweep-gate` and all
+              benchmark/eval jobs are `skipped`, it is a reuse run — follow it to the source full
+              sweep (the pinned `/reuse-sweep-run <id>`, else the latest successful `run-sweep.yml`
+              PR run whose commit is still in the PR). The authoritative run is that source run.
+            - A run counts as GREEN only if `status == completed` and `conclusion == success` and
+              its benchmark jobs actually ran (not all skipped). Confirm the authoritative run's
+              head SHA is a commit that is part of this PR.
+            - PASS if a green authoritative full-sweep run exists (directly on the head SHA, or
+              reused from an earlier in-PR commit). Otherwise FAIL and record which runs you found
+              and why none qualified (failed jobs, not part of the PR, still running, cancelled by
+              infra, reuse pointing at a non-green/non-existent source, etc.).
 
-            ## Check 2 — Evals pass on that green run
-            Using the green run from Check 1 (the SAME run):
-            - Confirm the eval jobs actually ran (e.g. `test-sweep-evals` / `collect-evals`) and
-              concluded `success`. A green run that ran NO evals does NOT satisfy this check.
+            ## Check 2 — Evals pass on the authoritative run
+            Using the AUTHORITATIVE run from Check 1 (the run that actually executed the sweep —
+            for a reused PR this is the source full-sweep run, NOT the skipped reuse run on the
+            head SHA):
+            - Confirm the eval jobs actually ran (e.g. `eval /` / `collect-evals`) and concluded
+              `success`. If the authoritative run's eval jobs are skipped or failed, FAIL.
             - Download and inspect the eval results to confirm the numbers are real and passing,
               not empty or erroring:
               ```bash
@@ -217,8 +241,11 @@ jobs:
               find ./evals -name '*.json' | head
               ```
               Read the aggregated eval JSON / the run's "Eval Summary" step summary and confirm
-              accuracy is present and meets the expected bar for the model. FAIL if eval jobs are
-              missing, skipped, failed, or the results are empty/below bar — say exactly which.
+              accuracy is present and meets the expected bar for the model. Also confirm the
+              authoritative run used the same inference-engine image as this PR's config (a reuse
+              is only valid if the validated artifacts match the merged recipe). FAIL if eval jobs
+              are missing, failed, the results are empty/below bar, or the image differs — say
+              exactly which.
 
             ## Check 3 — Recipe linked AND complete
             The InferenceX "recipe" for this PR = the files it changes under `benchmarks/`

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -1,38 +1,53 @@
 name: CODEOWNER Sign-off Verify
 
-# Independently re-verifies a CODEOWNER reviewer sign-off comment.
+# Independently re-verifies a CODEOWNER reviewer sign-off.
 #
-# A reviewer marks a PR ready by posting the sign-off checklist comment that
-# starts with "As a PR reviewer and CODEOWNER" (see e.g.
+# A reviewer marks a PR ready by posting the sign-off checklist that starts with
+# "As a PR reviewer and CODEOWNER" (see e.g.
 # https://github.com/SemiAnalysisAI/InferenceX/pull/1792#issuecomment-4781799476).
-# When that happens on a non-draft, open PR, this workflow asks Claude to
+# That sign-off can be posted three different ways, and all three trigger here:
+#   - a conversation comment            -> issue_comment
+#   - an Approve/Comment review summary  -> pull_request_review
+#   - an inline code-review comment      -> pull_request_review_comment
+#
+# When the sign-off lands on a non-draft, open PR, this workflow asks Claude to
 # independently confirm the three claims that actually gate a merge:
 #   1. PR validation has at least one fully-green run.
 #   2. Evals pass on that same green run.
-#   3. The single-node recipe(s) are linked in the sign-off comment AND the
-#      linked recipe PR/commit contains all of the reproduction information that
-#      is in this InferenceX PR.
+#   3. The single-node recipe(s) are linked in the sign-off AND the linked
+#      recipe PR/commit contains all of the reproduction information that is in
+#      this InferenceX PR.
 # If any of those are not to standard, Claude posts a single comment that
 # @-mentions the reviewer who signed off and explains exactly what is wrong.
 
 on:
   issue_comment:
     types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited]
+  pull_request_review_comment:
+    types: [created, edited]
 
 concurrency:
-  group: codeowner-signoff-verify-${{ github.event.issue.number }}
+  group: codeowner-signoff-verify-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Gate: only proceed for the sign-off checklist comment on an OPEN, non-draft
-  # PR. Resolves an immutable head SHA (TOCTOU-safe) and surfaces the comment
-  # metadata the verifier needs.
+  # Gate: only proceed for the sign-off checklist on an OPEN, non-draft PR.
+  # Normalizes the three event shapes (issue_comment / pull_request_review /
+  # pull_request_review_comment) into a single set of outputs, resolves an
+  # immutable head SHA (TOCTOU-safe), and hands the verifier a ready-to-run
+  # command for fetching the exact sign-off body.
   # ---------------------------------------------------------------------------
   gate:
     if: |
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, 'As a PR reviewer and CODEOWNER')
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body || '', 'As a PR reviewer and CODEOWNER')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body || '', 'As a PR reviewer and CODEOWNER'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,8 +56,9 @@ jobs:
       proceed: ${{ steps.resolve.outputs.proceed }}
       pr-number: ${{ steps.resolve.outputs.pr-number }}
       head-sha: ${{ steps.resolve.outputs.head-sha }}
-      comment-author: ${{ steps.resolve.outputs.comment-author }}
-      comment-id: ${{ steps.resolve.outputs.comment-id }}
+      signoff-author: ${{ steps.resolve.outputs.signoff-author }}
+      signoff-kind: ${{ steps.resolve.outputs.signoff-kind }}
+      signoff-fetch-cmd: ${{ steps.resolve.outputs.signoff-fetch-cmd }}
     steps:
       - name: Resolve PR state and sign-off metadata
         id: resolve
@@ -51,9 +67,33 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = context.payload.issue.number;
-            const commentAuthor = context.payload.comment.user.login;
-            const commentId = context.payload.comment.id;
+            const repoFull = `${owner}/${repo}`;
+            const eventName = context.eventName;
+
+            // Normalize the three event payloads.
+            let prNumber, author, refId, kind, fetchCmd;
+            if (eventName === 'issue_comment') {
+              prNumber = context.payload.issue.number;
+              author = context.payload.comment.user.login;
+              refId = context.payload.comment.id;
+              kind = 'conversation comment';
+              fetchCmd = `gh api repos/${repoFull}/issues/comments/${refId} --jq .body`;
+            } else if (eventName === 'pull_request_review') {
+              prNumber = context.payload.pull_request.number;
+              author = context.payload.review.user.login;
+              refId = context.payload.review.id;
+              kind = 'review summary';
+              fetchCmd = `gh api repos/${repoFull}/pulls/${prNumber}/reviews/${refId} --jq .body`;
+            } else if (eventName === 'pull_request_review_comment') {
+              prNumber = context.payload.pull_request.number;
+              author = context.payload.comment.user.login;
+              refId = context.payload.comment.id;
+              kind = 'inline review comment';
+              fetchCmd = `gh api repos/${repoFull}/pulls/comments/${refId} --jq .body`;
+            } else {
+              core.setOutput('proceed', 'false');
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber,
@@ -62,14 +102,15 @@ jobs:
             // "PRs marked ready" => open and not a draft.
             const ready = pr.state === 'open' && pr.draft === false;
             if (!ready) {
-              core.info(`PR #${prNumber} is not a ready PR (state=${pr.state}, draft=${pr.draft}); skipping.`);
+              core.info(`PR #${prNumber} is not ready (state=${pr.state}, draft=${pr.draft}); skipping.`);
             }
 
             core.setOutput('proceed', ready ? 'true' : 'false');
             core.setOutput('pr-number', String(prNumber));
             core.setOutput('head-sha', pr.head.sha);
-            core.setOutput('comment-author', commentAuthor);
-            core.setOutput('comment-id', String(commentId));
+            core.setOutput('signoff-author', author);
+            core.setOutput('signoff-kind', kind);
+            core.setOutput('signoff-fetch-cmd', fetchCmd);
 
   verify:
     needs: gate
@@ -104,7 +145,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.CLAUDE_PAT }}
-          track_progress: true
+          track_progress: false
           allowed_bots: ''
           additional_permissions: |
             actions: read
@@ -119,21 +160,22 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr-number }}
             PR HEAD SHA: ${{ needs.gate.outputs.head-sha }}
-            SIGN-OFF COMMENT ID: ${{ needs.gate.outputs.comment-id }}
-            SIGN-OFF AUTHOR: ${{ needs.gate.outputs.comment-author }}
+            SIGN-OFF AUTHOR: ${{ needs.gate.outputs.signoff-author }}
+            SIGN-OFF KIND: ${{ needs.gate.outputs.signoff-kind }}
 
             You are an automated merge-gate auditor for InferenceX.
 
-            A CODEOWNER (`${{ needs.gate.outputs.comment-author }}`) just posted the reviewer
-            sign-off checklist comment that marks PR #${{ needs.gate.outputs.pr-number }} as
-            ready to merge. Your job is to INDEPENDENTLY verify the three claims below. Do not
-            trust the reviewer's checkmarks — re-derive every conclusion from CI runs, the PR
-            diff, and the linked recipe yourself. Be rigorous and specific.
+            A CODEOWNER (`${{ needs.gate.outputs.signoff-author }}`) just posted the reviewer
+            sign-off checklist (as a ${{ needs.gate.outputs.signoff-kind }}) that marks
+            PR #${{ needs.gate.outputs.pr-number }} as ready to merge. Your job is to
+            INDEPENDENTLY verify the three claims below. Do not trust the reviewer's checkmarks
+            — re-derive every conclusion from CI runs, the PR diff, and the linked recipe
+            yourself. Be rigorous and specific.
 
-            Read the sign-off comment first so you have its exact contents, especially the
-            "Additional detail section":
+            Read the exact sign-off body first (especially its "Additional detail section").
+            The sign-off was posted as a ${{ needs.gate.outputs.signoff-kind }}, so fetch it with:
             ```bash
-            gh api repos/${{ github.repository }}/issues/comments/${{ needs.gate.outputs.comment-id }} --jq .body
+            ${{ needs.gate.outputs.signoff-fetch-cmd }}
             ```
 
             Get the PR metadata and the full diff (this is the "InferenceX PR recipe" you will
@@ -183,8 +225,8 @@ jobs:
             (especially `benchmarks/single_node/**/*.sh`) plus its entry in
             `.github/configs/*-master.yaml`. The merge standard is: the community must be able to
             reproduce this benchmark from a public recipe.
-            - (a) LINK PRESENT: The sign-off comment's "Additional detail section" MUST contain a
-              link to the corresponding recipe — a PR/commit in
+            - (a) LINK PRESENT: The sign-off's "Additional detail section" MUST contain a link to
+              the corresponding recipe — a PR/commit in
               `https://github.com/vllm-project/recipes` or
               `https://github.com/sgl-project/sglang` (cookbook under `docs_new`), or the
               published recipe page (`https://recipes.vllm.ai/` or
@@ -214,7 +256,7 @@ jobs:
               green run URL, that evals pass, and that the recipe link is present and complete.
               Do NOT @-mention anyone on a pass.
             - If anything is NOT to standard: the FIRST line of the comment body (after the
-              marker) must @-mention the sign-off author as `@${{ needs.gate.outputs.comment-author }}`.
+              marker) must @-mention the sign-off author as `@${{ needs.gate.outputs.signoff-author }}`.
               Then list, grouped under "❌ PR validation", "❌ Evals", and "❌ Recipe", each
               concrete problem with links (run URLs, the recipe link, specific missing fields).
               Be precise and actionable — tell them exactly what to fix before this PR can merge.


### PR DESCRIPTION
Adds `.github/workflows/codeowner-signoff-verify.yml`: when a CODEOWNER posts the sign-off checklist (body starts with `As a PR reviewer and CODEOWNER`), a Claude job re-verifies the merge-gating claims instead of trusting the checkmarks.

## Triggers
- `issue_comment` (conversation comment)
- `pull_request_review` (Approve/Comment review summary)
- `pull_request_review_comment` (inline review comment)
- Only on open, non-draft PRs.

## What Claude checks
- At least one fully-green `e2e-tests.yml` run on the current head SHA (stale-commit runs do not count).
- Evals actually ran and passed on that same run (downloads + inspects eval artifacts; no-eval runs fail).
- Recipe link present in the sign-off's "Additional detail section" AND the linked vLLM/SGLang recipe contains all reproduction info from this PR (model, SKU, engine + image tag, parallelism, quantization, kv-cache dtype, server flags, env vars, conc/seq-lens).

## Outcome
- Any failure: one comment that @-mentions the signer with the specific problems, grouped by PR validation / Evals / Recipe.
- All pass: brief confirmation, no @-mention.

## Notes
- Gate normalizes the three event payloads and pins an immutable head SHA (TOCTOU-safe).
- Idempotent via a hidden `<!-- codeowner-signoff-verify sha=... -->` marker.
- Standard is stricter than the checklist: a recipe link is required, not optional.
- Follows existing Claude-workflow conventions (pinned action SHAs, MCP setup, `CLAUDE_PAT`/`ANTHROPIC_API_KEY`).
- Comment events run only from the default-branch workflow file, so this fires only after merge to `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automation that posts PR comments and reads CI/actions with write permissions; it gates merge readiness but does not block merges by itself—wrong negatives could annoy reviewers or miss issues if Claude misjudges runs/recipes.
> 
> **Overview**
> Adds **`.github/workflows/codeowner-signoff-verify.yml`**, which runs when a CODEOWNER posts the standard sign-off checklist (`As a PR reviewer and CODEOWNER`) on an open, non-draft PR—whether as a conversation comment, review summary, or inline review comment.
> 
> A **`gate`** job normalizes those three event shapes, pins the PR **head SHA**, and skips drafts/closed PRs. The **`verify`** job checks out that SHA and runs **Claude** (same MCP/`CLAUDE_PAT` pattern as other Claude workflows) to independently re-check three merge gates: a fully green **`e2e-tests.yml`** run on the current head, **evals** passing on that same run (with artifact inspection), and a **recipe link** in the sign-off that matches all reproduction details from the InferenceX PR.
> 
> Outcomes are posted as a single PR comment—brief pass confirmation, or an @-mention to the signer with failures grouped under PR validation / Evals / Recipe. Comments are **idempotent** via a hidden `<!-- codeowner-signoff-verify sha=... -->` marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c73fc27e0b7b6d9127119d147b3e9402beaed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->