### PR TITLE
Update Qwen3.5 FP4 MI355X MTP recipe with tuned env/flags / 使用调优的环境变量和参数更新 Qwen3.5 FP4 MI355X MTP 配方

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh
@@ -15,14 +15,17 @@ if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
 
-hf download "$MODEL"
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 
 export SGLANG_USE_AITER=1
-export SGLANG_USE_AITER_UNIFIED_ATTN=1
-export AITER_FLYDSL_FORCE=1
+# AllReduce latency on TP=2: INT4 quick-reduce + single-stage AITER AllReduce.
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export AITER_AR_1STAGE=1
+# Built-in MTP head (NEXTN) runs on the ROCm-hardened spec-v1 chain path.
+export SGLANG_ENABLE_SPEC_V2=0
 
 SERVER_LOG=/workspace/server.log
-MEM_FRAC_STATIC=${MEM_FRAC_STATIC:-0.8}
+MEM_FRAC_STATIC=${MEM_FRAC_STATIC:-0.85}
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -40,9 +43,11 @@ python3 -m sglang.launch_server --model-path=$MODEL --trust-remote-code \
 --model-loader-extra-config '{"enable_multithread_load": true}' \
 --watchdog-timeout 1200  \
 --disable-radix-cache \
---enable-aiter-allreduce-fusion --max-running-requests $CONC \
---page-size 16 \
---speculative-algorithm EAGLE \
+--enable-dp-attention \
+--mamba-ssm-dtype bfloat16 \
+--disable-shared-experts-fusion \
+--max-running-requests $CONC \
+--speculative-algorithm NEXTN \
 --speculative-num-steps 3 \
 --speculative-eagle-topk 1 \
 --speculative-num-draft-tokens 4 \


### PR DESCRIPTION
## Summary

Updates the Qwen3.5-397B-A17B-MXFP4 MI355X **MTP** launch recipe
(`benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh`) with a tuned,
env/flags-only configuration. The change is **+4–11% throughput** across the
concurrency sweep, with lower TPOT and p99 TTFT, and it **unlocks concurrency 256**
(where the current script OOMs) — at no accuracy cost.

Scope: environment variables and server flags only. Tuned AITER kernel CSVs and
SGLang source patches are intentionally out of scope here and will be upstreamed
to their respective repos (aiter / sglang).

## What changed

`qwen3.5_fp4_mi355x_mtp.sh` (single file):

- Speculative algorithm **EAGLE → NEXTN** (built-in MTP head on the ROCm-hardened
  spec-v1 chain path); add `SGLANG_ENABLE_SPEC_V2=0`.
- Add `ROCM_QUICK_REDUCE_QUANTIZATION=INT4` and `AITER_AR_1STAGE=1`
  (INT4 quick-reduce + single-stage AITER AllReduce — reduces TP=2 AllReduce latency).
- Add `--enable-dp-attention`, `--mamba-ssm-dtype bfloat16`,
  `--disable-shared-experts-fusion`.
- `--mem-fraction-static` `0.8 → 0.85`.
- Drop `SGLANG_USE_AITER_UNIFIED_ATTN`, `AITER_FLYDSL_FORCE`,
  `--enable-aiter-allreduce-fusion`, `--page-size 16`.
- Guard `hf download` so local (absolute-path) model dirs are not re-downloaded.

## A/B results

Qwen3.5-397B-A17B-MXFP4, MI355X, TP=2, ISL=OSL=1024. Arm A = current `main` script,
Arm B = this recipe. Stock image `sglang-hyperloom-env:v1` (no tuned CSVs present —
isolates the env/flags layer). **3 interleaved passes per point**, server torn down
between runs; values are the per-point median (run-to-run CV ≤ ~1%).

| conc | A total tok/s | B total tok/s | Δtotal | A median TPOT (ms) | B median TPOT (ms) | A p99 TTFT (ms) | B p99 TTFT (ms) |
|-----:|--------------:|--------------:|-------:|-------------------:|-------------------:|----------------:|----------------:|
| 4    | 1168.4 | 1218.1 | **+4.3%**  | 6.5  | 6.5  | 289  | 256  |
| 8    | 1810.9 | 1936.9 | **+7.0%**  | 8.5  | 8.0  | 435  | 400  |
| 16   | 2705.1 | 2994.8 | **+10.7%** | 11.3 | 10.5 | 565  | 498  |
| 32   | 3782.4 | 4208.1 | **+11.3%** | 16.4 | 14.9 | 1161 | 919  |
| 64   | 5223.0 | 5712.5 | **+9.4%**  | 23.8 | 22.2 | 2143 | 1800 |
| 128  | 6565.2 | 7301.2 | **+11.2%** | 38.3 | 34.9 | 4138 | 3337 |
| 256  | **OOM** | 8925.5 | **n/a**   | —    | 57.4 | —    | 6554 |

(total tok/s = input + output.)

**Highlights**
- **+4–11% throughput** at every concurrency, largest in the conc 16–128 mid/high-batch regime.
- **Lower latency simultaneously** — median TPOT and p99 TTFT both drop (e.g. conc 128:
  TPOT 38.3 → 34.9 ms, p99 TTFT 4138 → 3337 ms ≈ −19%); not a throughput/latency trade.
- **Unlocks conc 256** — Arm A OOMs (EAGLE's separate draft model + mem-frac 0.8 leaves
  no KV pool); Arm B fits and serves it at ~8.9k tok/s (NEXTN has no separate draft model,
  mem-frac 0.85, shared-experts fusion disabled → more KV headroom on 2 GPUs).

## Accuracy

gsm8k 5-shot, strict exact-match, served via the launch script in `EVAL_ONLY` mode:

| Arm | strict exact-match |
|-----|-------------------:|
| A (EAGLE, main)   | 78.62% |
| B (NEXTN, recipe) | 78.70% |

No regression (+0.08 pts, within noise).


## 中文说明
更新 Qwen3.5-397B-A17B-MXFP4 MI355X MTP 启动配方，使用调优的环境变量和服务器参数配置。在并发扫描中提升 4-11% 吞吐量，降低 TPOT 和 p99 TTFT，并解锁 conc 256（当前脚本会 OOM）——且无精度损失。范围仅限环境变量和服务器标志，调优的 AITER 内核 CSV 和 SGLang 源码补丁不在本 PR 范围内。
