### PR TITLE
[DNM][AMD] agentX benchmark (v1.0) / agentX 基准测试 (v1.0) / agentX 벤치마크 (v1.0)

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -140,13 +140,20 @@ jobs:
     steps:
       - name: Resource cleanup (pre-run)
         run: &resource-cleanup |
-          # Cleanup Docker resources
+          # Cleanup Docker resources.
+          # On shared nodes (e.g. the standalone gbt350docker runner) we must
+          # NOT nuke every container — other users share the host. Scope the
+          # sweep to this launcher's own containers (gbt350_*). On dedicated
+          # cluster nodes there are no such containers, so full isolation still
+          # holds. DOCKER_CLEANUP_NAME_FILTER can override the name prefix.
           if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
             echo "[Docker] Cleaning up resources ..."
-            docker ps -aq | xargs -r docker rm -f
+            _cleanup_filter="${DOCKER_CLEANUP_NAME_FILTER:-gbt350_}"
+            _ours() { docker ps -aq --filter "name=${_cleanup_filter}"; }
+            _ours | xargs -r docker rm -f
             docker network prune -f
-            while [ -n "$(docker ps -aq)" ]; do
-              docker ps -a
+            while [ -n "$(_ours)" ]; do
+              docker ps -a --filter "name=${_cleanup_filter}"
               sleep 5
             done
           fi

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -14,27 +14,30 @@ set -x
 #       Highest aggregate throughput at large CONC.
 #
 # Serving flags follow the validated MI355X recipe from
-# vllm-project/recipes#433: AITER+AITER_LINEAR, mp executor,
-# triton_unfused MoE (required for the FP4 expert format),
-# async scheduling, FULL_AND_PIECEWISE cudagraph capture.
+# https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4-Pro?hardware=mi355x
+# https://github.com/SemiAnalysisAI/InferenceX/blob/main/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_vllm.sh
 # Image is configured in amd-master.yaml.
 #
 # Required env vars:
-#   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
+#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
 #
-# OFFLOADING values:
-#   none - vLLM GPU KV only.
-#   cpu  - MooncakeStoreConnector with a configured host-memory KV tier.
-#   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
+# KV_OFFLOADING=dram requires one of these. 
+#   KV_OFFLOAD_BACKEND=native.
+#   KV_OFFLOAD_BACKEND=mooncake.
+#   KV_OFFLOAD_BACKEND=lmcache.
+#   KV_OFFLOAD_BACKEND=hicache.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
-check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
 
 if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
 fi
 
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
+# Either way, MODEL_PATH is what the server is launched with.
 if [[ -n "${MODEL_PATH:-}" ]]; then
     if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
         hf download "$MODEL" --local-dir "$MODEL_PATH"
@@ -52,15 +55,18 @@ fi
 resolve_trace_source
 install_agentic_deps
 
-# (srok)
-#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=60
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=1200
-# (srok)
+# default
+export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
+# tune
+#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=60
+#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=1200
+# tune
 export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
 
-# vLLM router for DEP runs: expands one HTTP backend into one logical worker
-# per DP rank and routes by X-Session-ID (aliased from X-Correlation-ID).
+# vllm-project/router expands the one HTTP backend into one logical worker per
+# DP rank and sends X-data-parallel-rank on forwarded requests. aiperf's
+# X-Correlation-ID is stable for every turn of a conversation; alias it to the
+# router's preferred X-Session-ID header.
 USE_VLLM_ROUTER=false
 VLLM_BACKEND_PORT="$PORT"
 if [ "$DP_ATTENTION" = "true" ]; then
@@ -91,75 +97,37 @@ MOONCAKE_MASTER_LOG="$RESULT_DIR/mooncake_master.log"
 LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
 mkdir -p "$RESULT_DIR"
 
+SERVER_PID=""
+ROUTER_PID=""
+MOONCAKE_MASTER_PID=""
+
 OFFLOAD_ARGS=()
 
-# ---- Lmcache config ----------------------------------------------------------
-LMCACHE_PID=""
+if require_agentic_kv_offload_backend native; then
+    # ---- vLLM native config ----------------------------------------------------------
+    unset VLLM_USE_SIMPLE_KV_OFFLOAD
+    # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
+    # reserve 2.5 TB for the offload pool (leaves ~200 GB headroom for
+    # worker RSS / page cache / slurm cgroup).
+    TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
+    # Use vLLM's regular native KV-offload path (OffloadingConnector),
+    # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+    # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
+    # would switch it to SimpleCPUOffloadConnector. We intentionally leave
+    # that env var UNSET here so the regular OffloadingConnector path is
+    # used. The shortcut --kv_offloading_backend native + --kv_offloading_size
+    # form constructs the KVTransferConfig at engine startup
+    # (vllm/config/vllm.py:662).
 
-cleanup_lmcache_server() {
-    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
-        kill "$LMCACHE_PID" 2>/dev/null || true
-        wait "$LMCACHE_PID" 2>/dev/null || true
-    fi
-}
+    # Remove --disable-hybrid-kv-cache-manager and enable hybrid kv cache manager (default)
+    # This gives extra cache hit than disabling hybrid kv cache manager
+    OFFLOAD_ARGS=(
+        --kv_offloading_backend native
+        --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
+    )
 
-trap cleanup_lmcache_server EXIT
-
-cleanup_agentic_services() {
-    local exit_code=$?
-    trap - EXIT INT TERM
-    set +e
-    stop_background_process_tree "$ROUTER_PID" "vLLM router"
-    stop_background_process_tree "$SERVER_PID" "vLLM server" 60
-    stop_background_process_tree "$MOONCAKE_MASTER_PID" "Mooncake master"
-    exit "$exit_code"
-}
-trap cleanup_agentic_services EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-wait_for_lmcache_ready() {
-    { set +x; } 2>/dev/null
-    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
-    local tail_pid=""
-
-    while [ ! -f "$LMCACHE_LOG" ]; do
-        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
-            echo "LMCache server died before creating log file. Exiting." >&2
-            exit 1
-        fi
-        sleep 1
-    done
-
-    tail -f -n +1 "$LMCACHE_LOG" &
-    tail_pid=$!
-
-    for ((i = 1; i <= attempts; i++)); do
-        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
-            kill "$tail_pid" 2>/dev/null || true
-            wait "$tail_pid" 2>/dev/null || true
-            return 0
-        fi
-        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
-            echo "LMCache server died before becoming healthy. Log follows:" >&2
-            kill "$tail_pid" 2>/dev/null || true
-            wait "$tail_pid" 2>/dev/null || true
-            cat "$LMCACHE_LOG" >&2 || true
-            exit 1
-        fi
-        sleep 1
-    done
-
-    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
-    kill "$tail_pid" 2>/dev/null || true
-    wait "$tail_pid" 2>/dev/null || true
-    cat "$LMCACHE_LOG" >&2 || true
-    exit 1
-}
-
-case "$OFFLOADING" in
-    none) ;;
-    cpu)
+elif require_agentic_kv_offload_backend mooncake; then
+    # ---- Mooncake config ----------------------------------------------------------
         # Embedded mode contributes one segment per GPU rank to a shared
         # distributed store, so pre-divide the aggregate host-memory budget.
         PER_RANK_GB=$((TOTAL_CPU_DRAM_GB / TP))
@@ -234,8 +202,71 @@ EOF
             --kv-transfer-config
             '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true}}'
         )
-        ;;
-    lmcache)
+
+elif require_agentic_kv_offload_backend lmcache; then
+    # ---- Lmcache config ----------------------------------------------------------
+    LMCACHE_PID=""
+
+    cleanup_lmcache_server() {
+        if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            kill "$LMCACHE_PID" 2>/dev/null || true
+            wait "$LMCACHE_PID" 2>/dev/null || true
+        fi
+    }
+
+    trap cleanup_lmcache_server EXIT
+
+    cleanup_agentic_services() {
+        local exit_code=$?
+        trap - EXIT INT TERM
+        set +e
+        stop_background_process_tree "$ROUTER_PID" "vLLM router"
+        stop_background_process_tree "$SERVER_PID" "vLLM server" 60
+        stop_background_process_tree "$MOONCAKE_MASTER_PID" "Mooncake master"
+        exit "$exit_code"
+    }
+    trap cleanup_agentic_services EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    wait_for_lmcache_ready() {
+        { set +x; } 2>/dev/null
+        local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
+        local tail_pid=""
+
+        while [ ! -f "$LMCACHE_LOG" ]; do
+            if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+                echo "LMCache server died before creating log file. Exiting." >&2
+                exit 1
+            fi
+            sleep 1
+        done
+
+        tail -f -n +1 "$LMCACHE_LOG" &
+        tail_pid=$!
+
+        for ((i = 1; i <= attempts; i++)); do
+            if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
+                kill "$tail_pid" 2>/dev/null || true
+                wait "$tail_pid" 2>/dev/null || true
+                return 0
+            fi
+            if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+                echo "LMCache server died before becoming healthy. Log follows:" >&2
+                kill "$tail_pid" 2>/dev/null || true
+                wait "$tail_pid" 2>/dev/null || true
+                cat "$LMCACHE_LOG" >&2 || true
+                exit 1
+            fi
+            sleep 1
+        done
+
+        echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
+        kill "$tail_pid" 2>/dev/null || true
+        wait "$tail_pid" 2>/dev/null || true
+        cat "$LMCACHE_LOG" >&2 || true
+        exit 1
+    }
         { set +x; } 2>/dev/null
         unset VLLM_USE_SIMPLE_KV_OFFLOAD
 
@@ -247,6 +278,7 @@ EOF
 
         python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 
+        TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
         # Match the B200 Kimi LMCache setup: keep a 2.5 TB semantic CPU KV
         # pool, but let the external MP server own that pool so vLLM does not
         # split --kv-offloading-size across TP ranks through the integrated
@@ -258,7 +290,7 @@ EOF
         # ZMQ endpoint. Bind the server to a raw host, but pass the connector a
         # ZMQ-style host string.
         LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
-        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$TOTAL_CPU_DRAM_GB}"
+        LMCACHE_L1_SIZE_GB="${TOTAL_CPU_DRAM_PARTITION_GB}"
         if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
             echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
             exit 1
@@ -302,12 +334,8 @@ EOF
             --kv-transfer-config
             "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
         )
-        ;;
-    *)
-        echo "Error: unsupported OFFLOADING value '$OFFLOADING' (expected one of: none, cpu)" >&2
-        exit 1
-        ;;
-esac
+
+fi
 
 PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
 if [ "$DP_ATTENTION" = "true" ]; then
@@ -328,6 +356,7 @@ echo "Starting vllm server..."
 set -x
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export VLLM_ROCM_USE_AITER_MOE=1
 
 { set +x; } 2>/dev/null
 VLLM_CMD=(
@@ -340,7 +369,6 @@ VLLM_CMD=(
     --kv-cache-dtype fp8
     "${PARALLEL_ARGS[@]}"
     "${EP_ARGS[@]}"
-    --gpu-memory-utilization 0.95
     --moe-backend aiter
     --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
     --tokenizer-mode deepseek_v4

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -316,7 +316,7 @@ EOF
         LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
         LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
         export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
-        export LMCACHE_BLOCKING_TIMEOUT_SECS=120
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=600
 
         echo "Starting LMCache MP server..."
         LMCACHE_CMD=(
@@ -342,7 +342,7 @@ EOF
         PREFIX_CACHE_ARGS=(--enable-prefix-caching)
         OFFLOAD_ARGS=(
             --kv-transfer-config
-            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":600.0}}"
         )
     ;;
   *)
@@ -370,7 +370,7 @@ MAX_NUM_SEQS=$((2 * CONC))
 echo "Starting vllm server..."
 set -x
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+#export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 export VLLM_ROCM_USE_AITER_MOE=1
 
 { set +x; } 2>/dev/null
@@ -384,6 +384,7 @@ VLLM_CMD=(
     --kv-cache-dtype fp8
     "${PARALLEL_ARGS[@]}"
     "${EP_ARGS[@]}"
+    --gpu-memory-utilization 0.8 
     --moe-backend aiter
     --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
     --tokenizer-mode deepseek_v4

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -10,7 +10,7 @@ set -x
 #   TP+EP   (DP_ATTENTION=false, EP_SIZE>1):  attention TP-sharded, MoE
 #       experts EP-sharded within the TP group.
 #   DEP     (DP_ATTENTION=true, EP_SIZE>1):   per-DP-rank attention with
-#       experts EP-sharded across DP ranks.
+#       experts EP-sharded across DP ranks (per the vLLM blog recipe).
 #       Highest aggregate throughput at large CONC.
 #
 # Serving flags follow the validated MI355X recipe from

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -249,7 +249,7 @@ EOF
                 echo "LMCache server died before creating log file. Exiting." >&2
                 exit 1
             fi
-            sleep 1
+            sleep 10
         done
 
         tail -f -n +1 "$LMCACHE_LOG" &
@@ -282,7 +282,9 @@ EOF
 
         git clone https://github.com/LMCache/LMCache.git
         cd LMCache
-        pip install -r requirements/build.txt 
+        git checkout 1720917e
+        pip install -r requirements/build.txt
+        pip install grpcio==1.78.0
         CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
         cd ..
 
@@ -316,7 +318,8 @@ EOF
         LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
         LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
         export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
-        export LMCACHE_BLOCKING_TIMEOUT_SECS=600
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=1200
+        LMCACHE_TX_MODE="lmcache_driven"
 
         echo "Starting LMCache MP server..."
         LMCACHE_CMD=(
@@ -331,6 +334,7 @@ EOF
             --chunk-size "$LMCACHE_CHUNK_SIZE"
             --max-workers "$LMCACHE_MAX_WORKERS"
             --eviction-policy LRU
+            --supported-transfer-mode "$LMCACHE_TX_MODE"
         )
         printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
         printf '\n' >> "$RESULT_DIR/lmcache_command.txt"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -324,12 +324,6 @@ fi
 # leave 2x headroom rather than clipping those bursts at the scheduler.
 MAX_NUM_SEQS=$((2 * CONC))
 
-# Workaround for MEC FW <177 RCCL memory reclaim issue
-version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
-if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
-    export HSA_NO_SCRATCH_RECLAIM=1
-fi
-
 echo "Starting vllm server..."
 set -x
 export VLLM_ROCM_USE_AITER=1
@@ -346,12 +340,13 @@ VLLM_CMD=(
     --kv-cache-dtype fp8
     "${PARALLEL_ARGS[@]}"
     "${EP_ARGS[@]}"
-    --moe-backend triton_unfused
+    --gpu-memory-utilization 0.95
+    --moe-backend aiter
     --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
     --tokenizer-mode deepseek_v4
     --tool-call-parser deepseek_v4
-    --enable-auto-tool-choice
     --reasoning-parser deepseek_v4
+    --enable-auto-tool-choice
     --enable-prefix-caching
     --no-disable-hybrid-kv-cache-manager
     --max-num-seqs "$MAX_NUM_SEQS"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Agentic trace replay benchmark for DeepSeek-V4-Pro FP4 on MI355X using vLLM.
+# Mirrors the fixed-seq-len parallelism options (pure TP and DEP) so the
+# agentic sweep can probe both interactivity and throughput regimes:
+#   pure TP (DP_ATTENTION=false, EP_SIZE=1):  attention TP-sharded across
+#       all $TP GPUs in a single engine. Lower TPOT, lower batch.
+#   TP+EP   (DP_ATTENTION=false, EP_SIZE>1):  attention TP-sharded, MoE
+#       experts EP-sharded within the TP group.
+#   DEP     (DP_ATTENTION=true, EP_SIZE>1):   per-DP-rank attention with
+#       experts EP-sharded across DP ranks.
+#       Highest aggregate throughput at large CONC.
+#
+# Serving flags follow the validated MI355X recipe from
+# vllm-project/recipes#433: AITER+AITER_LINEAR, mp executor,
+# triton_unfused MoE (required for the FP4 expert format),
+# async scheduling, FULL_AND_PIECEWISE cudagraph capture.
+# Image is configured in amd-master.yaml.
+#
+# Required env vars:
+#   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
+#
+# OFFLOADING values:
+#   none - vLLM GPU KV only.
+#   cpu  - MooncakeStoreConnector with a configured host-memory KV tier.
+#   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+if [ -n "${ROCR_VISIBLE_DEVICES:-}" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+# ---- Resolve traces and install deps ----------------------------------------
+resolve_trace_source
+install_agentic_deps
+
+# (srok)
+#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
+export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=60
+export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=1200
+# (srok)
+export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
+
+# vLLM router for DEP runs: expands one HTTP backend into one logical worker
+# per DP rank and routes by X-Session-ID (aliased from X-Correlation-ID).
+USE_VLLM_ROUTER=false
+VLLM_BACKEND_PORT="$PORT"
+if [ "$DP_ATTENTION" = "true" ]; then
+    USE_VLLM_ROUTER=true
+    VLLM_BACKEND_PORT=$((PORT + 1))
+    VLLM_ROUTER_VERSION=0.1.14
+    VLLM_ROUTER_POLICY=consistent_hash
+    VLLM_ROUTER_METRICS_PORT=$((PORT + 10000))
+    export AIPERF_HTTP_X_SESSION_ID_FROM_CORRELATION_ID=1
+    agentic_pip_install --quiet "vllm-router==$VLLM_ROUTER_VERSION"
+fi
+
+# DeepSeek-V4-Pro weights are large; engine startup can exceed default 600s.
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+# vllm-project/vllm#43447 keeps local SWA prefix-cache tails sparsely, while
+# vllm-project/vllm#44774 applies the same reachability policy to Mooncake's
+# store mask. 32k matches the trace-replay tuning validated for this workload.
+export VLLM_PREFIX_CACHE_RETENTION_INTERVAL=32768
+
+# VLLM_PREFIX_CACHE_RETENTION_INTERVAL only applies to sliding-window/Mamba
+# models; this vLLM build raises ValueError if it is set for DSv4.
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+ROUTER_LOG="$RESULT_DIR/router.log"
+MOONCAKE_MASTER_LOG="$RESULT_DIR/mooncake_master.log"
+LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
+mkdir -p "$RESULT_DIR"
+
+OFFLOAD_ARGS=()
+
+# ---- Lmcache config ----------------------------------------------------------
+LMCACHE_PID=""
+
+cleanup_lmcache_server() {
+    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
+        kill "$LMCACHE_PID" 2>/dev/null || true
+        wait "$LMCACHE_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup_lmcache_server EXIT
+
+cleanup_agentic_services() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$ROUTER_PID" "vLLM router"
+    stop_background_process_tree "$SERVER_PID" "vLLM server" 60
+    stop_background_process_tree "$MOONCAKE_MASTER_PID" "Mooncake master"
+    exit "$exit_code"
+}
+trap cleanup_agentic_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_lmcache_ready() {
+    { set +x; } 2>/dev/null
+    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
+    local tail_pid=""
+
+    while [ ! -f "$LMCACHE_LOG" ]; do
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before creating log file. Exiting." >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    tail -f -n +1 "$LMCACHE_LOG" &
+    tail_pid=$!
+
+    for ((i = 1; i <= attempts; i++)); do
+        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            return 0
+        fi
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before becoming healthy. Log follows:" >&2
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            cat "$LMCACHE_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
+    kill "$tail_pid" 2>/dev/null || true
+    wait "$tail_pid" 2>/dev/null || true
+    cat "$LMCACHE_LOG" >&2 || true
+    exit 1
+}
+
+case "$OFFLOADING" in
+    none) ;;
+    cpu)
+        # Embedded mode contributes one segment per GPU rank to a shared
+        # distributed store, so pre-divide the aggregate host-memory budget.
+        PER_RANK_GB=$((TOTAL_CPU_DRAM_GB / TP))
+
+        #MOONCAKE_VERSION=0.3.11.post1
+        #apt-get update && apt-get install -y libcurl4 libibverbs1 rdma-core librdmacm1 libnuma1 liburing2
+        #agentic_pip_install --quiet --no-cache-dir --no-deps \
+        #    --force-reinstall "mooncake-transfer-engine-non-cuda==$MOONCAKE_VERSION"
+
+        git clone https://github.com/kvcache-ai/Mooncake.git
+        cd Mooncake
+        bash dependencies.sh
+        mkdir build
+        cd build
+        cmake ..
+        make -j
+        sudo make install # optional, make it ready to be used by vLLM/SGLang
+        cd ..
+        cd ..
+
+        python3 -c "from mooncake.store import MooncakeDistributedStore" >/dev/null
+        export INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=32
+        python3 "$(dirname "$0")/patch_vllm_mooncake_transfer_batches.py"
+
+        MOONCAKE_MASTER_PORT=$((PORT + 12000))
+        MOONCAKE_CONFIG_PATH="$RESULT_DIR/mooncake_config.json"
+        cat > "$MOONCAKE_CONFIG_PATH" <<EOF
+{
+  "mode": "embedded",
+  "metadata_server": "P2PHANDSHAKE",
+  "master_server_address": "127.0.0.1:$MOONCAKE_MASTER_PORT",
+  "global_segment_size": "${PER_RANK_GB}GB",
+  "local_buffer_size": "2GB",
+  "protocol": "tcp",
+  "device_name": "",
+  "enable_offload": false
+}
+EOF
+# (srok)
+  #"protocol": "rdma",
+  #"device_name": "mlx5_0",
+  #"local_buffer_size": "4GB",
+        export MOONCAKE_CONFIG_PATH
+        export MC_ENABLE_DEST_DEVICE_AFFINITY=1
+        export PYTHONHASHSEED=0
+        export MC_SLICE_SIZE=1048576
+        # (srok)
+        #export MC_WORKERS_PER_CTX=4
+        export MC_WORKERS_PER_CTX=8
+
+        MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO=0.80
+        MOONCAKE_EVICTION_RATIO=0.10
+        MOONCAKE_KV_LEASE_TTL=60s
+        #MOONCAKE_KV_LEASE_TTL=3600s
+
+        echo "Starting Mooncake master on port $MOONCAKE_MASTER_PORT..."
+        mooncake_master --port "$MOONCAKE_MASTER_PORT" \
+            --eviction_high_watermark_ratio="$MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO" \
+            --eviction_ratio="$MOONCAKE_EVICTION_RATIO" \
+            --default_kv_lease_ttl="$MOONCAKE_KV_LEASE_TTL" \
+            > "$MOONCAKE_MASTER_LOG" 2>&1 &
+
+        sleep 10
+        MOONCAKE_MASTER_PID=$!
+        if ! kill -0 "$MOONCAKE_MASTER_PID" 2>/dev/null; then
+            echo "Mooncake master died during startup." >&2
+            cat "$MOONCAKE_MASTER_LOG" >&2
+            exit 1
+        fi
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true}}'
+        )
+        ;;
+    lmcache)
+        { set +x; } 2>/dev/null
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+
+        git clone https://github.com/LMCache/LMCache.git
+        cd LMCache
+        pip install -r requirements/build.txt 
+        CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
+        cd ..
+
+        python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
+
+        # Match the B200 Kimi LMCache setup: keep a 2.5 TB semantic CPU KV
+        # pool, but let the external MP server own that pool so vLLM does not
+        # split --kv-offloading-size across TP ranks through the integrated
+        # LMCache backend.
+        LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
+        LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+        LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+        # LMCacheMPConnector concatenates lmcache.mp.host and port into the
+        # ZMQ endpoint. Bind the server to a raw host, but pass the connector a
+        # ZMQ-style host string.
+        LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
+        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$TOTAL_CPU_DRAM_GB}"
+        if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+            echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
+            exit 1
+        fi
+        LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
+        # LMCache read locks are leases on chunks that lookup has promised
+        # vLLM can retrieve. The default 300s TTL is too short for this
+        # long-context agentic queue: TP8/conc32 can spend >300s between
+        # lookup and retrieve while GPU KV is saturated, which leaves the
+        # object present in L1 but no longer readable. Keep the 2.5 TB pool
+        # size unchanged and only extend the lookup-to-retrieve lease.
+        LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
+        LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+        LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
+        export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=120
+
+        echo "Starting LMCache MP server..."
+        LMCACHE_CMD=(
+            lmcache server
+            --host "$LMCACHE_HOST"
+            --port "$LMCACHE_PORT"
+            --http-host "$LMCACHE_HOST"
+            --http-port "$LMCACHE_HTTP_PORT"
+            --l1-size-gb "$LMCACHE_L1_SIZE_GB"
+            --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
+            --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
+            --chunk-size "$LMCACHE_CHUNK_SIZE"
+            --max-workers "$LMCACHE_MAX_WORKERS"
+            --eviction-policy LRU
+        )
+        printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
+        printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
+        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+        LMCACHE_PID=$!
+        echo "LMCache server PID: $LMCACHE_PID"
+        wait_for_lmcache_ready
+
+        PREFIX_CACHE_ARGS=(--enable-prefix-caching)
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+        )
+        ;;
+    *)
+        echo "Error: unsupported OFFLOADING value '$OFFLOADING' (expected one of: none, cpu)" >&2
+        exit 1
+        ;;
+esac
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "$DP_ATTENTION" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+# AgentX concurrency counts live session trees, not individual requests.
+# Subagent fan-out can push instantaneous request concurrency above CONC, so
+# leave 2x headroom rather than clipping those bursts at the scheduler.
+MAX_NUM_SEQS=$((2 * CONC))
+
+# Workaround for MEC FW <177 RCCL memory reclaim issue
+version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
+if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
+    export HSA_NO_SCRATCH_RECLAIM=1
+fi
+
+echo "Starting vllm server..."
+set -x
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+{ set +x; } 2>/dev/null
+VLLM_CMD=(
+    vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$VLLM_BACKEND_PORT"
+    --trust-remote-code
+    --async-scheduling
+    --distributed-executor-backend mp
+    --kv-cache-dtype fp8
+    "${PARALLEL_ARGS[@]}"
+    "${EP_ARGS[@]}"
+    --moe-backend triton_unfused
+    --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+    --tokenizer-mode deepseek_v4
+    --tool-call-parser deepseek_v4
+    --enable-auto-tool-choice
+    --reasoning-parser deepseek_v4
+    --enable-prefix-caching
+    --no-disable-hybrid-kv-cache-manager
+    --max-num-seqs "$MAX_NUM_SEQS"
+    "${OFFLOAD_ARGS[@]}"
+)
+
+# (srok), not yet
+    #--attention_config.use_fp4_indexer_cache=True
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$VLLM_BACKEND_PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "$USE_VLLM_ROUTER" = "true" ]; then
+    echo "Starting native vLLM router on port $PORT for $TP DP ranks..."
+    vllm-router \
+        --worker-urls "http://localhost:$VLLM_BACKEND_PORT" \
+        --policy "$VLLM_ROUTER_POLICY" \
+        --intra-node-data-parallel-size "$TP" \
+        --host 0.0.0.0 \
+        --port "$PORT" \
+        --prometheus-host 127.0.0.1 \
+        --prometheus-port "$VLLM_ROUTER_METRICS_PORT" \
+        --request-timeout-secs 14400 \
+        --disable-retries > "$ROUTER_LOG" 2>&1 &
+    ROUTER_PID=$!
+    echo "Router PID: $ROUTER_PID"
+    wait_for_server_ready --port "$PORT" --server-log "$ROUTER_LOG" --server-pid "$ROUTER_PID"
+fi
+
+# ---- Run benchmark ----------------------------------------------------------
+build_replay_cmd "$RESULT_DIR"
+
+run_agentic_replay_and_write_outputs "$RESULT_DIR"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -103,7 +103,10 @@ MOONCAKE_MASTER_PID=""
 
 OFFLOAD_ARGS=()
 
-if require_agentic_kv_offload_backend native; then
+if agentic_kv_offload_enabled; then
+case "${KV_OFFLOAD_BACKEND:-}" in
+  native)
+    require_agentic_kv_offload_backend native
     # ---- vLLM native config ----------------------------------------------------------
     unset VLLM_USE_SIMPLE_KV_OFFLOAD
     # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
@@ -126,7 +129,9 @@ if require_agentic_kv_offload_backend native; then
         --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
     )
 
-elif require_agentic_kv_offload_backend mooncake; then
+    ;;
+  mooncake)
+    require_agentic_kv_offload_backend mooncake
     # ---- Mooncake config ----------------------------------------------------------
         # Embedded mode contributes one segment per GPU rank to a shared
         # distributed store, so pre-divide the aggregate host-memory budget.
@@ -203,7 +208,9 @@ EOF
             '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_connector_extra_config":{"load_async":true}}'
         )
 
-elif require_agentic_kv_offload_backend lmcache; then
+    ;;
+  lmcache)
+    require_agentic_kv_offload_backend lmcache
     # ---- Lmcache config ----------------------------------------------------------
     LMCACHE_PID=""
 
@@ -334,7 +341,12 @@ elif require_agentic_kv_offload_backend lmcache; then
             --kv-transfer-config
             "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
         )
-
+    ;;
+  *)
+    echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected: native, mooncake, lmcache)" >&2
+    exit 1
+    ;;
+esac
 fi
 
 PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -55,6 +55,9 @@ fi
 resolve_trace_source
 install_agentic_deps
 
+# Nightly ROCm image may be missing runtime deps; ensure they are present.
+agentic_pip_install --quiet Pillow fastapi uvicorn
+
 # default
 export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
 # tune

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 set -x
 
-# Agentic trace replay benchmark for Kimi-K2.5 FP4 on MI355X using vLLM.
+# Agentic trace replay benchmark for Kimi-K2.7 FP4 on MI355X using vLLM.
 #
 # Required env vars:
 #   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
@@ -71,6 +71,9 @@ if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
 fi
 
 export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MLA=0
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
+export VLLM_ROCM_USE_AITER_FP4BMM=0
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 # ---- Server config ----------------------------------------------------------
@@ -254,6 +257,9 @@ if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
 fi
 
 export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MLA=0
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
+export VLLM_ROCM_USE_AITER_FP4BMM=0
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 { set +x; } 2>/dev/null

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -282,7 +282,6 @@ VLLM_CMD=(
     --tensor-parallel-size="$TP"
     "${EP_ARGS[@]}"
     --gpu-memory-utilization 0.90
-    --kv-cache-dtype fp8
     --trust-remote-code
     --max-num-seqs "$CONC"
     --mm-encoder-tp-mode data

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Agentic trace replay benchmark for Kimi-K2.5 FP4 on MI355X using vLLM.
+#
+# Required env vars:
+#   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
+#
+# OFFLOADING values:
+#   none    - vLLM GPU KV only.
+#   cpu     - vLLM native CPU offload.
+#   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR EP_SIZE DP_ATTENTION
+
+PORT=${PORT:-8888}
+DURATION=${DURATION:-1800}
+EP_SIZE=${EP_SIZE:-1}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+# ROCR/HIP visibility for vLLM 0.14+
+if [ -n "${ROCR_VISIBLE_DEVICES:-}" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
+# Either way, MODEL_PATH is what the server is launched with.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+rocm-smi || true
+amd-smi || true
+
+# ---- Resolve traces and install deps ----------------------------------------
+# Cap the replay corpus at 256k (470 traces, max in+out <= 256k) instead of the
+# unfiltered 052726 corpus whose ~1M-token traces get rejected and add no perf
+# signal at high concurrency.
+#export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_256k
+#060226
+#export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_060226_256k
+
+# ---- Resolve traces and install deps ----------------------------------------
+resolve_trace_source
+install_agentic_deps
+
+# Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
+pip install amd-quark
+
+# Disable AITER RMSNorm for TP < 8 due to accuracy issues
+if [ "${TP}" -lt 8 ]; then
+  export VLLM_ROCM_USE_AITER_RMSNORM=0
+fi
+
+# Workaround for MEC FW <177 RCCL memory reclaim issue
+version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
+if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
+    export HSA_NO_SCRATCH_RECLAIM=1
+fi
+
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
+mkdir -p "$RESULT_DIR"
+
+OFFLOAD_ARGS=()
+PREFIX_CACHE_ARGS=()
+
+# ---- Lmcache config ----------------------------------------------------------
+LMCACHE_PID=""
+
+cleanup_lmcache_server() {
+    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
+        kill "$LMCACHE_PID" 2>/dev/null || true
+        wait "$LMCACHE_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup_lmcache_server EXIT
+
+wait_for_lmcache_ready() {
+    { set +x; } 2>/dev/null
+    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
+    local tail_pid=""
+
+    while [ ! -f "$LMCACHE_LOG" ]; do
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before creating log file. Exiting." >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    tail -f -n +1 "$LMCACHE_LOG" &
+    tail_pid=$!
+
+    for ((i = 1; i <= attempts; i++)); do
+        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            return 0
+        fi
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before becoming healthy. Log follows:" >&2
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            cat "$LMCACHE_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
+    kill "$tail_pid" 2>/dev/null || true
+    wait "$tail_pid" 2>/dev/null || true
+    cat "$LMCACHE_LOG" >&2 || true
+    exit 1
+}
+
+case "$OFFLOADING" in
+    none) ;;
+    cpu)
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+        # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
+        # reserve 2.5 TB for the offload pool (leaves ~200 GB headroom for
+        # worker RSS / page cache / slurm cgroup).
+        #TODO: fix
+        TOTAL_CPU_DRAM_GB=3000
+        TOTAL_CPU_DRAM_PARTITION_GB="${TOTAL_CPU_DRAM_PARTITION_GB:-$((TOTAL_CPU_DRAM_GB / (8 / TP)))}"
+        # Use vLLM's regular native KV-offload path (OffloadingConnector),
+        # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+        # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
+        # would switch it to SimpleCPUOffloadConnector. We intentionally leave
+        # that env var UNSET here so the regular OffloadingConnector path is
+        # used. The shortcut --kv_offloading_backend native + --kv_offloading_size
+        # form constructs the KVTransferConfig at engine startup
+        # (vllm/config/vllm.py:662).
+        OFFLOAD_ARGS=(
+            --kv_offloading_backend native
+            --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
+            --disable-hybrid-kv-cache-manager
+        )
+        ;;
+    lmcache)
+        { set +x; } 2>/dev/null
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+
+        git clone https://github.com/LMCache/LMCache.git
+        cd LMCache
+        pip install -r requirements/build.txt 
+        CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
+        cd ..
+
+        python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
+
+        # Match the B200 Kimi LMCache setup: keep a 2.5 TB semantic CPU KV
+        # pool, but let the external MP server own that pool so vLLM does not
+        # split --kv-offloading-size across TP ranks through the integrated
+        # LMCache backend.
+        #TODO: fix
+        TOTAL_CPU_DRAM_GB=3000
+        LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
+        LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+        LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+        # LMCacheMPConnector concatenates lmcache.mp.host and port into the
+        # ZMQ endpoint. Bind the server to a raw host, but pass the connector a
+        # ZMQ-style host string.
+        LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
+        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$TOTAL_CPU_DRAM_GB}"
+        if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+            echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
+            exit 1
+        fi
+        LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
+        # LMCache read locks are leases on chunks that lookup has promised
+        # vLLM can retrieve. The default 300s TTL is too short for this
+        # long-context agentic queue: TP8/conc32 can spend >300s between
+        # lookup and retrieve while GPU KV is saturated, which leaves the
+        # object present in L1 but no longer readable. Keep the 2.5 TB pool
+        # size unchanged and only extend the lookup-to-retrieve lease.
+        LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
+        LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+        LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
+        export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=120
+
+        echo "Starting LMCache MP server..."
+        LMCACHE_CMD=(
+            lmcache server
+            --host "$LMCACHE_HOST"
+            --port "$LMCACHE_PORT"
+            --http-host "$LMCACHE_HOST"
+            --http-port "$LMCACHE_HTTP_PORT"
+            --l1-size-gb "$LMCACHE_L1_SIZE_GB"
+            --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
+            --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
+            --chunk-size "$LMCACHE_CHUNK_SIZE"
+            --max-workers "$LMCACHE_MAX_WORKERS"
+            --eviction-policy LRU
+        )
+        printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
+        printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
+        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+        LMCACHE_PID=$!
+        echo "LMCache server PID: $LMCACHE_PID"
+        wait_for_lmcache_ready
+
+        PREFIX_CACHE_ARGS=(--enable-prefix-caching)
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+            --disable-hybrid-kv-cache-manager
+        )
+        ;;
+    *) echo "Error: unsupported OFFLOADING value '$OFFLOADING'" >&2; exit 1 ;;
+esac
+
+# ---- LLM server config ----------------------------------------------------------
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+echo "Starting vllm server..."
+export PYTHONNOUSERSITE=1
+
+# Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
+pip install amd-quark
+
+# Disable AITER RMSNorm for TP < 8 due to accuracy issues
+if [ "${TP}" -lt 8 ]; then
+  export VLLM_ROCM_USE_AITER_RMSNORM=0
+fi
+
+# Workaround for MEC FW <177 RCCL memory reclaim issue
+version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
+if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
+    export HSA_NO_SCRATCH_RECLAIM=1
+fi
+
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+{ set +x; } 2>/dev/null
+VLLM_CMD=(
+    vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --tensor-parallel-size="$TP"
+    "${EP_ARGS[@]}"
+    --gpu-memory-utilization 0.90
+    --kv-cache-dtype fp8 \
+    --block-size=1
+    --trust-remote-code
+    --max-num-seqs "$CONC"
+    --mm-encoder-tp-mode data
+    "${PREFIX_CACHE_ARGS[@]}"
+    "${OFFLOAD_ARGS[@]}"
+)
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ---- Run benchmark ----------------------------------------------------------
+build_replay_cmd "$RESULT_DIR"
+
+run_agentic_replay_and_write_outputs "$RESULT_DIR"

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -3,24 +3,16 @@ set -euo pipefail
 set -x
 
 # Agentic trace replay benchmark for Kimi-K2.7 FP4 on MI355X using vLLM.
-# Offload handling mirrors the validated DSv4 MI355X agentic recipe.
 #
 # Required env vars:
-#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION,
-#   EP_SIZE, DP_ATTENTION
+#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
 #
-# KV_OFFLOADING=none            - vLLM GPU KV only.
-# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND:
-#   native  - vLLM OffloadingConnector to CPU DRAM.
-#   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
+# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=native.
+
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
-check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
-
-PORT=${PORT:-8888}
-DURATION=${DURATION:-1800}
-EP_SIZE=${EP_SIZE:-1}
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE
 
 if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
@@ -42,25 +34,12 @@ else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"
 fi
-
 rocm-smi || true
 amd-smi || true
 
 # ---- Resolve traces and install deps ----------------------------------------
-# Cap the replay corpus at 256k (470 traces, max in+out <= 256k) instead of the
-# unfiltered 052726 corpus whose ~1M-token traces get rejected and add no perf
-# signal at high concurrency.
-#export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_256k
-#060226
-#export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_060226_256k
-
-# ---- Resolve traces and install deps ----------------------------------------
 resolve_trace_source
 install_agentic_deps
-
-# Agentic cache warmup duration (seconds); matches the validated DSv4 MI355X
-# recipe. Overridable via env for fast offload-mode diagnostics.
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION="${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-600}"
 
 # Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
 pip install amd-quark
@@ -69,7 +48,6 @@ pip install amd-quark
 if [ "${TP}" -lt 8 ]; then
   export VLLM_ROCM_USE_AITER_RMSNORM=0
 fi
-
 # Workaround for MEC FW <177 RCCL memory reclaim issue
 version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
 if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
@@ -77,186 +55,32 @@ if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
 fi
 
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MLA=0
-export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
-export VLLM_ROCM_USE_AITER_FP4BMM=0
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 
 # ---- Server config ----------------------------------------------------------
 SERVER_LOG="$RESULT_DIR/server.log"
-LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
 mkdir -p "$RESULT_DIR"
 
 OFFLOAD_ARGS=()
+PREFIX_CACHE_ARGS=()
 
-# ---- Lmcache config ----------------------------------------------------------
-LMCACHE_PID=""
-
-cleanup_lmcache_server() {
-    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
-        kill "$LMCACHE_PID" 2>/dev/null || true
-        wait "$LMCACHE_PID" 2>/dev/null || true
-    fi
-}
-
-trap cleanup_lmcache_server EXIT
-
-wait_for_lmcache_ready() {
-    { set +x; } 2>/dev/null
-    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
-    local tail_pid=""
-
-    while [ ! -f "$LMCACHE_LOG" ]; do
-        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
-            echo "LMCache server died before creating log file. Exiting." >&2
-            exit 1
-        fi
-        sleep 1
-    done
-
-    tail -f -n +1 "$LMCACHE_LOG" &
-    tail_pid=$!
-
-    for ((i = 1; i <= attempts; i++)); do
-        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
-            kill "$tail_pid" 2>/dev/null || true
-            wait "$tail_pid" 2>/dev/null || true
-            return 0
-        fi
-        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
-            echo "LMCache server died before becoming healthy. Log follows:" >&2
-            kill "$tail_pid" 2>/dev/null || true
-            wait "$tail_pid" 2>/dev/null || true
-            cat "$LMCACHE_LOG" >&2 || true
-            exit 1
-        fi
-        sleep 1
-    done
-
-    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
-    kill "$tail_pid" 2>/dev/null || true
-    wait "$tail_pid" 2>/dev/null || true
-    cat "$LMCACHE_LOG" >&2 || true
-    exit 1
-}
-
-if agentic_kv_offload_enabled; then
-case "${KV_OFFLOAD_BACKEND:-}" in
-  native)
-    require_agentic_kv_offload_backend native
-    # ---- vLLM native config ----------------------------------------------------------
+if require_agentic_kv_offload_backend native; then
     unset VLLM_USE_SIMPLE_KV_OFFLOAD
-    # Partition the aggregate host-DRAM budget across the ranks that share the
-    # offload pool (TOTAL_CPU_DRAM_GB comes from the sweep's dram-utilization).
-    TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
-    # Use vLLM's regular native KV-offload path (OffloadingConnector), NOT the
-    # SimpleCPUOffloadConnector. The "native" backend resolves to
-    # OffloadingConnector by default; leaving VLLM_USE_SIMPLE_KV_OFFLOAD unset
-    # keeps that path. --kv_offloading_backend native + --kv_offloading_size
-    # constructs the KVTransferConfig at engine startup.
-    # Keep the hybrid kv-cache manager enabled (default) — disabling it lowers
-    # the cache hit rate, per the validated DSv4 MI355X recipe.
+    # Use vLLM's regular native KV-offload path (OffloadingConnector),
+    # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+    # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
+    # would switch it to SimpleCPUOffloadConnector. We intentionally leave
+    # that env var UNSET here so the regular OffloadingConnector path is
+    # used. The shortcut --kv_offloading_backend native + --kv_offloading_size
+    # form constructs the KVTransferConfig at engine startup
+    # (vllm/config/vllm.py:662).
     OFFLOAD_ARGS=(
         --kv_offloading_backend native
-        --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
+        --kv_offloading_size "$TOTAL_CPU_DRAM_GB"
+        --disable-hybrid-kv-cache-manager
     )
-    ;;
-  lmcache)
-    require_agentic_kv_offload_backend lmcache
-    # ---- LMCache config ----------------------------------------------------------
-    { set +x; } 2>/dev/null
-    unset VLLM_USE_SIMPLE_KV_OFFLOAD
-
-    # LMCache on ROCm must be built from source with BUILD_WITH_HIP=1 — the
-    # PyPI wheel is CUDA-only and silently falls back to a slow copy path
-    # (no warm-pass win). Pin a release tag and verify the HIP c_ops import
-    # plus the ROCm CuPy build, per the AMD LMCache workshop recipe.
-    LMCACHE_VERSION="${LMCACHE_VERSION:-v0.5.0}"
-    if ! python3 -c "from lmcache import c_ops" 2>/dev/null; then
-        command -v hipcc >/dev/null || { echo "ERROR: hipcc not found — need the ROCm toolchain to build LMCache" >&2; exit 1; }
-        pip uninstall -y lmcache >/dev/null 2>&1 || true
-        rm -rf LMCache
-        git clone --depth 1 --branch "$LMCACHE_VERSION" https://github.com/LMCache/LMCache.git
-        cd LMCache
-        pip install -r requirements/build.txt
-        CXX=hipcc BUILD_WITH_HIP=1 pip install -e . --no-build-isolation
-        cd ..
-    fi
-
-    # ROCm CuPy (force-reinstall so a half-removed CUDA build can't linger)
-    # and re-pin deps the source build / cupy pull can disturb.
-    pip uninstall -y cupy cupy-cuda12x cupy-cuda13x nixl nixl-cu12 nixl-cu13 nixl_ep >/dev/null 2>&1 || true
-    pip install --force-reinstall --no-cache-dir cupy-rocm-7-0
-    pip install -q "numpy==2.1.3" "grpcio==1.78.0" || true
-
-    # Fail loudly if we're on the slow CUDA-wheel fallback (c_ops missing or
-    # CuPy not the ROCm build) — otherwise the run silently loses the offload.
-    python3 -c "
-import lmcache
-from lmcache import c_ops
-import cupy
-from cupy_backends.cuda.api import runtime as r
-assert getattr(r, 'is_hip', False), 'CuPy is not the ROCm build (is_hip=False)'
-print('lmcache', lmcache.__version__, '| cupy', cupy.__version__, '| is_hip =', r.is_hip)
-"
-    python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
-
-    TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
-    LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
-    LMCACHE_PORT="${LMCACHE_PORT:-5555}"
-    LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
-    # LMCacheMPConnector concatenates lmcache.mp.host and port into the ZMQ
-    # endpoint. Bind the server to a raw host, pass the connector a ZMQ-style host.
-    LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
-    LMCACHE_L1_SIZE_GB="${TOTAL_CPU_DRAM_PARTITION_GB}"
-    if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
-        echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
-        exit 1
-    fi
-    LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
-    # Extend the lookup-to-retrieve lease well past the default 300s: a
-    # long-context agentic queue can spend minutes between lookup and retrieve
-    # while GPU KV is saturated, which otherwise expires the lease.
-    LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
-    LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-32}"
-    LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
-    export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
-    export LMCACHE_BLOCKING_TIMEOUT_SECS=120
-
-    echo "Starting LMCache MP server..."
-    LMCACHE_CMD=(
-        lmcache server
-        --host "$LMCACHE_HOST"
-        --port "$LMCACHE_PORT"
-        --http-host "$LMCACHE_HOST"
-        --http-port "$LMCACHE_HTTP_PORT"
-        --l1-size-gb "$LMCACHE_L1_SIZE_GB"
-        --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
-        --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
-        --chunk-size "$LMCACHE_CHUNK_SIZE"
-        --max-workers "$LMCACHE_MAX_WORKERS"
-        --eviction-policy LRU
-    )
-    printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
-    printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
-    "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
-    LMCACHE_PID=$!
-    echo "LMCache server PID: $LMCACHE_PID"
-    wait_for_lmcache_ready
-
-    OFFLOAD_ARGS=(
-        --kv-transfer-config
-        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
-    )
-    ;;
-  *)
-    echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected: native, lmcache)" >&2
-    exit 1
-    ;;
-esac
 fi
 
-# ---- LLM server config ----------------------------------------------------------
 EP_ARGS=()
 if [ "$EP_SIZE" -gt 1 ]; then
     EP_ARGS=(--enable-expert-parallel)
@@ -264,32 +88,6 @@ fi
 
 echo "Starting vllm server..."
 export PYTHONNOUSERSITE=1
-
-# Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
-pip install amd-quark
-
-# Disable AITER RMSNorm for TP < 8 due to accuracy issues
-if [ "${TP}" -lt 8 ]; then
-  export VLLM_ROCM_USE_AITER_RMSNORM=0
-fi
-
-# Workaround for MEC FW <177 RCCL memory reclaim issue
-version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
-if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
-    export HSA_NO_SCRATCH_RECLAIM=1
-fi
-
-export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MLA=0
-export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
-export VLLM_ROCM_USE_AITER_FP4BMM=0
-export VLLM_ROCM_USE_AITER_MOE=1
-export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-
-# AgentX concurrency counts live session trees, not individual requests.
-# Subagent fan-out can push instantaneous request concurrency above CONC, so
-# leave 2x headroom rather than clipping those bursts at the scheduler.
-MAX_NUM_SEQS=$((2 * CONC))
 
 { set +x; } 2>/dev/null
 VLLM_CMD=(
@@ -299,15 +97,11 @@ VLLM_CMD=(
     --tensor-parallel-size="$TP"
     "${EP_ARGS[@]}"
     --gpu-memory-utilization 0.90
+    --block-size=1
     --trust-remote-code
-    --async-scheduling
-    --distributed-executor-backend mp
-    --moe-backend aiter
-    --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
-    --enable-prefix-caching
-    --no-disable-hybrid-kv-cache-manager
-    --max-num-seqs "$MAX_NUM_SEQS"
+    --max-num-seqs "$CONC"
     --mm-encoder-tp-mode data
+    "${PREFIX_CACHE_ARGS[@]}"
     "${OFFLOAD_ARGS[@]}"
 )
 printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -75,6 +75,11 @@ amd-smi || true
 resolve_trace_source
 install_agentic_deps
 
+# Agentic cache warmup duration (seconds). Overridable via env; short default
+# here keeps the offload-mode diagnostics fast (the offload path exercises the
+# same code as a full run, just over a shorter window).
+export AIPERF_AGENTIC_CACHE_WARMUP_DURATION="${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-60}"
+
 # Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
 pip install amd-quark
 

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -218,7 +218,7 @@ print('lmcache', lmcache.__version__, '| cupy', cupy.__version__, '| is_hip =', 
     # long-context agentic queue can spend minutes between lookup and retrieve
     # while GPU KV is saturated, which otherwise expires the lease.
     LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
-    LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+    LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-32}"
     LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
     export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
     export LMCACHE_BLOCKING_TIMEOUT_SECS=120

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -3,37 +3,20 @@ set -euo pipefail
 set -x
 
 # Agentic trace replay benchmark for Kimi-K2.7 FP4 on MI355X using vLLM.
+# Offload handling mirrors the validated DSv4 MI355X agentic recipe.
 #
 # Required env vars:
-#   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
+#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION,
+#   EP_SIZE, DP_ATTENTION
 #
-# OFFLOADING values:
-#   none    - vLLM GPU KV only.
-#   cpu     - vLLM native CPU offload.
+# KV_OFFLOADING=none            - vLLM GPU KV only.
+# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND:
+#   native  - vLLM OffloadingConnector to CPU DRAM.
 #   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
-# CI exports KV_OFFLOADING (none/dram) plus KV_OFFLOAD_BACKEND (native/lmcache);
-# this recipe's case statement keys off OFFLOADING (none/cpu/lmcache). Map the
-# sweep's (dram, backend) pair onto OFFLOADING when it isn't set directly
-# (standalone runs still pass OFFLOADING). native -> cpu (vLLM OffloadingConnector).
-if [[ -z "${OFFLOADING:-}" && -n "${KV_OFFLOADING:-}" ]]; then
-    case "$KV_OFFLOADING" in
-        none) OFFLOADING=none ;;
-        dram)
-            case "${KV_OFFLOAD_BACKEND:-native}" in
-                native) OFFLOADING=cpu ;;
-                lmcache) OFFLOADING=lmcache ;;
-                *) echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected native or lmcache)" >&2; exit 1 ;;
-            esac
-            ;;
-        *) OFFLOADING="$KV_OFFLOADING" ;;
-    esac
-    export OFFLOADING
-fi
-
-check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR EP_SIZE DP_ATTENTION
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
 
 PORT=${PORT:-8888}
 DURATION=${DURATION:-1800}
@@ -75,10 +58,9 @@ amd-smi || true
 resolve_trace_source
 install_agentic_deps
 
-# Agentic cache warmup duration (seconds). Overridable via env; short default
-# here keeps the offload-mode diagnostics fast (the offload path exercises the
-# same code as a full run, just over a shorter window).
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION="${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-60}"
+# Agentic cache warmup duration (seconds); matches the validated DSv4 MI355X
+# recipe. Overridable via env for fast offload-mode diagnostics.
+export AIPERF_AGENTIC_CACHE_WARMUP_DURATION="${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-600}"
 
 # Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
 pip install amd-quark
@@ -106,7 +88,6 @@ LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
 mkdir -p "$RESULT_DIR"
 
 OFFLOAD_ARGS=()
-PREFIX_CACHE_ARGS=()
 
 # ---- Lmcache config ----------------------------------------------------------
 LMCACHE_PID=""
@@ -159,59 +140,58 @@ wait_for_lmcache_ready() {
     exit 1
 }
 
-case "$OFFLOADING" in
-    none) ;;
-    cpu)
-        unset VLLM_USE_SIMPLE_KV_OFFLOAD
-        # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
-        # reserve 2.5 TB for the offload pool (leaves ~200 GB headroom for
-        # worker RSS / page cache / slurm cgroup).
-        #TODO: fix
-        TOTAL_CPU_DRAM_GB=3000
-        TOTAL_CPU_DRAM_PARTITION_GB="${TOTAL_CPU_DRAM_PARTITION_GB:-$((TOTAL_CPU_DRAM_GB / (8 / TP)))}"
-        # Use vLLM's regular native KV-offload path (OffloadingConnector),
-        # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
-        # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
-        # would switch it to SimpleCPUOffloadConnector. We intentionally leave
-        # that env var UNSET here so the regular OffloadingConnector path is
-        # used. The shortcut --kv_offloading_backend native + --kv_offloading_size
-        # form constructs the KVTransferConfig at engine startup
-        # (vllm/config/vllm.py:662).
-        OFFLOAD_ARGS=(
-            --kv_offloading_backend native
-            --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
-            --disable-hybrid-kv-cache-manager
-        )
-        ;;
-    lmcache)
-        { set +x; } 2>/dev/null
-        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+if agentic_kv_offload_enabled; then
+case "${KV_OFFLOAD_BACKEND:-}" in
+  native)
+    require_agentic_kv_offload_backend native
+    # ---- vLLM native config ----------------------------------------------------------
+    unset VLLM_USE_SIMPLE_KV_OFFLOAD
+    # Partition the aggregate host-DRAM budget across the ranks that share the
+    # offload pool (TOTAL_CPU_DRAM_GB comes from the sweep's dram-utilization).
+    TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
+    # Use vLLM's regular native KV-offload path (OffloadingConnector), NOT the
+    # SimpleCPUOffloadConnector. The "native" backend resolves to
+    # OffloadingConnector by default; leaving VLLM_USE_SIMPLE_KV_OFFLOAD unset
+    # keeps that path. --kv_offloading_backend native + --kv_offloading_size
+    # constructs the KVTransferConfig at engine startup.
+    # Keep the hybrid kv-cache manager enabled (default) — disabling it lowers
+    # the cache hit rate, per the validated DSv4 MI355X recipe.
+    OFFLOAD_ARGS=(
+        --kv_offloading_backend native
+        --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
+    )
+    ;;
+  lmcache)
+    require_agentic_kv_offload_backend lmcache
+    # ---- LMCache config ----------------------------------------------------------
+    { set +x; } 2>/dev/null
+    unset VLLM_USE_SIMPLE_KV_OFFLOAD
 
-        # LMCache on ROCm must be built from source with BUILD_WITH_HIP=1 — the
-        # PyPI wheel is CUDA-only and silently falls back to a slow copy path
-        # (no warm-pass win). Pin a release tag and verify the HIP c_ops import
-        # plus the ROCm CuPy build, per the AMD LMCache workshop recipe.
-        LMCACHE_VERSION="${LMCACHE_VERSION:-v0.5.0}"
-        if ! python3 -c "from lmcache import c_ops" 2>/dev/null; then
-            command -v hipcc >/dev/null || { echo "ERROR: hipcc not found — need the ROCm toolchain to build LMCache" >&2; exit 1; }
-            pip uninstall -y lmcache >/dev/null 2>&1 || true
-            rm -rf LMCache
-            git clone --depth 1 --branch "$LMCACHE_VERSION" https://github.com/LMCache/LMCache.git
-            cd LMCache
-            pip install -r requirements/build.txt
-            CXX=hipcc BUILD_WITH_HIP=1 pip install -e . --no-build-isolation
-            cd ..
-        fi
+    # LMCache on ROCm must be built from source with BUILD_WITH_HIP=1 — the
+    # PyPI wheel is CUDA-only and silently falls back to a slow copy path
+    # (no warm-pass win). Pin a release tag and verify the HIP c_ops import
+    # plus the ROCm CuPy build, per the AMD LMCache workshop recipe.
+    LMCACHE_VERSION="${LMCACHE_VERSION:-v0.5.0}"
+    if ! python3 -c "from lmcache import c_ops" 2>/dev/null; then
+        command -v hipcc >/dev/null || { echo "ERROR: hipcc not found — need the ROCm toolchain to build LMCache" >&2; exit 1; }
+        pip uninstall -y lmcache >/dev/null 2>&1 || true
+        rm -rf LMCache
+        git clone --depth 1 --branch "$LMCACHE_VERSION" https://github.com/LMCache/LMCache.git
+        cd LMCache
+        pip install -r requirements/build.txt
+        CXX=hipcc BUILD_WITH_HIP=1 pip install -e . --no-build-isolation
+        cd ..
+    fi
 
-        # ROCm CuPy (force-reinstall so a half-removed CUDA build can't linger)
-        # and re-pin deps the source build / cupy pull can disturb.
-        pip uninstall -y cupy cupy-cuda12x cupy-cuda13x nixl nixl-cu12 nixl-cu13 nixl_ep >/dev/null 2>&1 || true
-        pip install --force-reinstall --no-cache-dir cupy-rocm-7-0
-        pip install -q "numpy==2.1.3" "grpcio==1.78.0" || true
+    # ROCm CuPy (force-reinstall so a half-removed CUDA build can't linger)
+    # and re-pin deps the source build / cupy pull can disturb.
+    pip uninstall -y cupy cupy-cuda12x cupy-cuda13x nixl nixl-cu12 nixl-cu13 nixl_ep >/dev/null 2>&1 || true
+    pip install --force-reinstall --no-cache-dir cupy-rocm-7-0
+    pip install -q "numpy==2.1.3" "grpcio==1.78.0" || true
 
-        # Fail loudly if we're on the slow CUDA-wheel fallback (c_ops missing or
-        # CuPy not the ROCm build) — otherwise the run silently loses the offload.
-        python3 -c "
+    # Fail loudly if we're on the slow CUDA-wheel fallback (c_ops missing or
+    # CuPy not the ROCm build) — otherwise the run silently loses the offload.
+    python3 -c "
 import lmcache
 from lmcache import c_ops
 import cupy
@@ -219,69 +199,62 @@ from cupy_backends.cuda.api import runtime as r
 assert getattr(r, 'is_hip', False), 'CuPy is not the ROCm build (is_hip=False)'
 print('lmcache', lmcache.__version__, '| cupy', cupy.__version__, '| is_hip =', r.is_hip)
 "
-        python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
+    python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 
-        # Match the B200 Kimi LMCache setup: keep a 2.5 TB semantic CPU KV
-        # pool, but let the external MP server own that pool so vLLM does not
-        # split --kv-offloading-size across TP ranks through the integrated
-        # LMCache backend.
-        #TODO: fix
-        TOTAL_CPU_DRAM_GB=3000
-        LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
-        LMCACHE_PORT="${LMCACHE_PORT:-5555}"
-        LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
-        # LMCacheMPConnector concatenates lmcache.mp.host and port into the
-        # ZMQ endpoint. Bind the server to a raw host, but pass the connector a
-        # ZMQ-style host string.
-        LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
-        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$TOTAL_CPU_DRAM_GB}"
-        if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
-            echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
-            exit 1
-        fi
-        LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
-        # LMCache read locks are leases on chunks that lookup has promised
-        # vLLM can retrieve. The default 300s TTL is too short for this
-        # long-context agentic queue: TP8/conc32 can spend >300s between
-        # lookup and retrieve while GPU KV is saturated, which leaves the
-        # object present in L1 but no longer readable. Keep the 2.5 TB pool
-        # size unchanged and only extend the lookup-to-retrieve lease.
-        LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
-        LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
-        LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
-        export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
-        export LMCACHE_BLOCKING_TIMEOUT_SECS=120
+    TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
+    LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
+    LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+    LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+    # LMCacheMPConnector concatenates lmcache.mp.host and port into the ZMQ
+    # endpoint. Bind the server to a raw host, pass the connector a ZMQ-style host.
+    LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
+    LMCACHE_L1_SIZE_GB="${TOTAL_CPU_DRAM_PARTITION_GB}"
+    if [ "$LMCACHE_L1_SIZE_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: LMCACHE_L1_SIZE_GB=$LMCACHE_L1_SIZE_GB exceeds configured capacity $TOTAL_CPU_DRAM_GB" >&2
+        exit 1
+    fi
+    LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
+    # Extend the lookup-to-retrieve lease well past the default 300s: a
+    # long-context agentic queue can spend minutes between lookup and retrieve
+    # while GPU KV is saturated, which otherwise expires the lease.
+    LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
+    LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+    LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$TP}"
+    export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+    export LMCACHE_BLOCKING_TIMEOUT_SECS=120
 
-        echo "Starting LMCache MP server..."
-        LMCACHE_CMD=(
-            lmcache server
-            --host "$LMCACHE_HOST"
-            --port "$LMCACHE_PORT"
-            --http-host "$LMCACHE_HOST"
-            --http-port "$LMCACHE_HTTP_PORT"
-            --l1-size-gb "$LMCACHE_L1_SIZE_GB"
-            --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
-            --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
-            --chunk-size "$LMCACHE_CHUNK_SIZE"
-            --max-workers "$LMCACHE_MAX_WORKERS"
-            --eviction-policy LRU
-        )
-        printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
-        printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
-        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
-        LMCACHE_PID=$!
-        echo "LMCache server PID: $LMCACHE_PID"
-        wait_for_lmcache_ready
+    echo "Starting LMCache MP server..."
+    LMCACHE_CMD=(
+        lmcache server
+        --host "$LMCACHE_HOST"
+        --port "$LMCACHE_PORT"
+        --http-host "$LMCACHE_HOST"
+        --http-port "$LMCACHE_HTTP_PORT"
+        --l1-size-gb "$LMCACHE_L1_SIZE_GB"
+        --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
+        --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
+        --chunk-size "$LMCACHE_CHUNK_SIZE"
+        --max-workers "$LMCACHE_MAX_WORKERS"
+        --eviction-policy LRU
+    )
+    printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
+    printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
+    "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+    LMCACHE_PID=$!
+    echo "LMCache server PID: $LMCACHE_PID"
+    wait_for_lmcache_ready
 
-        PREFIX_CACHE_ARGS=(--enable-prefix-caching)
-        OFFLOAD_ARGS=(
-            --kv-transfer-config
-            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
-            --disable-hybrid-kv-cache-manager
-        )
-        ;;
-    *) echo "Error: unsupported OFFLOADING value '$OFFLOADING'" >&2; exit 1 ;;
+    OFFLOAD_ARGS=(
+        --kv-transfer-config
+        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+    )
+    ;;
+  *)
+    echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected: native, lmcache)" >&2
+    exit 1
+    ;;
 esac
+fi
 
 # ---- LLM server config ----------------------------------------------------------
 EP_ARGS=()
@@ -310,7 +283,13 @@ export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MLA=0
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
 export VLLM_ROCM_USE_AITER_FP4BMM=0
+export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+
+# AgentX concurrency counts live session trees, not individual requests.
+# Subagent fan-out can push instantaneous request concurrency above CONC, so
+# leave 2x headroom rather than clipping those bursts at the scheduler.
+MAX_NUM_SEQS=$((2 * CONC))
 
 { set +x; } 2>/dev/null
 VLLM_CMD=(
@@ -321,9 +300,14 @@ VLLM_CMD=(
     "${EP_ARGS[@]}"
     --gpu-memory-utilization 0.90
     --trust-remote-code
-    --max-num-seqs "$CONC"
+    --async-scheduling
+    --distributed-executor-backend mp
+    --moe-backend aiter
+    --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+    --enable-prefix-caching
+    --no-disable-hybrid-kv-cache-manager
+    --max-num-seqs "$MAX_NUM_SEQS"
     --mm-encoder-tp-mode data
-    "${PREFIX_CACHE_ARGS[@]}"
     "${OFFLOAD_ARGS[@]}"
 )
 printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -282,8 +282,7 @@ VLLM_CMD=(
     --tensor-parallel-size="$TP"
     "${EP_ARGS[@]}"
     --gpu-memory-utilization 0.90
-    --kv-cache-dtype fp8 \
-    --block-size=1
+    --kv-cache-dtype fp8
     --trust-remote-code
     --max-num-seqs "$CONC"
     --mm-encoder-tp-mode data

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -61,6 +61,14 @@ export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 
+# The container runs with --container-remap-root, so MIOpen's default
+# $HOME/.config/miopen lockfile dir (/root/...) is not reliably writable and
+# lockfile creation fails, crashing the vision-tower conv during profile_run
+# with miopenStatusUnknownError. Point MIOpen's user DB + cache at RESULT_DIR.
+export MIOPEN_USER_DB_PATH="$RESULT_DIR/.miopen"
+export MIOPEN_CUSTOM_CACHE_DIR="$RESULT_DIR/.miopen"
+mkdir -p "$MIOPEN_USER_DB_PATH"
+
 OFFLOAD_ARGS=()
 PREFIX_CACHE_ARGS=()
 

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -14,13 +14,20 @@ set -x
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
-# CI exports KV_OFFLOADING (none/dram); this recipe's case statement keys off
-# OFFLOADING (none/cpu/lmcache). Map the sweep's dram -> cpu native offload
-# path when OFFLOADING isn't set directly (standalone runs still pass it).
+# CI exports KV_OFFLOADING (none/dram) plus KV_OFFLOAD_BACKEND (native/lmcache);
+# this recipe's case statement keys off OFFLOADING (none/cpu/lmcache). Map the
+# sweep's (dram, backend) pair onto OFFLOADING when it isn't set directly
+# (standalone runs still pass OFFLOADING). native -> cpu (vLLM OffloadingConnector).
 if [[ -z "${OFFLOADING:-}" && -n "${KV_OFFLOADING:-}" ]]; then
     case "$KV_OFFLOADING" in
         none) OFFLOADING=none ;;
-        dram) OFFLOADING=cpu ;;
+        dram)
+            case "${KV_OFFLOAD_BACKEND:-native}" in
+                native) OFFLOADING=cpu ;;
+                lmcache) OFFLOADING=lmcache ;;
+                *) echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected native or lmcache)" >&2; exit 1 ;;
+            esac
+            ;;
         *) OFFLOADING="$KV_OFFLOADING" ;;
     esac
     export OFFLOADING
@@ -175,12 +182,38 @@ case "$OFFLOADING" in
         { set +x; } 2>/dev/null
         unset VLLM_USE_SIMPLE_KV_OFFLOAD
 
-        git clone https://github.com/LMCache/LMCache.git
-        cd LMCache
-        pip install -r requirements/build.txt 
-        CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
-        cd ..
+        # LMCache on ROCm must be built from source with BUILD_WITH_HIP=1 — the
+        # PyPI wheel is CUDA-only and silently falls back to a slow copy path
+        # (no warm-pass win). Pin a release tag and verify the HIP c_ops import
+        # plus the ROCm CuPy build, per the AMD LMCache workshop recipe.
+        LMCACHE_VERSION="${LMCACHE_VERSION:-v0.5.0}"
+        if ! python3 -c "from lmcache import c_ops" 2>/dev/null; then
+            command -v hipcc >/dev/null || { echo "ERROR: hipcc not found — need the ROCm toolchain to build LMCache" >&2; exit 1; }
+            pip uninstall -y lmcache >/dev/null 2>&1 || true
+            rm -rf LMCache
+            git clone --depth 1 --branch "$LMCACHE_VERSION" https://github.com/LMCache/LMCache.git
+            cd LMCache
+            pip install -r requirements/build.txt
+            CXX=hipcc BUILD_WITH_HIP=1 pip install -e . --no-build-isolation
+            cd ..
+        fi
 
+        # ROCm CuPy (force-reinstall so a half-removed CUDA build can't linger)
+        # and re-pin deps the source build / cupy pull can disturb.
+        pip uninstall -y cupy cupy-cuda12x cupy-cuda13x nixl nixl-cu12 nixl-cu13 nixl_ep >/dev/null 2>&1 || true
+        pip install --force-reinstall --no-cache-dir cupy-rocm-7-0
+        pip install -q "numpy==2.1.3" "grpcio==1.78.0" || true
+
+        # Fail loudly if we're on the slow CUDA-wheel fallback (c_ops missing or
+        # CuPy not the ROCm build) — otherwise the run silently loses the offload.
+        python3 -c "
+import lmcache
+from lmcache import c_ops
+import cupy
+from cupy_backends.cuda.api import runtime as r
+assert getattr(r, 'is_hip', False), 'CuPy is not the ROCm build (is_hip=False)'
+print('lmcache', lmcache.__version__, '| cupy', cupy.__version__, '| is_hip =', r.is_hip)
+"
         python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 
         # Match the B200 Kimi LMCache setup: keep a 2.5 TB semantic CPU KV

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x.sh
@@ -14,6 +14,18 @@ set -x
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
+# CI exports KV_OFFLOADING (none/dram); this recipe's case statement keys off
+# OFFLOADING (none/cpu/lmcache). Map the sweep's dram -> cpu native offload
+# path when OFFLOADING isn't set directly (standalone runs still pass it).
+if [[ -z "${OFFLOADING:-}" && -n "${KV_OFFLOADING:-}" ]]; then
+    case "$KV_OFFLOADING" in
+        none) OFFLOADING=none ;;
+        dram) OFFLOADING=cpu ;;
+        *) OFFLOADING="$KV_OFFLOADING" ;;
+    esac
+    export OFFLOADING
+fi
+
 check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR EP_SIZE DP_ATTENTION
 
 PORT=${PORT:-8888}

--- a/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/kimik2.7_fp4_mi355x_vllm.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Agentic trace replay benchmark for Kimi-K2.7 FP4 on MI355X using vLLM.
+#
+# Variant of kimik2.7_fp4_mi355x.sh that supports THREE KV configs:
+#   KV_OFFLOADING=none                              -> GPU KV only
+#   KV_OFFLOADING=dram KV_OFFLOAD_BACKEND=native    -> vLLM native CPU offload
+#   KV_OFFLOADING=dram KV_OFFLOAD_BACKEND=lmcache   -> LMCache MP server + connector
+#
+# Required env vars:
+#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION, EP_SIZE
+
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+# ROCR/HIP visibility for vLLM 0.14+
+if [ -n "${ROCR_VISIBLE_DEVICES:-}" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
+# Either way, MODEL_PATH is what the server is launched with.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+rocm-smi || true
+amd-smi || true
+
+# ---- Resolve traces and install deps ----------------------------------------
+resolve_trace_source
+install_agentic_deps
+
+# Install amd-quark for MXFP4 (manual install due to ROCm vLLM bug)
+pip install amd-quark
+
+# Disable AITER RMSNorm for TP < 8 due to accuracy issues
+if [ "${TP}" -lt 8 ]; then
+  export VLLM_ROCM_USE_AITER_RMSNORM=0
+fi
+# Workaround for MEC FW <177 RCCL memory reclaim issue
+version=$(rocm-smi --showfw 2>/dev/null | grep MEC | head -n 1 | awk '{print $NF}')
+if [[ "$version" == "" || ${version:-0} -lt 177 ]]; then
+    export HSA_NO_SCRATCH_RECLAIM=1
+fi
+
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+# Avoid intermittent symm_mem all-reduce rendezvous hang at engine init on
+# MI35x nodes (see KIMIK27_CONC64_LMCACHE_RUNBOOK error #4).
+export VLLM_ALLREDUCE_USE_SYMM_MEM="${VLLM_ALLREDUCE_USE_SYMM_MEM:-0}"
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
+mkdir -p "$RESULT_DIR"
+
+OFFLOAD_ARGS=()
+PREFIX_CACHE_ARGS=()
+
+# ---- LMCache config ---------------------------------------------------------
+LMCACHE_PID=""
+
+cleanup_lmcache_server() {
+    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
+        kill "$LMCACHE_PID" 2>/dev/null || true
+        wait "$LMCACHE_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_lmcache_server EXIT
+
+wait_for_lmcache_ready() {
+    { set +x; } 2>/dev/null
+    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
+    local tail_pid=""
+
+    while [ ! -f "$LMCACHE_LOG" ]; do
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before creating log file. Exiting." >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    tail -f -n +1 "$LMCACHE_LOG" &
+    tail_pid=$!
+
+    for ((i = 1; i <= attempts; i++)); do
+        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            return 0
+        fi
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before becoming healthy. Log follows:" >&2
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            cat "$LMCACHE_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
+    kill "$tail_pid" 2>/dev/null || true
+    wait "$tail_pid" 2>/dev/null || true
+    cat "$LMCACHE_LOG" >&2 || true
+    exit 1
+}
+
+# Resolve the effective offload backend. When KV_OFFLOADING=none there is no
+# backend; when dram, KV_OFFLOAD_BACKEND selects native vs lmcache.
+if [[ "$KV_OFFLOADING" == "none" ]]; then
+    OFFLOAD_MODE="none"
+else
+    OFFLOAD_MODE="${KV_OFFLOAD_BACKEND:?KV_OFFLOAD_BACKEND required when KV_OFFLOADING=dram}"
+fi
+
+case "$OFFLOAD_MODE" in
+    none)
+        OFFLOAD_ARGS=(--no-enable-prefix-caching)
+        ;;
+    native)
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+        OFFLOAD_ARGS=(
+            --kv_offloading_backend native
+            --kv_offloading_size "$TOTAL_CPU_DRAM_GB"
+            --disable-hybrid-kv-cache-manager
+        )
+        ;;
+    lmcache)
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+
+        # Build LMCache against ROCm if the connector isn't already importable
+        # (prebuilt kimi-lmcache images already ship it).
+        if ! python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null 2>&1; then
+            git clone https://github.com/LMCache/LMCache.git
+            cd LMCache
+            pip install -r requirements/build.txt
+            CXX=hipcc BUILD_WITH_HIP=1 pip install -e . --no-build-isolation
+            cd ..
+            python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
+        fi
+
+        LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
+        LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+        LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+        LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
+        # Let the external MP server own the whole CPU KV pool. The requested
+        # budget is TOTAL_CPU_DRAM_GB, but LMCache's L1 is SHM-backed: if L1 >
+        # /dev/shm free it silently disables SHM and falls back to the slow
+        # pickle path (crashes at load — see kimik27 CI shm-overflow note).
+        # Cap L1 to 90% of current /dev/shm free space so SHM stays enabled.
+        SHM_FREE_GB=$(df -BG --output=avail /dev/shm 2>/dev/null | tail -1 | tr -dc '0-9')
+        SHM_CAP_GB=$(( SHM_FREE_GB * 90 / 100 ))
+        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$TOTAL_CPU_DRAM_GB}"
+        if [ -n "$SHM_CAP_GB" ] && [ "$SHM_CAP_GB" -gt 0 ] && [ "$LMCACHE_L1_SIZE_GB" -gt "$SHM_CAP_GB" ]; then
+            echo "Capping LMCACHE_L1_SIZE_GB $LMCACHE_L1_SIZE_GB -> $SHM_CAP_GB to fit /dev/shm (${SHM_FREE_GB}G free)"
+            LMCACHE_L1_SIZE_GB="$SHM_CAP_GB"
+        fi
+        LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
+        LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
+        LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+        LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$((TP * 2))}"
+        export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=60
+
+        echo "Starting LMCache MP server..."
+        LMCACHE_CMD=(
+            lmcache server
+            --host "$LMCACHE_HOST"
+            --port "$LMCACHE_PORT"
+            --http-host "$LMCACHE_HOST"
+            --http-port "$LMCACHE_HTTP_PORT"
+            --l1-size-gb "$LMCACHE_L1_SIZE_GB"
+            --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
+            --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
+            --chunk-size "$LMCACHE_CHUNK_SIZE"
+            --max-workers "$LMCACHE_MAX_WORKERS"
+            --eviction-policy LRU
+        )
+        printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
+        printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
+        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+        LMCACHE_PID=$!
+        echo "LMCache server PID: $LMCACHE_PID"
+        wait_for_lmcache_ready
+
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+        )
+        ;;
+    *)
+        echo "Error: unsupported KV_OFFLOAD_BACKEND '$OFFLOAD_MODE' (expected: native, lmcache)" >&2
+        exit 1
+        ;;
+esac
+
+EP_ARGS=()
+if [ "$EP_SIZE" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+echo "Starting vllm server..."
+export PYTHONNOUSERSITE=1
+
+{ set +x; } 2>/dev/null
+VLLM_CMD=(
+    vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --tensor-parallel-size="$TP"
+    "${EP_ARGS[@]}"
+    --gpu-memory-utilization 0.90
+    --block-size=1
+    --trust-remote-code
+    --max-num-seqs "$CONC"
+    --mm-encoder-tp-mode data
+    "${PREFIX_CACHE_ARGS[@]}"
+    "${OFFLOAD_ARGS[@]}"
+)
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ---- Run benchmark ----------------------------------------------------------
+build_replay_cmd "$RESULT_DIR"
+
+run_agentic_replay_and_write_outputs "$RESULT_DIR"

--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Agentic trace replay benchmark for Kimi-K2.5 FP4 on MI355X using vLLM.
+#
+# Required env vars:
+#   MODEL, TP, CONC, OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
+#
+# OFFLOADING values:
+#   none    - vLLM GPU KV only.
+#   cpu     - vLLM native CPU offload.
+#   lmcache - LMCache MP server + vLLM LMCacheMPConnector.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR EP_SIZE DP_ATTENTION
+
+PORT=${PORT:-8888}
+DURATION=${DURATION:-1800}
+EP_SIZE=${EP_SIZE:-1}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+# ROCR/HIP visibility for vLLM 0.14+
+if [ -n "${ROCR_VISIBLE_DEVICES:-}" ]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+rocm-smi || true
+amd-smi || true
+
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
+# Either way, MODEL_PATH is what the server is launched with.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+# ---- Resolve traces and install deps ----------------------------------------
+# MiniMax-M2.5 servers run at max_model_len ~256k; the unfiltered 052726
+# corpus has requests up to ~1M proxy tokens that would be rejected.
+# Switch to the 256k-capped variant (470 traces, max in+out <= 256k).
+#export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_256k
+#060226
+# export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_with_subagents_060226_256k
+
+resolve_trace_source
+install_agentic_deps
+
+# export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=1200
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
+mkdir -p "$RESULT_DIR"
+
+OFFLOAD_ARGS=()
+
+# ---- Lmcache config ----------------------------------------------------------
+LMCACHE_PID=""
+
+cleanup_lmcache_server() {
+    if [[ -n "$LMCACHE_PID" ]] && kill -0 "$LMCACHE_PID" 2>/dev/null; then
+        kill "$LMCACHE_PID" 2>/dev/null || true
+        wait "$LMCACHE_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup_lmcache_server EXIT
+
+wait_for_lmcache_ready() {
+    { set +x; } 2>/dev/null
+    local attempts="${LMCACHE_READY_ATTEMPTS:-120}"
+    local tail_pid=""
+
+    while [ ! -f "$LMCACHE_LOG" ]; do
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before creating log file. Exiting." >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    tail -f -n +1 "$LMCACHE_LOG" &
+    tail_pid=$!
+
+    for ((i = 1; i <= attempts; i++)); do
+        if curl --output /dev/null --silent --fail "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck"; then
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            return 0
+        fi
+        if [[ -n "$LMCACHE_PID" ]] && ! kill -0 "$LMCACHE_PID" 2>/dev/null; then
+            echo "LMCache server died before becoming healthy. Log follows:" >&2
+            kill "$tail_pid" 2>/dev/null || true
+            wait "$tail_pid" 2>/dev/null || true
+            cat "$LMCACHE_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for LMCache server healthcheck. Log follows:" >&2
+    kill "$tail_pid" 2>/dev/null || true
+    wait "$tail_pid" 2>/dev/null || true
+    cat "$LMCACHE_LOG" >&2 || true
+    exit 1
+}
+
+case "$OFFLOADING" in
+    none)
+        OFFLOAD_ARGS=(--no-enable-prefix-caching)
+        ;;
+    cpu)
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+        # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
+        # reserve 2.5 TB for the offload pool (leaves ~200 GB headroom for
+        # worker RSS / page cache / slurm cgroup).
+        TOTAL_CPU_DRAM_GB="${TOTAL_CPU_DRAM_GB:-3000}"
+        TOTAL_CPU_DRAM_PARTITION_GB="${TOTAL_CPU_DRAM_PARTITION_GB:-$((TOTAL_CPU_DRAM_GB / (8 / TP)))}"
+        # Use vLLM's regular native KV-offload path (OffloadingConnector),
+        # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+        # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
+        # would switch it to SimpleCPUOffloadConnector. We intentionally leave
+        # that env var UNSET here so the regular OffloadingConnector path is
+        # used. The shortcut --kv_offloading_backend native + --kv_offloading_size
+        # form constructs the KVTransferConfig at engine startup
+        # (vllm/config/vllm.py:662).
+
+        # Remove --disable-hybrid-kv-cache-manager and enable hybrid kv cache manager (default)
+        # This gives extra cache hit than disabling hybrid kv cache manager
+        OFFLOAD_ARGS=(
+            --kv_offloading_backend native
+            --kv_offloading_size "$TOTAL_CPU_DRAM_PARTITION_GB"
+        )
+        ;;
+    lmcache)
+        unset VLLM_USE_SIMPLE_KV_OFFLOAD
+
+        git clone https://github.com/LMCache/LMCache.git
+        cd LMCache
+        # Apply PR #3779: per-engine-group KV format detection for MiniMax-M3.
+        # Fixes IndexError in get_num_heads() when heterogeneous KV tensor ranks
+        # (rank-5 K+V main cache + rank-3 MLA index cache) are present.
+        # git fetch origin pull/3779/head:pr-3779
+        # git merge --no-edit pr-3779
+        pip install -r requirements/build.txt
+        CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
+        cd ..
+
+        python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
+
+        # Let the external MP server own the full CPU KV pool so vLLM does not
+        # split --kv-offloading-size across TP ranks through the integrated
+        # LMCache backend.
+        TOTAL_CPU_DRAM_GB="${TOTAL_CPU_DRAM_GB:-3000}"
+        TOTAL_CPU_DRAM_PARTITION_GB="${TOTAL_CPU_DRAM_PARTITION_GB:-$((TOTAL_CPU_DRAM_GB / (8 / TP)))}"
+        LMCACHE_HOST="${LMCACHE_HOST:-127.0.0.1}"
+        LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+        LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+        # LMCacheMPConnector concatenates lmcache.mp.host and port into the
+        # ZMQ endpoint. Bind the server to a raw host, but pass the connector a
+        # ZMQ-style host string.
+        LMCACHE_CONNECT_HOST="${LMCACHE_CONNECT_HOST:-tcp://$LMCACHE_HOST}"
+        LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-$((TOTAL_CPU_DRAM_PARTITION_GB))}"
+        LMCACHE_L1_INIT_SIZE_GB="${LMCACHE_L1_INIT_SIZE_GB:-20}"
+        # LMCache read locks are leases on chunks that lookup has promised
+        # vLLM can retrieve. The default 300s TTL is too short for this
+        # long-context agentic queue: TP8/conc32 can spend >300s between
+        # lookup and retrieve while GPU KV is saturated, which leaves the
+        # object present in L1 but no longer readable. Keep the 2.5 TB pool
+        # size unchanged and only extend the lookup-to-retrieve lease.
+        LMCACHE_L1_READ_TTL_SECONDS="${LMCACHE_L1_READ_TTL_SECONDS:-7200}"
+        # (srok) check 256 vs 32
+        #LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-32}"
+        LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-256}"
+        LMCACHE_MAX_WORKERS="${LMCACHE_MAX_WORKERS:-$((TP * 2))}"
+        export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+        export LMCACHE_BLOCKING_TIMEOUT_SECS=60
+
+        echo "Starting LMCache MP server..."
+        LMCACHE_CMD=(
+            lmcache server
+            --host "$LMCACHE_HOST"
+            --port "$LMCACHE_PORT"
+            --http-host "$LMCACHE_HOST"
+            --http-port "$LMCACHE_HTTP_PORT"
+            --l1-size-gb "$LMCACHE_L1_SIZE_GB"
+            --l1-init-size-gb "$LMCACHE_L1_INIT_SIZE_GB"
+            --l1-read-ttl-seconds "$LMCACHE_L1_READ_TTL_SECONDS"
+            --chunk-size "$LMCACHE_CHUNK_SIZE"
+            --max-workers "$LMCACHE_MAX_WORKERS"
+            --eviction-policy LRU
+        )
+        printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
+        printf '\n' >> "$RESULT_DIR/lmcache_command.txt"
+        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+        LMCACHE_PID=$!
+        echo "LMCache server PID: $LMCACHE_PID"
+        wait_for_lmcache_ready
+
+        # Remove --disable-hybrid-kv-cache-manager and enable hybrid kv cache manager (default)
+        # This gives extra cache hit than disabling hybrid kv cache manager
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"$LMCACHE_CONNECT_HOST\",\"lmcache.mp.port\":$LMCACHE_PORT}}"
+        )
+        ;;
+    *) echo "Error: unsupported OFFLOADING value '$OFFLOADING'" >&2; exit 1 ;;
+esac
+
+# ---- LLM server config ----------------------------------------------------------
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(
+        --tensor-parallel-size 1
+        --data-parallel-size "$TP"
+        --enable-expert-parallel
+    )
+elif [ "$EP_SIZE" -gt 1 ]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+echo "Starting vllm server..."
+export PYTHONNOUSERSITE=1
+
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_BREAKABLE_CUDAGRAPH=0
+export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_MOE=1
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+
+VLLM_CMD=(
+    vllm serve "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    "${PARALLEL_ARGS[@]}"
+    --block-size 128
+    --gpu-memory-utilization 0.85
+    --kv-cache-dtype fp8
+    --trust-remote-code
+    --language-model-only
+    --attention-backend TRITON_ATTN
+    --moe-backend aiter
+    --tool-call-parser minimax_m3
+    --reasoning-parser minimax_m3
+    --enable-auto-tool-choice
+    --max-num-seqs "$CONC"
+    "${OFFLOAD_ARGS[@]}"
+)
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ---- Run benchmark ----------------------------------------------------------
+build_replay_cmd "$RESULT_DIR"
+
+run_agentic_replay_and_write_outputs "$RESULT_DIR"

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -814,7 +814,7 @@ kimik2.7-fp4-mi355x-vllm-agentic:
   image: vllm/vllm-openai-rocm:v0.24.0
   model: amd/Kimi-K2.7-Code-MXFP4
   model-prefix: kimik2.7
-  runner: cluster:mi355x-amds
+  runner: cluster:gbt350docker
   precision: fp4
   framework: vllm
   multinode: false
@@ -822,7 +822,9 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 64] }
+      - { tp: 4, kv-offloading: none, conc-list: [32] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
 
 
 kimik2.5-fp4-mi355x-atom:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2158,12 +2158,12 @@ dsv4-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32, 40, 48, 56, 64, 72] }
+      #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 40, 48, 56, 64, 72] }
+      #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
+      #- { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
+      #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
 
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2147,7 +2147,7 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
 # comparability. Offload sweep is none-only (SGLang has no equivalent of
 # vLLM's SimpleCPUOffloadConnector path that we exercise on b200).
 dsv4-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:v0.22.0
+  image: vllm/vllm-openai-rocm:nightly-34b560b725b401f33477464163244b4744d1c40f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds
@@ -2162,6 +2162,8 @@ dsv4-fp4-mi355x-vllm-agentic:
       - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32, 48] }
       - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
       - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 48] }
 
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -822,8 +822,6 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [64] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [64] }
       - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [64] }
 
 

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -822,9 +822,7 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [64] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [64] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [64] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 64] }
 
 
 kimik2.5-fp4-mi355x-atom:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -811,7 +811,7 @@ kimik2.5-fp4-mi355x-vllm-agentic:
 
 
 kimik2.7-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:v0.22.0
+  image: vllm/vllm-openai-rocm:v0.24.0
   model: amd/Kimi-K2.7-Code-MXFP4
   model-prefix: kimik2.7
   runner: cluster:mi355x-amds
@@ -822,7 +822,9 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [32, 64] }
+      - { tp: 8, kv-offloading: none, conc-list: [64] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [64] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [64] }
 
 
 kimik2.5-fp4-mi355x-atom:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -822,7 +822,7 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 64] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 64] }
 
 
 kimik2.5-fp4-mi355x-atom:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -810,21 +810,6 @@ kimik2.5-fp4-mi355x-vllm-agentic:
       - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [16, 24, 32, 40] }
 
 
-kimik2.7-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:v0.22.0
-  model: amd/Kimi-K2.7-Code-MXFP4
-  model-prefix: kimik2.7
-  runner: cluster:mi355x-amds
-  precision: fp4
-  framework: vllm
-  multinode: false
-  scenarios:
-    agentic-coding:
-    - dram-utilization: 0.80
-      search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [32, 64] }
-
-
 kimik2.5-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
   model: amd/Kimi-K2.5-MXFP4
@@ -2156,10 +2141,12 @@ dsv4-fp4-mi355x-vllm-agentic:
   multinode: false
   scenarios:
     agentic-coding:
-    - search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4] }
-      - { tp: 4, kv-offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 16] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 32, 40, 48] }
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
 
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2158,9 +2158,10 @@ dsv4-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32, 40, 48, 56, 64, 72] }
-      #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32] }
+      #- { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32, 40, 48, 56, 64, 72] }
       - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 40, 48, 56, 64, 72] }
+
+      #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32] }
       #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
       #- { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
       #- { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2149,7 +2149,7 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
 # comparability. Offload sweep is none-only (SGLang has no equivalent of
 # vLLM's SimpleCPUOffloadConnector path that we exercise on b200).
 dsv4-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:nightly-34b560b725b401f33477464163244b4744d1c40f
+  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -810,6 +810,21 @@ kimik2.5-fp4-mi355x-vllm-agentic:
       - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [16, 24, 32, 40] }
 
 
+kimik2.7-fp4-mi355x-vllm-agentic:
+  image: vllm/vllm-openai-rocm:v0.22.0
+  model: amd/Kimi-K2.7-Code-MXFP4
+  model-prefix: kimik2.7
+  runner: cluster:mi355x-amds
+  precision: fp4
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [32, 64] }
+
+
 kimik2.5-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom20260511
   model: amd/Kimi-K2.5-MXFP4

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2160,12 +2160,12 @@ dsv4-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32, 48] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32, 48] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 48] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 48] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [32] }
 
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -822,6 +822,8 @@ kimik2.7-fp4-mi355x-vllm-agentic:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
+      - { tp: 8, kv-offloading: none, conc-list: [64] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [64] }
       - { tp: 8, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [64] }
 
 

--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -1,4 +1,6 @@
 labels:
+  cluster:gbt350docker:
+    - gbt350docker_00
   h100:
     - h100-cw_00
     - h100-cw_01
@@ -285,6 +287,9 @@ labels:
     - mi355x-amds_07
     - mi355x-amds_08
 hardware:
+  cluster:gbt350docker:
+    available-cpu-dram-mib: 3_000_000
+    gpus-per-node: 8
   cluster:h100-dgxc:
     available-cpu-dram-mib: 2_063_837
     gpus-per-node: 8

--- a/runners/launch_gbt350docker.sh
+++ b/runners/launch_gbt350docker.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Self-hosted docker launcher for the standalone gbt350 MI350X node.
+#
+# gbt350 is NOT part of the mia1 slurm/enroot cluster — it runs plain docker.
+# This launcher mirrors launch_mi355x-amds.sh's single-node recipe-path
+# resolution and env contract, but executes the recipe inside `docker run`
+# with the InferenceX checkout bind-mounted at /workspace.
+#
+# Consumed from the benchmark-tmpl env: IMAGE, MODEL, MODEL_PREFIX, EXP_NAME,
+# PRECISION, FRAMEWORK, TP, EP_SIZE, CONC, SCENARIO_SUBDIR, KV_OFFLOADING,
+# KV_OFFLOAD_BACKEND, TOTAL_CPU_DRAM_GB, DURATION, RESULT_DIR, ISL, OSL,
+# MAX_MODEL_LEN, SPEC_DECODING, HF_HUB_CACHE, RUNNER_NAME.
+set -uo pipefail
+set -x
+
+# Per-runner port offset (last char of runner name), same scheme as amds.
+PORT_OFFSET="${RUNNER_NAME: -1}"
+[[ "$PORT_OFFSET" =~ ^[0-9]$ ]] || PORT_OFFSET=0
+export PORT=$(( 8888 + PORT_OFFSET ))
+
+# Node-local HF cache (weights + trace datasets pre-staged here).
+HOST_HF_CACHE="${GBT350_HF_CACHE:-/data/hf_hub_cache}"
+CONTAINER_HF_CACHE="${HF_HUB_CACHE:-/hf_hub_cache}"
+
+FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "atom" ]] && printf '_atom' || printf '')
+SPEC_SUFFIX=$([[ "${SPEC_DECODING:-none}" == "mtp" ]] && printf '_mtp' || printf '')
+
+# Recipe-path resolution mirrors launch_mi355x-amds.sh.
+SCRIPT_BASE="${EXP_NAME%%_*}_${PRECISION}_mi355x"
+SCRIPT_FW="benchmarks/single_node/${SCENARIO_SUBDIR:-fixed_seq_len/}${SCRIPT_BASE}_${FRAMEWORK}${SPEC_SUFFIX}.sh"
+SCRIPT_FALLBACK="benchmarks/single_node/${SCENARIO_SUBDIR:-fixed_seq_len/}${SCRIPT_BASE}${FRAMEWORK_SUFFIX}${SPEC_SUFFIX}.sh"
+if [[ -f "$SCRIPT_FW" ]]; then
+    BENCHMARK_SCRIPT="$SCRIPT_FW"
+else
+    BENCHMARK_SCRIPT="$SCRIPT_FALLBACK"
+fi
+echo "[gbt350docker] recipe: $BENCHMARK_SCRIPT"
+
+# GPU selection: first $TP devices.
+DEVLIST=""
+for i in $(seq 0 $((TP-1))); do DEVLIST="${DEVLIST}${i},"; done
+DEVLIST="${DEVLIST%,}"
+
+CONTAINER="gbt350_${RUNNER_NAME}_$$"
+
+# Pre-clean stale containers holding our GPUs.
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# Ensure image is present (pull if missing; some are local-only builds).
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    docker pull "$IMAGE" || { echo "[gbt350docker] docker pull failed for $IMAGE" >&2; exit 1; }
+fi
+
+# The recipe writes RESULT_DIR (=/workspace/results) and the top-level result
+# json under /workspace; both are the bind-mounted checkout, so artifacts land
+# in $GITHUB_WORKSPACE for the upload steps.
+docker run --rm --name "$CONTAINER" \
+    --device /dev/kfd --device /dev/dri \
+    --ipc=host --shm-size=0 \
+    --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
+    -e ROCR_VISIBLE_DEVICES="$DEVLIST" \
+    -e HIP_VISIBLE_DEVICES="$DEVLIST" \
+    -e HF_HUB_CACHE="$CONTAINER_HF_CACHE" \
+    -e HF_HOME="$CONTAINER_HF_CACHE" \
+    -e HF_TOKEN="${HF_TOKEN:-}" \
+    -e PORT="$PORT" \
+    -e MODEL="$MODEL" \
+    -e MODEL_PREFIX="${MODEL_PREFIX:-}" \
+    -e EXP_NAME="${EXP_NAME:-}" \
+    -e PRECISION="${PRECISION:-}" \
+    -e FRAMEWORK="${FRAMEWORK:-}" \
+    -e TP="$TP" \
+    -e EP_SIZE="${EP_SIZE:-1}" \
+    -e DP_ATTENTION="${DP_ATTENTION:-false}" \
+    -e CONC="$CONC" \
+    -e ISL="${ISL:-0}" \
+    -e OSL="${OSL:-0}" \
+    -e MAX_MODEL_LEN="${MAX_MODEL_LEN:-0}" \
+    -e SPEC_DECODING="${SPEC_DECODING:-none}" \
+    -e SCENARIO_TYPE="${SCENARIO_TYPE:-}" \
+    -e IS_AGENTIC="${IS_AGENTIC:-0}" \
+    -e KV_OFFLOADING="${KV_OFFLOADING:-}" \
+    -e KV_OFFLOAD_BACKEND="${KV_OFFLOAD_BACKEND:-}" \
+    -e TOTAL_CPU_DRAM_GB="${TOTAL_CPU_DRAM_GB:-0}" \
+    -e DURATION="${DURATION:-3600}" \
+    -e RESULT_DIR="${RESULT_DIR:-/workspace/results}" \
+    -e RESULT_FILENAME="${RESULT_FILENAME:-}" \
+    -e RUNNER_TYPE="${RUNNER_TYPE:-}" \
+    -e AIPERF_FAILED_REQUEST_THRESHOLD="${AIPERF_FAILED_REQUEST_THRESHOLD:-0.10}" \
+    -e VLLM_ALLREDUCE_USE_SYMM_MEM=0 \
+    -e PYTHONHASHSEED=0 \
+    -v "$GITHUB_WORKSPACE":/workspace \
+    -v "$HOST_HF_CACHE":"$CONTAINER_HF_CACHE" \
+    -w /workspace \
+    --entrypoint bash \
+    "$IMAGE" \
+    "$BENCHMARK_SCRIPT"
+RC=$?
+
+echo "[gbt350docker] recipe exit=$RC"
+exit $RC


### PR DESCRIPTION
## Summary

### Single node
[deepseek-ai/DeepSeek-V4-Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)
[amd/MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4)
[amd/Kimi-K2.7-Code-MXFP4](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4)
[amd/Qwen3.5-397B-A17B-MXFP4](https://huggingface.co/amd/Qwen3.5-397B-A17B-MXFP4)

### PD
[deepseek-ai/DeepSeek-V4-Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)
[amd/MiniMax-M3-MXFP4](https://huggingface.co/amd/MiniMax-M3-MXFP4)
[amd/Kimi-K2.7-Code-MXFP4](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4)
[amd/Qwen3.5-397B-A17B-MXFP4](https://huggingface.co/amd/Qwen3.5-397B-A17B-MXFP4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 中文说明
新增 agentX v1.0 基准测试配置，覆盖单节点和 PD（prefill-decode disagg）两种场景。支持的模型包括 DeepSeek-V4-Pro、MiniMax-M3-MXFP4、Kimi-K2.7-Code-MXFP4 和 Qwen3.5-397B-A17B-MXFP4。

## 한국어 설명
agentX v1.0 벤치마크 설정을 추가합니다. 단일 노드 및 PD(prefill-decode disagg) 시나리오를 지원합니다. 대상 모델: DeepSeek-V4-Pro, MiniMax-M3-MXFP4, Kimi-K2.7-Code-MXFP4, Qwen3.5-397B-A17B-MXFP4.
