### PR TITLE
feat(agentic): wire AgentX runtime plumbing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,23 +3,16 @@
 In order to test configurations described in `.github/configs`, the primary workflow file used is `.github/workflows/e2e-tests.yml`. As input, this workflow takes in the CLI arguments for the `utils/matrix_logic/generate_sweep_configs.py` script. The usage for this script is shown below:
 
 ```
-usage: generate_sweep_configs.py [-h] {full-sweep,runner-model-sweep,test-config} ...
+usage: generate_sweep_configs.py [-h] {full-sweep,test-config} ...
 
 Generate benchmark configurations from YAML config files
 
 positional arguments:
-  {full-sweep,runner-model-sweep,test-config}
+  {full-sweep,test-config}
                         Available commands
     full-sweep          Generate full sweep configurations with optional
                         filtering by model, precision, framework, runner type,
                         and sequence lengths
-    runner-model-sweep  Given a runner type, find all configurations matching
-                        the type, and run that configuration on all individual
-                        runner nodes for the specified runner type. This is
-                        meant to validate that all runner nodes work on all
-                        configurations for a runner type. For instance, to
-                        validate that all configs that specify an h200 runner
-                        successfully run across all h200 runner nodes.
     test-config         Generate full sweep for specific config keys.
                         Supports wildcard patterns (* and ?) for matching
                         multiple keys at once.
@@ -92,46 +85,10 @@ full-sweep --single-node --max-conc 64 --max-tp 4 --config-files .github/configs
 full-sweep --multi-node --config-files .github/configs/nvidia-master.yaml
 ```
 
-## `runner-model-sweep` Command
-
-The `runner-model-sweep` command validates that all runner nodes of a specific type work with all model configurations. You can specify `--single-node`, `--multi-node`, or both. If neither is specified, both types are generated.
-
+**Test agentic configurations:**
 ```
-usage: generate_sweep_configs.py runner-model-sweep
-    --config-files CONFIG_FILES [CONFIG_FILES ...]
-    [--runner-config RUNNER_CONFIG]
-    [--no-evals | --evals-only] [--all-evals]
-    --runner-type RUNNER_TYPE
-    [--runner-node-filter RUNNER_NODE_FILTER]
-    [--single-node] [--multi-node]
+full-sweep --scenario-type agentic-coding --config-files .github/configs/nvidia-master.yaml .github/configs/amd-master.yaml
 ```
-
-### Scenario: Validating Runner Infrastructure
-
-I just upgraded the CUDA drivers on all H200 runners and need to verify that all models that use H200 still work correctly across all H200 nodes.
-
-Go to the GitHub Actions UI, click on the `End-to-End Tests` workflow, and enter the following command as the text input:
-```
-runner-model-sweep --single-node --runner-type h200 --config-files .github/configs/amd-master.yaml .github/configs/nvidia-master.yaml
-```
-
-This will run a test (just the highest available parallelism and lowest available concurrency) for each configuration that specifies the `h200` runner type, across all H200 runner nodes defined in `.github/configs/runners.yaml`.
-
-For example, if you have configs `dsr1-fp8-h200-sglang`, `dsr1-fp8-h200-trt`, and `gptoss-fp4-h200-vllm` that all use `runner: h200`, and you have 8 H200 nodes (`h200-cw_0`, `h200-cw_1`, etc.), this will run all 3 configs on all 8 nodes (24 total test runs).
-
-This is particularly useful when:
-- You've made infrastructure changes to a specific runner type (driver updates, system configuration, Docker setup)
-- You've added new runner nodes and want to validate they work with all existing model configurations
-- You want to verify that all models remain compatible with a specific GPU type after system updates
-
-### Filtering Runner Nodes
-
-Use `--runner-node-filter` to only test a subset of runner nodes:
-```
-runner-model-sweep --single-node --runner-type mi300x --runner-node-filter mi300x-amd --config-files .github/configs/amd-master.yaml
-```
-
-This will only include runner nodes whose names contain "mi300x-amd"
 
 ## `test-config` Command
 

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -91,13 +91,14 @@ on:
         type: string
         required: false
         default: ""
+      # Agentic-coding inputs. Fixed-seq-len jobs leave these empty.
       scenario-type:
         description: "Scenario type (fixed-seq-len or agentic-coding)"
         type: string
         required: false
         default: fixed-seq-len
       conc:
-        description: "Concurrency for agentic-coding scenarios (single value per matrix entry)"
+        description: "First concurrency for agentic-coding scenarios; CONC_LIST carries the full batch"
         type: string
         required: false
         default: ""
@@ -105,12 +106,15 @@ on:
         description: "Agentic trace replay duration in seconds"
         type: string
         required: false
-        default: "1800"
-      offloading:
-        description: "KV offload backend for agentic scenarios (none/cpu/ssd)"
+        default: "3600"
+      kv-offloading:
+        description: "KV offload mode for agentic scenarios (none/dram)"
         required: false
         type: string
-        default: 'none'
+      kv-offload-backend:
+        description: "KV offload backend for agentic scenarios when kv-offloading is not none"
+        required: false
+        type: string
       total-cpu-dram-gb:
         description: "Total CPU DRAM in GB for KV offloading"
         required: false
@@ -143,12 +147,14 @@ env:
   RUN_EVAL: ${{ inputs.run-eval }}
   EVAL_ONLY: ${{ inputs.eval-only }}
   EVAL_CONC: ${{ inputs.eval-conc }}
+  # Agentic-coding env. Fixed-seq-len jobs leave these empty.
   SCENARIO_TYPE: ${{ inputs.scenario-type }}
   SCENARIO_SUBDIR: ${{ inputs.scenario-type == 'agentic-coding' && 'agentic/' || 'fixed_seq_len/' }}
   IS_AGENTIC: ${{ inputs.scenario-type == 'agentic-coding' && '1' || '0' }}
   CONC: ${{ inputs.conc }}
   DURATION: ${{ inputs.duration }}
-  OFFLOADING: ${{ inputs.offloading }}
+  KV_OFFLOADING: ${{ inputs.kv-offloading }}
+  KV_OFFLOAD_BACKEND: ${{ inputs.kv-offload-backend }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   PYTHONDONTWRITEBYTECODE: '1'
   PYTHONPYCACHEPREFIX: /tmp/inferencex-pycache
@@ -176,10 +182,10 @@ jobs:
       - name: Slurm cleanup (pre-run)
         run: &slurm-cleanup |
           if command -v squeue >/dev/null 2>&1; then
-            echo "[Slurm] Cleaning up jobs with name: ${{ runner.name }} ..."
+            echo "[Slurm] Cleaning up jobs named: ${{ runner.name }} ..."
             scancel --name="${{ runner.name }}" || true
-            while [ -n "$(squeue --name='${{ runner.name }}' --noheader --format='%i')" ]; do
-              squeue --name="${{ runner.name }}"
+            while [ -n "$(squeue --user="$USER" --name='${{ runner.name }}' --noheader --format='%i')" ]; do
+              squeue --user="$USER" --name="${{ runner.name }}"
               sleep 5
             done
           fi
@@ -192,13 +198,6 @@ jobs:
           clean: true
           submodules: true
 
-      - name: Cleanup stale eval outputs (pre-run)
-        if: ${{ inputs.run-eval || inputs.eval-only }}
-        run: |
-          rm -f meta_env.json || true
-          rm -f results*.json || true
-          rm -f sample*.jsonl || true
-
       - name: Launch multi-node job script
         env:
           RUNNER_NAME: ${{ runner.name }}
@@ -208,7 +207,7 @@ jobs:
         run: |
           set -x
           # Export RESULT_FILENAME early so it's available for artifact uploads even if cancelled
-          echo "RESULT_FILENAME=${RESULT_FILENAME}" >> $GITHUB_ENV
+          echo "RESULT_FILENAME=${RESULT_FILENAME}" >> "$GITHUB_ENV"
 
           export ${{ join(fromJson(inputs.prefill-additional-settings), ' ') }} ${{ join(fromJson(inputs.decode-additional-settings), ' ') }}
           export IS_MULTINODE=true
@@ -221,12 +220,25 @@ jobs:
               exit 1
             fi
           elif [ "${{ inputs.scenario-type }}" = "agentic-coding" ]; then
-            if [ -f "${RESULT_FILENAME}.json" ]; then
-              echo "Found agentic result file: ${RESULT_FILENAME}.json"
-            else
-              echo "Run failed: Agentic benchmark result ${RESULT_FILENAME}.json not found." >&2
+            expected_count=$(wc -w <<< "$CONC_LIST" | tr -d ' ')
+            shopt -s nullglob
+            agentic_results=("${RESULT_FILENAME}"_conc*.json)
+            shopt -u nullglob
+            if [ "${#agentic_results[@]}" -ne "$expected_count" ]; then
+              echo "Run failed: expected $expected_count agentic results, found ${#agentic_results[@]}." >&2
               exit 1
             fi
+            # Existence is not enough: the agentic aggregation step writes the
+            # aggregate even when aiperf recorded zero valid requests. Require
+            # successful requests in every concurrency result.
+            for result_file in "${agentic_results[@]}"; do
+              echo "Found agentic result file: $result_file"
+              ok=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(int(bool(d.get('num_requests_successful'))))" "$result_file" 2>/dev/null || echo 0)
+              if [ "$ok" != "1" ]; then
+                echo "Run failed: $result_file has zero successful requests." >&2
+                exit 1
+              fi
+            done
           else
             # Check if at least one result file was created
             if ls ${RESULT_FILENAME}_*.json 1> /dev/null 2>&1; then
@@ -276,6 +288,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: multinode_server_logs_${{ env.RESULT_FILENAME }}
+          # multinode launchers package server logs into this tarball.
           path: multinode_server_logs.tar.gz
           if-no-files-found: ignore
 
@@ -284,7 +297,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bmk_agentic_${{ env.RESULT_FILENAME }}
-          path: ${{ env.RESULT_FILENAME }}.json
+          path: ${{ env.RESULT_FILENAME }}_conc*.json
 
       - name: Upload agentic raw results
         if: ${{ always() && inputs.scenario-type == 'agentic-coding' }}
@@ -292,12 +305,9 @@ jobs:
         with:
           name: agentic_${{ env.RESULT_FILENAME }}
           path: |
-            LOGS/agentic/benchmark.log
-            LOGS/agentic/benchmark_command.txt
-            LOGS/agentic/workload_distribution_summary.txt
-            LOGS/agentic/workload_distribution_plots.png
-            LOGS/agentic/aiperf_artifacts/detailed_results.csv
-            LOGS/agentic/aiperf_artifacts/debug_trace.jsonl
+            LOGS/agentic/**
+            !LOGS/agentic/**/aiperf_artifacts/inputs.json
+            !LOGS/agentic/**/aiperf_artifacts/profile_export_raw.jsonl
           if-no-files-found: ignore
 
       - name: Upload eval results (if any)

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -67,26 +67,30 @@ on:
         description: "Git ref (branch/sha) to checkout"
         required: false
         type: string
+      # Agentic-coding inputs. Fixed-seq-len jobs leave these empty.
       scenario-type:
         description: "Scenario type (fixed-seq-len or agentic-coding)"
         required: false
         type: string
         default: 'fixed-seq-len'
-      offloading:
-        description: "KV offload backend for agentic scenarios (none/cpu/ssd/lmcache/lmcache-mp/hicache)"
+      kv-offloading:
+        description: "KV offload mode for agentic scenarios (none/dram)"
         required: false
         type: string
-        default: 'none'
+      kv-offload-backend:
+        description: "KV offload backend for agentic scenarios when kv-offloading is not none"
+        required: false
+        type: string
       total-cpu-dram-gb:
-        description: "Total CPU DRAM in GB for KV offloading"
+        description: "Configured CPU DRAM capacity in GB for KV offloading"
         required: false
         type: string
-        default: '600'
+        default: '0'
       duration:
         description: "Benchmark duration in seconds"
         required: false
         type: string
-        default: '1800'
+        default: '3600'
 env:
   RANDOM_RANGE_RATIO: 0.8
   HF_TOKEN: ${{ secrets.INFERENCEX_OFFICIAL_RO_HF_TOKEN }}
@@ -108,12 +112,15 @@ env:
   DISAGG: ${{ inputs.disagg }}
   RUN_EVAL: ${{ inputs.run-eval }}
   EVAL_ONLY: ${{ inputs.eval-only }}
+  # Agentic-coding env. Fixed-seq-len jobs leave these empty.
   SCENARIO_TYPE: ${{ inputs.scenario-type }}
   SCENARIO_SUBDIR: ${{ inputs.scenario-type == 'agentic-coding' && 'agentic/' || 'fixed_seq_len/' }}
   IS_AGENTIC: ${{ inputs.scenario-type == 'agentic-coding' && '1' || '0' }}
-  OFFLOADING: ${{ inputs.offloading }}
+  KV_OFFLOADING: ${{ inputs.kv-offloading }}
+  KV_OFFLOAD_BACKEND: ${{ inputs.kv-offload-backend }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   DURATION: ${{ inputs.duration }}
+  AIPERF_FAILED_REQUEST_THRESHOLD: '0.10'
   RESULT_DIR: /workspace/results
   PYTHONDONTWRITEBYTECODE: '1'
   PYTHONPYCACHEPREFIX: /tmp/inferencex-pycache
@@ -150,12 +157,6 @@ jobs:
             done
           fi
 
-          # Cleanup results/ from a prior job on this runner. Agentic jobs
-          # write to fixed subpaths (aiperf_artifacts/, metrics_*, etc.), so stale
-          # data from a previous job would otherwise be picked up as this
-          # job's output when replay fails early.
-          rm -rf "${{ github.workspace }}/results" 2>/dev/null || true
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.REPO_PAT }}
@@ -163,14 +164,6 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           clean: true
           submodules: true
-
-      - name: Cleanup stale outputs (pre-run)
-        run: |
-          rm -f meta_env.json || true
-          rm -f results*.json || true
-          rm -f sample*.jsonl || true
-          rm -f server.log || true
-          rm -f gpu_metrics.csv || true
 
       - name: Launch job script
         env:
@@ -209,6 +202,12 @@ jobs:
               echo "Run failed: Benchmark result $RESULT_FILENAME.json not found." >&2
               exit 1
             fi
+
+            if [ "${{ inputs.scenario-type }}" = "agentic-coding" ]; then
+              python3 -m utils.agentic.validation.validate_agentic_result \
+                results/aiperf_artifacts \
+                --failed-request-threshold "$AIPERF_FAILED_REQUEST_THRESHOLD"
+            fi
           fi
 
       - name: Process result
@@ -238,38 +237,9 @@ jobs:
         with:
           name: agentic_${{ env.RESULT_FILENAME }}
           path: |
-            results/server.log
-            results/lmcache_server.log
-            results/benchmark.log
-            results/config.yaml
-            results/lmcache_command.txt
-            results/sglang_command.txt
-            results/vllm_command.txt
-            results/benchmark_command.txt
-            results/workload_distribution_summary.txt
-            results/workload_distribution_plots.png
-            results/metrics_plots.png
-            results/aiperf_artifacts/profile_export.jsonl
-            results/aiperf_artifacts/profile_export_aiperf.json
-            results/aiperf_artifacts/profile_export_aiperf.csv
-            results/aiperf_artifacts/profile_export_aiperf_timeslices.json
-            results/aiperf_artifacts/profile_export_aiperf_timeslices.csv
-            results/aiperf_artifacts/profile_export_aiperf_aggregate.json
-            results/aiperf_artifacts/profile_export_aiperf_aggregate.csv
-            results/aiperf_artifacts/profile_export_aiperf_collated.json
-            results/aiperf_artifacts/server_metrics_export.json
-            results/aiperf_artifacts/server_metrics_export.jsonl
-            results/aiperf_artifacts/server_metrics_export.csv
-            results/aiperf_artifacts/server_metrics_export.parquet
-            results/aiperf_artifacts/gpu_telemetry_export.jsonl
-            results/aiperf_artifacts/logs/aiperf.log
-            results/aiperf_artifacts/logs/*.log
-          # Excluded by design (multi-GB debug artifacts, not consumed by
-          # post-processing): results/aiperf_artifacts/inputs.json (pre-formatted
-          # request bodies — the mmap'd binary equivalent is rebuilt from
-          # --public-dataset + --random-seed) and
-          # results/aiperf_artifacts/profile_export_raw.jsonl (full HTTP bodies
-          # per request — recoverable by re-running the same trace).
+            results/**
+            !results/aiperf_artifacts/inputs.json
+            !results/aiperf_artifacts/profile_export_raw.jsonl
           if-no-files-found: ignore
 
       - name: Upload server logs
@@ -277,9 +247,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.eval-only && 'eval_server_logs_' || 'server_logs_' }}${{ env.RESULT_FILENAME }}
+          # fixed-seq writes server.log at root; agentic writes logs under results/.
           path: |
-            ${{ inputs.scenario-type == 'agentic-coding' && 'results/server.log' || 'server.log' }}
-            ${{ inputs.scenario-type == 'agentic-coding' && 'results/lmcache_server.log' || '' }}
+            server.log
+            results/*.log
+            results/*_config.json
           if-no-files-found: ignore
 
       - name: Upload GPU metrics

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -95,7 +95,7 @@ jobs:
             )
             ```
 
-            The `generate-cli-command` input accepts arguments for `generate_sweep_configs.py`. Usage: `generate_sweep_configs.py` `[-h]` `{full-sweep,runner-model-sweep,test-config}`
+            The `generate-cli-command` input accepts arguments for `generate_sweep_configs.py`. Usage: `generate_sweep_configs.py` `[-h]` `{full-sweep,test-config}`
 
             **Subcommand reference:**
             - `full-sweep`: Use this subcommand with filter flags like `--model-prefix`, `--framework`, `--precision`, `--runner-type`, `--min-conc`, `--max-conc`, `--seq-lens`. This is the primary subcommand for running benchmarks.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,7 +184,9 @@ jobs:
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
-            offloading: ${{ matrix.config.offloading }}
+            kv-offloading: ${{ matrix.config['kv-offloading'] }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'] }}
+            total-cpu-dram-gb: ${{ matrix.config['total-cpu-dram-gb'] }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             isl: '0'
             osl: '0'
@@ -216,7 +218,7 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
-            conc-list: '[${{ matrix.config.conc }}]'
+            conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
             prefill-num-worker: ${{ matrix.config.prefill.num-worker }}
@@ -229,7 +231,7 @@ jobs:
             decode-ep: ${{ matrix.config.decode.ep }}
             decode-dp-attn: ${{ matrix.config.decode.dp-attn }}
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
-            conc: ${{ matrix.config.conc }}
+            conc: ${{ matrix.config.conc[0] }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             run-eval: false
             scenario-type: agentic-coding

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -488,7 +488,9 @@ jobs:
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
-            offloading: ${{ matrix.config.offloading }}
+            kv-offloading: ${{ matrix.config['kv-offloading'] }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'] }}
+            total-cpu-dram-gb: ${{ matrix.config['total-cpu-dram-gb'] }}
             duration: ${{ matrix.config.duration }}
             isl: '0'
             osl: '0'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "utils/aiperf"]
 	path = utils/aiperf
 	url = https://github.com/SemiAnalysisAI/aiperf.git
-	branch = cjq/agentx-v0.3
+	branch = cjq/agentx-v0.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Artifacts: see "Fetching GitHub Actions Benchmark Results" below.
 
 ### Adding a benchmark configuration
 
-Add entry to `.github/configs/nvidia-master.yaml` or `amd-master.yaml`, append to `perf-changelog.yaml`, validate with `generate_sweep_configs.py full-sweep`.
+Add entries to `.github/configs/nvidia-master.yaml` or `amd-master.yaml` (agentic-coding entries live in the Agentic benchmark configurations section at the bottom), append to `perf-changelog.yaml`, then validate with `generate_sweep_configs.py full-sweep`.
 
 ### Adding a runner
 
@@ -142,7 +142,7 @@ Eval selection is marked by `mark_eval_entries()` in `utils/matrix_logic/generat
 
 ## Key Files
 
-`utils/matrix_logic/validation.py` (config schemas), `generate_sweep_configs.py` (config generation), `utils/bench_serving/benchmark_serving.py` (benchmark client), `.github/configs/nvidia-master.yaml` (NVIDIA benchmark definitions), `.github/workflows/run-sweep.yml` (main CI/CD), `.github/workflows/collect-evals.yml` (eval collection), `benchmarks/benchmark_lib.sh` (shared utilities), `utils/evals/` (eval task definitions), `utils/collect_eval_results.py` (aggregator).
+`utils/matrix_logic/validation.py` (config schemas), `generate_sweep_configs.py` (config generation), `utils/bench_serving/benchmark_serving.py` (benchmark client), `.github/configs/nvidia-master.yaml` / `.github/configs/amd-master.yaml` (benchmark definitions, with agentic sections at the bottom), `.github/workflows/run-sweep.yml` (main CI/CD), `.github/workflows/collect-evals.yml` (eval collection), `benchmarks/benchmark_lib.sh` (shared utilities), `utils/evals/` (eval task definitions), `utils/collect_eval_results.py` (aggregator).
 
 ## Important Notes
 

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -16,6 +16,94 @@ mkdir -p "$PYTHONPYCACHEPREFIX" 2>/dev/null || true
 # nothing upstream set it.
 export PORT="${PORT:-8888}"
 
+agentic_kv_offload_enabled() {
+    if [[ -z "${KV_OFFLOADING+x}" || -z "$KV_OFFLOADING" ]]; then
+        echo "Error: KV_OFFLOADING must be set for agentic benchmarks" >&2
+        exit 1
+    fi
+    [[ "$KV_OFFLOADING" != "none" ]]
+}
+
+require_agentic_kv_offload_none() {
+    if agentic_kv_offload_enabled; then
+        echo "Error: expected KV_OFFLOADING=none, got '$KV_OFFLOADING'" >&2
+        exit 1
+    fi
+    if [[ -n "${KV_OFFLOAD_BACKEND:-}" ]]; then
+        echo "Error: KV_OFFLOAD_BACKEND must be empty when KV_OFFLOADING=none" >&2
+        exit 1
+    fi
+}
+
+require_agentic_kv_offload_backend() {
+    local expected_backend="$1"
+    if [[ -z "${KV_OFFLOADING+x}" || -z "$KV_OFFLOADING" ]]; then
+        echo "Error: KV_OFFLOADING must be set for agentic benchmarks" >&2
+        exit 1
+    fi
+    case "$KV_OFFLOADING" in
+        none)
+            if [[ -n "${KV_OFFLOAD_BACKEND:-}" ]]; then
+                echo "Error: KV_OFFLOAD_BACKEND must be empty when KV_OFFLOADING=none" >&2
+                exit 1
+            fi
+            return 1
+            ;;
+        dram)
+            if [[ "${KV_OFFLOAD_BACKEND:-}" != "$expected_backend" ]]; then
+                echo "Error: expected KV_OFFLOAD_BACKEND=$expected_backend when KV_OFFLOADING=dram, got '${KV_OFFLOAD_BACKEND:-}'" >&2
+                exit 1
+            fi
+            if [[ ! "${TOTAL_CPU_DRAM_GB:-}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Error: DRAM KV offloading requires a positive TOTAL_CPU_DRAM_GB capacity" >&2
+                exit 1
+            fi
+            return 0
+            ;;
+        *)
+            echo "Error: unsupported KV_OFFLOADING value '$KV_OFFLOADING' (expected one of: none, dram)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# Agentic replays must use the model's native context limit. Ignore inherited
+# workflow or shell overrides so neither the server nor AIPerf applies a cap.
+_benchmark_caller="${BASH_SOURCE[1]:-}"
+if [[ "$_benchmark_caller" == */agentic/* ||
+      "$_benchmark_caller" == */agentic_*.sh ||
+      "${IS_AGENTIC:-0}" == "1" ||
+      "${SCENARIO_TYPE:-}" == "agentic-coding" ]]; then
+    unset MAX_MODEL_LEN
+    if [[ -z "${KV_OFFLOADING+x}" || -z "$KV_OFFLOADING" ]]; then
+        echo "Error: KV_OFFLOADING must be set for agentic benchmarks" >&2
+        exit 1
+    fi
+    case "$KV_OFFLOADING" in
+        none)
+            if [[ -n "${KV_OFFLOAD_BACKEND:-}" ]]; then
+                echo "Error: KV_OFFLOAD_BACKEND must be empty when KV_OFFLOADING=none" >&2
+                exit 1
+            fi
+            ;;
+        dram)
+            if [[ -z "${KV_OFFLOAD_BACKEND:-}" || "${KV_OFFLOAD_BACKEND:-}" == "none" ]]; then
+                echo "Error: KV_OFFLOAD_BACKEND is required when KV_OFFLOADING=dram" >&2
+                exit 1
+            fi
+            if [[ ! "${TOTAL_CPU_DRAM_GB:-}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Error: DRAM KV offloading requires a positive configured TOTAL_CPU_DRAM_GB capacity" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Error: unsupported KV_OFFLOADING value '$KV_OFFLOADING' (expected one of: none, dram)" >&2
+            exit 1
+            ;;
+    esac
+fi
+unset _benchmark_caller
+
 # --------------------------------
 # GPU monitoring helpers
 # --------------------------------
@@ -73,6 +161,71 @@ stop_gpu_monitor() {
         fi
     fi
     GPU_MONITOR_PID=""
+}
+
+# Return success only while a PID exists and is not a zombie waiting to be
+# reaped. `kill -0` alone treats zombies as live processes.
+_background_process_is_running() {
+    local pid="$1"
+    local state
+    kill -0 "$pid" 2>/dev/null || return 1
+    state=$(ps -o stat= -p "$pid" 2>/dev/null) || return 1
+    [[ -n "$state" && "${state:0:1}" != "Z" ]]
+}
+
+_background_process_descendants() {
+    local parent_pid="$1"
+    local child_pid
+    while read -r child_pid; do
+        [[ -n "$child_pid" ]] || continue
+        echo "$child_pid"
+        _background_process_descendants "$child_pid"
+    done < <(pgrep -P "$parent_pid" 2>/dev/null || true)
+}
+
+# Stop a background service and every process that descended from it. Capture
+# descendants before terminating the root because orphaned workers are
+# reparented and can otherwise keep a Slurm step alive after the benchmark
+# script exits.
+stop_background_process_tree() {
+    local root_pid="${1:-}"
+    local label="${2:-background process}"
+    local grace_seconds="${3:-30}"
+
+    if [[ ! "$root_pid" =~ ^[1-9][0-9]*$ ]] || ! _background_process_is_running "$root_pid"; then
+        return 0
+    fi
+
+    local descendants
+    local child_pid
+    descendants=$(_background_process_descendants "$root_pid")
+
+    echo "Stopping $label (PID=$root_pid)..."
+    kill -TERM "$root_pid" 2>/dev/null || true
+
+    local deadline=$((SECONDS + grace_seconds))
+    while _background_process_is_running "$root_pid" && [[ $SECONDS -lt $deadline ]]; do
+        sleep 1
+    done
+
+    local forced_stop=false
+    while read -r child_pid; do
+        [[ -n "$child_pid" ]] || continue
+        if _background_process_is_running "$child_pid"; then
+            if [[ "$forced_stop" == "false" ]]; then
+                echo "Force-stopping remaining $label processes."
+                forced_stop=true
+            fi
+            echo "  PID=$child_pid"
+            kill -KILL "$child_pid" 2>/dev/null || true
+        fi
+    done <<EOF
+$root_pid
+$descendants
+EOF
+
+    wait "$root_pid" 2>/dev/null || true
+    echo "Stopped $label."
 }
 
 # Check if required environment variables are set
@@ -1073,6 +1226,15 @@ run_eval() {
 INFMAX_CONTAINER_WORKSPACE="${INFMAX_CONTAINER_WORKSPACE:-/workspace}"
 AGENTIC_DIR="${AGENTIC_DIR:-${INFMAX_CONTAINER_WORKSPACE}/utils/agentic-benchmark}"
 AIPERF_DIR="${AIPERF_DIR:-${INFMAX_CONTAINER_WORKSPACE}/utils/aiperf}"
+AIPERF_RUNTIME_DIR="${AIPERF_RUNTIME_DIR:-${TMPDIR:-/tmp}/inferencex-agentic-${SLURM_JOB_ID:-$$}}"
+AIPERF_VENV="${AIPERF_VENV:-${AIPERF_RUNTIME_DIR}/venv}"
+AIPERF_UV_INSTALL_DIR="${AIPERF_UV_INSTALL_DIR:-${AIPERF_RUNTIME_DIR}/uv/bin}"
+AIPERF_UV_CACHE_DIR="${AIPERF_UV_CACHE_DIR:-${AIPERF_RUNTIME_DIR}/uv-cache}"
+AIPERF_PYTHON="${AIPERF_VENV}/bin/python"
+AIPERF_CLI="${AIPERF_VENV}/bin/aiperf"
+AIPERF_HF_CLI="${AIPERF_VENV}/bin/hf"
+AIPERF_DEPS_READY=0
+AIPERF_FAILED_REQUEST_THRESHOLD="${AIPERF_FAILED_REQUEST_THRESHOLD:-0.10}"
 
 agentic_pip_install() {
     local pip_install=(python3 -m pip install)
@@ -1083,14 +1245,62 @@ agentic_pip_install() {
     "${pip_install[@]}" "$@"
 }
 
-ensure_hf_cli() {
-    if command -v hf >/dev/null 2>&1; then
-        return 0
+ensure_agentic_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        AIPERF_UV_BIN="$(command -v uv)"
+        return
     fi
 
-    # Some lean runtime images used by multinode SGLang include Python but not
-    # the Hugging Face CLI. Install just the hub CLI before prefetching traces.
-    agentic_pip_install --quiet "huggingface_hub[cli]>=0.25.0"
+    AIPERF_UV_BIN="${AIPERF_UV_INSTALL_DIR}/uv"
+    if [ ! -x "$AIPERF_UV_BIN" ]; then
+        mkdir -p "$AIPERF_UV_INSTALL_DIR"
+        curl -LsSf https://astral.sh/uv/install.sh |
+            UV_INSTALL_DIR="$AIPERF_UV_INSTALL_DIR" sh
+    fi
+
+    if [ ! -x "$AIPERF_UV_BIN" ]; then
+        echo "ERROR: uv installation did not create $AIPERF_UV_BIN" >&2
+        return 1
+    fi
+}
+
+install_agentic_deps() {
+    if [ "$AIPERF_DEPS_READY" = "1" ]; then
+        return
+    fi
+
+    # AIPerf must not share site-packages with the inference server. Installing
+    # it into vLLM/SGLang's system Python can upgrade FastAPI, Starlette,
+    # transformers, or other packages while the server imports from that same
+    # environment.
+    if ! command -v git >/dev/null 2>&1; then
+        apt-get update && apt-get install -y git
+    fi
+
+    ensure_agentic_uv
+    rm -rf "$AIPERF_VENV"
+    mkdir -p "$AIPERF_UV_CACHE_DIR"
+
+    UV_CACHE_DIR="$AIPERF_UV_CACHE_DIR" \
+        "$AIPERF_UV_BIN" venv --python "$(command -v python3)" "$AIPERF_VENV"
+    UV_CACHE_DIR="$AIPERF_UV_CACHE_DIR" \
+        "$AIPERF_UV_BIN" pip install --python "$AIPERF_PYTHON" \
+        -r "$AGENTIC_DIR/requirements.txt" \
+        -e "$AIPERF_DIR" \
+        "datasets>=4.7.0" \
+        "huggingface_hub[cli]>=0.25.0" \
+        urllib3 \
+        requests
+
+    if [ ! -x "$AIPERF_CLI" ] || [ ! -x "$AIPERF_HF_CLI" ]; then
+        echo "ERROR: isolated AIPerf environment is incomplete at $AIPERF_VENV" >&2
+        return 1
+    fi
+    AIPERF_DEPS_READY=1
+}
+
+ensure_hf_cli() {
+    install_agentic_deps
 }
 
 resolve_trace_source() {
@@ -1098,54 +1308,77 @@ resolve_trace_source() {
     # public-dataset loader names allowed by the inferencex-agentx-mvp
     # scenario. Used by recipes whose servers have non-default context
     # caps (e.g. minimaxm2.5 at max_model_len ~256k can't replay the
-    # unfiltered 052726 corpus and switches to the 256k-capped variant).
-    local loader="${WEKA_LOADER_OVERRIDE:-semianalysis_cc_traces_weka_with_subagents}"
+    # unfiltered corpus and switches to the 256k-capped variant), or
+    # by recipes that want to pin an older corpus generation.
+    #
+    # Default (no override): the 062126 v7 corpus, selected by model family.
+    # DSv4 (full context) rides the unfiltered base corpus; every non-DSv4
+    # recipe defaults to the 256k-capped variant because those servers run at
+    # max_model_len ~256k and would reject >256k requests. Any recipe can still
+    # pin a specific corpus via WEKA_LOADER_OVERRIDE.
+    local default_loader
+    if [[ "${MODEL_PREFIX:-}" == dsv4* ]]; then
+        default_loader="semianalysis_cc_traces_weka_062126"
+    else
+        default_loader="semianalysis_cc_traces_weka_062126_256k"
+    fi
+    local loader="${WEKA_LOADER_OVERRIDE:-$default_loader}"
     local dataset
     case "$loader" in
         semianalysis_cc_traces_weka_with_subagents)
-            dataset="semianalysisai/cc-traces-weka-with-subagents-052726"
+            dataset="semianalysisai/cc-traces-weka-061526"
             ;;
         semianalysis_cc_traces_weka_with_subagents_256k)
-            dataset="semianalysisai/cc-traces-weka-with-subagents-052726-256k"
+            dataset="semianalysisai/cc-traces-weka-061526-256k"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060226)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060226"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060226_256k)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060226-256k"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060526)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060526"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060526_256k)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060526-256k"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060826)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060826"
+            ;;
+        semianalysis_cc_traces_weka_with_subagents_060826_256k)
+            dataset="semianalysisai/cc-traces-weka-with-subagents-060826-256k"
+            ;;
+        semianalysis_cc_traces_weka_061326)
+            dataset="semianalysisai/cc-traces-weka-061326"
+            ;;
+        semianalysis_cc_traces_weka_061326_256k)
+            dataset="semianalysisai/cc-traces-weka-061326-256k"
+            ;;
+        semianalysis_cc_traces_weka_061526)
+            dataset="semianalysisai/cc-traces-weka-061526"
+            ;;
+        semianalysis_cc_traces_weka_061526_256k)
+            dataset="semianalysisai/cc-traces-weka-061526-256k"
+            ;;
+        semianalysis_cc_traces_weka_062126)
+            dataset="semianalysisai/cc-traces-weka-062126"
+            ;;
+        semianalysis_cc_traces_weka_062126_256k)
+            dataset="semianalysisai/cc-traces-weka-062126-256k"
             ;;
         *)
-            echo "Error: unknown WEKA_LOADER_OVERRIDE='$loader'. Allowed: semianalysis_cc_traces_weka_with_subagents, semianalysis_cc_traces_weka_with_subagents_256k" >&2
+            echo "Error: unknown WEKA_LOADER_OVERRIDE='$loader'. Allowed: semianalysis_cc_traces_weka_with_subagents, semianalysis_cc_traces_weka_with_subagents_256k, semianalysis_cc_traces_weka_with_subagents_060226, semianalysis_cc_traces_weka_with_subagents_060226_256k, semianalysis_cc_traces_weka_with_subagents_060526, semianalysis_cc_traces_weka_with_subagents_060526_256k, semianalysis_cc_traces_weka_with_subagents_060826, semianalysis_cc_traces_weka_with_subagents_060826_256k, semianalysis_cc_traces_weka_061326, semianalysis_cc_traces_weka_061326_256k, semianalysis_cc_traces_weka_061526, semianalysis_cc_traces_weka_061526_256k, semianalysis_cc_traces_weka_062126, semianalysis_cc_traces_weka_062126_256k" >&2
             exit 1
             ;;
     esac
     TRACE_SOURCE_FLAG="--public-dataset $loader"
-    echo "Loading traces via aiperf public-dataset: $loader ($dataset)"
+    echo "Loading traces via aiperf public-dataset: $loader ($dataset) [MODEL_PREFIX=${MODEL_PREFIX:-unset}]"
     # Pre-download the dataset into the shared HF_HUB_CACHE (same mount used
     # for model weights) so subsequent runs read from cache instead of
     # re-downloading every job.
     ensure_hf_cli
-    hf download --repo-type dataset "$dataset"
-}
-
-install_agentic_deps() {
-    # vllm/vllm-openai container ships without git. pip needs git to
-    # introspect the aiperf source tree on install. Install on demand;
-    # no-op when git is already present (e.g. AMD images that ship it).
-    if ! command -v git >/dev/null 2>&1; then
-        apt-get update && apt-get install -y git
-    fi
-    agentic_pip_install --quiet urllib3 requests 2>/dev/null || true
-    agentic_pip_install -q -r "$AGENTIC_DIR/requirements.txt"
-    # Editable install of aiperf from the submodule — gives us the
-    # `aiperf` CLI plus the inferencex-agentx-mvp scenario plugin.
-    #
-    # `--ignore-installed` sidesteps the distutils-uninstall error that
-    # vLLM containers hit on apt-managed system packages (blinker, etc.)
-    # when pip's resolver tries to upgrade one of aiperf's transitive
-    # deps. Installing fresh into the user/site location is safe — the
-    # system package stays in place and pip's import order picks up our
-    # newer copy first.
-    agentic_pip_install -q --ignore-installed -e "$AIPERF_DIR"
-    # Force-upgrade datasets: containers often ship an older version without
-    # the `Json` feature type used by the HF traces dataset. `Json` was added
-    # in datasets 4.7.0 (March 2025). Unpinned installs won't upgrade an
-    # already-present package.
-    agentic_pip_install --upgrade "datasets>=4.7.0"
+    "$AIPERF_HF_CLI" download --repo-type dataset "$dataset"
 }
 
 build_replay_cmd() {
@@ -1159,7 +1392,7 @@ build_replay_cmd() {
     # session.
     #
     # The scenario plugin locks: --cache-bust first_turn_prefix and
-    # --trace-idle-gap-cap-seconds 60 (per-trace idle-gap compression
+    # --trace-idle-gap-cap-seconds 10 (per-trace idle-gap compression
     # against parent + subagent request-start timestamps; supersedes the
     # legacy --use-think-time-only / --inter-turn-delay-cap-seconds path),
     # and auto-injects them — so we do not pass them. See
@@ -1178,7 +1411,7 @@ build_replay_cmd() {
     # aiperf validates that SERVICE_PROFILE_CONFIGURE_TIMEOUT >=
     # DATASET_CONFIGURATION_TIMEOUT at startup. Bump it in lockstep.
     export AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT=1800
-    REPLAY_CMD="aiperf profile --scenario inferencex-agentx-mvp"
+    REPLAY_CMD="$AIPERF_CLI profile --scenario inferencex-agentx-mvp"
     REPLAY_CMD+=" --url http://localhost:$PORT"
     REPLAY_CMD+=" --endpoint /v1/chat/completions"
     REPLAY_CMD+=" --endpoint-type chat"
@@ -1191,13 +1424,20 @@ build_replay_cmd() {
     # transient low-rate failures from killing long sweeps while still
     # catching malformed payloads or server crashes before they get aggregated
     # as benchmarkable data.
-    REPLAY_CMD+=" --failed-request-threshold 0.10"
+    REPLAY_CMD+=" --failed-request-threshold $AIPERF_FAILED_REQUEST_THRESHOLD"
     # Sample each trajectory's warmup start position uniformly from
-    # [25%, 75%] of the trace's turn count (was hardcoded 0%-70% upstream).
-    # Avoids starting trajectories right at turn 0 where the KV cache is
-    # cold and skews early steady-state samples.
+    # [25%, 75%] of the trace's turn count, clamped by AIPerf to leave at
+    # least one profile turn after warmup.
     REPLAY_CMD+=" --trajectory-start-min-ratio 0.25"
     REPLAY_CMD+=" --trajectory-start-max-ratio 0.75"
+    # Optional cache-pressure warmup for long agentic traces. AIPerf first
+    # completes its normal t* snapshot warmup, then continues those exact
+    # trajectories with one-token outputs and no idle delays for this many
+    # seconds. Profiling begins only after those requests drain and resumes
+    # from the resulting live trajectory state.
+    if [ -n "${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-}" ]; then
+        REPLAY_CMD+=" --agentic-cache-warmup-duration $AIPERF_AGENTIC_CACHE_WARMUP_DURATION"
+    fi
     # Use server-reported usage fields (prompt_tokens / completion_tokens) for
     # ISL/OSL instead of client-side tokenizer.encode(). Auto-enables
     # stream_options.include_usage on the OpenAI chat endpoint. Skips the
@@ -1205,6 +1445,27 @@ build_replay_cmd() {
     # CPU on minimax-m2.5 at high concurrency. Lossless for vLLM (server
     # usage is authoritative).
     REPLAY_CMD+=" --use-server-token-count"
+    # Dynamo's KV router needs an explicit conversation session binding to
+    # keep later turns on the prefill worker that owns their prefix blocks.
+    # X-Correlation-ID is useful tracing metadata but does not establish that
+    # binding by itself. AIPerf emits nvext.session_control bind/close actions
+    # keyed by the stable conversation correlation ID when this flag is set.
+    if [[ "${FRAMEWORK:-}" == dynamo-* ]]; then
+        REPLAY_CMD+=" --use-dynamo-conv-aware-routing"
+        # The upstream 300s affinity TTL is shorter than an overloaded
+        # high-concurrency agentic request. Keep bindings alive across long
+        # prefills, generation, and capped inter-turn delay. This controls the
+        # router's inactivity lease; it does not relax HTTP/request failures.
+        REPLAY_CMD+=" --dynamo-session-timeout-seconds ${AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS:-3600}"
+    fi
+    # Disable DCGM GPU telemetry collection. aiperf's GpuMetricTimeSeries
+    # freezes its metric schema on the first DCGM scrape, then KeyErrors when
+    # an optional field (xid_errors, power_violation, encoder_utilization)
+    # first appears mid-run. We don't consume the gpu_telemetry artifact in
+    # downstream processing, and the server-metrics path (Prometheus /metrics
+    # from vLLM) is unaffected by this flag and still gives us KV usage,
+    # prefix cache hit rate, etc.
+    REPLAY_CMD+=" --no-gpu-telemetry"
     # aiperf's dataset manager (separate from the inference parser) loads
     # the model's tokenizer for trace-prompt tokenization regardless of
     # --use-server-token-count. Models like kimi (amd/Kimi-K2.5-MXFP4,
@@ -1220,10 +1481,10 @@ build_replay_cmd() {
         REPLAY_CMD+=" --max-context-length $MAX_MODEL_LEN"
     fi
     # Default --num-dataset-entries is 100; the with-subagents Weka corpus
-    # has 472. Cap at 472 so all unique traces are loaded (the loader treats
+    # has 393. Cap at 393 so all unique traces are loaded (the loader treats
     # this as a ``min(cap, available)`` ceiling, not a target — see
     # semianalysis_cc_traces_weka.py).
-    REPLAY_CMD+=" --num-dataset-entries 472"
+    REPLAY_CMD+=" --num-dataset-entries 393"
     # 1-second timeslices on the server-metrics scrape so the post-run
     # plotter has per-window time series (KV usage, cache hit rate,
     # throughput, etc.). Matches kv-cache-tester's poll_interval=1.0
@@ -1231,6 +1492,24 @@ build_replay_cmd() {
     # Without this, aiperf only emits aggregate stats and the 6x2 panels
     # collapse to flat lines.
     REPLAY_CMD+=" --slice-duration 1.0"
+    # Multi-node launchers can provide the Prometheus endpoints for every
+    # inference worker as a comma-separated list. AIPerf accepts multiple
+    # values after one --server-metrics flag and preserves endpoint_url on
+    # every exported series. The inference frontend's automatically detected
+    # /metrics endpoint remains enabled as well.
+    if [ -n "${AIPERF_SERVER_METRICS_URLS:-}" ]; then
+        local metrics_url
+        local -a metrics_urls
+        IFS=',' read -r -a metrics_urls <<< "$AIPERF_SERVER_METRICS_URLS"
+        REPLAY_CMD+=" --server-metrics"
+        for metrics_url in "${metrics_urls[@]}"; do
+            if [ -z "$metrics_url" ] || [[ "$metrics_url" == *[[:space:]]* ]]; then
+                echo "ERROR: AIPERF_SERVER_METRICS_URLS must be a comma-separated list of non-empty URLs" >&2
+                return 1
+            fi
+            REPLAY_CMD+=" $metrics_url"
+        done
+    fi
     REPLAY_CMD+=" --output-artifact-dir $result_dir/aiperf_artifacts"
     # The inferencex-agentx-mvp scenario enforces a 900s minimum
     # benchmark duration. For smoke tests with shorter durations, opt
@@ -1244,21 +1523,26 @@ build_replay_cmd() {
 
 write_agentic_result_json() {
     # Aggregate aiperf's profile_export.{json,jsonl} + server_metrics_export.json
-    # into $AGENTIC_OUTPUT_DIR/$RESULT_FILENAME.json. The workflow's existing
-    # retry-based existence check is the single success gate.
+    # into $AGENTIC_OUTPUT_DIR/$RESULT_FILENAME.json. The workflow checks that
+    # this file exists; run_agentic_replay_and_write_outputs separately rejects
+    # aggregates whose request error rate exceeds the configured limit.
     local result_dir="$1"
-    RESULT_DIR="$result_dir" AGENTIC_OUTPUT_DIR="${AGENTIC_OUTPUT_DIR:-$INFMAX_CONTAINER_WORKSPACE}" \
-        python3 "$INFMAX_CONTAINER_WORKSPACE/utils/process_agentic_result.py"
+    (
+        cd "$INFMAX_CONTAINER_WORKSPACE"
+        RESULT_DIR="$result_dir" AGENTIC_OUTPUT_DIR="${AGENTIC_OUTPUT_DIR:-$INFMAX_CONTAINER_WORKSPACE}" \
+            "$AIPERF_PYTHON" -m utils.agentic.aggregation.process_agentic_result
+    )
 
     # Generate metrics_plots.png from the same aiperf artifacts. Best-effort:
     # don't fail the launcher if plot generation has trouble (e.g. matplotlib
     # missing in a stripped-down image). The agg JSON is the success gate.
-    python3 "$INFMAX_CONTAINER_WORKSPACE/utils/generate_aiperf_plots.py" "$result_dir" 2>&1 || true
+    "$AIPERF_PYTHON" "$INFMAX_CONTAINER_WORKSPACE/utils/generate_aiperf_plots.py" "$result_dir" 2>&1 || true
 }
 
 run_agentic_replay_and_write_outputs() {
     local result_dir="$1"
     local replay_rc
+    local validation_rc
 
     echo "$REPLAY_CMD" > "$result_dir/benchmark_command.txt"
 
@@ -1271,11 +1555,26 @@ run_agentic_replay_and_write_outputs() {
 
     write_agentic_result_json "$result_dir"
 
-    python3 "$AGENTIC_DIR/scripts/analyze_benchmark_distributions.py" \
+    "$AIPERF_PYTHON" "$AGENTIC_DIR/scripts/analyze_benchmark_distributions.py" \
         "$result_dir/aiperf_artifacts" -o "$result_dir" 2>&1 || true
+
+    set +e
+    (
+        cd "$INFMAX_CONTAINER_WORKSPACE"
+        "$AIPERF_PYTHON" -m utils.agentic.validation.validate_agentic_result \
+            "$result_dir/aiperf_artifacts" \
+            --failed-request-threshold "$AIPERF_FAILED_REQUEST_THRESHOLD"
+    )
+    validation_rc=$?
+    set -e
 
     if [ "$replay_rc" -ne 0 ]; then
         echo "ERROR: agentic trace replay exited with code $replay_rc after writing available results" >&2
         return "$replay_rc"
+    fi
+
+    if [ "$validation_rc" -ne 0 ]; then
+        echo "ERROR: agentic trace replay produced invalid results after writing available artifacts" >&2
+        return "$validation_rc"
     fi
 }

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -432,8 +432,49 @@ else
     # and gpu-15 names no longer exist. gpu-2 currently has 10 fully-idle GPU
     # nodes (all of gpu-2-[0-9]); gpu-1 has 2 drained (gpu-1-4, gpu-1-8). We
     # land on gpu-2 to avoid drained nodes and skip the per-node excludes.
-    salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
+    SALLOC_MEMORY_ARGS=()
+    if [[ "${OFFLOADING:-none}" != "none" ]]; then
+        # Host KV tiers (vLLM Mooncake cpu offload, SGLang HiCache) allocate
+        # multi-TB pinned host pools. Without an explicit request, Slurm caps
+        # this exclusive job at 2 TB and OOM-kills it even though the B200
+        # node has about 4 TB of physical RAM.
+        SALLOC_MEMORY_ARGS=(--mem=0)
+    fi
+    DEFAULT_SALLOC_TIME_LIMIT=180
+    if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "${DURATION:-0}" -ge 10800 ]]; then
+        # Three-hour profiles need enough lifecycle headroom for model startup,
+        # warmup, request draining, and CPU-heavy result processing.
+        DEFAULT_SALLOC_TIME_LIMIT=480
+    elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "${DURATION:-0}" -ge 5400 ]]; then
+        # A 90-minute profile plus model startup, warmup, request draining,
+        # and result processing can exceed the normal three-hour lifecycle.
+        DEFAULT_SALLOC_TIME_LIMIT=300
+    elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "$FRAMEWORK" == "sglang" && "${OFFLOADING:-none}" == "hicache" && "$CONC" -ge 512 ]]; then
+        # C512 replays 694 long-context warmup trajectories before the timed
+        # profile. The normal three-hour allocation expires during warmup.
+        DEFAULT_SALLOC_TIME_LIMIT=300
+    fi
+    SALLOC_TIME_LIMIT="${SALLOC_TIME_LIMIT:-$DEFAULT_SALLOC_TIME_LIMIT}"
+    salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive "${SALLOC_MEMORY_ARGS[@]}" --time="$SALLOC_TIME_LIMIT" --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
+
+    # DSv4 is also staged on the compute nodes' local RAID. Loading the 806 GB
+    # checkpoint independently from Lustre on every TP rank leaves the loader
+    # threads blocked in Lustre I/O for hours. Select the local copy only after
+    # Slurm assigns a node, and retain the shared-Lustre path as a fallback for
+    # nodes whose local staging is incomplete.
+    if [[ "$MODEL_PREFIX" == "dsv4" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "sglang" ]]; then
+        LOCAL_MODEL_PATH=/raid/models/DeepSeek-V4-Pro-NVFP4
+        if srun --jobid="$JOB_ID" bash -c \
+            'test -f "$1/config.json" && test -f "$1/model.safetensors.index.json" && test "$(find "$1" -maxdepth 1 -name "model-*.safetensors" | wc -l)" -eq 64' \
+            _ "$LOCAL_MODEL_PATH"; then
+            export MODEL_PATH="$LOCAL_MODEL_PATH"
+            export MODEL="$MODEL_PATH"
+            echo "Using node-local DSv4 checkpoint: $MODEL_PATH"
+        else
+            echo "Node-local DSv4 checkpoint unavailable; using shared checkpoint: $MODEL_PATH"
+        fi
+    fi
 
     # Use flock to serialize concurrent imports to the same squash file
     # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -449,9 +449,33 @@ else
         fi
     )
 
+    SALLOC_MEMORY_ARGS=()
+    if [[ "${OFFLOADING:-none}" != "none" ]]; then
+        # Host KV tiers (vLLM Mooncake cpu offload, SGLang HiCache) allocate
+        # multi-TB pinned host pools. Give them the full memory allocation of
+        # the exclusive node instead of Slurm's implicit 2 TB default.
+        SALLOC_MEMORY_ARGS=(--mem=0)
+    fi
+    DEFAULT_SALLOC_TIME_LIMIT=180
+    if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "${DURATION:-0}" -ge 10800 ]]; then
+        # Three-hour profiles need enough lifecycle headroom for model startup,
+        # warmup, request draining, and CPU-heavy result processing.
+        DEFAULT_SALLOC_TIME_LIMIT=480
+    elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "${DURATION:-0}" -ge 5400 ]]; then
+        # A 90-minute profile plus model startup, warmup, request draining,
+        # and result processing can exceed the normal three-hour lifecycle.
+        DEFAULT_SALLOC_TIME_LIMIT=300
+    elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "dsv4" && "$FRAMEWORK" == "sglang" ]]; then
+        if [[ "$CONC" -ge 512 || ( "$DP_ATTENTION" == "true" && "$CONC" -ge 96 ) ]]; then
+            # C512 and high-concurrency DP replays can spend multiple hours in
+            # long-context warmup before the 30-minute profiling phase.
+            DEFAULT_SALLOC_TIME_LIMIT=300
+        fi
+    fi
+    SALLOC_TIME_LIMIT="${SALLOC_TIME_LIMIT:-$DEFAULT_SALLOC_TIME_LIMIT}"
     # Default 180 min; AL-matrix collection (16 server starts) needs longer and
     # overrides via SALLOC_TIME_LIMIT.
-    salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT -N 1 --gres=gpu:$TP --exclusive --time="${SALLOC_TIME_LIMIT:-180}" --no-shell --job-name="$RUNNER_NAME"
+    salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT -N 1 --gres=gpu:$TP --exclusive "${SALLOC_MEMORY_ARGS[@]}" --time="$SALLOC_TIME_LIMIT" --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
 
     srun --jobid=$JOB_ID \
@@ -459,6 +483,7 @@ else
         --container-image=$SQUASH_FILE \
         --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE_MOUNT,$WRITABLE_MODELS_DIR:$WRITABLE_MODELS_DIR \
         --no-container-mount-home \
+        --container-remap-root \
         --container-workdir=$CONTAINER_MOUNT_DIR \
         --no-container-entrypoint --export=ALL,PORT=8888 \
         bash "$BENCH_SCRIPT"

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -52,7 +52,11 @@ elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/kimi-k2.5-nvfp4"
         export SRT_SLURM_MODEL_PREFIX="kimi-k2.5-nvfp4"
     elif [[ $MODEL_PREFIX == "dsv4" && $PRECISION == "fp4" ]]; then
-        export MODEL_PATH="/mnt/lustre01/models/deepseek-v4-pro"
+        # The FP4 checkpoint is staged on compute-visible Lustre. The former
+        # /mnt/numa1 path is no longer present on watchtower compute nodes;
+        # the lowercase Lustre sibling is the FP8 checkpoint, so keep the
+        # NVFP4 path explicit here.
+        export MODEL_PATH="/mnt/lustre01/models/DeepSeek-V4-Pro-NVFP4/"
         export SRT_SLURM_MODEL_PREFIX="deepseek-v4-pro"
     elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/MiniMax-M2.5-NVFP4"
@@ -266,8 +270,21 @@ fi
 
 # TODO(CJQ): make first class upon srt-slurm upstream refactor
 if [[ "$IS_AGENTIC" == "1" ]]; then
-    git clone --branch cam/sa-submission-q2-2026 --single-branch https://github.com/cquil11/srt-slurm-nv.git "$SRT_REPO_DIR"
+    # Agentic multi-node uses the same pinned cquil11/srt-slurm-nv commit as
+    # launch_gb300-nv.sh — everything the agentic recipes need is there:
+    #   - BenchmarkType.CUSTOM + benchmark.command + benchmark.env
+    #     (the hook that hands off to benchmarks/multi_node/agentic_srt.sh)
+    #   - DynamoConfig.wheel (recipes pin the ai-dynamo wheel)
+    #   - srtctl apply --no-preflight (model path /mnt/numa1 is compute-node
+    #     local NVMe, invisible to the login-node runner)
+    #   - benchmark_stage srun_options propagation (container-remap-root
+    #     must reach the agentic_srt.sh srun)
+    git clone https://github.com/cquil11/srt-slurm-nv.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
+    git checkout de59739b172e507e15ebf145bfe305f606e82fbf
+    mkdir -p recipes/vllm/deepseek-v4/agentic
+    cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic" \
+        recipes/vllm/deepseek-v4/agentic
 elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv4" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
@@ -366,6 +383,24 @@ SRTCTL_ROOT="${GITHUB_WORKSPACE}/srt-slurm"
 if uses_watchtower_shared_fs; then
     SRTCTL_ROOT="$SRT_REPO_DIR"
 fi
+
+# Agentic runs bind-mount two persistent caches into every worker container
+# (Lustre, shared across nodes): aiperf's content-addressed dataset mmap
+# cache (~65 GB per corpus, re-tokenized from scratch without it) and the
+# HF hub cache holding the trace dataset download. The container-side paths
+# are referenced by the agentic recipes' benchmark.env
+# (AIPERF_DATASET_MMAP_CACHE_DIR=/aiperf_mmap_cache, HF_HUB_CACHE=/hf_hub_cache).
+DEFAULT_MOUNTS_BLOCK=""
+if [[ "$IS_AGENTIC" == "1" ]]; then
+    AIPERF_MMAP_CACHE_HOST_PATH="/mnt/lustre01/users-public/sa-shared/ai-perf-cache"
+    HF_HUB_CACHE_HOST_PATH="/mnt/lustre01/users-public/sa-shared/hf-hub-cache"
+    mkdir -p "$AIPERF_MMAP_CACHE_HOST_PATH" "$HF_HUB_CACHE_HOST_PATH"
+    chmod 777 "$AIPERF_MMAP_CACHE_HOST_PATH" "$HF_HUB_CACHE_HOST_PATH" 2>/dev/null || true
+    DEFAULT_MOUNTS_BLOCK="default_mounts:
+  ${AIPERF_MMAP_CACHE_HOST_PATH}: /aiperf_mmap_cache
+  ${HF_HUB_CACHE_HOST_PATH}: /hf_hub_cache"
+fi
+
 echo "Creating srtslurm.yaml configuration..."
 cat > srtslurm.yaml <<EOF
 # SRT SLURM Configuration for GB200
@@ -390,6 +425,15 @@ containers:
   dynamo-sglang: ${SQUASH_FILE}
   "${IMAGE}": ${SQUASH_FILE}
   nginx-sqsh: ${NGINX_SQUASH_FILE}
+# srtctl defaults this to true, which adds #SBATCH --segment=<total_nodes>.
+# On watchtower the whole batch partition (blue-cn01-18) is a single NVL72
+# rack, so segment contiguity buys nothing for MNNVL — but it DOES make
+# jobs unschedulable when the partition is fragmented: Slurm backfills a
+# non-contiguous node set, fails segment placement at start, and the job
+# dies with "CANCELLED Reason=Resources" at RunTime=0 (hit by the first
+# gb200 agentic run, job 18582). Mirror launch_gb300-nv.sh and disable.
+use_segment_sbatch_directive: false
+${DEFAULT_MOUNTS_BLOCK}
 EOF
 
 echo "Generated srtslurm.yaml:"
@@ -421,16 +465,36 @@ fi
 
 echo "Submitting job with srtctl..."
 
-# Override the job name in the config file with the runner name
+# Resolve the recipe path before editing or submitting it.
 CONFIG_PATH="${CONFIG_FILE%%:*}"
 if [[ ! -f "$CONFIG_PATH" ]]; then
     echo "Error: CONFIG_FILE does not exist after srt-slurm setup: $CONFIG_PATH" >&2
     echo "Current directory: $(pwd)" >&2
     exit 1
 fi
+
+# Keep the Slurm job name aligned with the GitHub runner name.
 sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_PATH"
 
+# Don't leak the login-node venv to the compute-node orchestrator. sbatch's
+# default --export=ALL propagates VIRTUAL_ENV (set by `source
+# .venv/bin/activate` above) into job_script_minimal.j2, whose
+# `uv run` step then tries to inspect the *active* venv — and dies with
+# "Broken symlink at .venv/bin/python3" because the login-node interpreter
+# path doesn't exist on compute nodes (gb200 agentic R2, job 18587).
+# srtctl itself still resolves through PATH (.venv/bin is on it).
+unset VIRTUAL_ENV
+
+# --no-preflight is only used on the agentic path, where the recipe resolves
+# model.path to /mnt/numa1 (compute-node-only NVMe) that the login-node
+# runner can't see. Fixed-seq-len recipes keep enforcement on.
+PREFLIGHT_ARGS=()
+if [[ "$IS_AGENTIC" == "1" ]]; then
+    PREFLIGHT_ARGS=(--no-preflight)
+fi
+
 SRTCTL_APPLY_ARGS=(
+    "${PREFLIGHT_ARGS[@]}"
     -f "$CONFIG_PATH"
     --tags "gb200,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)"
 )

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -17,6 +17,14 @@ export ENROOT_ROOTFS_WRITABLE=1
 # write to it.
 export AIPERF_MMAP_CACHE_HOST_PATH="/data/home/sa-shared/gharunners/ai-perf-cache"
 
+# Persistent HF hub cache for the agentic trace datasets — mounted into
+# worker containers at /hf_hub_cache; the agentic recipes set
+# HF_HUB_CACHE=/hf_hub_cache in benchmark.env. Without it the workflow-level
+# HF_HUB_CACHE (/mnt/hf_hub_cache) doesn't exist on these nodes and every
+# run re-downloads the corpus into the ephemeral container overlay.
+export HF_HUB_CACHE_HOST_PATH="/data/home/sa-shared/gharunners/hf-hub-cache"
+mkdir -p "$HF_HUB_CACHE_HOST_PATH"
+
 export MODEL_PATH=$MODEL
 
 if [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
@@ -254,6 +262,7 @@ srtctl_root: "${SRTCTL_ROOT}"
 # re-tokenized + re-written every job.
 default_mounts:
   "${AIPERF_MMAP_CACHE_HOST_PATH}": "/aiperf_mmap_cache"
+  "${HF_HUB_CACHE_HOST_PATH}": "/hf_hub_cache"
 
 # Model path aliases
 model_paths:

--- a/runners/launch_h100-dgxc-slurm.sh
+++ b/runners/launch_h100-dgxc-slurm.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/bash
+set -eo pipefail
 
 # System-specific configuration for H100 DGXC Slurm cluster
 SLURM_PARTITION="hpc-gpu-1"
 SLURM_ACCOUNT="customer"
-SLURM_EXCLUDED_NODELIST="hpc-gpu-1-7"
+SLURM_EXCLUDED_NODELIST="hpc-gpu-1-7,hpc-gpu-1-13"
 
 # Route spec-decoding=mtp configs to the _mtp benchmark script (parity with
 # the h200 launchers, which have carried SPEC_SUFFIX since #392).
@@ -290,6 +291,11 @@ else
 
     salloc --exclude="$SLURM_EXCLUDED_NODELIST" --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
+    if [[ -z "$JOB_ID" ]]; then
+        echo "ERROR: failed to resolve H100 Slurm allocation" >&2
+        exit 1
+    fi
+    trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 
     # flock-serialize the enroot import so concurrent sweep jobs on the same
     # shared NFS path don't race each other into 'File already exists' (race

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -eo pipefail
 
 # System-specific configuration for H200 DGXC Slurm cluster
 SLURM_PARTITION="main"
@@ -281,6 +282,11 @@ else
 
     salloc --partition=$SLURM_PARTITION --account=$SLURM_ACCOUNT --gres=gpu:$TP --exclusive --time=180 --no-shell --job-name="$RUNNER_NAME"
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
+    if [[ -z "$JOB_ID" ]]; then
+        echo "ERROR: failed to resolve H200 Slurm allocation" >&2
+        exit 1
+    fi
+    trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 
     # Use flock to serialize concurrent imports to the same squash file
     # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes

--- a/runners/launch_mi300x-amds.sh
+++ b/runners/launch_mi300x-amds.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 export HF_HUB_CACHE_MOUNT="/raid/hf-hub-cache/"
 export PORT=8888
@@ -15,12 +16,15 @@ set -x
 
 # Exclude known-bad nodes; let Slurm pick from anything else:
 #   chi-mi300x-049: persistent /nvme_home disk-full
-JOB_ID=$(salloc --partition=$PARTITION --exclude=chi-mi300x-049 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+#   chi-mi300x-121: provisioning incomplete; missing /raid and Enroot storage
+JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --exclude=chi-mi300x-049,chi-mi300x-121 --gres=gpu:$TP --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job"
     exit 1
 fi
+
+trap 'rc=$?; scancel "$JOB_ID" 2>/dev/null || true; exit "$rc"' EXIT
 
 # Use flock to serialize concurrent imports to the same squash file
 srun --jobid=$JOB_ID --job-name="$RUNNER_NAME" bash -c "

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -2,6 +2,7 @@ import fnmatch
 import json
 import argparse
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 # Ensure sibling modules are importable regardless of how script is invoked
@@ -12,7 +13,8 @@ from validation import (
     validate_agentic_matrix_entry,
     load_config_files,
     load_runner_file,
-    Fields
+    Fields,
+    DEFAULT_AGENTIC_DURATION_SECONDS,
 )
 
 seq_len_stoi = {
@@ -21,6 +23,12 @@ seq_len_stoi = {
 }
 
 MIN_EVAL_CONC = 16
+# Bound how many multinode agentic conc points share one server allocation.
+MAX_MULTINODE_AGENTIC_CONCURRENCIES_PER_ALLOCATION = 4
+BYTES_PER_MIB = 1024 * 1024
+BYTES_PER_GB = 1_000_000_000
+# 3 TB decimal DRAM cap, expressed in MiB, before utilization scaling.
+MAX_AGENTIC_AVAILABLE_CPU_DRAM_MIB = 2_861_022
 
 # Reverse mapping for exp-name generation
 seq_len_itos = {v: k for k, v in seq_len_stoi.items()}
@@ -33,6 +41,83 @@ def seq_len_to_str(isl: int, osl: int) -> str:
     otherwise returns 'isl_osl' format.
     """
     return seq_len_itos.get((isl, osl), f"{isl}_{osl}")
+
+
+def runner_labels(runner_data: dict) -> dict:
+    """Return runner scheduling labels."""
+    return runner_data["labels"]
+
+
+def runner_hardware(runner_data: dict) -> dict:
+    """Return runner hardware metadata, if present."""
+    return runner_data.get("hardware", {})
+
+
+def runner_nodes_for_label(runner: str, runner_data: dict) -> list[str]:
+    """Return concrete runner names for a scheduling label."""
+    return runner_labels(runner_data).get(runner, [])
+
+
+def runner_hardware_int(runner: str, runner_data: dict, field: str) -> int:
+    """Return an integer hardware field for a runner label."""
+    hardware = runner_hardware(runner_data).get(runner, {})
+    value = hardware.get(field)
+    if value is None:
+        available = ", ".join(sorted(runner_hardware(runner_data).keys()))
+        raise ValueError(
+            f"Runner '{runner}' requires '{field}' "
+            f"in runner hardware metadata. Available hardware keys: {available}"
+        )
+    return value
+
+
+def runner_available_cpu_dram_mib(runner: str, runner_data: dict) -> int:
+    """Return available CPU DRAM for a runner label."""
+    return runner_hardware_int(runner, runner_data, Fields.AVAILABLE_CPU_DRAM_MIB.value)
+
+
+def runner_gpus_per_node(runner: str, runner_data: dict) -> int:
+    """Return GPUs per node for a runner label."""
+    return runner_hardware_int(runner, runner_data, Fields.GPUS_PER_NODE.value)
+
+
+def agentic_dram_offload_gb(
+    agentic_config: dict, benchmark: dict, runner: str, runner_data: dict
+) -> int:
+    """Return the aggregate DRAM offload budget for a single-node entry."""
+    kv_offloading = benchmark[Fields.KV_OFFLOADING.value]
+    if kv_offloading != "dram":
+        return 0
+
+    available_mib = min(
+        runner_available_cpu_dram_mib(runner, runner_data),
+        MAX_AGENTIC_AVAILABLE_CPU_DRAM_MIB,
+    )
+    utilization = Decimal(str(agentic_config[Fields.DRAM_UTILIZATION.value]))
+    gpus_per_node = runner_gpus_per_node(runner, runner_data)
+    tp = benchmark[Fields.TP.value]
+    if tp > gpus_per_node:
+        raise ValueError(
+            f"tp={tp} exceeds {Fields.GPUS_PER_NODE.value}={gpus_per_node} "
+            f"for runner '{runner}'"
+        )
+    proportional_bytes = (
+        Decimal(available_mib) * BYTES_PER_MIB * utilization * tp / gpus_per_node
+    )
+    return int(proportional_bytes / BYTES_PER_GB)
+
+
+def agentic_kv_offload_suffix(kv_offloading: str, kv_offload_backend: str | None) -> str:
+    """Return a compact exp-name suffix for agentic KV offload settings."""
+    if kv_offloading == "none":
+        return "kvnone"
+    return f"kv{kv_offloading}-{kv_offload_backend}"
+
+
+def chunk_multinode_agentic_concurrencies(conc_values: list[int]) -> list[list[int]]:
+    """Bound sequential agentic profiles sharing one server allocation."""
+    size = MAX_MULTINODE_AGENTIC_CONCURRENCIES_PER_ALLOCATION
+    return [conc_values[index:index + size] for index in range(0, len(conc_values), size)]
 
 
 def _freeze_matrix_value(value):
@@ -226,7 +311,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
     # Validate runner types if specified
     if args.runner_type:
-        valid_runner_types = set(runner_data.keys())
+        valid_runner_types = set(runner_labels(runner_data).keys())
         invalid_runners = set(args.runner_type) - valid_runner_types
         if invalid_runners:
             raise ValueError(
@@ -278,7 +363,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
         # Compute filtered runner nodes for this config if filter is specified
         runner_nodes_to_use = None
         if args.runner_node_filter:
-            runner_nodes = runner_data.get(runner, [])
+            runner_nodes = runner_nodes_for_label(runner, runner_data)
             runner_nodes_to_use = [
                 node for node in runner_nodes if args.runner_node_filter in node]
             if not runner_nodes_to_use:
@@ -490,21 +575,33 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
         # ---- Agentic-coding scenarios ----
         agentic_configs = scenarios.get(Fields.AGENTIC_CODING.value, []) if (scenario_filter is None or 'agentic-coding' in scenario_filter) else []
+        if is_multinode and not args.multi_node:
+            continue
+        if not is_multinode and not args.single_node:
+            continue
 
         for agentic_config in agentic_configs:
             bmk_space = agentic_config[Fields.SEARCH_SPACE.value]
-            duration = agentic_config.get(Fields.DURATION.value, 1800)
+            duration = DEFAULT_AGENTIC_DURATION_SECONDS
 
             for bmk in bmk_space:
                 if is_multinode:
                     prefill = bmk[Fields.PREFILL.value]
                     decode = bmk[Fields.DECODE.value]
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
+                    kv_offloading = "none"
+                    kv_offload_backend = None
                 else:
                     tp = bmk[Fields.TP.value]
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
-                offloading = bmk.get(Fields.OFFLOADING.value, "none")
+                    kv_offloading = bmk[Fields.KV_OFFLOADING.value]
+                    kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
+                total_cpu_dram_gb = (
+                    0
+                    if is_multinode
+                    else agentic_dram_offload_gb(agentic_config, bmk, runner, runner_data)
+                )
 
                 # Get concurrency values
                 conc_list = bmk.get(Fields.CONC_LIST.value)
@@ -533,9 +630,9 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
                 runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
 
-                for conc in conc_values:
+                if is_multinode:
                     for runner_value in runners_for_entry:
-                        if is_multinode:
+                        for conc_batch in chunk_multinode_agentic_concurrencies(conc_values):
                             entry = {
                                 Fields.IMAGE.value: image,
                                 Fields.MODEL.value: model,
@@ -546,16 +643,22 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 Fields.SPEC_DECODING.value: spec_decoding,
                                 Fields.PREFILL.value: prefill,
                                 Fields.DECODE.value: decode,
-                                Fields.CONC.value: conc,
+                                Fields.CONC.value: conc_batch,
+                                Fields.KV_OFFLOADING.value: "none",
                                 Fields.DURATION.value: duration,
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_p{prefill[Fields.NUM_WORKER.value]}x{prefill[Fields.TP.value]}"
-                                    f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}_conc{conc}"
+                                    f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}"
+                                    f"_conc{'x'.join(str(c) for c in conc_batch)}"
                                 ),
                                 Fields.DISAGG.value: disagg,
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
-                        else:
+                            validate_agentic_matrix_entry(entry)
+                            matrix_values.append(entry)
+                else:
+                    for conc in conc_values:
+                        for runner_value in runners_for_entry:
                             entry = {
                                 Fields.IMAGE.value: image,
                                 Fields.MODEL.value: model,
@@ -567,14 +670,19 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 Fields.EP.value: ep if ep is not None else 1,
                                 Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
                                 Fields.CONC.value: conc,
-                                Fields.OFFLOADING.value: offloading,
+                                Fields.KV_OFFLOADING.value: kv_offloading,
+                                Fields.TOTAL_CPU_DRAM_GB.value: total_cpu_dram_gb,
                                 Fields.DURATION.value: duration,
-                                Fields.EXP_NAME.value: f"{model_code}_tp{tp}_conc{conc}_offload{offloading}",
+                                Fields.EXP_NAME.value: (
+                                    f"{model_code}_tp{tp}_conc{conc}_"
+                                    f"{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                                ),
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
-
-                        validate_agentic_matrix_entry(entry)
-                        matrix_values.append(entry)
+                            if kv_offload_backend is not None:
+                                entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            validate_agentic_matrix_entry(entry)
+                            matrix_values.append(entry)
 
     return matrix_values
 
@@ -583,7 +691,7 @@ def _runner_values_for_filter(runner: str, runner_data: dict, runner_node_filter
     if not runner_node_filter:
         return [runner]
 
-    candidates = runner_data.get(runner, [])
+    candidates = runner_nodes_for_label(runner, runner_data)
     if runner_node_filter in runner:
         candidates = [runner, *candidates]
 
@@ -746,18 +854,27 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
         # ---- Agentic-coding scenarios ----
         agentic_configs = val[Fields.SCENARIOS.value].get(Fields.AGENTIC_CODING.value, []) if (scenario_filter is None or 'agentic-coding' in scenario_filter) else []
         for agentic_config in agentic_configs:
-            duration = agentic_config.get(Fields.DURATION.value, 1800)
+            duration = DEFAULT_AGENTIC_DURATION_SECONDS
+            bmk_space = agentic_config[Fields.SEARCH_SPACE.value]
 
-            for bmk in agentic_config[Fields.SEARCH_SPACE.value]:
+            for bmk in bmk_space:
                 if is_multinode:
                     prefill = bmk[Fields.PREFILL.value]
                     decode = bmk[Fields.DECODE.value]
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
+                    kv_offloading = "none"
+                    kv_offload_backend = None
                 else:
                     tp = bmk[Fields.TP.value]
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
-                offloading = bmk.get(Fields.OFFLOADING.value, "none")
+                    kv_offloading = bmk[Fields.KV_OFFLOADING.value]
+                    kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
+                total_cpu_dram_gb = (
+                    0
+                    if is_multinode
+                    else agentic_dram_offload_gb(agentic_config, bmk, runner, runner_data)
+                )
 
                 conc_list = bmk.get(Fields.CONC_LIST.value)
                 if conc_list:
@@ -780,9 +897,9 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                 if not conc_values:
                     continue
 
-                for conc in conc_values:
+                if is_multinode:
                     for runner_value in runners_for_entry:
-                        if is_multinode:
+                        for conc_batch in chunk_multinode_agentic_concurrencies(conc_values):
                             entry = {
                                 Fields.IMAGE.value: image,
                                 Fields.MODEL.value: model,
@@ -793,16 +910,21 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.SPEC_DECODING.value: spec_decoding,
                                 Fields.PREFILL.value: prefill,
                                 Fields.DECODE.value: decode,
-                                Fields.CONC.value: conc,
+                                Fields.CONC.value: conc_batch,
+                                Fields.KV_OFFLOADING.value: "none",
                                 Fields.DURATION.value: duration,
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_p{prefill[Fields.NUM_WORKER.value]}x{prefill[Fields.TP.value]}"
-                                    f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}_conc{conc}"
+                                    f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}"
+                                    f"_conc{'x'.join(str(c) for c in conc_batch)}"
                                 ),
                                 Fields.DISAGG.value: disagg,
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
-                        else:
+                            matrix_values.append(validate_agentic_matrix_entry(entry))
+                else:
+                    for conc in conc_values:
+                        for runner_value in runners_for_entry:
                             entry = {
                                 Fields.IMAGE.value: image,
                                 Fields.MODEL.value: model,
@@ -814,12 +936,18 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.EP.value: ep if ep is not None else 1,
                                 Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
                                 Fields.CONC.value: conc,
-                                Fields.OFFLOADING.value: offloading,
+                                Fields.KV_OFFLOADING.value: kv_offloading,
+                                Fields.TOTAL_CPU_DRAM_GB.value: total_cpu_dram_gb,
                                 Fields.DURATION.value: duration,
-                                Fields.EXP_NAME.value: f"{model_code}_tp{tp}_conc{conc}_offload{offloading}",
+                                Fields.EXP_NAME.value: (
+                                    f"{model_code}_tp{tp}_conc{conc}_"
+                                    f"{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                                ),
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
-                        matrix_values.append(validate_agentic_matrix_entry(entry))
+                            if kv_offload_backend is not None:
+                                entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            matrix_values.append(validate_agentic_matrix_entry(entry))
 
     return matrix_values
 

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -1,6 +1,7 @@
 """Comprehensive tests for generate_sweep_configs.py"""
 import pytest
 import argparse
+import copy
 from generate_sweep_configs import (
     MIN_EVAL_CONC,
     seq_len_stoi,
@@ -109,11 +110,23 @@ def sample_multinode_config():
 def sample_runner_config():
     """Runner config based on .github/configs/runners.yaml."""
     return {
-        "h100": ["h100-cr_0", "h100-cr_1", "h100-cw_0", "h100-cw_1"],
-        "h200": ["h200-cw_0", "h200-cw_1", "h200-nb_0", "h200-nb_1"],
-        "b200": ["b200-nvd_0", "b200-nvd_1", "b200-dgxc_1"],
-        "mi300x": ["mi300x-amd_0", "mi300x-amd_1", "mi300x-cr_0"],
-        "gb200": ["gb200-nv_0"],
+        "labels": {
+            "h100": ["h100-cr_0", "h100-cr_1", "h100-cw_0", "h100-cw_1"],
+            "h200": ["h200-cw_0", "h200-cw_1", "h200-nb_0", "h200-nb_1"],
+            "b200": ["b200-nvd_0", "b200-nvd_1", "b200-dgxc_1"],
+            "b300": ["b300-nv_0", "b300-nv_1"],
+            "cluster:b300-nv": ["b300-nv_0", "b300-nv_1"],
+            "mi300x": ["mi300x-amd_0", "mi300x-amd_1", "mi300x-cr_0"],
+            "gb200": ["gb200-nv_0"],
+        },
+        "hardware": {
+            "cluster:h100-dgxc": {"available-cpu-dram-mib": 2063837, "gpus-per-node": 8},
+            "cluster:h200-dgxc": {"available-cpu-dram-mib": 1471356, "gpus-per-node": 8},
+            "cluster:b200-dgxc": {"available-cpu-dram-mib": 3774874, "gpus-per-node": 8},
+            "cluster:b300-nv": {"available-cpu-dram-mib": 2964436, "gpus-per-node": 8},
+            "cluster:mi300x-amds": {"available-cpu-dram-mib": 2321924, "gpus-per-node": 8},
+            "cluster:gb200-nv": {"available-cpu-dram-mib": 860160, "gpus-per-node": 4},
+        },
     }
 
 
@@ -1860,17 +1873,18 @@ class TestGenerateTestConfigSweep:
                 "model-prefix": "qwen3.5",
                 "precision": "fp8",
                 "framework": "sglang",
-                "runner": "mi300x",
+                "runner": "cluster:b300-nv",
                 "multinode": False,
                 "scenarios": {
                     "agentic-coding": [
                         {
-                            "duration": 1800,
+                            "dram-utilization": 0.80,
                             "search-space": [
                                 {
                                     "tp": 8,
                                     "ep": 1,
-                                    "offloading": "hicache",
+                                    "kv-offloading": "dram",
+                                    "kv-offload-backend": "hicache",
                                     "conc-list": [64],
                                 }
                             ],
@@ -1884,14 +1898,136 @@ class TestGenerateTestConfigSweep:
             seq_lens=None,
             conc=None,
             scenario_type=["agentic-coding"],
-            runner_node_filter="mi300x-amd_1",
+            runner_node_filter="b300-nv_1",
         )
 
         result = generate_test_config_sweep(args, config, sample_runner_config)
 
         assert len(result) == 1
-        assert result[0]["runner"] == "mi300x-amd_1"
+        assert result[0]["runner"] == "b300-nv_1"
         assert result[0]["scenario-type"] == "agentic-coding"
+        assert result[0]["total-cpu-dram-gb"] == 2399
+        assert result[0]["duration"] == 3600
+
+    def test_agentic_node_dram_uses_explicit_gpu_count(self, sample_runner_config):
+        config = {
+            "dsv4-b300-agentic": {
+                "image": "vllm/vllm-openai:v0.23.0",
+                "model": "deepseek-ai/DeepSeek-V4-Pro",
+                "model-prefix": "dsv4",
+                "precision": "fp4",
+                "framework": "vllm",
+                "runner": "cluster:b300-nv",
+                "multinode": False,
+                "scenarios": {
+                    "agentic-coding": [{
+                        "dram-utilization": 0.80,
+                        "search-space": [
+                            {
+                                "tp": 4,
+                                "kv-offloading": "dram",
+                                "kv-offload-backend": "native",
+                                "conc-list": [32],
+                            },
+                        ],
+                    }],
+                },
+            },
+        }
+        args = argparse.Namespace(
+            config_keys=["dsv4-b300-agentic"],
+            seq_lens=None,
+            conc=None,
+            scenario_type=["agentic-coding"],
+            runner_node_filter=None,
+        )
+
+        result = generate_test_config_sweep(args, config, sample_runner_config)
+
+        budgets = {entry["tp"]: entry["total-cpu-dram-gb"] for entry in result}
+        assert budgets == {4: 1199}
+        assert result[0]["duration"] == 3600
+
+    def test_agentic_node_dram_rejects_tp_above_runner_gpus(self, sample_runner_config):
+        config = {
+            "dsv4-b300-agentic": {
+                "image": "vllm/vllm-openai:v0.23.0",
+                "model": "deepseek-ai/DeepSeek-V4-Pro",
+                "model-prefix": "dsv4",
+                "precision": "fp4",
+                "framework": "vllm",
+                "runner": "cluster:b300-nv",
+                "multinode": False,
+                "scenarios": {
+                    "agentic-coding": [{
+                        "dram-utilization": 0.80,
+                        "search-space": [
+                            {
+                                "tp": 4,
+                                "kv-offloading": "dram",
+                                "kv-offload-backend": "native",
+                                "conc-list": [32],
+                            },
+                        ],
+                    }],
+                },
+            },
+        }
+        runner_config = copy.deepcopy(sample_runner_config)
+        runner_config["hardware"]["cluster:b300-nv"]["gpus-per-node"] = 2
+        args = argparse.Namespace(
+            config_keys=["dsv4-b300-agentic"],
+            seq_lens=None,
+            conc=None,
+            scenario_type=["agentic-coding"],
+            runner_node_filter=None,
+        )
+
+        with pytest.raises(ValueError, match="exceeds gpus-per-node"):
+            generate_test_config_sweep(args, config, runner_config)
+
+    def test_multinode_agentic_groups_concurrencies_per_search_entry(self):
+        """One server allocation should run the selected concurrency batch."""
+        config = {
+            "dsv4-agentic-2p1d": {
+                "image": "vllm/vllm-openai:v0.23.0",
+                "model": "deepseek-ai/DeepSeek-V4-Pro",
+                "model-prefix": "dsv4",
+                "precision": "fp4",
+                "framework": "dynamo-vllm",
+                "runner": "gb200",
+                "multinode": True,
+                "disagg": True,
+                "scenarios": {
+                    "agentic-coding": [
+                        {
+                            "search-space": [
+                                {
+                                    "conc-list": [16, 32, 64, 128, 256],
+                                    "prefill": {"num-worker": 2, "tp": 8, "ep": 8, "dp-attn": False},
+                                    "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        }
+        args = argparse.Namespace(
+            config_keys=["dsv4-agentic-2p1d"],
+            seq_lens=None,
+            conc=[16, 32, 64, 128, 256],
+            scenario_type=["agentic-coding"],
+            runner_node_filter=None,
+        )
+
+        result = generate_test_config_sweep(args, config)
+
+        assert len(result) == 2
+        assert result[0]["conc"] == [16, 32, 64, 128]
+        assert result[0]["exp-name"] == "dsv4_p2x8_d1x8_conc16x32x64x128"
+        assert result[1]["conc"] == [256]
+        assert result[1]["exp-name"] == "dsv4_p2x8_d1x8_conc256"
 
 
 # =============================================================================
@@ -1976,6 +2112,71 @@ class TestGenerateFullSweepMixed:
         )
         assert len(result) > 0
         assert all("prefill" in entry for entry in result), "All entries should be multinode"
+
+    def test_node_type_filters_apply_to_agentic_configs(
+        self,
+        sample_runner_config,
+        full_sweep_args_single_node,
+        full_sweep_args_multi_node,
+    ):
+        """--single-node and --multi-node should split agentic configs too."""
+        config = {
+            "qwen-agentic": {
+                "image": "sglang",
+                "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+                "model-prefix": "qwen3.5",
+                "precision": "fp8",
+                "framework": "sglang",
+                "runner": "cluster:b300-nv",
+                "multinode": False,
+                "scenarios": {
+                    "agentic-coding": [{
+                        "search-space": [
+                            {"tp": 8, "kv-offloading": "none", "conc-list": [16]},
+                        ],
+                    }],
+                },
+            },
+            "dsv4-agentic-multinode": {
+                "image": "vllm/vllm-openai:v0.23.0",
+                "model": "deepseek-ai/DeepSeek-V4-Pro",
+                "model-prefix": "dsv4",
+                "precision": "fp4",
+                "framework": "dynamo-vllm",
+                "runner": "cluster:gb200-nv",
+                "multinode": True,
+                "disagg": True,
+                "scenarios": {
+                    "agentic-coding": [{
+                        "search-space": [
+                            {
+                                "conc-list": [16, 32],
+                                "prefill": {"num-worker": 2, "tp": 8, "ep": 8, "dp-attn": False},
+                                "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
+                            },
+                        ],
+                    }],
+                },
+            },
+        }
+
+        single_result = generate_full_sweep(
+            full_sweep_args_single_node,
+            config,
+            sample_runner_config,
+        )
+        multi_result = generate_full_sweep(
+            full_sweep_args_multi_node,
+            config,
+            sample_runner_config,
+        )
+
+        assert len(single_result) == 1
+        assert "prefill" not in single_result[0]
+        assert single_result[0]["runner"] == "cluster:b300-nv"
+        assert len(multi_result) == 1
+        assert "prefill" in multi_result[0]
+        assert multi_result[0]["runner"] == "cluster:gb200-nv"
 
 
 # =============================================================================

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -7,6 +7,7 @@ from validation import (
     MultiNodeMatrixEntry,
     WorkerConfig,
     SingleNodeSearchSpaceEntry,
+    AgenticCodingConfig,
     AgenticCodingSearchSpaceEntry,
     MultiNodeSearchSpaceEntry,
     SingleNodeSeqLenConfig,
@@ -172,11 +173,21 @@ def valid_multinode_master_config():
 def valid_runner_config():
     """Valid runner config based on .github/configs/runners.yaml."""
     return {
-        "h100": ["h100-cr_0", "h100-cr_1", "h100-cw_0", "h100-cw_1"],
-        "h200": ["h200-cw_0", "h200-cw_1", "h200-nb_0", "h200-nb_1"],
-        "b200": ["b200-nvd_0", "b200-nvd_1", "b200-dgxc_1"],
-        "mi300x": ["mi300x-amd_0", "mi300x-amd_1", "mi300x-cr_0"],
-        "gb200": ["gb200-nv_0"],
+        "labels": {
+            "h100": ["h100-cr_0", "h100-cr_1", "h100-cw_0", "h100-cw_1"],
+            "h200": ["h200-cw_0", "h200-cw_1", "h200-nb_0", "h200-nb_1"],
+            "b200": ["b200-nvd_0", "b200-nvd_1", "b200-dgxc_1"],
+            "cluster:b200-dgxc": ["b200-dgxc_1"],
+            "mi300x": ["mi300x-amd_0", "mi300x-amd_1", "mi300x-cr_0"],
+            "gb200": ["gb200-nv_0"],
+        },
+        "hardware": {
+            "cluster:h100-dgxc": {"available-cpu-dram-mib": 2063837, "gpus-per-node": 8},
+            "cluster:h200-dgxc": {"available-cpu-dram-mib": 1471356, "gpus-per-node": 8},
+            "cluster:b200-dgxc": {"available-cpu-dram-mib": 3774874, "gpus-per-node": 8},
+            "cluster:mi300x-amds": {"available-cpu-dram-mib": 2321924, "gpus-per-node": 8},
+            "cluster:gb200-nv": {"available-cpu-dram-mib": 860160, "gpus-per-node": 4},
+        },
     }
 
 
@@ -315,52 +326,131 @@ class TestSingleNodeMatrixEntry:
 class TestAgenticMatrixEntries:
     """Tests for agentic coding validation models."""
 
-    def test_lmcache_mp_offloading_is_valid_for_single_node_agentic_entry(self):
-        """LMCache MP is a valid agentic offloading backend."""
+    def test_arbitrary_backend_is_valid_for_single_node_agentic_entry(self):
         entry = SingleNodeAgenticMatrixEntry(**{
             "image": "cquil/vllm-openai:v0.21.0-8813c92",
             "model": "deepseek-ai/DeepSeek-V4-Pro",
             "model-prefix": "dsv4",
             "precision": "fp4",
             "framework": "vllm",
-            "runner": "b200-dgxc",
+            "runner": "cluster:b200-dgxc",
             "tp": 8,
             "ep": 1,
             "dp-attn": False,
             "conc": 1,
-            "offloading": "lmcache-mp",
-            "duration": 1800,
-            "exp-name": "dsv4_tp8_conc1_offloadlmcache-mp",
+            "kv-offloading": "dram",
+            "kv-offload-backend": "future-backend",
+            "total-cpu-dram-gb": 2949,
+            "duration": 3600,
+            "exp-name": "dsv4_tp8_conc1_kvdram-future-backend",
             "scenario-type": "agentic-coding",
         })
-        assert entry.offloading == "lmcache-mp"
+        assert entry.kv_offloading == "dram"
+        assert entry.kv_offload_backend == "future-backend"
 
-    def test_lmcache_mp_offloading_is_valid_for_agentic_search_space(self):
-        """Agentic search-space entries can request LMCache MP offloading."""
+    def test_arbitrary_backend_is_valid_for_agentic_search_space(self):
         entry = AgenticCodingSearchSpaceEntry(**{
             "tp": 8,
-            "offloading": "lmcache-mp",
+            "kv-offloading": "dram",
+            "kv-offload-backend": "future-backend",
             "conc-list": [1, 2],
         })
-        assert entry.offloading == "lmcache-mp"
+        assert entry.kv_offloading == "dram"
+        assert entry.kv_offload_backend == "future-backend"
 
-    def test_lmcache_offloading_is_valid_for_agentic_search_space(self):
-        """Agentic search-space entries can request in-process LMCache."""
-        entry = AgenticCodingSearchSpaceEntry(**{
-            "tp": 8,
-            "offloading": "lmcache",
-            "conc-list": [1, 2],
-        })
-        assert entry.offloading == "lmcache"
+    def test_kv_offload_backend_requires_dram_mode(self):
+        with pytest.raises(Exception, match="kv-offload-backend"):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "none",
+                "kv-offload-backend": "lmcache",
+                "conc-list": [1, 2],
+            })
 
-    def test_hicache_offloading_is_valid_for_agentic_search_space(self):
-        """Agentic search-space entries can request SGLang HiCache."""
-        entry = AgenticCodingSearchSpaceEntry(**{
-            "tp": 8,
-            "offloading": "hicache",
-            "conc-list": [1, 2],
+    def test_dram_kv_offload_requires_backend(self):
+        with pytest.raises(Exception, match="kv-offload-backend"):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "dram",
+                "conc-list": [1, 2],
+            })
+
+    def test_single_node_agentic_requires_explicit_kv_offloading(self):
+        with pytest.raises(Exception, match="kv-offloading"):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "conc-list": [1, 2],
+            })
+
+    def test_dram_kv_offload_requires_dram_utilization(self):
+        with pytest.raises(Exception, match="dram-utilization"):
+            AgenticCodingConfig(**{
+                "search-space": [{
+                    "tp": 4,
+                    "kv-offloading": "dram",
+                    "kv-offload-backend": "native",
+                    "conc-list": [16],
+                }],
+            })
+
+    def test_agentic_search_space_rejects_total_cpu_dram_gb(self):
+        with pytest.raises(Exception, match="total-cpu-dram-gb"):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "dram",
+                "kv-offload-backend": "native",
+                "total-cpu-dram-gb": 1000,
+                "conc-list": [1, 2],
+            })
+
+    def test_dram_kv_offload_accepts_scaled_capacity(self):
+        config = AgenticCodingConfig(**{
+            "dram-utilization": 0.80,
+            "search-space": [{
+                "tp": 4,
+                "kv-offloading": "dram",
+                "kv-offload-backend": "native",
+                "conc-list": [16],
+            }],
         })
-        assert entry.offloading == "hicache"
+        assert config.dram_utilization == 0.80
+
+    def test_gpus_per_node_is_not_a_master_config_field(self):
+        with pytest.raises(Exception, match="gpus-per-node"):
+            AgenticCodingConfig(**{
+                "dram-utilization": 0.80,
+                "gpus-per-node": 8,
+                "search-space": [{
+                    "tp": 4,
+                    "kv-offloading": "dram",
+                    "kv-offload-backend": "native",
+                    "conc-list": [16],
+                }],
+            })
+
+    def test_available_cpu_dram_is_not_a_master_config_field(self):
+        with pytest.raises(Exception, match="available-cpu-dram-mib"):
+            AgenticCodingConfig(**{
+                "available-cpu-dram-mib": 2964436,
+                "dram-utilization": 0.80,
+                "search-space": [{
+                    "tp": 4,
+                    "kv-offloading": "dram",
+                    "kv-offload-backend": "native",
+                    "conc-list": [16],
+                }],
+            })
+
+    def test_duration_is_not_a_master_config_field(self):
+        with pytest.raises(Exception, match="duration"):
+            AgenticCodingConfig(**{
+                "duration": 1800,
+                "search-space": [{
+                    "tp": 8,
+                    "kv-offloading": "none",
+                    "conc-list": [16],
+                }],
+            })
 
 
 # =============================================================================
@@ -745,6 +835,76 @@ class TestMasterConfigEntries:
         config = SingleNodeMasterConfigEntry(**valid_single_node_master_config)
         assert config.disagg is False
 
+    def test_single_node_agentic_master_config_requires_cluster_runner(self):
+        """Single-node agentic configs must pin an exact cluster label."""
+        config = {
+            "image": "vllm/vllm-openai:test",
+            "model": "deepseek-ai/DeepSeek-V4-Pro",
+            "model-prefix": "dsv4",
+            "precision": "fp4",
+            "framework": "vllm",
+            "runner": "b200",
+            "multinode": False,
+            "scenarios": {
+                "agentic-coding": [
+                    {
+                        "search-space": [
+                            {"tp": 8, "conc-list": [1], "kv-offloading": "none"}
+                        ],
+                    }
+                ]
+            },
+        }
+
+        with pytest.raises(Exception, match="Agentic master configs must use"):
+            SingleNodeMasterConfigEntry(**config)
+
+        config["runner"] = "cluster:b200-dgxc"
+        assert SingleNodeMasterConfigEntry(**config).runner == "cluster:b200-dgxc"
+
+    def test_multinode_agentic_master_config_requires_cluster_runner(self):
+        """Multinode agentic configs must also pin an exact cluster label."""
+        config = {
+            "image": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:test",
+            "model": "deepseek-r1-fp4",
+            "model-prefix": "dsr1",
+            "precision": "fp4",
+            "framework": "dynamo-trt",
+            "runner": "b200-multinode",
+            "multinode": True,
+            "disagg": True,
+            "scenarios": {
+                "agentic-coding": [
+                    {
+                        "search-space": [
+                            {
+                                "spec-decoding": "none",
+                                "conc-list": [1],
+                                "prefill": {
+                                    "num-worker": 1,
+                                    "tp": 4,
+                                    "ep": 4,
+                                    "dp-attn": True,
+                                },
+                                "decode": {
+                                    "num-worker": 1,
+                                    "tp": 8,
+                                    "ep": 8,
+                                    "dp-attn": False,
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+
+        with pytest.raises(Exception, match="Agentic master configs must use"):
+            MultiNodeMasterConfigEntry(**config)
+
+        config["runner"] = "cluster:b200-dgxc"
+        assert MultiNodeMasterConfigEntry(**config).runner == "cluster:b200-dgxc"
+
 
 # =============================================================================
 # Test validate_master_config function
@@ -799,7 +959,9 @@ class TestValidateRunnerConfig:
     def test_value_must_be_list(self):
         """Runner config values must be lists."""
         config = {
-            "h100": "h100-cr_0",  # Not a list
+            "labels": {
+                "h100": "h100-cr_0",  # Not a list
+            },
         }
         with pytest.raises(ValueError) as exc_info:
             validate_runner_config(config)
@@ -808,7 +970,9 @@ class TestValidateRunnerConfig:
     def test_list_must_contain_strings(self):
         """Runner config lists must contain only strings."""
         config = {
-            "h100": ["h100-cr_0", 123],  # Contains non-string
+            "labels": {
+                "h100": ["h100-cr_0", 123],  # Contains non-string
+            },
         }
         with pytest.raises(ValueError) as exc_info:
             validate_runner_config(config)
@@ -817,7 +981,9 @@ class TestValidateRunnerConfig:
     def test_list_cannot_be_empty(self):
         """Runner config lists cannot be empty."""
         config = {
-            "mi355x": [],
+            "labels": {
+                "mi355x": [],
+            },
         }
         with pytest.raises(ValueError) as exc_info:
             validate_runner_config(config)
@@ -826,10 +992,35 @@ class TestValidateRunnerConfig:
     def test_multiple_runner_types(self, valid_runner_config):
         """Multiple runner types should work."""
         result = validate_runner_config(valid_runner_config)
-        assert "h100" in result
-        assert "h200" in result
-        assert "mi300x" in result
-        assert "gb200" in result
+        assert "h100" in result["labels"]
+        assert "h200" in result["labels"]
+        assert "mi300x" in result["labels"]
+        assert "gb200" in result["labels"]
+
+    def test_flat_runner_config_is_rejected(self):
+        config = {
+            "h100": ["h100-cr_0", "h100-cw_0"],
+        }
+        with pytest.raises(ValueError, match="labels mapping"):
+            validate_runner_config(config)
+
+    def test_hardware_available_dram_must_be_positive(self):
+        config = {
+            "labels": {"h100": ["h100-cr_0"]},
+            "hardware": {"h100": {"available-cpu-dram-mib": 0, "gpus-per-node": 8}},
+        }
+        with pytest.raises(ValueError) as exc_info:
+            validate_runner_config(config)
+        assert "available-cpu-dram-mib" in str(exc_info.value)
+
+    def test_hardware_gpus_per_node_must_be_positive(self):
+        config = {
+            "labels": {"h100": ["h100-cr_0"]},
+            "hardware": {"h100": {"available-cpu-dram-mib": 2063837, "gpus-per-node": 0}},
+        }
+        with pytest.raises(ValueError) as exc_info:
+            validate_runner_config(config)
+        assert "gpus-per-node" in str(exc_info.value)
 
 
 # =============================================================================
@@ -963,25 +1154,31 @@ class TestLoadRunnerFile:
         """Should load and validate runner config file."""
         runner_file = tmp_path / "runners.yaml"
         runner_file.write_text("""
-h100:
-- h100-node-0
-- h100-node-1
+labels:
+  h100:
+  - h100-node-0
+  - h100-node-1
+hardware:
+  h100:
+    available-cpu-dram-mib: 2063837
+    gpus-per-node: 8
 """)
         result = load_runner_file(str(runner_file))
-        assert "h100" in result
-        assert len(result["h100"]) == 2
+        assert "h100" in result["labels"]
+        assert len(result["labels"]["h100"]) == 2
 
     def test_load_runner_file_without_validation(self, tmp_path):
         """Should load runner config file without validation when validate=False."""
         runner_file = tmp_path / "runners.yaml"
         runner_file.write_text("""
-h100:
-- h100-node-0
-- h100-node-1
+labels:
+  h100:
+  - h100-node-0
+  - h100-node-1
 """)
         result = load_runner_file(str(runner_file), validate=False)
-        assert "h100" in result
-        assert len(result["h100"]) == 2
+        assert "h100" in result["labels"]
+        assert len(result["labels"]["h100"]) == 2
 
     def test_nonexistent_runner_file(self):
         """Nonexistent runner file should raise error."""
@@ -993,7 +1190,8 @@ h100:
         """Validation should run by default and catch invalid configs."""
         runner_file = tmp_path / "runners.yaml"
         runner_file.write_text("""
-h100: not-a-list
+labels:
+  h100: not-a-list
 """)
         with pytest.raises(ValueError) as exc_info:
             load_runner_file(str(runner_file))

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -1,9 +1,12 @@
 from pydantic import BaseModel, Field, ValidationError, ConfigDict, model_validator
-from typing import List, Optional, Union, Literal
+from typing import List, Optional, Union, Literal, Dict
 from enum import Enum
 
 import pprint
 import yaml
+
+CLUSTER_LABEL_PREFIX = "cluster:"
+DEFAULT_AGENTIC_DURATION_SECONDS = 3600
 
 """
     The below class defines the field names expected to be present in the JSON entries
@@ -50,7 +53,12 @@ class Fields(Enum):
     ADDITIONAL_SETTINGS = 'additional-settings'
 
     # Agentic coding fields
-    OFFLOADING = 'offloading'
+    KV_OFFLOADING = 'kv-offloading'
+    KV_OFFLOAD_BACKEND = 'kv-offload-backend'
+    TOTAL_CPU_DRAM_GB = 'total-cpu-dram-gb'
+    AVAILABLE_CPU_DRAM_MIB = 'available-cpu-dram-mib'
+    DRAM_UTILIZATION = 'dram-utilization'
+    GPUS_PER_NODE = 'gpus-per-node'
     DURATION = 'duration'
 
     # Matrix entry fields
@@ -160,12 +168,20 @@ class SingleNodeAgenticMatrixEntry(BaseModel):
     ep: int
     dp_attn: bool = Field(alias=Fields.DP_ATTN.value)
     conc: int
-    offloading: Literal["none", "cpu", "ssd", "lmcache", "lmcache-mp", "hicache"] = Field(
-        alias=Fields.OFFLOADING.value
+    kv_offloading: Literal["none", "dram"] = Field(
+        alias=Fields.KV_OFFLOADING.value
     )
-    duration: int = Field(default=1800, alias=Fields.DURATION.value)
+    kv_offload_backend: Optional[str] = Field(
+        default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
+    )
+    total_cpu_dram_gb: int = Field(alias=Fields.TOTAL_CPU_DRAM_GB.value, ge=0)
+    duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     scenario_type: str = Field(alias=Fields.SCENARIO_TYPE.value)
+
+    @model_validator(mode='after')
+    def validate_kv_offload_fields(self):
+        return _validate_kv_offload_fields(self)
 
 
 class MultiNodeAgenticMatrixEntry(BaseModel):
@@ -183,8 +199,9 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
     runner: str
     prefill: WorkerConfig
     decode: WorkerConfig
-    conc: int
-    duration: int = Field(default=1800, alias=Fields.DURATION.value)
+    conc: list[int]
+    kv_offloading: Literal["none"] = Field(alias=Fields.KV_OFFLOADING.value)
+    duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     disagg: bool
     scenario_type: str = Field(alias=Fields.SCENARIO_TYPE.value)
@@ -277,6 +294,38 @@ def _validate_conc_fields(self):
     return self
 
 
+def _validate_agentic_runner_is_cluster(runner: str, scenarios) -> None:
+    if scenarios.agentic_coding and not runner.startswith(CLUSTER_LABEL_PREFIX):
+        raise ValueError(
+            f"Agentic master configs must use a '{CLUSTER_LABEL_PREFIX}<name>' runner "
+            "so every point runs on one exact hardware fleet."
+        )
+
+
+def _validate_kv_offload_fields(self):
+    backend = getattr(self, "kv_offload_backend", None)
+    if self.kv_offloading is None:
+        if backend not in (None, ""):
+            raise ValueError(
+                f"{Fields.KV_OFFLOAD_BACKEND.value} requires "
+                f"{Fields.KV_OFFLOADING.value}"
+            )
+        return self
+    if self.kv_offloading == "none":
+        if backend not in (None, ""):
+            raise ValueError(
+                f"{Fields.KV_OFFLOAD_BACKEND.value} can only be set when "
+                f"{Fields.KV_OFFLOADING.value} is not 'none'"
+            )
+        return self
+    if backend is None or not backend.strip():
+        raise ValueError(
+            f"{Fields.KV_OFFLOAD_BACKEND.value} is required when "
+            f"{Fields.KV_OFFLOADING.value} is '{self.kv_offloading}'"
+        )
+    return self
+
+
 class SingleNodeSearchSpaceEntry(BaseModel):
     """Single node search space configuration."""
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
@@ -350,8 +399,11 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
         default="none", alias=Fields.SPEC_DECODING.value)
     prefill: Optional[WorkerConfig] = None
     decode: Optional[WorkerConfig] = None
-    offloading: Literal["none", "cpu", "ssd", "lmcache", "lmcache-mp", "hicache"] = Field(
-        default="none", alias=Fields.OFFLOADING.value
+    kv_offloading: Optional[Literal["none", "dram"]] = Field(
+        default=None, alias=Fields.KV_OFFLOADING.value
+    )
+    kv_offload_backend: Optional[str] = Field(
+        default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
     )
     conc_start: Optional[int] = Field(default=None, alias=Fields.CONC_START.value)
     conc_end: Optional[int] = Field(default=None, alias=Fields.CONC_END.value)
@@ -360,6 +412,10 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
     @model_validator(mode='after')
     def validate_conc_fields(self):
         return _validate_conc_fields(self)
+
+    @model_validator(mode='after')
+    def validate_kv_offload_fields(self):
+        return _validate_kv_offload_fields(self)
 
     @model_validator(mode='after')
     def validate_topology_fields(self):
@@ -372,15 +428,33 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
             valid = has_complete_multinode
         if not valid:
             raise ValueError("Agentic search-space entries must specify either tp or both prefill and decode")
+        if has_single_node and self.kv_offloading is None:
+            raise ValueError(
+                f"Single-node agentic search-space entries must specify "
+                f"{Fields.KV_OFFLOADING.value}"
+            )
         return self
-
 
 class AgenticCodingConfig(BaseModel):
     """Agentic coding scenario configuration for trace replay benchmarks."""
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
 
     search_space: List[AgenticCodingSearchSpaceEntry] = Field(alias=Fields.SEARCH_SPACE.value)
-    duration: int = Field(default=1800, alias=Fields.DURATION.value)
+    dram_utilization: Optional[float] = Field(
+        default=None, alias=Fields.DRAM_UTILIZATION.value, gt=0, le=1
+    )
+
+    @model_validator(mode='after')
+    def validate_dram_offload_capacity(self):
+        for entry in self.search_space:
+            if entry.kv_offloading != "dram":
+                continue
+            if self.dram_utilization is None:
+                raise ValueError(
+                    f"{Fields.KV_OFFLOADING.value}='dram' requires "
+                    f"{Fields.DRAM_UTILIZATION.value} with runner hardware metadata"
+                )
+        return self
 
 
 class SingleNodeScenarios(BaseModel):
@@ -429,6 +503,11 @@ class SingleNodeMasterConfigEntry(BaseModel):
     disagg: bool = Field(default=False)
     scenarios: SingleNodeScenarios
 
+    @model_validator(mode='after')
+    def validate_agentic_runner(self):
+        _validate_agentic_runner_is_cluster(self.runner, self.scenarios)
+        return self
+
 
 class MultiNodeMasterConfigEntry(BaseModel):
     """Top-level multinode master configuration entry."""
@@ -443,6 +522,11 @@ class MultiNodeMasterConfigEntry(BaseModel):
     multinode: Literal[True]
     disagg: bool = Field(default=False)
     scenarios: MultiNodeScenarios
+
+    @model_validator(mode='after')
+    def validate_agentic_runner(self):
+        _validate_agentic_runner_is_cluster(self.runner, self.scenarios)
+        return self
 
 
 def validate_master_config(master_configs: dict) -> List[dict]:
@@ -463,9 +547,8 @@ def validate_master_config(master_configs: dict) -> List[dict]:
 # Runner Config Validation
 
 
-def validate_runner_config(runner_configs: dict) -> List[dict]:
-    """Validate input master configuration structure."""
-    for key, value in runner_configs.items():
+def _validate_runner_labels(labels: dict) -> None:
+    for key, value in labels.items():
         if not isinstance(value, list):
             raise ValueError(
                 f"Runner config entry '{key}' must be a list, got {type(value).__name__}")
@@ -478,6 +561,37 @@ def validate_runner_config(runner_configs: dict) -> List[dict]:
             raise ValueError(
                 f"Runner config entry '{key}' cannot be an empty list")
 
+
+class RunnerHardwareConfig(BaseModel):
+    """Per-hardware runner facts used when generating benchmark matrices."""
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
+    available_cpu_dram_mib: int = Field(
+        alias=Fields.AVAILABLE_CPU_DRAM_MIB.value, gt=0
+    )
+    gpus_per_node: int = Field(
+        alias=Fields.GPUS_PER_NODE.value, gt=0
+    )
+
+
+class RunnerConfig(BaseModel):
+    """Top-level runner configuration file."""
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
+    labels: Dict[str, List[str]]
+    hardware: Dict[str, RunnerHardwareConfig] = Field(default_factory=dict)
+
+
+def validate_runner_config(runner_configs: dict) -> dict:
+    """Validate runner labels and hardware metadata."""
+    labels = runner_configs.get("labels")
+    if not isinstance(labels, dict):
+        raise ValueError("Runner config must define a labels mapping")
+    _validate_runner_labels(labels)
+    try:
+        RunnerConfig(**runner_configs)
+    except ValidationError as e:
+        raise ValueError(f"Runner config failed validation:\n{e}")
     return runner_configs
 
 

--- a/utils/runner_setup/RUNNER_SETUP.md
+++ b/utils/runner_setup/RUNNER_SETUP.md
@@ -148,8 +148,8 @@ key off that name:
    For a brand-new cluster, add a `runners/launch_<BASE_RUNNER_NAME>.sh` first.
    Corollary: `BASE_RUNNER_NAME` itself must not contain `_` (use hyphens).
 
-2. **Sweep scheduling looks runners up by exact name.** Jobs are distributed across the
-   runner names listed per SKU in
+2. **Sweep scheduling looks runner nodes up by label.** Jobs are distributed across the
+   runner names listed under each `labels` entry in
    [`.github/configs/runners.yaml`](../../.github/configs/runners.yaml). New runners do
    **not** receive sweep jobs until they are added there, and the entries must match the
    registered names exactly — including zero-padding. (Some older fleets predate the
@@ -163,15 +163,19 @@ key off that name:
 
 - `slurm` — the runner submits work through Slurm.
 - The SKU name (`b200`, `b300`, `h200`, `gb300`, …) — coarse hardware targeting.
-- Optional sub-fleet tags, e.g. `b200-dgxc`, `b200-dsv4` — used to carve out dedicated
-  capacity.
+- Exactly one `cluster:<name>` label, e.g. `cluster:b200-dgxc` — required exact
+  hardware/fleet identity for success-rate reporting and hardware-specific config.
+  Every runner in the same physical cluster with identical hardware should use the same
+  cluster label.
+- Optional capacity tags, e.g. `b200-dsv4`, `b300-p1` — used to carve out dedicated
+  benchmark subsets.
 
 The per-runner name label (`b300-nv_07`) is what `runs-on` resolves for sweep jobs, so
 always keep it (the script appends it automatically). A typical registered runner ends
 up with labels like:
 
 ```
-self-hosted, Linux, X64, slurm, b200, b200-dsv4, b200-dgxc, b200-dgxc_00
+self-hosted, Linux, X64, slurm, b200, b200-dsv4, cluster:b200-dgxc, b200-dgxc_00
 ```
 
 Labels can be edited later on the runners settings page without re-registering.
@@ -226,7 +230,7 @@ the new `runners/launch_<cluster>.sh`.
   `SESSION_NAME` argument.
 - **Removing runners:** from the runner directory, stop the process and run
   `./config.sh remove --token <removal-token>` (token from the runners settings page).
-  Remember to also delete the name from `.github/configs/runners.yaml`.
+  Remember to also delete the name from the matching `labels` entry in `.github/configs/runners.yaml`.
 
 ## Record the cluster in the team canvas (SemiAnalysis only)
 


### PR DESCRIPTION
## Group
Wires the shared AgentX runtime and CI plumbing.

## What changed
- Updates workflow templates, matrix schema/generation, runner launchers, and shared benchmark helpers for AgentX jobs.
- Bumps the AIPerf submodule used by AgentX runs.
- Adds tests for the new matrix generation and validation behavior.

## Why
Provides the common dispatch/execution path used by the model-specific recipe layers above this PR.

## Validation
- `python -m pytest utils/matrix_logic/ utils/agentic/aggregation/test_process_agentic_result.py utils/agentic/aggregation/test_server_log_metrics.py utils/agentic/datasets/test_build_weka_hf_dataset.py utils/agentic/validation/test_validate_agentic_result.py utils/test_calc_success_rate.py -q`
