### PR TITLE
[codex] update MiniMax M3 FP8 MI355X vLLM MTP image

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2562,7 +2562,7 @@ minimaxm3-fp8-mi355x-vllm:
 # acceptance dilutes in big batches, and the draft weights + draft KV shave
 # headroom — tp2-ep2 is dropped since its KV headroom was already thin.
 minimaxm3-fp8-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:minimax-m3
+  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4229,3 +4229,10 @@
     - "Reuse the pinned vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e image, text-only target path, TRITON_ATTN, automatic tool choice, MiniMax-M3 parsers, VLLM_USE_BREAKABLE_CUDAGRAPH=0, default KV-cache dtype, and automatic MoE backend selection."
     - "Pass --use-chat-template for MTP acceptance and mirror the existing MiniMax-M3 MXFP8 MI355X MTP TP/EP/DP-attention search space at 1k1k and 8k1k."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1939
+
+- config-keys:
+    - minimaxm3-fp8-mi355x-vllm-mtp
+  description:
+    - "Update the MiniMax-M3 MXFP8 MI355X vLLM EAGLE3 benchmark image from vllm/vllm-openai-rocm:minimax-m3 to vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e."
+    - "Benchmark configuration, EAGLE3 draft model, serving flags, and search space are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1941


### PR DESCRIPTION
## What changed

- update `minimaxm3-fp8-mi355x-vllm-mtp` from `vllm/vllm-openai-rocm:minimax-m3` to the immutable `vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e` image
- append the required performance changelog trigger

## Why

This moves the MiniMax-M3 MXFP8 MI355X EAGLE3 sweep onto the same current ROCm nightly used by the MXFP4 coverage while keeping its draft model, serving flags, and search space unchanged.

## Validation

- generated 53 filtered MTP entries with the requested image
- `python -m pytest utils/matrix_logic/ -q` (180 passed)
