### PR TITLE
[Klaud Cold] Document /reuse-sweep-run and full-sweep labels for contributors

### DIFF
--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -36,11 +36,15 @@ jobs:
             const body = `${marker}
             Thanks for the contribution! Please reach out to respective companies' [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) to fill in the latest [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) before pinging core maintainer on Slack for review.
 
+            For PR verification, add the \`full-sweep-enabled\` or \`full-sweep-fail-fast\` label to this PR — the benchmark sweep only runs on labeled PRs.
+
             **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.** A lot of the time, failures are just flakes and simply re-running the failed jobs will fix it. [See GitHub's docs on re-running failed jobs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow)
 
             ---
 
             感谢你的贡献！请联系相应公司的 [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) 填写最新的 [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md)，然后再在 Slack 上联系核心维护者进行审阅。
+
+            如需进行 PR 验证，请为此 PR 添加 \`full-sweep-enabled\` 或 \`full-sweep-fail-fast\` 标签 — 基准测试 sweep 仅在带有标签的 PR 上运行。
 
             **PR 作者有责任确保合并后所有 GitHub Action 任务完全通过。** 很多时候失败只是偶发抖动（flake），重新运行失败的任务即可解决。[参见 GitHub 关于重新运行失败任务的文档](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow)`.replace(/^            /gm, '');
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Thanks for contributing! PRs are welcome. This page covers the review process ev
 
 ## PR review flow
 
-1. Open your PR and get it through PR validation (a green full sweep, including evals, on a commit in your PR).
+1. Open your PR and get it through PR validation: add the `full-sweep-enabled` (or `full-sweep-fail-fast`) label so the benchmark sweep runs, and get a green full sweep — including evals — on a commit in your PR.
 2. Request a review from your respective company's [CODEOWNER](.github/CODEOWNERS).
 3. The CODEOWNER reviews and posts the **PR Review Checklist** sign-off (see below) in their approval comment.
 4. Only after the checklist sign-off is posted should you ping a core maintainer on Slack for final approval.
+5. An authorized maintainer posts `/reuse-sweep-run` (see below) and the PR is merged via the reuse path.
 
 ## The PR Review Checklist (CODEOWNER sign-off)
 
@@ -25,6 +26,15 @@ A friendly reminder — please follow the latest checklist template **correctly*
 - Fill in the "Additional detail section" with the links the checklist asks for (validation/eval workflow runs, the corresponding [vLLM recipe](https://github.com/vllm-project/recipes) / [SGLang cookbook](https://github.com/sgl-project/sglang/tree/main/docs_new) PR, and any exception reasoning).
 
 Once the sign-off is posted, CI independently re-verifies the claims that gate a merge — CODEOWNER status, a green sweep + evals on a commit in the PR, the linked recipe, the `/reuse-sweep-run` command, use of the latest checklist template, upstream [vLLM](https://hub.docker.com/u/vllm)/[SGLang](https://hub.docker.com/u/lmsysorg) images, no architecture-changing benchmark hacks, and chat-template usage for speculative decoding — and posts a verdict comment on the PR. Checkmarks are not taken on trust, so please only check items you have actually verified.
+
+## `/reuse-sweep-run` — reusing your PR's green sweep at merge
+
+A full benchmark sweep is expensive GPU time, and the runners are shared by every open PR. Without reuse, an approved PR's sweep would run **twice** — once for PR validation and again on `main` after merge. The reuse path avoids that:
+
+- After your PR has an eligible green full sweep, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) comments `/reuse-sweep-run` on the PR (optionally pinning a specific run: `/reuse-sweep-run <run_id>`).
+- The merge-to-`main` run then validates and ingests the PR sweep's artifacts instead of re-running the whole sweep on `main`.
+- **This reduces CI queue time for everyone** — each reused merge frees hours of GPU runner time for other PRs, so please prefer the reuse path over merging without it. A green sweep alone is not enough: the `/reuse-sweep-run` comment must be on record (the sign-off verification checks for it), otherwise `main` silently re-runs the full sweep.
+- `utils/merge_with_reuse.sh <pr-number>` is the supported merge path; it posts the command, syncs the branch with `main`, waits for checks, and squash-merges. See the [workflows README](.github/workflows/README.md#reusing-an-approved-pr-full-sweep) for eligibility details.
 
 ## After merging
 


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: adds a `/reuse-sweep-run` section — after an eligible green full sweep, an authorized maintainer posts `/reuse-sweep-run` so the merge-to-main run ingests the PR sweep's artifacts instead of re-running the whole GPU sweep, which reduces CI queue time for everyone on the shared runners. Points at `utils/merge_with_reuse.sh` as the supported merge path and the [workflows README](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/README.md#reusing-an-approved-pr-full-sweep) for eligibility. The PR review flow now also mentions adding the `full-sweep-enabled`/`full-sweep-fail-fast` label and the reuse merge step.
- **pr-recipe-reminder.yml**: the reminder comment now tells PR authors to add the `full-sweep-enabled` or `full-sweep-fail-fast` label for PR verification, since the benchmark sweep only runs on labeled PRs (English + Chinese).

## Test plan
- YAML validated; the JS template-literal comment body was rendered via node locally and reads correctly in both languages (backticks escaped properly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)