### PR TITLE
feat(agentic): register AgentX sweep configs

### DIFF
--- a/.github/configs/CONFIGS.md
+++ b/.github/configs/CONFIGS.md
@@ -35,7 +35,10 @@ The below list describes what each field is:
 - `image`: The image used to serve the benchmark, e.g., `vllm/vllm-openai:v0.10.2`
 - `model`: The model to server, e.g., `openai/gpt-oss-120b`
 - `model-prefix`: The canonical InferenceMAX model prefix reference, i.e., `dsr1` for Deepseek, `gptoss` for gptoss-120b, etc. This value is used to decipher which script in `benchmarks/` should be used in order to launch the benchmark.
-- `runner`: This is the runner on which to run the benchmark. This must be a valid runner (key or value) from `runners.yaml`.
+- `runner`: This is the runner label on which to run the benchmark. This must be a valid key under `labels` in `runners.yaml`.
+  Agentic configs must use an exact `cluster:<name>` runner label, not a broad
+  SKU or capacity label, so every search-space point runs on the same hardware
+  fleet.
 - `precision`: The precision to run the benchmark. Again, this is used to find which script to run in `benchmarks/`.
 - `framework`: The framework (serving runtime) to serve the benchmark, e.g., `vllm`, `sglang`, `trt`.
 - `scenarios`: A dictionary of benchmark scenario types. At least one must be specified. Currently supported:
@@ -53,10 +56,39 @@ The below list describes what each field is:
     - `trace-source`: Identifier for the trace dataset to use.
     - `search-space`: Same structure as `fixed-seq-len` search-space entries.
 
+Agentic duration is not a master YAML field. Matrix generation defaults agentic
+jobs to 3600 seconds; reusable workflow callers may override the `duration`
+input.
+
 Notes:
 - No extra fields besides the ones listed may be specified, or else the benchmarks will fail to run.
 - Setting the fields above, particularly `ep` and `dp-attn`, only guarantee that the respective values will be passed as environment variables to the benchmark scripts! Actually using those environment variables is an implementation detail at the level of the benchmark Bash script.
 
 ## Runners
 
-The `runners.yaml` config represents the available runners in the repository. The keys are the runner *types* (i.e., the GPUs as well as some specific combinations like `b200-trt`) whereas the value is a list of *runner nodes*. This config is used to verify the master configs.
+The `runners.yaml` config represents available runner labels and reusable
+hardware facts in the repository. It has two top-level sections:
+
+```yaml
+labels:
+  cluster:b300-nv:
+    - b300-nv_01
+    - b300-nv_02
+
+hardware:
+  cluster:b300-nv:
+    available-cpu-dram-mib: 2964436
+    gpus-per-node: 8
+```
+
+`labels` maps a schedulable runner label to the concrete runner node names that
+can satisfy that label. `hardware` maps hardware or fleet keys to host resource
+facts. Matrix generation reads the `hardware` entry whose key matches the
+master config's `runner` label when a benchmark needs derived hardware facts.
+Use `cluster:<name>` labels for hardware metadata that depends on an exact
+cluster/fleet rather than a broad SKU label. Agentic master configs must use a
+`cluster:<name>` runner label.
+`available-cpu-dram-mib` is the host CPU DRAM available to benchmark jobs, in
+MiB. Agentic DRAM KV-offload matrices combine it with `gpus-per-node` and the
+master config's `dram-utilization` to emit `total-cpu-dram-gb` for benchmark
+templates.

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -18,14 +18,6 @@ dsr1-fp4-mi355x-sglang:
       search-space:
       - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 64 }
-    # Agentic-coding sweep commented out for this image-bump PR — the
-    # 10-conc agentic matrix amplifies sweep cost and the bump validation
-    # only needs the fixed-seq-len throughput shape. Re-enable once the
-    # bump merges; the next agentic cron PR will pick it up.
-    # agentic-coding:
-    # - duration: 1800
-    #   search-space:
-    #   - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 32, 64, 128, 256] }
 
 dsr1-fp4-mi355x-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-rocm700-mi35x
@@ -299,24 +291,19 @@ qwen3.5-fp8-mi355x-sglang-mtp:
       search-space:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
-# Diverged from qwen3.5-fp8-mi355x-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's qwen3.5-fp8-mi355x-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original qwen3.5-fp8-mi355x-sglang entry stays byte-identical to origin/main.
 qwen3.5-fp8-mi355x-sglang-agentic:
   image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260414
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: mi355x
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+    - search-space:
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+
 
 qwen3.5-fp8-mi355x-atom:
   image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
@@ -679,7 +666,7 @@ glm5-fp8-mi355x-atom:
       - { tp: 8, conc-start: 4, conc-end: 256 }
 
 glm5.1-fp4-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260622
+  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
   model: amd/GLM-5.1-MXFP4
   model-prefix: glm5.1
   runner: mi355x
@@ -698,26 +685,6 @@ glm5.1-fp4-mi355x-sglang:
       search-space:
       - { tp: 2, conc-start: 4, conc-end: 256 }
       - { tp: 4, conc-start: 4, conc-end: 16 }
-
-# Diverged from glm5.1-fp4-mi355x-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's glm5.1-fp4-mi355x-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original glm5.1-fp4-mi355x-sglang entry stays byte-identical to origin/main.
-glm5.1-fp4-mi355x-sglang-agentic:
-  image: lmsysorg/sglang-rocm:v0.5.10rc0-rocm720-mi35x-20260415
-  model: amd/GLM-5.1-MXFP4
-  model-prefix: glm5.1
-  runner: mi355x
-  precision: fp4
-  framework: sglang
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      # sglang manages KV eviction; mi355x glm5.1 caps at tp=4 conc=16 in fixed-seq, so cap conservatively
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
 
 glm5.1-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post
@@ -818,37 +785,30 @@ kimik2.5-fp4-mi355x-vllm:
       - { tp: 8, conc-start: 4, conc-end: 64 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
 
-# Diverged from kimik2.5-fp4-mi355x-vllm (agentic-coding sibling). Reasons below;
-# the original kimik2.5-fp4-mi355x-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - image: 'vllm/vllm-openai-rocm:v0.18.0' -> 'vllm/vllm-openai-rocm:v0.21.0'
 kimik2.5-fp4-mi355x-vllm-agentic:
-  # v0.21.0 (released 2026-05-14) supersedes the prior nightly pin
-  # (51f22dcf...) which was carrying the SimpleCPUOffloadConnector ROCm
-  # cpu_offload_blocks > 0 fix. v0.21.0 is much newer than that fix and
-  # includes all subsequent ROCm offload work.
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:v0.22.0
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
-  runner: mi355x
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 24, 32, 40, 48] }
-      # CPU offload only above the KV cliff. Lower concurrencies fit
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 24, 32, 40, 48] }
+      # DRAM offload only above the KV cliff. Lower concurrencies fit
       # entirely on-GPU, so paying the offload-path overhead there would
       # just slow them down without measuring anything new.
-      - { tp: 8, offloading: cpu,  conc-list: [32, 40, 48, 56] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 40, 48, 56] }
       # TP=4 probe: half-node layout doubles per-GPU weight footprint
       # (~62 GB on MI355X's 288 GB HBM, plenty of headroom). Restrict to
       # cliff-region concurrencies on both offload modes so we can directly
       # compare TP=4 vs TP=8 at the same conc points.
-      - { tp: 4, offloading: none, conc-list: [16, 24, 32, 40] }
-      - { tp: 4, offloading: cpu,  conc-list: [16, 24, 32, 40] }
+      - { tp: 4, kv-offloading: none, conc-list: [16, 24, 32, 40] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [16, 24, 32, 40] }
+
 
 kimik2.5-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
@@ -1703,7 +1663,7 @@ dsr1-fp4-mi355x-sglang-disagg-1k1k-mtp:
           additional-settings:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=1"
-  
+
 
 dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
@@ -2150,32 +2110,47 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260521
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: mi355x
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, ep: 1, offloading: hicache, conc-list: [16, 32, 48, 64] }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 48, 64] }
 
+
+
+# DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
+# amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
+# image tag, so bumping sglang is just an image tag bump here. Sweeps
+# DP-attention on/off and EP=8.
+
+# CONC ranges mirror dsv4-fp4-b200-vllm-agentic for cross-hardware
+# comparability. Offload sweep is none-only (SGLang has no equivalent of
+# vLLM's SimpleCPUOffloadConnector path that we exercise on b200).
 dsv4-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:v0.22.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: mi355x
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4] }
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 16] }
-      - { tp: 4, ep: 4, dp-attn: true, offloading: none, conc-list: [16, 24, 32, 40, 48] }
+    - search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4] }
+      - { tp: 4, kv-offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 16] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 32, 40, 48] }
+
+
+# DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
+# amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
+# image tag, so bumping sglang is just an image tag bump here. Sweeps
+# DP-attention on/off and EP=8.
 
 dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
@@ -2404,56 +2379,31 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
           additional-settings:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=1"
-      
+
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
 # amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
 # image tag, so bumping sglang is just an image tag bump here. Sweeps
 # DP-attention on/off and EP=8.
 
-# Diverged from dsv4-fp4-mi355x-sglang (agentic-coding sibling). Reasons below;
-# the original dsv4-fp4-mi355x-sglang entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - scenarios: replaced fixed-seq-len with agentic-coding.
-# Image is identical to the base entry (rocm/sgl-dev DSv4 build).
-# CONC ranges mirror dsv4-fp4-b200-vllm-agentic for cross-hardware
-# comparability. Offload sweep is none-only (SGLang has no equivalent of
-# vLLM's SimpleCPUOffloadConnector path that we exercise on b200).
 dsv4-fp4-mi355x-sglang-agentic:
   image: rocm/sgl-dev:rocm720-mi35x-0363e6c-20260509-DSv4
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: mi355x
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, offloading: none, conc-list: [16, 32, 64] }
-      - { tp: 8, dp-attn: true, offloading: none, conc-list: [64, 128, 256] }
+    - search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [16, 32, 64] }
+      - { tp: 8, dp-attn: true, kv-offloading: none, conc-list: [64, 128, 256] }
 
-# DSv4 on MI355X via vLLM, using the official vllm/vllm-openai-rocm
-# nightly image. DSv4 base ROCm support (vllm-project/vllm#40871) merged
-# on 2026-05-05, so any nightly built after that includes the
-# DeepseekV4ForCausalLM model class.
-#
-# IMPORTANT: pin to a digest-suffixed nightly tag rather than the
-# floating `:nightly`. launch_mi355x-amds.sh caches enroot squashfs
-# files keyed on the image string and short-circuits re-import if the
-# file already exists, so the floating tag silently keeps a stale build
-# even after Docker Hub updates `:nightly`.
-#
-# DeepSeek-V4-Pro is FP4+FP8 mixed (FP4 MoE expert weights, FP8 for the
-# rest); InferenceX classifies this as fp4 — same as the sister sglang
-# and atom DSv4 mi355x entries below. Image and serving flags follow the
-# validated recipe from vllm-project/recipes#433: AITER+AITER_LINEAR, mp
-# executor, triton_unfused MoE (required for the FP4 expert format),
-# async scheduling, max-num-seqs=128, max-num-batched-tokens=8192,
-# gpu-mem-util=0.6. TP8 sweeps conc 4-64; DEP8 has a single conc=64
-# probe to validate the ROCm DP+EP path.
 
+# MiniMax-M3 MXFP8 MI355X recipe:
+# https://github.com/vllm-project/recipes/commit/2a3728ed9892debfd767a72a58ebc90b33f186e5
+# MXFP8 runs from TP=4 on gfx950; block size 128 is mandatory for MSA.
 dsv4-fp4-mi355x-atom-disagg:
   image: rocm/atom-dev:nightly_202606101403
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -2666,7 +2616,7 @@ minimaxm3-fp4-mi355x-vllm:
 # tokens. Search space mirrors the MI355X MXFP8 MTP entry, trimming the base
 # FP4 sweep at extreme concurrency where speculative decoding loses value.
 minimaxm3-fp4-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
+  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x
@@ -3156,3 +3106,49 @@ minimaxm3-fp8-mi355x-vllm-disagg:
           dp-attn: false
           additional-settings:
           - "DECODE_NODES=1"
+minimaxm3-fp8-mi300x-vllm-agentic:
+  image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: cluster:mi300x-amds
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # FP8 KV cache is 29,952 bytes/token/GPU for TP/TEP. Projecting the
+    # measured BF16 cache budget gives about 2.76M active tokens on MI300X;
+    # the June-21 service-time-weighted request is 269k tokens, so sample every
+    # integer around the expected conc-10 cliff rather than geometric jumps.
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+
+minimaxm3-fp8-mi325x-vllm-agentic:
+  image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: cluster:mi325x-amds
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # Measured FP8 capacities: TP4 1.66M tokens, TP8 4.93M tokens, and DEP8
+    # 12.69M aggregate tokens. With the June-21 service-time-weighted 269k
+    # active request, their expected cliffs are conc 6, 18, and 47. Use dense
+    # bands around each cliff; Mooncake rows overlap those bands because host
+    # storage improves prefix retention but does not hold active decode KV.
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 4, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 4, ep: 4, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
+      - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80] }
+      - { tp: 4, ep: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96] }

--- a/.github/configs/nvidia-master.yaml
+++ b/.github/configs/nvidia-master.yaml
@@ -384,24 +384,6 @@ dsr1-fp4-b200-dynamo-trt:
           ep: 8
           dp-attn: true
 
-    agentic-coding:
-    - duration: 300
-      search-space:
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          # https://github.com/cquil11/srt-slurm-nv/blob/cam/sa-submission-q2-2026/recipes/trtllm/b200-fp4/agentic/ctx1_gen1_tep8_128k_agentic.yaml
-          - "CONFIG_FILE=recipes/trtllm/b200-fp4/agentic/ctx1_gen1_tep8_128k_agentic.yaml"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: false
 
 dsr1-fp8-b200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
@@ -1690,14 +1672,6 @@ dsr1-fp4-b200-sglang:
       - { tp: 4, ep: 4, conc-start: 1, conc-end: 128 }
       - { tp: 4, ep: 4, dp-attn: true, conc-start: 64, conc-end: 256 }
       - { tp: 8, ep: 8, conc-list: [1] }
-    # agentic-coding: temporarily disabled — blocked by e2e-tests.yml artifact
-    # name mismatch (downloads `agentic_*` but benchmark-tmpl.yml uploads as
-    # `bmk_agentic_*`). Re-enable once that workflow is aligned.
-    # agentic-coding:
-    # - duration: 1800
-    #   search-space:
-    #   - { tp: 4, ep: 4, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 24, 32, 48, 64, 128, 256] }
-    #   - { tp: 8, ep: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 32, 64, 128, 256, 512] }
 
 dsr1-fp4-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130
@@ -1779,27 +1753,27 @@ dsv4-fp4-b200-vllm:
       - { tp: 8, conc-start: 1, conc-end: 32 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 64, conc-end: 1024 }
 
-# Diverged from dsv4-fp4-b200-vllm (agentic-coding sibling). Reasons below;
-# the original dsv4-fp4-b200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - runner: 'b200-dsv4' -> 'b200-dgxc'
 dsv4-fp4-b200-vllm-agentic:
-  image: vllm/vllm-openai:v0.20.0-cu130
+  image: vllm/vllm-openai:v0.23.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: b200-dgxc
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      # cpu offload only this iteration — none entries already validated in
-      # earlier runs (B200 25332045030: TP=8 1..32 + DEP=8 16..128 all 100%).
-      # Re-add when investigating regressions in offload=none.
-      - { tp: 8, offloading: cpu,  conc-list: [16, 32, 64] }
-      - { tp: 8, ep: 8, dp-attn: true, offloading: cpu,  conc-list: [64, 128, 256] }
+      # Pure TP is only competitive at very low concurrency.
+      - { tp: 8, kv-offloading: none,  conc-list: [1, 2, 3, 4, 5] }
+      # Sample the useful MooncakeStore range without repeating its collapsed
+      # high-concurrency tail.
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [8, 10, 16] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [16, 32, 38, 44, 50] }
+      # Retain the external-cache transition and peak-throughput region.
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [16, 38, 44, 56, 64, 66, 68] }
+
 
 dsv4-fp4-b200-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-c185066
@@ -2106,23 +2080,6 @@ qwen3.5-bf16-b200-sglang-mtp:
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
-# agentic-coding sibling — temporarily disabled, blocked by e2e-tests.yml
-# artifact-name mismatch (downloads `agentic_*` but benchmark-tmpl.yml uploads
-# as `bmk_agentic_*`). Re-enable once that workflow is aligned.
-# qwen3.5-bf16-b200-sglang-agentic:
-#   image: lmsysorg/sglang:v0.5.12-cu130
-#   model: Qwen/Qwen3.5-397B-A17B
-#   model-prefix: qwen3.5
-#   runner: b200
-#   precision: bf16
-#   framework: sglang
-#   multinode: false
-#   scenarios:
-#     agentic-coding:
-#     - duration: 1800
-#       search-space:
-#       - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-
 qwen3.5-fp8-b200-sglang:
   image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
@@ -2144,24 +2101,19 @@ qwen3.5-fp8-b200-sglang:
       - { tp: 8, conc-start: 4, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
-# Diverged from qwen3.5-fp8-b200-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's qwen3.5-fp8-b200-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original qwen3.5-fp8-b200-sglang entry stays byte-identical to origin/main.
 qwen3.5-fp8-b200-sglang-agentic:
   image: lmsysorg/sglang:nightly-dev-20260422-de962f32
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: b200
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+    - search-space:
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+
 
 qwen3.5-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.12-cu130
@@ -2246,25 +2198,6 @@ glm5-fp8-b200-sglang-mtp:
   # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
   # does not have a B300-specific recipe, so this config reuses the existing GLM5 FP8
   # B200 SGLang recipe as-is until B300-specific tuning is available.
-# Diverged from glm5-fp8-b200-sglang (agentic-coding sibling). Metadata is
-# identical to origin/main's glm5-fp8-b200-sglang; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original glm5-fp8-b200-sglang entry stays byte-identical to origin/main.
-glm5-fp8-b200-sglang-agentic:
-  image: lmsysorg/sglang:v0.5.12-cu130
-  model: zai-org/GLM-5-FP8
-  model-prefix: glm5
-  runner: b200
-  precision: fp8
-  framework: sglang
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      # sglang manages its own KV eviction via radix cache, so just sweep concurrency on offloading=none
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64, 128] }
 
 glm5-fp8-b300-sglang:
   image: lmsysorg/sglang:v0.5.12-cu130
@@ -2711,7 +2644,7 @@ qwen3.5-fp8-b200-sglang-mtp:
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 4, spec-decoding: mtp }
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
-    
+
 
 qwen3.5-fp8-b300-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130
@@ -2857,33 +2790,22 @@ kimik2.5-int4-b200-vllm:
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
 # Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
-# Diverged from kimik2.5-int4-b200-vllm (agentic-coding sibling). Reasons below;
-# the original kimik2.5-int4-b200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - runner: 'b200' -> 'b200-dgxc'
+
 kimik2.5-int4-b200-vllm-agentic:
-  # Bumped from v0.19.1 — that release tripped a bug in
-  # `flashinfer_trtllm_mxint4_moe` ('list' object has no attribute 'to')
-  # during warmup `profile_run` on the agentic-coding path
-  # (max_model_len=131072 + prefix caching enabled). v0.20.x carries the
-  # flashinfer fix.
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.22.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
-  runner: b200-dgxc
+  runner: cluster:b200-dgxc
   precision: int4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, offloading: cpu,  conc-list: [32, 64, 96, 128] }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 64, 96, 128] }
 
-# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
-# does not have a B300-specific recipe, so this config reuses the existing
-# Kimi-K2.5 INT4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-int4-b300-vllm:
   image: vllm/vllm-openai:v0.21.0
@@ -2925,28 +2847,25 @@ kimik2.5-int4-h200-vllm:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
-# Diverged from kimik2.5-int4-h200-vllm (agentic-coding sibling). Reasons below;
-# the original kimik2.5-int4-h200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - runner: 'h200' -> 'h200-dgxc'
 kimik2.5-int4-h200-vllm-agentic:
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.22.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
-  # Pinned to h200-dgxc (NVIDIA DGX Cloud Slurm pool) so we hit a host with
-  # the /home/sa-shared/gharunners/ai-perf-cache mount where aiperf's
-  # content-addressed dataset mmap cache lives. Other h200 pools (cw, nb)
-  # don't have that mount and would re-materialize 65 GB to /tmp every job.
-  runner: h200-dgxc
+  runner: cluster:h200-dgxc
   precision: int4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7] }
-      - { tp: 8, offloading: cpu,  conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
+
+
+# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
+# does not have a B300-specific recipe, so this config reuses the existing
+# Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b200-vllm:
   image: vllm/vllm-openai:v0.22.0
@@ -2968,34 +2887,6 @@ kimik2.5-fp4-b200-vllm:
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
       - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
-
-# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
-# does not have a B300-specific recipe, so this config reuses the existing
-# Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
-# Diverged from kimik2.5-fp4-b200-vllm (agentic-coding sibling). Reasons below;
-# the original kimik2.5-fp4-b200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - image: 'vllm/vllm-openai:v0.17.0' -> 'vllm/vllm-openai:v0.20.2'
-#   - runner: 'b200' -> 'b200-dgxc'
-kimik2.5-fp4-b200-vllm-agentic:
-  # Same image as the INT4 sibling: v0.20.x carries the flashinfer fix that
-  # cleared the agentic-coding warmup crash on max_model_len=131072 +
-  # prefix caching.
-  image: vllm/vllm-openai:v0.20.2
-  model: nvidia/Kimi-K2.5-NVFP4
-  model-prefix: kimik2.5
-  runner: b200-dgxc
-  precision: fp4
-  framework: vllm
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 24] }
-      - { tp: 8, ep: 1, offloading: cpu,  conc-list: [16, 24, 32, 36] }
-      - { tp: 4, ep: 1, offloading: none, conc-list: [8, 12, 14, 16, 18, 20] }
-      - { tp: 4, ep: 1, offloading: cpu,  conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -3064,33 +2955,26 @@ dsr1-fp8-b300-sglang-mtp:
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 512, spec-decoding: mtp }
 
-# Diverged from kimik2.5-fp4-b300-vllm (agentic-coding sibling). Reasons below;
-# the original kimik2.5-fp4-b300-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - image: 'lmsysorg/sglang:v0.5.10.post1-cu130' -> 'vllm/vllm-openai:v0.20.0-cu130'
-#   - model: 'deepseek-ai/DeepSeek-R1-0528' -> 'nvidia/Kimi-K2.5-NVFP4'
-#   - model-prefix: 'dsr1' -> 'kimik2.5'
-#   - precision: 'fp8' -> 'fp4'
-#   - framework: 'sglang' -> 'vllm'
 kimik2.5-fp4-b300-vllm-agentic:
   # v0.20.2 (cu129) lacks the flashinfer kernels for B300's reported SM
   # (sm_12x); workers hit "Only SM 10.x and 11.x are supported" in the
   # trtllm_fp4_block_scale_moe path. v0.20.0-cu130 is the Blackwell-targeted
   # build that has the full sm_10x/sm_11x/sm_12x kernel set and is what the
   # INT4 B300 sister already uses successfully.
-  image: vllm/vllm-openai:v0.20.0-cu130
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
-  runner: b300
+  runner: cluster:b300-nv
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
-      - { tp: 8, ep: 1, offloading: cpu,  conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: native, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
+
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
@@ -3228,28 +3112,24 @@ dsv4-fp8-h200-vllm-mtp:
 # DeepSeek-V4-Pro H200 single-node with SGLang (Marlin FP8, TP-only).
 # Pinned to the h200-dgxc-slurm runner pool because the deepseek-v4-hopper
 # image needs the /ix mount layout that only launch_h200-dgxc-slurm.sh sets up.
-# Diverged from dsv4-fp8-h200-vllm (agentic-coding sibling). Reasons below;
-# the original dsv4-fp8-h200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - image: 'vllm/vllm-openai:v0.20.1@sha256:9eff9734a30b6713a8566217d36f8277630fd2d31cec7f0a0292835901a23aa4' -> 'vllm/vllm-openai:deepseekv4-cu129'
+
 dsv4-fp8-h200-vllm-agentic:
-  image: vllm/vllm-openai:deepseekv4-cu129
+  image: vllm/vllm-openai:v0.22.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: h200
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 8, ep: 8, dp-attn: true, offloading: none, conc-list: [1, 2, 4, 8, 16] }
+    - search-space:
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [1, 2, 4, 8, 16] }
 
-# MTP variant of dsv4-fp8-h200-vllm. Uses the canonical v0.20.1 image
-# (the non-MTP entry above is still on the deepseekv4-cu129 tag) and adds
-# --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.
 
+# MTP variant of dsv4-fp8-h200-sglang. Mirrors the non-MTP recipe (same image,
+# runner pool, search space) and adds EAGLE speculative decoding via
+# --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
 dsv4-fp8-h200-sglang:
   image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -3325,29 +3205,27 @@ dsv4-fp4-b300-vllm:
       - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 512 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 2048, conc-end: 2048 }
 
-# Diverged from dsv4-fp4-b300-vllm (agentic-coding sibling). Metadata is
-# identical to origin/main's dsv4-fp4-b300-vllm; the split exists because this
-# PR adds an agentic-coding scenarios block that differs from main
-# (either main had none or had a different conc/offload sweep).
-# The original dsv4-fp4-b300-vllm entry stays byte-identical to origin/main.
 dsv4-fp4-b300-vllm-agentic:
-  image: vllm/vllm-openai:v0.20.0-cu130
+  image: vllm/vllm-openai:v0.23.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: b300
+  runner: cluster:b300-nv
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      # cpu offload only this iteration — none entries already validated in
-      # earlier runs. Re-add when investigating regressions in offload=none.
-      - { tp: 4, offloading: cpu,  conc-list: [16, 32, 64] }
-      - { tp: 8, offloading: cpu,  conc-list: [16, 32, 64] }
-      - { tp: 4, ep: 4, dp-attn: true, offloading: cpu,  conc-list: [64, 128, 256] }
-      - { tp: 8, ep: 8, dp-attn: true, offloading: cpu,  conc-list: [128, 256, 512] }
+      # Compare native GPU-cache and MooncakeStore CPU-offload cliffs.
+      - { tp: 4, kv-offloading: none,  conc-list: [1, 4, 8, 16] }
+      # TP8 remains cache-resident through conc 52.
+      - { tp: 8, kv-offloading: none,  conc-list: [1, 4, 8, 16, 32, 40, 48, 52] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none,  conc-list: [8, 16] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [32] }
+      # TP8 DEP retains representative low, peak, and transition points.
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [52, 72, 100, 128, 144] }
+
 
 dsv4-fp4-b300-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-c185066
@@ -4584,27 +4462,6 @@ gptoss-fp4-b200-vllm:
       - { tp: 2, conc-start: 4, conc-end: 128 }
       - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 4 }
-
-# Diverged from gptoss-fp4-b200-vllm (agentic-coding sibling). Reasons below;
-# the original gptoss-fp4-b200-vllm entry is left identical to origin/main so
-# its fixed-seq-len sweep is unaffected.
-#   - image: 'vllm/vllm-openai:v0.15.1' -> 'vllm/vllm-openai:v0.19.1'
-gptoss-fp4-b200-vllm-agentic:
-  image: vllm/vllm-openai:v0.19.1
-  model: openai/gpt-oss-120b
-  model-prefix: gptoss
-  runner: b200
-  precision: fp4
-  framework: vllm
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 4, offloading: cpu,  conc-list: [64, 96, 128, 192, 256] }
-      - { tp: 8, offloading: cpu,  conc-list: [64, 96, 128, 192, 256] }
 
 gptoss-fp4-h100-vllm:
   image: vllm/vllm-openai:v0.21.0
@@ -11081,24 +10938,22 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
 
 
 kimik2.5-int4-h100-vllm:
-  image: vllm/vllm-openai:v0.20.2
+  image: vllm/vllm-openai:v0.22.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
-  runner: h100
+  runner: cluster:h100-dgxc
   precision: int4
   framework: vllm
   multinode: false
   scenarios:
-    # New entry, agentic-coding only: this PR intentionally does NOT add
-    # fixed-seq-len coverage for kimik2.5-int4 on H100 to keep the
-    # fixed-seq-len test surface identical to origin/main.
     # H100 has 80 GB HBM per GPU (smallest in this set); the KV cliff arrives
     # early. Sweep saturates conc=20 to keep total HBM headroom.
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 20] }
-      - { tp: 8, offloading: cpu,  conc-list: [1, 2, 4, 8, 12, 16, 20] }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [1, 2, 4, 8, 12, 16, 20] }
+
 
 qwen3.5-fp8-h100-sglang:
   image: lmsysorg/sglang:v0.5.12-cu130
@@ -11651,65 +11506,57 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
   image: lmsysorg/sglang:nightly-dev-cu13-20260520-425dffbd
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: b300
+  runner: cluster:b300-nv
   precision: fp8
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 4, ep: 1, offloading: hicache, conc-list: [16, 32, 48, 64] }
+      - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 48, 64] }
+
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
-  runner: b200-dgxc
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: vllm
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, offloading: none, conc-list: [1, 2, 4, 8, 16, 24] }
-      - { tp: 8, ep: 1, offloading: lmcache,  conc-list: [16, 24, 32, 36] }
-      - { tp: 4, ep: 1, offloading: none, conc-list: [8, 12, 14, 16, 18, 20] }
-      - { tp: 4, ep: 1, offloading: lmcache,  conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 24] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [16, 24, 32, 36] }
+      - { tp: 4, ep: 1, kv-offloading: none, conc-list: [8, 12, 14, 16, 18, 20] }
+      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
 
-# NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
-# does not have a B300-specific recipe, so this config reuses the existing
-# Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
-# Diverged from dsv4-fp4-gb300-dynamo-vllm (agentic-coding sibling). Reasons
-# below; the original dsv4-fp4-gb300-dynamo-vllm entry is left identical to
-# origin/main so its fixed-seq-len sweep is unaffected.
-#   - scenarios: replaced fixed-seq-len with agentic-coding; single 1p6d shape
-#     mirroring the conc=192 point in the base entry's fixed-seq-len sweep.
-#   - additional-settings.CONFIG_FILE: points at the new agentic recipe under
-#     recipes/vllm/deepseek-v4/agentic/, which runners/launch_gb300-nv.sh
-#     overlays into the cquil11/srt-slurm-nv fork at run time (the IS_AGENTIC
-#     branch). Local-overlay pattern mirrors the existing 8k1k overlay.
+# CONC range conservative for H100's 80 GB HBM3 under the long-ISL with-
+# subagents corpus. hicache arm capped at conc 16 since high-conc + hicache
+# tends to flake on first runs and conc 16 covers the cliff. The bench script
+# sets WEKA_LOADER_OVERRIDE to the 256k-capped corpus variant.
 dsv4-fp4-gb300-dynamo-vllm-agentic:
   image: vllm/vllm-openai:v0.21.0-ubuntu2404
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  # gb300-nv (not generic gb300) — the generic label is shared by both NV
-  # and CW runner pools, so runs-on: gb300 lets CW runners pick up shards.
-  # The gb300-nv label is on NV runners only (per .github/configs/runners.yaml
-  # + actual runner label listings). Pins agentic to the NVIDIA cluster
+  # cluster:gb300-nv (not generic gb300) — the generic label is shared by both
+  # NV and CW runner pools, so runs-on: gb300 lets CW runners pick up shards.
+  # The cluster label is on NV runners only (per .github/configs/runners.yaml
+  # + actual runner label listings), pinning agentic to the NVIDIA cluster.
   # for initial validation. Drop -nv suffix to widen later.
-  runner: gb300-nv
+  runner: cluster:gb300-nv
   precision: fp4
   framework: dynamo-vllm
   multinode: true
   disagg: true
   scenarios:
     agentic-coding:
-    - duration: 1800
-      search-space:
+    - search-space:
       # Low-latency: same 1p6d shape as the mid tier but at much lower conc
       # (32 vs 192). 32/6 ≈ 5 seqs per decode worker — well below saturation,
       # so each request gets ~6× the per-request decode compute it would get
@@ -11762,92 +11609,27 @@ dsv4-fp4-gb300-dynamo-vllm-agentic:
           ep: 8
           dp-attn: true
 
-# Keep the legacy config key for changelog compatibility; execution now uses
-# the generic GB300 runner pool.
-dsv4-fp4-gb300-cw-dynamo-vllm-agentic:
-  image: vllm/vllm-openai:v0.21.0-ubuntu2404
-  model: deepseek-ai/DeepSeek-V4-Pro
-  model-prefix: dsv4
-  runner: gb300
-  precision: fp4
-  framework: dynamo-vllm
-  multinode: true
-  disagg: true
-  scenarios:
-    agentic-coding:
-    - duration: 1800
-      search-space:
-      # Low-latency: 1p6d at conc=32.
-      - spec-decoding: none
-        conc-list: [32]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb300-1p6d-dep4-tp4-agentic.yaml"
-        decode:
-          num-worker: 6
-          tp: 4
-          ep: 1
-          dp-attn: false
-      # Mid: 1p6d at conc=192.
-      - spec-decoding: none
-        conc-list: [192]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb300-1p6d-dep4-tp4-agentic.yaml"
-        decode:
-          num-worker: 6
-          tp: 4
-          ep: 1
-          dp-attn: false
-      # High-throughput: 4p1d at conc=4096.
-      - spec-decoding: none
-        conc-list: [4096]
-        prefill:
-          num-worker: 4
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb300-4p1d-dep4-dep8-24-c4096-agentic.yaml"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
 
-# Diverged from qwen3.5-fp8-h100-sglang (agentic-coding sibling). Reasons below;
-# the original qwen3.5-fp8-h100-sglang entry stays byte-identical to origin/main
-# so its fixed-seq-len sweep is unaffected.
-#   - scenarios: replaced fixed-seq-len with agentic-coding.
-#   - runner: 'h100' -> 'h100-dgxc' (agentic runs need the dgxc-slurm cluster).
-# Image is identical to the base entry (lmsysorg/sglang:v0.5.12-cu130).
-# CONC range conservative for H100's 80 GB HBM3 under the long-ISL with-
-# subagents corpus. hicache arm capped at conc 16 since high-conc + hicache
-# tends to flake on first runs and conc 16 covers the cliff. The bench script
-# sets WEKA_LOADER_OVERRIDE to the 256k-capped corpus variant.
+
 qwen3.5-fp8-h100-sglang-agentic:
   image: lmsysorg/sglang:v0.5.12-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: h100-dgxc
+  runner: cluster:h100-dgxc
   precision: fp8
   framework: sglang
   multinode: false
   scenarios:
     agentic-coding:
-    - duration: 1800
+    - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 8, offloading: none,    conc-list: [1, 2, 4, 8, 12, 14, 16] }
-      - { tp: 8, ep: 8, offloading: hicache, conc-list: [12, 14, 16, 20, 24, 28, 32, 42] }
+      - { tp: 8, ep: 8, kv-offloading: none,    conc-list: [1, 2, 4, 8, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [12, 14, 16, 20, 24, 28, 32, 42] }
 
+
+# MiniMax-M3 NVFP4 disagg sweep on the same B300 topology matrix as the MXFP8
+# baseline above. The image includes vLLM PR #46380, so no runtime patch is
+# needed.
 minimaxm3-fp8-b300-dynamo-vllm:
   image: vllm/vllm-openai:minimax-m3-0618-x86_64-cu130
   model: MiniMaxAI/MiniMax-M3-MXFP8
@@ -13274,4 +13056,207 @@ kimik2.5-fp4-gb300-dynamo-vllm:
           num-worker: 1
           tp: 1
           ep: 24
+          dp-attn: true
+minimaxm3-fp8-h100-vllm-agentic:
+  image: vllm/vllm-openai:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: cluster:h100-dgxc
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # FP8 KV cache is 29,952 bytes/token/GPU for TP/TEP: 60 layers of
+    # sharded FP8 K/V plus 57 layers of BF16 indexer cache. The June-21 trace
+    # has a 269k-token service-time-weighted active request, placing the H100
+    # 1.64M-token HBM cliff near conc 6. Sample every integer through the
+    # cliff; Mooncake extends prefix retention, not active-request HBM.
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+
+
+minimaxm3-fp8-h200-vllm-agentic:
+  image: vllm/vllm-openai:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
+  model: MiniMaxAI/MiniMax-M3-MXFP8
+  model-prefix: minimaxm3
+  runner: cluster:h200-dgxc
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # The same 29,952-byte FP8 TP/TEP cache layout gives H200 about 2.56M
+    # active tokens. Against the June-21 service-time-weighted 269k-token
+    # request, the expected HBM cliff is near conc 10; sample densely from
+    # 5-14 and retain post-cliff points through 20.
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+
+
+
+dsv4-fp4-b200-sglang-agentic-hicache:
+  image: lmsysorg/sglang:v0.5.13-cu130
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: cluster:b200-dgxc
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, kv-offloading: none,     conc-list: [1, 2, 3, 4, 5] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [8, 10, 16, 32, 40, 44] }
+      # DEP without HiCache is already degraded at conc 52 (2,098 tok/s/GPU),
+      # so resolve its pre-52 cliff instead of repeating the collapsed tail.
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,    conc-list: [16, 24, 32, 38, 44, 48, 50, 52] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 38, 44, 50, 56, 64, 66, 68] }
+
+
+
+# GB200 DeepSeek-V4 disaggregated AgentX frontier. The 3P/2D TEP8/TP8 curve
+# covers the middle/high-interactivity range omitted by the one-decode DEP
+# throughput curves below. Each engine start carries at most four concurrencies.
+dsv4-fp4-b300-sglang-agentic-hicache:
+  image: lmsysorg/sglang:v0.5.13-cu130
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: cluster:b300-nv
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 4, kv-offloading: none, conc-list: [1, 4, 8, 16, 20, 24, 32] }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 4, 8, 16, 32, 40, 48, 52, 56, 60, 64, 72] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [8, 16, 24, 32, 40, 64] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [32, 40, 48, 56, 64, 72, 80, 88, 96, 128] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [52, 72, 100, 128, 144, 196, 512] }
+
+
+# DEP8 prefill uses an 8K batch because 16K OOMs in the FP4 MoE intermediate;
+# decode uses FULL_DECODE_ONLY after the controlled graph test restored decode
+# throughput. Dynamo KV routing and AIPerf conversation-aware routing remain
+# enabled by framework=dynamo-vllm.
+dsv4-fp4-gb200-dynamo-vllm-agentic-3p2d-tep8-tp8:
+  image: vllm/vllm-openai:v0.23.0
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: cluster:gb200-nv
+  precision: fp4
+  framework: dynamo-vllm
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - search-space:
+      # Ultra-high-interactivity probes below the historical c16 endpoint.
+      - spec-decoding: none
+        conc-list: [4, 8]
+        prefill:
+          num-worker: 3
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-3p2d-tep8-tp8-agentic.yaml"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 1
+          dp-attn: false
+      - spec-decoding: none
+        conc-list: [16, 24, 32, 40]
+        prefill:
+          num-worker: 3
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-3p2d-tep8-tp8-agentic.yaml"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 1
+          dp-attn: false
+      - spec-decoding: none
+        conc-list: [48, 56, 64, 80]
+        prefill:
+          num-worker: 3
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-3p2d-tep8-tp8-agentic.yaml"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 1
+          dp-attn: false
+
+dsv4-fp4-gb200-dynamo-vllm-agentic-2p1d-dep8-dep8:
+  image: vllm/vllm-openai:v0.23.0
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: cluster:gb200-nv
+  precision: fp4
+  framework: dynamo-vllm
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - spec-decoding: none
+        conc-list: [32, 48, 64, 80]
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-2p1d-dep8-dep8-agentic.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+      - spec-decoding: none
+        conc-list: [96, 128, 160]
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-2p1d-dep8-dep8-agentic.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+      # Exploratory tail beyond the measured c160 normalized-throughput peak.
+      - spec-decoding: none
+        conc-list: [192, 224, 256]
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/disagg-gb200-2p1d-dep8-dep8-agentic.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 8
           dp-attn: true

--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -1,163 +1,326 @@
-h100:
-- 'h100-cw_00'
-- 'h100-cw_01'
-- 'h100-dgxc-slurm_00'
-- 'h100-dgxc-slurm_01'
-- 'h100-dgxc-slurm_02'
-- 'h100-dgxc-slurm_03'
-- 'h100-dgxc-slurm_04'
-- 'h100-dgxc-slurm_05'
-- 'h100-dgxc-slurm_06'
-- 'h100-dgxc-slurm_07'
-- 'h100-dgxc-slurm_08'
-- 'h100-dgxc-slurm_09'
-- 'h100-dgxc-slurm_10'
-- 'h100-dgxc-slurm_11'
-- 'h100-dgxc-slurm_12'
-- 'h100-dgxc-slurm_13'
-- 'h100-dgxc-slurm_14'
-- 'h100-dgxc-slurm_15'
-- 'h100-dgxc-slurm_16'
-- 'h100-dgxc-slurm_17'
-- 'h100-dgxc-slurm_18'
-- 'h100-dgxc-slurm_19'
-h100-multinode:
-- 'h100-dgxc-slurm_16'
-- 'h100-dgxc-slurm_17'
-- 'h100-dgxc-slurm_18'
-- 'h100-dgxc-slurm_19'
-h200:
-- 'h200-cw_00'
-- 'h200-cw_01'
-- 'h200-nb_0'
-- 'h200-nb_1'
-- 'h200-dgxc-slurm_0'
-- 'h200-dgxc-slurm_1'
-- 'h200-dgxc-slurm_2'
-- 'h200-dgxc-slurm_3'
-- 'h200-dgxc-slurm_4'
-- 'h200-dgxc-slurm_5'
-- 'h200-dgxc-slurm_6'
-- 'h200-dgxc-slurm_7'
-- 'h200-dgxc-slurm_8'
-- 'h200-dgxc-slurm_9'
-- 'h200-dgxc-slurm_10'
-- 'h200-dgxc-slurm_11'
-- 'h200-dgxc-slurm_12'
-- 'h200-dgxc-slurm_13'
-h200-multinode:
-- 'h200-dgxc-slurm_11'
-- 'h200-dgxc-slurm_12'
-- 'h200-dgxc-slurm_13'
-h200-dgxc:
-- 'h200-dgxc-slurm_0'
-- 'h200-dgxc-slurm_1'
-- 'h200-dgxc-slurm_2'
-- 'h200-dgxc-slurm_3'
-- 'h200-dgxc-slurm_4'
-- 'h200-dgxc-slurm_5'
-- 'h200-dgxc-slurm_6'
-- 'h200-dgxc-slurm_7'
-- 'h200-dgxc-slurm_8'
-- 'h200-dgxc-slurm_9'
-- 'h200-dgxc-slurm_10'
-- 'h200-dgxc-slurm_11'
-- 'h200-dgxc-slurm_12'
-- 'h200-dgxc-slurm_13'
-b200:
-- 'b200-cw_00'
-- 'b200-cw_01'
-- 'b200-nb_0'
-- 'b200-nb_1'
-- 'b200-dgxc_00'
-- 'b200-dgxc_01'
-- 'b200-dgxc_02'
-- 'b200-dgxc_03'
-- 'b200-dgxc_04'
-- 'b200-dgxc_05'
-- 'b200-dgxc_06'
-- 'b200-dgxc_07'
-- 'b200-dgxc_08'
-- 'b200-dgxc_09'
-b200-dgxc:
-- 'b200-dgxc_00'
-- 'b200-dgxc_01'
-- 'b200-dgxc_02'
-- 'b200-dgxc_03'
-- 'b200-dgxc_04'
-- 'b200-dgxc_05'
-- 'b200-dgxc_06'
-- 'b200-dgxc_07'
-- 'b200-dgxc_08'
-- 'b200-dgxc_09'
-b200-multinode:
-- 'b200-dgxc-slurm_7'
-- 'b200-dgxc-slurm_8'
-- 'b200-dgxc-slurm_9'
-mi300x:
-- 'mi300x-amds_00'
-- 'mi300x-amds_01'
-- 'mi300x-amds_02'
-- 'mi300x-amds_03'
-- 'mi300x-amds_04'
-- 'mi300x-amds_05'
-- 'mi300x-amds_06'
-- 'mi300x-amds_07'
-- 'mi300x-amds_08'
-mi300x-disagg:
-- 'mi300x-amds_06'
-- 'mi300x-amds_07'
-- 'mi300x-amds_08'
-mi325x:
-- 'mi325x-amds_00'
-- 'mi325x-amds_01'
-- 'mi325x-amds_02'
-- 'mi325x-amds_03'
-- 'mi325x-amds_04'
-- 'mi325x-amds_05'
-- 'mi325x-amds_06'
-- 'mi325x-amds_07'
-- 'mi325x-amds_08'
-- 'mi325x-amds_09'
-mi325x-disagg:
-- 'mi325x-amds_00'
-- 'mi325x-amds_01'
-- 'mi325x-amds_02'
-- 'mi325x-amds_03'
-- 'mi325x-amds_06'
-- 'mi325x-amds_07'
-- 'mi325x-amds_08'
-mi355x:
-- 'mi355x-amds_00'
-- 'mi355x-amds_01'
-- 'mi355x-amds_02'
-- 'mi355x-amds_03'
-- 'mi355x-amds_04'
-- 'mi355x-amds_05'
-- 'mi355x-amds_06'
-- 'mi355x-amds_07'
-- 'mi355x-amds_08'
-mi355x-disagg:
-- 'mi355x-amds_06'
-- 'mi355x-amds_07'
-- 'mi355x-amds_08'
-gb200:
-- gb200-nv_0
-- gb200-nv_1
-- gb200-nv_2
-b300:
-- 'b300-nv_0'
-- 'b300-nv_1'
-- 'b300-nv_2'
-- 'b300-nv_3'
-- 'b300-nv_4'
-- 'b300-nv_5'
-- 'b300-nv_6'
-- 'b300-nv_7'
-- 'b300-nv_8'
-b300-p1:
-- 'b300-p1'
-gb300:
-- 'gb300-nv_0'
-- 'gb300-nv_1'
-- 'gb300-nv_2'
+labels:
+  h100:
+    - h100-cw_00
+    - h100-cw_01
+    - h100-dgxc-slurm_00
+    - h100-dgxc-slurm_01
+    - h100-dgxc-slurm_02
+    - h100-dgxc-slurm_03
+    - h100-dgxc-slurm_04
+    - h100-dgxc-slurm_05
+    - h100-dgxc-slurm_06
+    - h100-dgxc-slurm_07
+    - h100-dgxc-slurm_08
+    - h100-dgxc-slurm_09
+    - h100-dgxc-slurm_10
+    - h100-dgxc-slurm_11
+    - h100-dgxc-slurm_12
+    - h100-dgxc-slurm_13
+    - h100-dgxc-slurm_14
+    - h100-dgxc-slurm_15
+    - h100-dgxc-slurm_16
+    - h100-dgxc-slurm_17
+    - h100-dgxc-slurm_18
+    - h100-dgxc-slurm_19
+  h100-multinode:
+    - h100-dgxc-slurm_16
+    - h100-dgxc-slurm_17
+    - h100-dgxc-slurm_18
+    - h100-dgxc-slurm_19
+  h200:
+    - h200-cw_00
+    - h200-cw_01
+    - h200-nb_0
+    - h200-nb_1
+    - h200-dgxc-slurm_0
+    - h200-dgxc-slurm_1
+    - h200-dgxc-slurm_2
+    - h200-dgxc-slurm_3
+    - h200-dgxc-slurm_4
+    - h200-dgxc-slurm_5
+    - h200-dgxc-slurm_6
+    - h200-dgxc-slurm_7
+    - h200-dgxc-slurm_8
+    - h200-dgxc-slurm_9
+    - h200-dgxc-slurm_10
+    - h200-dgxc-slurm_11
+    - h200-dgxc-slurm_12
+    - h200-dgxc-slurm_13
+  h200-multinode:
+    - h200-dgxc-slurm_11
+    - h200-dgxc-slurm_12
+    - h200-dgxc-slurm_13
+  b200:
+    - b200-cw_00
+    - b200-cw_01
+    - b200-nb_0
+    - b200-nb_1
+    - b200-dgxc_00
+    - b200-dgxc_01
+    - b200-dgxc_02
+    - b200-dgxc_03
+    - b200-dgxc_04
+    - b200-dgxc_05
+    - b200-dgxc_06
+    - b200-dgxc_07
+    - b200-dgxc_08
+    - b200-dgxc_09
+  b200-dsv4:
+    - b200-dgxc_00
+    - b200-dgxc_01
+    - b200-dgxc_02
+    - b200-dgxc_03
+    - b200-dgxc_04
+    - b200-dgxc_05
+    - b200-dgxc_06
+    - b200-dgxc_07
+    - b200-dgxc_08
+    - b200-dgxc_09
+  b200-multinode:
+    - b200-dgxc-slurm_7
+    - b200-dgxc-slurm_8
+    - b200-dgxc-slurm_9
+  mi300x:
+    - mi300x-amds_00
+    - mi300x-amds_01
+    - mi300x-amds_02
+    - mi300x-amds_03
+    - mi300x-amds_04
+    - mi300x-amds_05
+    - mi300x-amds_06
+    - mi300x-amds_07
+    - mi300x-amds_08
+  mi300x-disagg:
+    - mi300x-amds_06
+    - mi300x-amds_07
+    - mi300x-amds_08
+  mi325x:
+    - mi325x-amds_00
+    - mi325x-amds_01
+    - mi325x-amds_02
+    - mi325x-amds_03
+    - mi325x-amds_04
+    - mi325x-amds_05
+    - mi325x-amds_06
+    - mi325x-amds_07
+    - mi325x-amds_08
+  mi325x-disagg:
+    - mi325x-amds_00
+    - mi325x-amds_01
+    - mi325x-amds_02
+    - mi325x-amds_03
+    - mi325x-amds_06
+    - mi325x-amds_07
+    - mi325x-amds_08
+  mi355x:
+    - mi355x-amds_00
+    - mi355x-amds_01
+    - mi355x-amds_02
+    - mi355x-amds_03
+    - mi355x-amds_04
+    - mi355x-amds_05
+    - mi355x-amds_06
+    - mi355x-amds_07
+    - mi355x-amds_08
+  mi355x-disagg:
+    - mi355x-amds_06
+    - mi355x-amds_07
+    - mi355x-amds_08
+  gb200:
+    - gb200-nv_0
+    - gb200-nv_1
+    - gb200-nv_2
+  b300:
+    - b300-nv_01
+    - b300-nv_02
+    - b300-nv_03
+    - b300-nv_04
+    - b300-nv_05
+    - b300-nv_06
+    - b300-nv_07
+    - b300-nv_08
+    - b300-nv_09
+    - b300-nv_10
+    - b300-nv_11
+    - b300-nv_12
+    - b300-nv_13
+    - b300-nv_14
+    - b300-nv_15
+    - b300-nv_16
+    - b300-nv_17
+  b300-p1:
+    - b300-nv_13
+    - b300-nv_14
+    - b300-nv_15
+    - b300-nv_16
+    - b300-nv_17
+  gb300:
+    - gb300-nv_0
+    - gb300-nv_1
+    - gb300-nv_2
+  cluster:h100-cw:
+    - h100-cw_00
+    - h100-cw_01
+  cluster:h100-dgxc:
+    - h100-dgxc-slurm_00
+    - h100-dgxc-slurm_01
+    - h100-dgxc-slurm_02
+    - h100-dgxc-slurm_03
+    - h100-dgxc-slurm_04
+    - h100-dgxc-slurm_05
+    - h100-dgxc-slurm_06
+    - h100-dgxc-slurm_07
+    - h100-dgxc-slurm_08
+    - h100-dgxc-slurm_09
+    - h100-dgxc-slurm_10
+    - h100-dgxc-slurm_11
+    - h100-dgxc-slurm_12
+    - h100-dgxc-slurm_13
+    - h100-dgxc-slurm_14
+    - h100-dgxc-slurm_15
+    - h100-dgxc-slurm_16
+    - h100-dgxc-slurm_17
+    - h100-dgxc-slurm_18
+    - h100-dgxc-slurm_19
+  cluster:h200-cw:
+    - h200-cw_00
+    - h200-cw_01
+  cluster:h200-dgxc:
+    - h200-dgxc-slurm_0
+    - h200-dgxc-slurm_1
+    - h200-dgxc-slurm_2
+    - h200-dgxc-slurm_3
+    - h200-dgxc-slurm_4
+    - h200-dgxc-slurm_5
+    - h200-dgxc-slurm_6
+    - h200-dgxc-slurm_7
+    - h200-dgxc-slurm_8
+    - h200-dgxc-slurm_9
+    - h200-dgxc-slurm_10
+    - h200-dgxc-slurm_11
+    - h200-dgxc-slurm_12
+    - h200-dgxc-slurm_13
+  cluster:h200-nb:
+    - h200-nb_0
+  cluster:b200-dgxc:
+    - b200-dgxc_00
+    - b200-dgxc_01
+    - b200-dgxc_02
+    - b200-dgxc_03
+    - b200-dgxc_04
+    - b200-dgxc_05
+    - b200-dgxc_06
+    - b200-dgxc_07
+    - b200-dgxc_08
+    - b200-dgxc_09
+  cluster:b300-cw:
+    - b300-cw_0
+    - b300-cw_01
+    - b300-cw_02
+    - b300-cw_03
+    - b300-cw_04
+  cluster:b300-nv:
+    - b300-nv_01
+    - b300-nv_02
+    - b300-nv_03
+    - b300-nv_04
+    - b300-nv_05
+    - b300-nv_06
+    - b300-nv_07
+    - b300-nv_08
+    - b300-nv_09
+    - b300-nv_10
+    - b300-nv_11
+    - b300-nv_12
+    - b300-nv_13
+    - b300-nv_14
+    - b300-nv_15
+    - b300-nv_16
+    - b300-nv_17
+  cluster:gb200-nv:
+    - gb200-nv_0
+    - gb200-nv_1
+    - gb200-nv_2
+  cluster:gb300-nv:
+    - gb300-nv_0
+    - gb300-nv_1
+    - gb300-nv_2
+  cluster:mi300x-amds:
+    - mi300x-amds_00
+    - mi300x-amds_01
+    - mi300x-amds_02
+    - mi300x-amds_03
+    - mi300x-amds_04
+    - mi300x-amds_05
+    - mi300x-amds_06
+    - mi300x-amds_07
+    - mi300x-amds_08
+  cluster:mi300x-tw:
+    - mi300x-tw_00
+    - mi300x-tw_01
+  cluster:mi325x-amds:
+    - mi325x-amds_00
+    - mi325x-amds_01
+    - mi325x-amds_02
+    - mi325x-amds_03
+    - mi325x-amds_04
+    - mi325x-amds_05
+    - mi325x-amds_06
+    - mi325x-amds_07
+    - mi325x-amds_08
+    - mi325x-amds_09
+  cluster:mi325x-tw:
+    - mi325x-tw_00
+    - mi325x-tw_01
+    - mi325x-tw_02
+    - mi325x-tw_03
+  cluster:mi355x-amds:
+    - mi355x-amds_00
+    - mi355x-amds_01
+    - mi355x-amds_02
+    - mi355x-amds_03
+    - mi355x-amds_04
+    - mi355x-amds_05
+    - mi355x-amds_06
+    - mi355x-amds_07
+    - mi355x-amds_08
+hardware:
+  cluster:h100-dgxc:
+    available-cpu-dram-mib: 2_063_837
+    gpus-per-node: 8
+  cluster:h100-cw:
+    available-cpu-dram-mib: 1_998_848
+    gpus-per-node: 8
+  cluster:h200-dgxc:
+    available-cpu-dram-mib: 1_471_356
+    gpus-per-node: 8
+  cluster:h200-cw:
+    available-cpu-dram-mib: 1_998_848
+    gpus-per-node: 8
+  cluster:h200-nb:
+    available-cpu-dram-mib: 1_472_512
+    gpus-per-node: 8
+  cluster:b200-dgxc:
+    available-cpu-dram-mib: 3_774_874
+    gpus-per-node: 8
+  cluster:b300-nv:
+    available-cpu-dram-mib: 2_964_436
+    gpus-per-node: 8
+  cluster:gb200-nv:
+    available-cpu-dram-mib: 860_160
+    gpus-per-node: 4
+  cluster:mi300x-amds:
+    available-cpu-dram-mib: 2_321_924
+    gpus-per-node: 8
+  cluster:mi300x-tw:
+    available-cpu-dram-mib: 2_322_328
+    gpus-per-node: 8
+  cluster:mi325x-amds:
+    available-cpu-dram-mib: 3_091_589
+    gpus-per-node: 8
+  cluster:mi325x-tw:
+    available-cpu-dram-mib: 3_095_792
+    gpus-per-node: 8
+  cluster:mi355x-amds:
+    available-cpu-dram-mib: 3_095_781
+    gpus-per-node: 8


### PR DESCRIPTION
## Group
Registers the final AgentX sweep surface.

## What changed
- Updates NVIDIA/AMD master configs, runner metadata, and config docs for the final AgentX v1.0 matrices.
- Consolidates the final config state into one squashed layer instead of preserving exploratory config-testing commits.

## Why
Makes the reviewable config surface explicit and keeps test/probe churn out of the PR history.

## Validation
- `python -m pytest utils/matrix_logic/ utils/agentic/aggregation/test_process_agentic_result.py utils/agentic/aggregation/test_server_log_metrics.py utils/agentic/datasets/test_build_weka_hf_dataset.py utils/agentic/validation/test_validate_agentic_result.py utils/test_calc_success_rate.py -q`
