### PR TITLE
[Klaud Cold][DO NOT MERGE] Test signoff-verify Check 6 with vendor rocm/sgl-dev image on MI300X

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -82,7 +82,7 @@ dsr1-fp4-mi355x-atom-mtp:
       - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi30x
+  image: rocm/sgl-dev:sglang-0.5.12-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x


### PR DESCRIPTION
## Summary
- Swaps `dsr1-fp8-mi300x-sglang` from upstream `lmsysorg/sglang:v0.5.12-rocm700-mi30x` to vendor fork `rocm/sgl-dev:sglang-0.5.12-rocm700-mi30x`.
- NEGATIVE test for the updated `codeowner-signoff-verify` workflow (#2015): MI300X is established hardware and DeepSeek-R1 is upstream-supported, so Check 6(a) should FAIL naming the non-upstream image.
- Will be closed without merging once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)