### PR TITLE
[Klaud Cold][DO NOT MERGE] Test signoff-verify Check 7 with --hf-overrides indexer hack

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_h200.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp8_h200.sh
@@ -85,6 +85,7 @@ $PARALLEL_ARGS \
 --max-cudagraph-capture-size $CAPTURE_SIZE \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --stream-interval 20 --no-enable-prefix-caching \
+--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!


### PR DESCRIPTION
## Summary
- Adds `--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'` to the MiniMax M3 MXFP8 H200 vLLM launch command — an architecture-changing benchmark hack of exactly the kind `docs/PR_REVIEW_CHECKLIST.md` forbids.
- This is a NEGATIVE test for the updated `codeowner-signoff-verify` workflow (#2015): after a sign-off comment is posted, Check 7 should FAIL naming this flag.
- Will be closed without merging once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)