### PR TITLE
[WIP][NV] Add MiniMax-M3 MXFP8 B300 1k/1k Dynamo-vLLM sweep

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -11604,8 +11604,11 @@ qwen3.5-fp8-h100-sglang-agentic:
       - { tp: 8, ep: 8, offloading: none,    conc-list: [1, 2, 4, 8, 12, 14, 16] }
       - { tp: 8, ep: 8, offloading: hicache, conc-list: [12, 14, 16, 20, 24, 28, 32, 42] }
 
-minimaxm3-fp8-b300-dynamo-vllm:
-  image: vllm/vllm-openai:minimax-m3-0618-x86_64-cu130
+# MiniMax-M3 MXFP8 B300 Dynamo-vLLM, 1k/1k sweep on the vllm-minimax-m3-perf image.
+# Split from the 8k/1k key below only because the two currently run different
+# container images; see the note there.
+minimaxm3-fp8-b300-dynamo-vllm-1k1k:
+  image: vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: b300
@@ -11709,6 +11712,23 @@ minimaxm3-fp8-b300-dynamo-vllm:
           tp: 8
           ep: 8
           dp-attn: false
+
+# MiniMax-M3 MXFP8 B300 Dynamo-vLLM, 8k/1k sweep (the key name omits the sequence
+# length). The 1k/1k sweep lives in minimaxm3-fp8-b300-dynamo-vllm-1k1k above. The
+# two keys are diverged only because they currently run different container images:
+# 1k/1k on the vllm-minimax-m3-perf image, 8k/1k on the minimax-m3-0618 image. They
+# are to be recombined into one key once 8k/1k moves to the same image as 1k/1k.
+minimaxm3-fp8-b300-dynamo-vllm:
+  image: vllm/vllm-openai:minimax-m3-0618-x86_64-cu130
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: b300
+  precision: fp8
+  framework: dynamo-vllm
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
     - isl: 8192
       osl: 1024
       search-space:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tep8-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p1d-fp8-dep2-tep8-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -58,6 +60,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tp4-marlin-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p1d-dep2-tp4-marlin-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p1d-fp8-dep2-tp4-marlin-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -45,6 +45,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -60,6 +62,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p2d-dep2-dep4-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/1p2d-dep2-dep4-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p2d-fp8-dep2-dep4-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -60,6 +62,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-dep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-dep8-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p1d-fp8-dep2-dep8-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -60,6 +62,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p1d-dep2-tep8-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p1d-fp8-dep2-tep8-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -58,6 +60,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p2d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/2p2d-dep2-tep8-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p2d-fp8-dep2-tep8-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -58,6 +60,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/3p2d-dep2-tep8-1k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp8/1k1k/3p2d-dep2-tep8-1k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-3p2d-fp8-dep2-tep8-1k1k"
 
 model:
   path: "MiniMaxAI/MiniMax-M3-MXFP8"
-  container: "vllm/vllm-openai:minimax-m3-0618-x86_64-cu130"
+  container: "vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223"
   precision: "fp8"
 
 resources:
@@ -44,6 +44,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304
@@ -58,6 +60,8 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
+      kv-cache-dtype: fp8
       block-size: 128
       gpu-memory-utilization: 0.90
       max-model-len: 2304

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4115,3 +4115,10 @@
     - "Use the dedicated ARM64 MiniMax-M3 performance image; benchmark settings unchanged"
     - "Allocate FlashInfer MNNVL workspace for one-shot TP8 all-reduce during CUDA graph capture"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1897
+
+- config-keys:
+    - minimaxm3-fp8-b300-dynamo-vllm-1k1k
+  description:
+    - "Add the MiniMax-M3 MXFP8 B300 Dynamo-vLLM 1k/1k disagg sweep on the vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223 image"
+    - "Enable FlashInfer attention (use_trtllm_attention, fp8 indexer KV) and fp8 KV cache on the prefill and decode workers"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4121,4 +4121,4 @@
   description:
     - "Add the MiniMax-M3 MXFP8 B300 Dynamo-vLLM 1k/1k disagg sweep on the vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-7a67223 image"
     - "Enable FlashInfer attention (use_trtllm_attention, fp8 indexer KV) and fp8 KV cache on the prefill and decode workers"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1906

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -91,12 +91,23 @@ elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "minimaxm3" && $PRECISIO
     git checkout sa-submission-q2-2026
     mkdir -p recipes/vllm/minimax-m3
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3" recipes/vllm/minimax-m3
-    SRTCTL_SETUP_SCRIPT="minimax-m3-vllm-fixes.sh"
+    # minimax-m3-vllm-fixes.sh monkeypatches the vLLM that ships in the
+    # minimax-m3-0618 image (the NIXL base_worker heterogeneous-TP KV-length fix
+    # and the MSA sparse-attention .contiguous() fix). The vllm-minimax-m3-perf
+    # image already carries these fixes and its vLLM source no longer matches the
+    # patch anchors, so running the patch there aborts with "missing or ambiguous
+    # patch anchor" and the server never starts. Only patch the 0618 image; the
+    # perf image needs no patch.
+    if [[ "${IMAGE:-}" != *vllm-minimax-m3-perf* ]]; then
+        SRTCTL_SETUP_SCRIPT="minimax-m3-vllm-fixes.sh"
+    fi
     # NVIDIA/srt-slurm#38
     git show 22d46ba9971615016d2339c9ffbc7b4597accfad --format= -- src/srtctl/core/ip_utils/get_node_ip.sh | git apply - || exit 1
-    cp \
-        "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/configs/$SRTCTL_SETUP_SCRIPT" \
-        "configs/$SRTCTL_SETUP_SCRIPT"
+    if [[ -n "$SRTCTL_SETUP_SCRIPT" ]]; then
+        cp \
+            "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/configs/$SRTCTL_SETUP_SCRIPT" \
+            "configs/$SRTCTL_SETUP_SCRIPT"
+    fi
 else
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR" || exit 1


### PR DESCRIPTION
Adds a dedicated `minimaxm3-fp8-b300-dynamo-vllm-1k1k` config for the MiniMax-M3 MXFP8 B300 Dynamo-vLLM 1k/1k disaggregated sweep. The 1k/1k recipe changes are taken from #1900.

1k/1k is kept as its own config key, separate from the 8k/1k sweep (`minimaxm3-fp8-b300-dynamo-vllm`), which is handled in #1891, to be recombined later. The 8k/1k config and recipes are unchanged.