### PR TITLE
Bump vLLM version for DSV4 B300 disagg

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9622,7 +9622,7 @@ dsv4-fp4-gb200-dynamo-sglang-mtp:
           ep: 16
           dp-attn: true
 dsv4-fp4-b300-dynamo-vllm:
-  image: vllm/vllm-openai:v0.20.1
+  image: vllm/vllm-openai:v0.23.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-high-tpt-megamoe.yaml
@@ -4,7 +4,7 @@ name: "svf-vllm-disagg-b300-high-tpt-megamoe"
 # one full 8-GPU B300 node, plus a dedicated NATS/etcd infra node.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -124,7 +124,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.1"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-low-latency.yaml
@@ -4,7 +4,7 @@ name: "svf-vllm-disagg-b300-low-latency"
 # one full 8-GPU B300 node, plus a dedicated NATS/etcd infra node.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -118,7 +118,7 @@ benchmark:
 
 identity:
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.1"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-low-middle-curve.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-low-middle-curve.yaml
@@ -4,7 +4,7 @@ name: "svf-vllm-disagg-b300-low-middle-curve"
 # one full 8-GPU B300 node, plus a dedicated NATS/etcd infra node.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -119,7 +119,7 @@ benchmark:
 
 identity:
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.1"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-max-tpt-megamoe.yaml
@@ -4,7 +4,7 @@ name: "svf-vllm-disagg-b300-max-tpt-megamoe"
 # one full 8-GPU B300 node, plus a dedicated NATS/etcd infra node.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -124,7 +124,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.1"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-mid-curve-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b300-mid-curve-megamoe.yaml
@@ -4,7 +4,7 @@ name: "svf-vllm-disagg-b300-mid-curve-megamoe"
 # one full 8-GPU B300 node, plus a dedicated NATS/etcd infra node.
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:v0.20.1"
+  container: "vllm/vllm-openai:v0.23.0"
   precision: "fp4"
 
 dynamo:
@@ -124,7 +124,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.1"
+    image: "vllm/vllm-openai:v0.23.0"
   frameworks:
     dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.1"
+    vllm: "0.23.0"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4307,4 +4307,4 @@
     - dsv4-fp4-b300-dynamo-vllm
   description:
     - "Update the DeepSeek-V4-Pro B300 disaggregated Dynamo-vLLM benchmark to the vllm/vllm-openai:v0.23.0 image"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1899
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1952

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4302,3 +4302,9 @@
     - "Update the MiniMax-M3 MXFP8 MI355X vLLM image from vllm/vllm-openai-rocm:minimax-m3 to vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e."
     - "Benchmark serving flags and TP/EP/DP-attention search space are unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1942
+
+- config-keys:
+    - dsv4-fp4-b300-dynamo-vllm
+  description:
+    - "Update the DeepSeek-V4-Pro B300 disaggregated Dynamo-vLLM benchmark to the vllm/vllm-openai:v0.23.0 image"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1899


### PR DESCRIPTION
Bumps the DeepSeek-V4-Pro B300 disaggregated Dynamo-vLLM recipes from `vllm/vllm-openai:v0.20.1` to `v0.23.0`.

Mirrors the B200 image bump from #1899 for the B300 equivalents. Updates `model.container`, `identity.container.image`, and `identity.frameworks.vllm` across all five B300 recipes:
- `disagg-b300-low-latency.yaml`
- `disagg-b300-low-middle-curve.yaml`
- `disagg-b300-high-tpt-megamoe.yaml`
- `disagg-b300-mid-curve-megamoe.yaml`
- `disagg-b300-max-tpt-megamoe.yaml`

Also updates the `dsv4-fp4-b300-dynamo-vllm` image in `nvidia-master.yaml`.

The `max-num-batched-tokens` and `gpu-memory-utilization` reductions applied to B200 in #1899 are not mirrored here — B300 recipes already carry more conservative values (0.85/0.8 vs B200's pre-bump 0.95) reflecting the different hardware.