### PR TITLE
[Klaud Cold][DO NOT MERGE] Test signoff Check 3 N/A on disagg-only PR

### DIFF
--- a/benchmarks/multi_node/minimaxm3_fp4_mi355x_vllm-disagg.sh
+++ b/benchmarks/multi_node/minimaxm3_fp4_mi355x_vllm-disagg.sh
@@ -76,3 +76,5 @@ if [[ $? -ne 0 ]]; then
 fi
 
 echo "$JOB_ID"
+
+# test: verifying disagg Check 3 N/A in codeowner-signoff-verify (PR will be closed without merging)


### PR DESCRIPTION
## Summary
- Trailing comment in a `benchmarks/multi_node/**` vLLM-disagg script — a disagg-only change to verify #2030: the sign-off verifier's Check 3 (recipe link) should report N/A, not FAIL, when no recipe link is provided.
- Will be closed without merging once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)