### PR TITLE
[AMD] Enable AITER MoE for MiniMax-M3 FP4 MI355X vLLM STP

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2641,7 +2641,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
 # language-model path and mirror the MXFP8 MI355X search space for a direct
 # precision comparison.
 minimaxm3-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
+  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
@@ -3,7 +3,7 @@
 # MiniMax-M3 MXFP4 MI355X (gfx950) single-node vLLM recipe.
 # https://huggingface.co/amd/MiniMax-M3-MXFP4#reproduction
 # Block size 128 is mandatory for MSA. This fixed-sequence benchmark uses the
-# text-only language-model path and lets vLLM select the MoE backend.
+# text-only language-model path with AITER MoE (vllm-project/vllm#46419).
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -32,6 +32,9 @@ fi
 SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -59,6 +62,7 @@ vllm serve "$MODEL" --port "$PORT" \
     --language-model-only \
     --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \
+    --moe-backend aiter \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \
     --reasoning-parser minimax_m3 > "$SERVER_LOG" 2>&1 &

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4316,3 +4316,10 @@
   description:
     - "Update the DeepSeek-V4-Pro B300 disaggregated Dynamo-vLLM benchmark to the vllm/vllm-openai:v0.23.0 image"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1952
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm
+  description:
+    - "Enable AITER MoE on MiniMax-M3 MXFP4 MI355X single-node vLLM STP: export VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1; pass --moe-backend aiter."
+    - "Pin vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1 (from nightly-3f5a1e1733200760169ff31ebe60a271072b199e) for AITER MoE and shared-expert fusion support (vllm-project/vllm#46419, vllm-project/vllm#46545)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1954


### PR DESCRIPTION
## Summary

- Export `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` in all MiniMax-M3 MI355X single-node vLLM benchmark scripts (MXFP4/MXFP8, STP and EAGLE3 MTP).
- Broaden the `perf-changelog.yaml` trigger to cover `minimaxm3-fp4-mi355x-vllm`, `minimaxm3-fp4-mi355x-vllm-mtp`, `minimaxm3-fp8-mi355x-vllm`, and `minimaxm3-fp8-mi355x-vllm-mtp`.

## Why

Upstream vLLM folds the MiniMax-M3 shared expert MLP into the routed grouped GEMM when this flag is set (vllm-project/vllm#46545), reducing per-layer kernel launches on decode-heavy workloads. The optimization is backend-agnostic and does not require the master `VLLM_ROCM_USE_AITER` switch, so it is safe to enable on the existing pinned nightly without turning on the full AITER MoE path.

## Test plan

- [x] `bash -n` on all four MiniMax-M3 MI355X vLLM benchmark scripts
- [x] `python utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files .github/configs/amd-master.yaml --model-prefix minimaxm3 --framework vllm --runner-type mi355x`