### PR TITLE
[Klaud Cold][DO NOT MERGE] Test signoff-verify Check 5 with stale checklist template

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ Full list of supporters & quotes: https://inferencex.semianalysis.com/quotes
 
 <img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/dcbda40c-4a6e-43a3-aca2-c830d3f2fb8d" />
 
+
+<!-- test: stale-checklist signoff verification (PR will be closed without merging) -->

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,3 +85,5 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 <img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/589bfdda-905d-425f-94dc-f2551746dd9d" />
 
 
+
+<!-- test: stale-checklist signoff verification (PR will be closed without merging) -->


### PR DESCRIPTION
## Summary
- Trivial README touch (mirrored in README_zh per the bilingual rule) to host a CODEOWNER sign-off that uses a STALE pre-#1956 checklist template — missing the upstream-Docker-image item and the no-benchmark-hacks item.
- NEGATIVE test for the updated `codeowner-signoff-verify` workflow (#2015): Check 5 should FAIL naming the missing items.
- Will be closed without merging once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)