### PR TITLE
[Klaud Cold] PR checklist: invite community to improve the signoff verifier

### DIFF
--- a/docs/PR_REVIEW_CHECKLIST.md
+++ b/docs/PR_REVIEW_CHECKLIST.md
@@ -10,6 +10,8 @@ When [CODEOWNER](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/
 
 We welcome InferenceX partners & the community to submit PRs for reasonable additions to this checklist — or deletions — that follow the principles of InferenceX, and the general principle that deleting a guideline should be as easy a process as adding a new one.
 
+We also welcome InferenceX partners & the ML community to improve [codeowner-signoff-verify.yml](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) — the CI bot that independently verifies these sign-offs — and make it more rigorous too.
+
 ## Template
 ```
 As a PR reviewer and CODEOWNER, I have reviewed this and have:

--- a/docs/PR_REVIEW_CHECKLIST_zh.md
+++ b/docs/PR_REVIEW_CHECKLIST_zh.md
@@ -10,6 +10,8 @@
 
 我们欢迎 InferenceX 合作伙伴与社区提交 PR，对本清单进行符合 InferenceX 原则的合理增补或删减 — 总体原则是：删除一条准则的流程应当与新增一条准则同样容易。
 
+我们同样欢迎 InferenceX 合作伙伴与机器学习社区改进 [codeowner-signoff-verify.yml](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml)（独立复核这些签署的 CI 机器人），使其更加严谨。
+
 > **重要：模板请保持英文原文，原样复制粘贴，不要翻译。** CI 签署验证工作流 [`codeowner-signoff-verify.yml`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) 通过开头语句 "As a PR reviewer and CODEOWNER, I have reviewed this and have" 触发；模板被改写或翻译后，签署验证 CI 将不会触发。
 
 ## 模板（请复制英文原文）


### PR DESCRIPTION
## Summary
- Adds to [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) (and the `_zh` version): we welcome InferenceX partners & the ML community to improve [codeowner-signoff-verify.yml](https://github.com/SemiAnalysisAI/InferenceX/blob/main/.github/workflows/codeowner-signoff-verify.yml) — the CI bot that independently verifies CODEOWNER sign-offs — and make it more rigorous too.

## Invitation
@chunfangamd @kedarpotdar-nv — inviting you both: the sign-off verifier now independently checks CODEOWNER sign-offs against the PR review checklist (green sweep + evals on an in-PR commit, recipe links for single-node recipes, upstream vLLM/SGLang images, no architecture-changing benchmark hacks, spec-decode chat templates, `/reuse-sweep-run`, and more). PRs from you and your teams to tighten these checks — or add ones we're missing — are very welcome!

🤖 Generated with [Claude Code](https://claude.com/claude-code)