### PR TITLE
[Klaud Cold] Recipe reminder: note the signoff bot trigger-phrase requirement

### DIFF
--- a/.github/workflows/pr-recipe-reminder.yml
+++ b/.github/workflows/pr-recipe-reminder.yml
@@ -34,7 +34,7 @@ jobs:
             }
 
             const body = `${marker}
-            Thanks for the contribution! Please reach out to respective companies' [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) to fill in the latest [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) before pinging core maintainer on Slack for review.
+            Thanks for the contribution! Please reach out to respective companies' [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) to fill in the latest [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) before pinging core maintainer on Slack for review. In order for the signoff PR check bot to trigger, you must follow the PR_REVIEW_CHECKLIST.md template correctly, including the phrase \`As a PR reviewer and CODEOWNER, I have reviewed this and have\`.
 
             For PR verification, add the \`full-sweep-enabled\` or \`full-sweep-fail-fast\` label to this PR — the benchmark sweep only runs on labeled PRs.
 
@@ -42,7 +42,7 @@ jobs:
 
             ---
 
-            感谢你的贡献！请联系相应公司的 [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) 填写最新的 [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md)，然后再在 Slack 上联系核心维护者进行审阅。
+            感谢你的贡献！请联系相应公司的 [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/CODEOWNERS) 填写最新的 [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md)，然后再在 Slack 上联系核心维护者进行审阅。为了触发 signoff PR 检查机器人，你必须正确遵循 PR_REVIEW_CHECKLIST.md 模板，包括保留英文语句 \`As a PR reviewer and CODEOWNER, I have reviewed this and have\`。
 
             如需进行 PR 验证，请为此 PR 添加 \`full-sweep-enabled\` 或 \`full-sweep-fail-fast\` 标签 — 基准测试 sweep 仅在带有标签的 PR 上运行。
 


### PR DESCRIPTION
## Summary
- Extends the PR recipe reminder's first paragraph (English + Chinese): in order for the signoff PR check bot ([codeowner-signoff-verify.yml](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml)) to trigger, reviewers must follow the [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) template correctly, including the exact phrase `As a PR reviewer and CODEOWNER, I have reviewed this and have`.

## Test plan
- Comment body rendered through node locally (JS template literal, escaped backticks) — reads correctly in both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)