### PR TITLE
Bump dsv4-fp4-b200-sglang image to SGLang nightly 20260624

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -1719,7 +1719,7 @@ dsr1-fp4-b200-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 512, spec-decoding: mtp }
 
 dsv4-fp4-b200-sglang:
-  image: lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4aa9ecf59451002b49ba00cae58042de9e2a96378bbd21b404dd62c7b
+  image: lmsysorg/sglang:nightly-dev-cu13-20260624-b2c8f7a2
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b200-dsv4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4153,3 +4153,9 @@
     - "Run the PR #1891 MiniMax-M3 MXFP8 B300 Dynamo-vLLM recipe set on top of current main."
     - "Uses the vllm/vllm-openai:minimax-m3-0618-x86_64-cu130 image and the TEP4/TEP8 8k1k topologies not covered by PR #1890."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1891
+
+- config-keys:
+    - dsv4-fp4-b200-sglang
+  description:
+    - "Bump SGLang image from lmsysorg/sglang:deepseek-v4-blackwell (digest sha256:df18bfc4...) to mainline nightly lmsysorg/sglang:nightly-dev-cu13-20260624-b2c8f7a2."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1922


### PR DESCRIPTION
Update `dsv4-fp4-b200-sglang` to the latest SGLang mainline nightly container.

- Previous: `lmsysorg/sglang:deepseek-v4-blackwell@sha256:df18bfc4...` (DeepSeek-V4 Blackwell feature-branch tag, last updated 2026-04-29; the live `deepseek-v4-blackwell` tag has since moved to a different digest)
- New: `lmsysorg/sglang:nightly-dev-cu13-20260624-b2c8f7a2`