### PR TITLE
exclude B300-004 temporarily to avoid kv tx issues due to mlx5_10

### DIFF
--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -3,8 +3,8 @@
 # System-specific configuration for B300 NV Slurm cluster (sa-shared)
 SLURM_PARTITION="batch_1"
 SLURM_ACCOUNT="benchmark"
-# b300-018 repeatedly times out UCX/NIXL transfers; allow an empty override to disable this.
-MINIMAX_M3_SLURM_EXCLUDED_NODELIST="${MINIMAX_M3_SLURM_EXCLUDED_NODELIST-b300-018}"
+# b300-018 and b300-004 repeatedly time out UCX/NIXL transfers; allow an empty override to disable this.
+MINIMAX_M3_SLURM_EXCLUDED_NODELIST="${MINIMAX_M3_SLURM_EXCLUDED_NODELIST-b300-018,b300-004}"
 
 set -x
 


### PR DESCRIPTION
Intermittent KV transfer failure on a specific node/NIC ( b300-004 / mlx5_10) is causing garbage results. 

Silent KV corruption - KV transfer fails and decode continues without valid prefill KV frontend still returns HTTP 200 - 