### PR TITLE
fix(ci): format AgentX KV offload job labels

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -181,8 +181,8 @@ jobs:
       ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}/EP${{ inputs.prefill-ep }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
       x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}/EP${{ inputs.decode-ep }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
-      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('kv={0}', inputs.kv-offloading) || '' }}
-      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && format('kv_backend={0}', inputs.kv-offload-backend) || '' }}
+      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
+      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}
       conc=${{ inputs.conc != '' && inputs.conc || join(fromJson(inputs.conc-list), 'x') }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
 
     steps:

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -136,8 +136,8 @@ jobs:
       ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
       TP${{ inputs.tp }}/EP${{ inputs.ep }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
-      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('kv={0}', inputs.kv-offloading) || '' }}
-      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && format('kv_backend={0}', inputs.kv-offload-backend) || '' }}
+      ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
+      ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}
       conc=${{ inputs.conc }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
     steps:
       - name: Resource cleanup (pre-run)


### PR DESCRIPTION
## Summary
- Change AgentX job-name KV offload text from key/value labels to natural wording.
- A job with DRAM offload and Mooncake now renders as `dram KV offload mooncake`.
- Keep the label conditional so default/no-offload jobs remain unchanged.

## Validation
- Parsed updated workflow YAML files with PyYAML.
- Checked representative label composition for `dram` + `mooncake`.
