### PR TITLE
[Klaud Cold] Add Chinese doc versions, bilingual-docs rule, and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Bash: source shared utilities via `source benchmark_lib.sh` (`check_env_vars`, `
 
 Git: conventional commit messages. `[skip-sweep]` in the latest PR head commit skips that PR's benchmark setup after changelog validation. It is ignored on pushes to `main`. Changes to `perf-changelog.yaml` trigger benchmark runs.
 
-Docs: the README is bilingual — `README.md` (English, default) and `README_zh.md` (Simplified Chinese), with an `English | 中文` switcher under the badges. **Any edit to `README.md` MUST be mirrored in `README_zh.md`, and vice versa** — keep the two in sync (same sections, links, badges, images) and update both in the same PR.
+Docs: all contributor-facing docs are bilingual — **every such Markdown doc MUST have a Simplified Chinese version** named `<name>_zh.md` alongside it, with an `English | 中文` switcher at the top. Current pairs: `README.md`/`README_zh.md`, `CONTRIBUTING.md`/`CONTRIBUTING_zh.md`, `docs/PR_REVIEW_CHECKLIST.md`/`docs/PR_REVIEW_CHECKLIST_zh.md`. **Any edit to an English doc MUST be mirrored in its `_zh` counterpart (and vice versa) in the same PR** — same sections, links, badges, images — and a new doc must ship with its `_zh` version in the same PR. Exceptions: agent-instruction files (`AGENTS.md`, `CLAUDE.md`, `KLAUD_DEBUG.md`) and internal references under `.github/`/`utils/` are English-only; the sign-off template inside `docs/PR_REVIEW_CHECKLIST*.md` stays in English verbatim in BOTH versions, because `codeowner-signoff-verify.yml` triggers on its exact English opening phrase.
 
 ### Pull Request Sweep Labels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+All guidance for working with this repository lives in [AGENTS.md](AGENTS.md) — read that.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # Contributing to InferenceX
 
+<div align="center">
+
+**English** | [中文](./CONTRIBUTING_zh.md)
+
+</div>
+
 Thanks for contributing! PRs are welcome. This page covers the review process every PR goes through before it can be merged.
 
 ## PR review flow

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,0 +1,47 @@
+# 为 InferenceX 做贡献
+
+<div align="center">
+
+[English](./CONTRIBUTING.md) | **中文**
+
+</div>
+
+感谢你的贡献！我们欢迎 PR。本页介绍每个 PR 在合并前需要经过的审阅流程。
+
+## PR 审阅流程
+
+1. 打开你的 PR 并通过 PR 验证：添加 `full-sweep-enabled`（或 `full-sweep-fail-fast`）标签以运行基准测试 sweep，并在 PR 的某个 commit 上获得全绿的完整 sweep（包括 evals）。
+2. 向你所在公司的 [CODEOWNER](.github/CODEOWNERS) 请求审阅。
+3. CODEOWNER 审阅后在批准评论中填写 **PR Review Checklist** 签署（见下文）。
+4. 只有在清单签署发布之后，才应在 Slack 上联系核心维护者进行最终批准。
+5. 由授权维护者发布 `/reuse-sweep-run`（见下文），然后通过 reuse 路径合并 PR。
+
+## PR Review Checklist（CODEOWNER 签署）
+
+CODEOWNER 批准 PR 时，必须在批准评论中填写最新的 [PR_REVIEW_CHECKLIST.md](docs/PR_REVIEW_CHECKLIST.md)（[中文说明](docs/PR_REVIEW_CHECKLIST_zh.md)）模板。
+
+友情提醒 — 请**正确**遵循最新的清单模板：
+
+- 务必从 `main` 分支上**当前**的 [docs/PR_REVIEW_CHECKLIST.md](docs/PR_REVIEW_CHECKLIST.md) 复制模板。清单会不断演进；使用过期副本的签署会被标记为缺项。
+- 保持模板的开头语句原样不变（必须保留英文原文）：
+
+  > As a PR reviewer and CODEOWNER, I have reviewed this and have:
+
+  我们的 CI 验证工作流 [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) 正是通过这句话触发的。**如果你的批准评论没有遵循清单模板 — 包括这句话 — 签署验证 CI 将完全不会触发**，你的签署也不会计入合并要求。
+- 签署可以以普通会话评论、review 总结或行内 review 评论的形式发布 — 三种方式都会触发验证。
+- 请在 "Additional detail section" 中填写清单要求的链接（验证/评测工作流运行、对应的 [vLLM recipe](https://github.com/vllm-project/recipes) / [SGLang cookbook](https://github.com/sgl-project/sglang/tree/main/docs_new) PR，以及任何例外理由）。
+
+签署发布后，CI 会独立复核决定合并的各项声明 — CODEOWNER 身份、PR 内 commit 上的全绿 sweep + evals、所链接的 recipe、`/reuse-sweep-run` 命令、是否使用最新清单模板、上游 [vLLM](https://hub.docker.com/u/vllm)/[SGLang](https://hub.docker.com/u/lmsysorg) 镜像、没有更改模型架构的基准测试 hack，以及投机解码是否使用 chat template — 并在 PR 上发布裁定评论。勾选项不会被无条件信任，请只勾选你确实核实过的条目。
+
+## `/reuse-sweep-run` — 在合并时复用 PR 的全绿 sweep
+
+完整基准测试 sweep 花费昂贵的 GPU 时间，且 runner 由所有打开的 PR 共享。如果不复用，一个已批准 PR 的 sweep 将运行**两次** — PR 验证一次，合并后在 `main` 上再一次。reuse 路径避免了这一点：
+
+- 当你的 PR 拥有符合条件的全绿完整 sweep 后，授权维护者（`OWNER`/`MEMBER`/`COLLABORATOR`）在 PR 上评论 `/reuse-sweep-run`（也可固定某次运行：`/reuse-sweep-run <run_id>`）。
+- 合并到 `main` 的运行随后会验证并摄取该 PR sweep 的 artifacts，而不是在 `main` 上重新运行整个 sweep。
+- **这为每个人减少了 CI 排队时间** — 每次复用合并都会为其他 PR 释放数小时的 GPU runner 时间，因此请优先选择 reuse 路径，而不是不带它直接合并。仅有全绿 sweep 还不够：`/reuse-sweep-run` 评论必须在记录中（签署验证会检查这一点），否则 `main` 会静默地重新运行完整 sweep。
+- `utils/merge_with_reuse.sh <pr-number>` 是受支持的合并路径；它会发布命令、将分支与 `main` 同步、等待检查并 squash 合并。资格详情见 [workflows README](.github/workflows/README.md#reusing-an-approved-pr-full-sweep)。
+
+## 合并之后
+
+**PR 作者有责任确保合并后所有 GitHub Action 任务完全通过。** 很多时候失败只是偶发抖动（flake），重新运行失败的任务即可解决。[参见 GitHub 关于重新运行失败任务的文档](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow)。

--- a/docs/PR_REVIEW_CHECKLIST.md
+++ b/docs/PR_REVIEW_CHECKLIST.md
@@ -8,6 +8,8 @@
 
 When [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) from the respective hardware AI chip company is reviewing & approving their respective PRs, please fill in the following form in your approval comment before pinging an core maintainer for final approval
 
+We welcome InferenceX partners & the community to submit PRs for reasonable additions to this checklist — or deletions — that follow the principles of InferenceX, and the general principle that deleting a guideline should be as easy a process as adding a new one.
+
 ## Template
 
 As a PR reviewer and CODEOWNER, I have reviewed this and have:

--- a/docs/PR_REVIEW_CHECKLIST_zh.md
+++ b/docs/PR_REVIEW_CHECKLIST_zh.md
@@ -1,14 +1,16 @@
-# PR Review Checklist
+# PR 审阅清单
 
 <div align="center">
 
-**English** | [中文](./PR_REVIEW_CHECKLIST_zh.md)
+[English](./PR_REVIEW_CHECKLIST.md) | **中文**
 
 </div>
 
-When [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) from the respective hardware AI chip company is reviewing & approving their respective PRs, please fill in the following form in your approval comment before pinging an core maintainer for final approval
+当相应硬件 AI 芯片公司的 [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) 审阅并批准其相关 PR 时，请在批准评论中填写以下表单，然后再联系核心维护者进行最终批准。
 
-## Template
+> **重要：模板请保持英文原文，原样复制粘贴，不要翻译。** CI 签署验证工作流 [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) 通过开头语句 "As a PR reviewer and CODEOWNER, I have reviewed this and have" 触发；模板被改写或翻译后，签署验证 CI 将不会触发。
+
+## 模板（请复制英文原文）
 
 As a PR reviewer and CODEOWNER, I have reviewed this and have:
 - [ ] Verified that as of the moment of typing this, this is the latest version of [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/edit/main/docs/PR_REVIEW_CHECKLIST.md)
@@ -28,10 +30,22 @@ As a PR reviewer and CODEOWNER, I have reviewed this and have:
 
 Signed: `FILL_IN_GITHUB_USERNAME`
 
-## Example
+## 各条目中文对照说明
+
+1. 已确认在填写此清单时，使用的是 [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) 的最新版本。
+2. 已确认整体代码质量达到 InferenceX 标准，且不会使代码质量变差。
+3. 已确认该 PR 通过了 PR 验证，并附上能证明这一点的 GitHub Action 工作流链接。
+4. 已确认该 PR 通过了 evals（准确性评测），并附上能证明这一点的 GitHub Action 工作流链接。
+5. 已确认投机解码（speculative decoding）PR 使用 chat template，使接受长度（AL）分布与真实场景对齐。
+6. 已确认模型架构未被基准测试 hack 更改 — 例如在不原生支持的模型上使用 `--hf-overrides` 每 x 层跳过 indexer。一般规则：不接受减少模型架构 FLOPs 的优化；让同样的计算跑得更快没有问题；更低精度的 FLOPs 也可以，前提是该配置通过私有 evals。北极星原则：只使用在意准确性的客户在生产中实际使用的优化。
+7. 如果公司声称在其硬件上将 vLLM/SGLang 作为一等 LLM 推理引擎支持，已确认相应 vLLM 提交使用上游 [vLLM docker 仓库](https://hub.docker.com/u/vllm)、SGLang 提交使用上游 [lmsysorg docker 仓库](https://hub.docker.com/u/lmsysorg)。唯一例外：新硬件（如 MI455X UALoE72、Vera Rubin NVL72、Rubin NVL8 等），以及经 vLLM/SGLang 社区维护者确认上游尚未从根本上支持的新模型架构。
+8. 如果公司声称在其硬件上将 vLLM/SGLang 作为一等上游 in-tree LLM 推理引擎支持，已确认相应 vLLM/SGLang 提交先于其他框架（TRT-LLM、ATOM 等）完成。例外情形同上。
+9. 已确认单节点 recipe 与官方 [vLLM recipes](https://recipes.vllm.ai/) 和/或 [SGLang cookbook](https://docs.sglang.io/cookbook/intro) 相似；如果不相似，已确认在 [vLLM recipe 仓库](https://github.com/vllm-project/recipes)或 [SGLang 仓库](https://github.com/sgl-project/sglang/tree/main/docs_new)开了 PR，并在下方 Additional detail section 中给出链接。
+10. 如果上述任何条目无法合理满足，已在下方提供额外说明。
+
+## 示例
 
 <img width="667" height="701" alt="image" src="https://github.com/user-attachments/assets/0c832d48-c81b-4bdb-bb53-43f39ff18b9b" />
 
 
 <img width="569" height="632" alt="image" src="https://github.com/user-attachments/assets/491d9763-ab09-4734-b0f1-39eefe1ab5c4" />
-

--- a/docs/PR_REVIEW_CHECKLIST_zh.md
+++ b/docs/PR_REVIEW_CHECKLIST_zh.md
@@ -8,6 +8,8 @@
 
 当相应硬件 AI 芯片公司的 [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) 审阅并批准其相关 PR 时，请在批准评论中填写以下表单，然后再联系核心维护者进行最终批准。
 
+我们欢迎 InferenceX 合作伙伴与社区提交 PR，对本清单进行符合 InferenceX 原则的合理增补或删减 — 总体原则是：删除一条准则的流程应当与新增一条准则同样容易。
+
 > **重要：模板请保持英文原文，原样复制粘贴，不要翻译。** CI 签署验证工作流 [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) 通过开头语句 "As a PR reviewer and CODEOWNER, I have reviewed this and have" 触发；模板被改写或翻译后，签署验证 CI 将不会触发。
 
 ## 模板（请复制英文原文）


### PR DESCRIPTION
## Summary
- **`CONTRIBUTING_zh.md`**: Simplified Chinese version of `CONTRIBUTING.md` (PR review flow, checklist sign-off, `/reuse-sweep-run`, post-merge responsibility). Both files get the README-style `English | 中文` switcher.
- **`docs/PR_REVIEW_CHECKLIST_zh.md`**: Chinese version of the PR review checklist. The copy-paste sign-off template is kept in **English verbatim** with a prominent note explaining why: [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) triggers on the exact phrase "As a PR reviewer and CODEOWNER, I have reviewed this and have", so a translated template would never be verified. A Chinese per-item explanation list follows the template.
- **`docs/PR_REVIEW_CHECKLIST.md` / `_zh.md`**: adds a note that InferenceX partners & the community are welcome to submit PRs for reasonable checklist additions — or deletions — following InferenceX principles, with deleting a guideline as easy a process as adding one.
- **`AGENTS.md`**: the README-only bilingual rule is generalized — all contributor-facing docs MUST have a `_zh.md` version, kept in sync in the same PR, with the sign-off-template-stays-English exception spelled out. Agent-instruction files (`AGENTS.md`, `CLAUDE.md`, `KLAUD_DEBUG.md`) and internal references are exempt.
- **`CLAUDE.md`**: added, just points to `AGENTS.md`.

## Test plan
- Docs-only change; links verified against existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)