### PR TITLE
[Klaud Cold] Add CONTRIBUTING.md covering the PR Review Checklist flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to InferenceX
+
+Thanks for contributing! PRs are welcome. This page covers the review process every PR goes through before it can be merged.
+
+## PR review flow
+
+1. Open your PR and get it through PR validation (a green full sweep, including evals, on a commit in your PR).
+2. Request a review from your respective company's [CODEOWNER](.github/CODEOWNERS).
+3. The CODEOWNER reviews and posts the **PR Review Checklist** sign-off (see below) in their approval comment.
+4. Only after the checklist sign-off is posted should you ping a core maintainer on Slack for final approval.
+
+## The PR Review Checklist (CODEOWNER sign-off)
+
+When a CODEOWNER approves a PR, they must fill in the latest [PR_REVIEW_CHECKLIST.md](docs/PR_REVIEW_CHECKLIST.md) template in their approval comment.
+
+A friendly reminder — please follow the latest checklist template **correctly**:
+
+- Always copy the template from the **current** [docs/PR_REVIEW_CHECKLIST.md](docs/PR_REVIEW_CHECKLIST.md) on `main`. The checklist evolves; a sign-off made from a stale copy will be flagged as missing items.
+- Keep the template's opening phrase intact:
+
+  > As a PR reviewer and CODEOWNER, I have reviewed this and have:
+
+  Our CI verification workflow, [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml), triggers on exactly this phrase. **If your approval comment does not follow the checklist template — including that phrase — the sign-off verification CI will not trigger at all**, and your sign-off won't count toward merge.
+- The sign-off can be posted as a regular conversation comment, a review summary, or an inline review comment — all three trigger verification.
+- Fill in the "Additional detail section" with the links the checklist asks for (validation/eval workflow runs, the corresponding [vLLM recipe](https://github.com/vllm-project/recipes) / [SGLang cookbook](https://github.com/sgl-project/sglang/tree/main/docs_new) PR, and any exception reasoning).
+
+Once the sign-off is posted, CI independently re-verifies the claims that gate a merge — CODEOWNER status, a green sweep + evals on a commit in the PR, the linked recipe, the `/reuse-sweep-run` command, use of the latest checklist template, upstream [vLLM](https://hub.docker.com/u/vllm)/[SGLang](https://hub.docker.com/u/lmsysorg) images, no architecture-changing benchmark hacks, and chat-template usage for speculative decoding — and posts a verdict comment on the PR. Checkmarks are not taken on trust, so please only check items you have actually verified.
+
+## After merging
+
+**PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.** A lot of the time, failures are just flakes and simply re-running the failed jobs will fix it. [See GitHub's docs on re-running failed jobs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow).


### PR DESCRIPTION
## Summary
- Adds a root `CONTRIBUTING.md` documenting the PR review flow: CODEOWNER review first, checklist sign-off, then core-maintainer ping on Slack.
- Friendly reminder to follow the **latest** [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) template correctly, with an explicit warning: if the approval comment doesn't follow the template — including the exact phrase "As a PR reviewer and CODEOWNER, I have reviewed this and have" — the [codeowner-signoff-verify.yml](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) CI verification will not trigger.
- Summarizes what the sign-off verification independently re-checks (per #2015) and keeps the post-merge "all GitHub Action jobs must pass / re-run flakes" responsibility note.

## Test plan
- Docs-only change; GitHub picks up root `CONTRIBUTING.md` automatically for the "contributing guidelines" link on new PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)