### PR TITLE
fix(ci): show AgentX KV offload in job names

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -181,6 +181,8 @@ jobs:
       ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}/EP${{ inputs.prefill-ep }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
       x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}/EP${{ inputs.decode-ep }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
+      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('kv={0}', inputs.kv-offloading) || '' }}
+      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && format('kv_backend={0}', inputs.kv-offload-backend) || '' }}
       conc=${{ inputs.conc != '' && inputs.conc || join(fromJson(inputs.conc-list), 'x') }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
 
     steps:

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -136,6 +136,8 @@ jobs:
       ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
       TP${{ inputs.tp }}/EP${{ inputs.ep }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
+      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('kv={0}', inputs.kv-offloading) || '' }}
+      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && format('kv_backend={0}', inputs.kv-offload-backend) || '' }}
       conc=${{ inputs.conc }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
     steps:
       - name: Resource cleanup (pre-run)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,9 +184,9 @@ jobs:
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
-            kv-offloading: ${{ matrix.config['kv-offloading'] }}
-            kv-offload-backend: ${{ matrix.config['kv-offload-backend'] }}
-            total-cpu-dram-gb: ${{ matrix.config['total-cpu-dram-gb'] }}
+            kv-offloading: ${{ matrix.config.kv-offloading }}
+            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             isl: '0'
             osl: '0'
@@ -232,6 +232,8 @@ jobs:
             decode-dp-attn: ${{ matrix.config.decode.dp-attn }}
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             conc: ${{ matrix.config.conc[0] }}
+            kv-offloading: ${{ matrix.config.kv-offloading }}
+            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             run-eval: false
             scenario-type: agentic-coding

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -488,9 +488,9 @@ jobs:
             ep: ${{ matrix.config.ep }}
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
-            kv-offloading: ${{ matrix.config['kv-offloading'] }}
-            kv-offload-backend: ${{ matrix.config['kv-offload-backend'] }}
-            total-cpu-dram-gb: ${{ matrix.config['total-cpu-dram-gb'] }}
+            kv-offloading: ${{ matrix.config.kv-offloading }}
+            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
             duration: ${{ matrix.config.duration }}
             isl: '0'
             osl: '0'
@@ -542,6 +542,8 @@ jobs:
             decode-dp-attn: ${{ matrix.config.decode.dp-attn }}
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             conc: ${{ matrix.config.conc }}
+            kv-offloading: ${{ matrix.config.kv-offloading }}
+            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
             duration: ${{ matrix.config.duration }}
             run-eval: false
             scenario-type: agentic-coding


### PR DESCRIPTION
## Summary
- Add `kv=<mode>` to single-node and multi-node reusable benchmark job names when agentic KV offloading is enabled.
- Add `kv_backend=<backend>` when an explicit non-default backend is present.
- Pass multi-node agentic KV offload metadata through to the reusable multi-node benchmark template so future non-default values can be displayed consistently.

## Validation
- Parsed updated workflow YAML files with PyYAML.
- Generated a representative B200 AgentX matrix entry and confirmed it carries `kv-offloading: dram` and `kv-offload-backend: mooncake`.
- `actionlint` is not installed in this environment.
