### PR TITLE
[AMD] MiniMax-M3 FP4 MI355X vLLM MTP: close gap vs ATOM (INT4 all-reduce + index-sharing) / MiniMax-M3 FP4 MI355X vLLM MTP：缩小与 ATOM 的性能差距（INT4 all-reduce + 跨层索引共享）

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -2666,7 +2666,7 @@ minimaxm3-fp4-mi355x-vllm:
 # tokens. Search space mirrors the MI355X MXFP8 MTP entry, trimming the base
 # FP4 sweep at extreme concurrency where speculative decoding loses value.
 minimaxm3-fp4-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
+  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm_mtp.sh
@@ -5,6 +5,16 @@
 # minimaxm3_fp4_mi355x_vllm.sh and uses three speculative tokens from
 # Inferact/MiniMax-M3-EAGLE3. The pinned nightly includes upstream AMD
 # MiniMax-M3 SupportsEagle3 support, so no runtime model patch is needed.
+#
+# Mirrors the three high-concurrency levers from minimaxm3_fp4_mi355x_vllm.sh:
+#   * INT4 quantized all-reduce (env knobs below) -- reduces the all-reduce
+#     cost (the biggest decode kernel); measured ~-12% to -17% TPOT at conc
+#     64/128/256. Works on any nightly.
+#   * fp8 KV cache (--kv-cache-dtype fp8).
+#   * cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4) --
+#     requires vllm-project/vllm#47269 (merged).
+# Pin the image (.github/configs/amd-master.yaml) to a nightly containing
+# #47269 before sweeping for the full curve.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -48,6 +58,13 @@ export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+# INT4 quantized all-reduce for the (~1.5 MB) decode all-reduces, which are the
+# single biggest decode kernel at high concurrency. The MIN_SIZE_KB override is
+# required: vLLM's default INT4 quick-reduce size gate for (bf16, TP4) is 16 MB,
+# so it never fires for decode-sized tensors without it.
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -78,6 +95,8 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \
     --moe-backend aiter \
+    --kv-cache-dtype fp8 \
+    --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}' \
     --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS}" \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4396,6 +4396,14 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1933
 
 - config-keys:
+    - minimaxm3-fp4-mi355x-vllm-mtp
+  description:
+    - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM MTP (EAGLE3 spec decoding). Mirror the STP recipe (#1969): add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
+    - "INT4 quick-reduce reduces the all-reduce cost (the biggest decode kernel); the MIN_SIZE_KB override lowers the quantization codec threshold."
+    - "index_topk_freq needs vllm-project/vllm#47269 (merged); bump the image to vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa (contains it)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+
+- config-keys:
     - dsv4-fp4-b200-sglang
   description:
     - "Bump SGLang image from lmsysorg/sglang:deepseek-v4-blackwell (digest sha256:df18bfc4...) to mainline nightly lmsysorg/sglang:nightly-dev-cu13-20260628-da802ddc."

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4401,7 +4401,7 @@
     - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM MTP (EAGLE3 spec decoding). Mirror the STP recipe (#1969): add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
     - "INT4 quick-reduce reduces the all-reduce cost (the biggest decode kernel); the MIN_SIZE_KB override lowers the quantization codec threshold."
     - "index_topk_freq needs vllm-project/vllm#47269 (merged); bump the image to vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa (contains it)."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1979
 
 - config-keys:
     - dsv4-fp4-b200-sglang


### PR DESCRIPTION
## Summary
Mirrors the STP recipe from #1969 onto the EAGLE3 spec-decoding (MTP) variant `minimaxm3-fp4-mi355x-vllm-mtp`, adding the same three high-concurrency levers plus the image bump:

1. **INT4 quantized all-reduce** — env knobs `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4` + `..._CAST_BF16_TO_FP16=0` + `..._QUANTIZATION_MIN_SIZE_KB=256`. Reduces the all-reduce cost (the biggest decode kernel). Works on any nightly.
2. **fp8 KV cache** (`--kv-cache-dtype fp8`). Works on any nightly.
3. **Cross-layer indexer top-k sharing** (`--hf-overrides index_topk_freq=4`) — requires vllm-project/vllm#47269 (merged).

## Image
Bumps `.github/configs/amd-master.yaml` → `minimaxm3-fp4-mi355x-vllm-mtp.image` to `vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa` (latest nightly, contains #47269).

## Relation to #1969
Same recipe, applied to the MTP (EAGLE3, 3 draft tokens) variant instead of STP. The levers are orthogonal to speculative decoding, so the STP measurements/accuracy characterization carry over; see #1969 for the local ATOM-parity numbers and GSM8K accuracy.

## Duplicate check
No open InferenceX PR adds these knobs to the M3 FP4 MI355X MTP recipe.

AI assistance (Claude) was used to develop and validate this change.

Made with [Cursor](https://cursor.com)

## 中文说明
将 #1969 中 STP 配置的三项高并发优化（INT4 量化 all-reduce、fp8 KV 缓存、跨层索引 top-k 共享）同步应用到 EAGLE3 投机解码（MTP）变体 `minimaxm3-fp4-mi355x-vllm-mtp`。同时将镜像升级至包含 vllm-project/vllm#47269 的最新 nightly。性能与精度特征沿用 STP 的测试结果（详见 #1969）。