### PR TITLE
Add DSV4 FP4 B200 Dynamo-vLLM point-specific disagg recipes

### DIFF
--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -9029,40 +9029,66 @@ dsv4-fp4-b200-dynamo-vllm:
       search-space:
       # B200 adaptation of the DSV4 GB200 vLLM disagg recipes. Each worker
       # maps to one full 8-GPU B200 node.
-      - conc-list: [1, 16, 32, 64, 128]
+      - conc-list: [1]
         prefill:
           num-worker: 1
           tp: 8
           ep: 8
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency.yaml"
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c1.yaml"
         decode:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
-      - conc-list: [256, 512, 1024]
+      - conc-list: [32, 128]
         prefill:
-          num-worker: 2
+          num-worker: 1
           tp: 8
           ep: 8
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-high-tpt-megamoe.yaml"
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c32-c128.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+      - conc-list: [64]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c64.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+      - conc-list: [256]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c256.yaml"
         decode:
           num-worker: 1
           tp: 8
           ep: 8
           dp-attn: true
-      - conc-list: [8192, 12345]
+      - conc-list: [512]
         prefill:
-          num-worker: 3
+          num-worker: 1
           tp: 8
           ep: 8
           dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-max-tpt-megamoe.yaml"
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c512.yaml"
         decode:
           num-worker: 1
           tp: 8

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c1.yaml
@@ -1,0 +1,113 @@
+name: "svf-vllm-disagg-b200-low-latency-c1"
+model:
+  path: "deepseek-v4-pro"
+  container: "vllm/vllm-openai:v0.23.0"
+  precision: "fp4"
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260426"
+setup_script: vllm-container-deps.sh
+slurm:
+  time_limit: "8:00:00"
+health_check:
+  interval_seconds: 10
+  max_attempts: 1440
+sbatch_directives:
+  segment: "1"
+resources:
+  decode_nodes: 1
+  decode_workers: 1
+  gpu_type: b200
+  gpus_per_decode: 8
+  gpus_per_node: 8
+  gpus_per_prefill: 8
+  prefill_nodes: 1
+  prefill_workers: 1
+infra:
+  etcd_nats_dedicated_node: true
+frontend:
+  enable_multiple_frontends: false
+  type: dynamo
+backend:
+  connector: null
+  decode_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_SERVER_DEV_MODE: '1'
+  prefill_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: '1024'
+  type: vllm
+  vllm_config:
+    decode:
+      block-size: 256
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      enable-sleep-mode: true
+      gpu-memory-utilization: 0.9
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-cudagraph-capture-size: 256
+      max-model-len: 9280
+      max-num-batched-tokens: 256
+      max-num-seqs: 256
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      stream-interval: 50
+      tensor-parallel-size: 8
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+    prefill:
+      block-size: 256
+      data-parallel-rpc-port: 13345
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      enable-sleep-mode: true
+      enforce-eager: true
+      gpu-memory-utilization: 0.8
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-model-len: 9280
+      max-num-batched-tokens: 32768
+      max-num-seqs: 16
+      no-async-scheduling: true
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      numa-bind: true
+      offload-group-size: 3
+      offload-num-in-group: 1
+      offload-prefetch-step: 2
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      tensor-parallel-size: 1
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+benchmark:
+  concurrencies: "1"
+  custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
+  isl: 8192
+  osl: 1024
+  req_rate: "inf"
+  type: "sa-bench"
+  use_chat_template: true
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+  container:
+    image: "vllm/vllm-openai:v0.23.0"
+  frameworks:
+    dynamo: "1.2.0.dev20260426"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c32-c128.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c32-c128.yaml
@@ -1,0 +1,113 @@
+name: "svf-vllm-disagg-b200-low-latency-c32-c128"
+model:
+  path: "deepseek-v4-pro"
+  container: "vllm/vllm-openai:v0.23.0"
+  precision: "fp4"
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260426"
+setup_script: vllm-container-deps.sh
+slurm:
+  time_limit: "8:00:00"
+health_check:
+  interval_seconds: 10
+  max_attempts: 1440
+sbatch_directives:
+  segment: "1"
+resources:
+  decode_nodes: 1
+  decode_workers: 1
+  gpu_type: b200
+  gpus_per_decode: 8
+  gpus_per_node: 8
+  gpus_per_prefill: 8
+  prefill_nodes: 1
+  prefill_workers: 1
+infra:
+  etcd_nats_dedicated_node: false
+frontend:
+  enable_multiple_frontends: false
+  type: dynamo
+backend:
+  connector: null
+  decode_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_SERVER_DEV_MODE: '1'
+  prefill_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: '1024'
+  type: vllm
+  vllm_config:
+    decode:
+      block-size: 256
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      enable-sleep-mode: true
+      gpu-memory-utilization: 0.9
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-cudagraph-capture-size: 128
+      max-model-len: 9280
+      max-num-batched-tokens: 128
+      max-num-seqs: 128
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      stream-interval: 50
+      tensor-parallel-size: 8
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+    prefill:
+      block-size: 256
+      data-parallel-rpc-port: 13345
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      enable-sleep-mode: true
+      enforce-eager: true
+      gpu-memory-utilization: 0.8
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-model-len: 9280
+      max-num-batched-tokens: 32768
+      max-num-seqs: 16
+      no-async-scheduling: true
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      numa-bind: true
+      offload-group-size: 3
+      offload-num-in-group: 1
+      offload-prefetch-step: 2
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      tensor-parallel-size: 1
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+benchmark:
+  concurrencies: "32x128"
+  custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
+  isl: 8192
+  osl: 1024
+  req_rate: "inf"
+  type: "sa-bench"
+  use_chat_template: true
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+  container:
+    image: "vllm/vllm-openai:v0.23.0"
+  frameworks:
+    dynamo: "1.2.0.dev20260426"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c64.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-latency-c64.yaml
@@ -1,0 +1,113 @@
+name: "svf-vllm-disagg-b200-low-latency-c64"
+model:
+  path: "deepseek-v4-pro"
+  container: "vllm/vllm-openai:v0.23.0"
+  precision: "fp4"
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260426"
+setup_script: vllm-container-deps.sh
+slurm:
+  time_limit: "8:00:00"
+health_check:
+  interval_seconds: 10
+  max_attempts: 1440
+sbatch_directives:
+  segment: "1"
+resources:
+  decode_nodes: 1
+  decode_workers: 1
+  gpu_type: b200
+  gpus_per_decode: 8
+  gpus_per_node: 8
+  gpus_per_prefill: 8
+  prefill_nodes: 1
+  prefill_workers: 1
+infra:
+  etcd_nats_dedicated_node: false
+frontend:
+  enable_multiple_frontends: false
+  type: dynamo
+backend:
+  connector: null
+  decode_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_SERVER_DEV_MODE: '1'
+  prefill_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: '1024'
+  type: vllm
+  vllm_config:
+    decode:
+      block-size: 256
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      enable-sleep-mode: true
+      gpu-memory-utilization: 0.9
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-cudagraph-capture-size: 256
+      max-model-len: 9280
+      max-num-batched-tokens: 256
+      max-num-seqs: 256
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      stream-interval: 50
+      tensor-parallel-size: 8
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+    prefill:
+      block-size: 256
+      data-parallel-rpc-port: 13345
+      data-parallel-size: 8
+      enable-expert-parallel: true
+      enable-sleep-mode: true
+      enforce-eager: true
+      gpu-memory-utilization: 0.8
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-model-len: 9280
+      max-num-batched-tokens: 32768
+      max-num-seqs: 16
+      no-async-scheduling: true
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      numa-bind: true
+      offload-group-size: 3
+      offload-num-in-group: 1
+      offload-prefetch-step: 2
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      tensor-parallel-size: 1
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+benchmark:
+  concurrencies: "64"
+  custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
+  isl: 8192
+  osl: 1024
+  req_rate: "inf"
+  type: "sa-bench"
+  use_chat_template: true
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+  container:
+    image: "vllm/vllm-openai:v0.23.0"
+  frameworks:
+    dynamo: "1.2.0.dev20260426"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c256.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c256.yaml
@@ -1,0 +1,117 @@
+name: "svf-vllm-disagg-b200-low-middle-c256"
+model:
+  path: "deepseek-v4-pro"
+  container: "vllm/vllm-openai:v0.23.0"
+  precision: "fp4"
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260426"
+setup_script: vllm-container-deps.sh
+slurm:
+  time_limit: "8:00:00"
+health_check:
+  interval_seconds: 10
+  max_attempts: 1440
+sbatch_directives:
+  segment: "1"
+resources:
+  decode_nodes: 1
+  decode_workers: 1
+  gpu_type: b200
+  gpus_per_decode: 8
+  gpus_per_node: 8
+  gpus_per_prefill: 8
+  prefill_nodes: 1
+  prefill_workers: 1
+infra:
+  etcd_nats_dedicated_node: false
+frontend:
+  enable_multiple_frontends: false
+  type: dynamo
+backend:
+  connector: null
+  decode_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_SERVER_DEV_MODE: '1'
+  prefill_environment:
+    NCCL_CUMEM_ENABLE: '1'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: '1024'
+  type: vllm
+  vllm_config:
+    decode:
+      block-size: 256
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      data-parallel-rpc-port: 13345
+      data-parallel-size: 8
+      enable-ep-weight-filter: true
+      enable-expert-parallel: true
+      enable-sleep-mode: true
+      gpu-memory-utilization: 0.9
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-cudagraph-capture-size: 256
+      max-model-len: 9280
+      max-num-batched-tokens: 256
+      max-num-seqs: 256
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      stream-interval: 50
+      tensor-parallel-size: 1
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+    prefill:
+      block-size: 256
+      data-parallel-rpc-port: 13345
+      data-parallel-size: 8
+      enable-ep-weight-filter: true
+      enable-expert-parallel: true
+      enable-sleep-mode: true
+      enforce-eager: true
+      gpu-memory-utilization: 0.95
+      kv-cache-dtype: fp8
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      max-model-len: 9280
+      max-num-batched-tokens: 32768
+      max-num-seqs: 16
+      no-async-scheduling: true
+      no-disable-hybrid-kv-cache-manager: true
+      no-enable-flashinfer-autotune: true
+      no-enable-prefix-caching: true
+      numa-bind: true
+      pipeline-parallel-size: 1
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      tensor-parallel-size: 1
+      tokenizer-mode: deepseek_v4
+      trust-remote-code: true
+benchmark:
+  concurrencies: "256"
+  custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
+  isl: 8192
+  osl: 1024
+  req_rate: "inf"
+  type: "sa-bench"
+  use_chat_template: true
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+  container:
+    image: "vllm/vllm-openai:v0.23.0"
+  frameworks:
+    dynamo: "1.2.0.dev20260426"
+    vllm: "0.23.0"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c512.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-low-middle-c512.yaml
@@ -1,0 +1,118 @@
+name: "svf-vllm-disagg-b200-low-middle-c512"
+model:
+  path: "deepseek-v4-pro"
+  container: "vllm/vllm-openai:v0.23.0"
+  precision: "fp4"
+dynamo:
+  install: true
+  wheel: "1.2.0.dev20260426"
+setup_script: vllm-container-deps.sh
+slurm:
+  time_limit: "8:00:00"
+health_check:
+  max_attempts: 1440
+  interval_seconds: 10
+sbatch_directives:
+  segment: "1"
+resources:
+  gpu_type: b200
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 8
+  gpus_per_decode: 8
+infra:
+  etcd_nats_dedicated_node: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+backend:
+  type: vllm
+  connector: null
+  prefill_environment:
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    NCCL_CUMEM_ENABLE: '1'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: '1024'
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+  decode_environment:
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    NCCL_CUMEM_ENABLE: '1'
+    VLLM_SERVER_DEV_MODE: '1'
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_NET_DEVICES: mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_10:1,mlx5_11:1
+    VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: '2048'
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: '0'
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      kv-cache-dtype: fp8
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      enforce-eager: true
+      max-model-len: 9280
+      max-num-seqs: 16
+      max-num-batched-tokens: 32768
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      no-enable-flashinfer-autotune: true
+      no-async-scheduling: true
+      block-size: 256
+      gpu-memory-utilization: 0.95
+      no-disable-hybrid-kv-cache-manager: true
+      enable-sleep-mode: true
+      numa-bind: true
+      tokenizer-mode: deepseek_v4
+    decode:
+      kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
+      served-model-name: deepseek-ai/DeepSeek-V4-Pro
+      kv-cache-dtype: fp8
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      max-model-len: 9280
+      max-num-seqs: 512
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 512
+      trust-remote-code: true
+      no-enable-prefix-caching: true
+      no-enable-flashinfer-autotune: true
+      block-size: 256
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      gpu-memory-utilization: 0.9
+      stream-interval: 50
+      no-disable-hybrid-kv-cache-manager: true
+      enable-sleep-mode: true
+      tokenizer-mode: deepseek_v4
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "512"
+  req_rate: "inf"
+  use_chat_template: true
+  custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+  container:
+    image: "vllm/vllm-openai:v0.23.0"
+  frameworks:
+    dynamo: "1.2.0.dev20260426"
+    vllm: "0.23.0"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4343,3 +4343,11 @@
     - "Use nvidia/MiniMax-M3-NVFP4 from /scratch/models/MiniMax-M3-NVFP4 with vllm/vllm-openai:vllm-minimax-m3-perf-x86_64-13.0.1-8b00f41, which includes vllm-project/vllm PR #46380; no runtime patch needed"
     - "Reuse the existing MXFP8 B300 topology and concurrency matrix across 15 srt-slurm recipes, while dropping the FP8-only Marlin override from TP4 decode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1931
+
+- config-keys:
+    - dsv4-fp4-b200-dynamo-vllm
+  description:
+    - "Add point-specific DeepSeek-V4-Pro FP4 B200 Dynamo-vLLM disaggregated recipes for the 8k/1k concurrency points c=1, 32, 64, 128, 256, 512."
+    - "Wire those rows in nvidia-master.yaml; c=16, 1024, 8192, and 12345 are not part of this update."
+    - "Recipes use vllm/vllm-openai:v0.23.0, DSV4 revision 0366e4e064385807ea86b088a5c6c878ff23343b, max-model-len 9280, with per-point P1/D1 (1 prefill node DEP=8 / 1 decode node) serving knobs."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4350,4 +4350,4 @@
     - "Add point-specific DeepSeek-V4-Pro FP4 B200 Dynamo-vLLM disaggregated recipes for the 8k/1k concurrency points c=1, 32, 64, 128, 256, 512."
     - "Wire those rows in nvidia-master.yaml; c=16, 1024, 8192, and 12345 are not part of this update."
     - "Recipes use vllm/vllm-openai:v0.23.0, DSV4 revision 0366e4e064385807ea86b088a5c6c878ff23343b, max-model-len 9280, with per-point P1/D1 (1 prefill node DEP=8 / 1 decode node) serving knobs."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1963


### PR DESCRIPTION
Adds point-specific DeepSeek-V4-Pro FP4 B200 Dynamo-vLLM disaggregated recipes for the 8k/1k concurrency points c=1, 32, 64, 128, 256, 512, and wires those rows in `nvidia-master.yaml` (c=16, 1024, 8192, 12345 are left out of this update).

Recipes use `vllm/vllm-openai:v0.23.0`, DSV4 revision `0366e4e064385807ea86b088a5c6c878ff23343b`, and max-model-len 9280, with per-point P1/D1 (1 prefill node DEP=8 / 1 decode node) serving knobs.