### PR TITLE
[Klaud Cold] Revert accidental merge of test PR #2028

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ Full list of supporters & quotes: https://inferencex.semianalysis.com/quotes
 
 <img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/dcbda40c-4a6e-43a3-aca2-c830d3f2fb8d" />
 
-
-<!-- test: required signoff check gating (PR will be closed without merging) -->

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,5 +85,3 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 <img width="1400" height="682" alt="image" src="https://github.com/user-attachments/assets/589bfdda-905d-425f-94dc-f2551746dd9d" />
 
 
-
-<!-- test: required signoff check gating (PR will be closed without merging) -->


### PR DESCRIPTION
## Summary
- Reverts #2028 (test HTML comments in README.md / README_zh.md), which was accidentally merged during required-check gating tests: the REST merge endpoint silently applied the "Protect main" ruleset's OrganizationAdmin always-bypass, unlike the GraphQL merge path which correctly refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)