### PR TITLE
ci: use Opus 4.8 for all Claude workflows

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,7 +53,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-opus-4-6'
+            --model 'claude-opus-4-8'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__inferencemax-repos__*,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude sonnet') && 'claude-sonnet-4-6' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-opus-4-6' }}
+            --model ${{ contains(github.event.comment.body || github.event.issue.body || '', '@claude sonnet') && 'claude-sonnet-4-6' || contains(github.event.comment.body || github.event.issue.body || '', '@claude haiku') && 'claude-haiku-4-5-20251001' || 'claude-opus-4-8' }}
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Write,Edit,Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -212,7 +212,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-opus-4-6'
+            --model 'claude-opus-4-8'
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |


### PR DESCRIPTION
Bumps every Claude-powered workflow from `claude-opus-4-6` to `claude-opus-4-8`.

- `claude.yml` — default model bumped to `claude-opus-4-8`; the `@claude sonnet` / `@claude haiku` overrides are left as-is (explicit user choices).
- `claude-pr-review.yml` — `claude-opus-4-8`.
- `codeowner-signoff-verify.yml` — `claude-opus-4-8`.

The other `model:` references in the repo's workflows are the benchmarked LLMs (DeepSeek, etc.), not Claude, and are untouched.
