### PR TITLE
[Klaud Cold] AGENTS.md: PR titles & descriptions must be bilingual / AGENTS.md：PR 标题与描述必须中英双语

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidance for AI agents working with InferenceX.
 
+> **PR titles & PR descriptions must be bilingual — include a Simplified Chinese version in addition to English.** Title format: `<English title> / <中文标题>`. In the PR body, follow the English content with its Chinese translation (e.g. a `## 中文说明` section mirroring the summary). This applies to every PR, matching the bilingual docs rule in Code Conventions.
+
 > **Before debugging a failing Klaud-Cold / claude/* image-bump PR, read [`KLAUD_DEBUG.md`](KLAUD_DEBUG.md).** It captures recurring failure modes (vLLM CUDA-graph OOM, B300 sglang regressions, cluster docker/perms/disk issues), the exact workarounds, and gh-CLI gotchas — most cron-PR failures are already cataloged there.
 
 ## Project Overview


### PR DESCRIPTION
## Summary
- Adds a rule at the top of `AGENTS.md`: every PR's title and description must include a Simplified Chinese version in addition to English — title as `<English title> / <中文标题>`, and the body with a Chinese section (e.g. `## 中文说明`) mirroring the English content.
- This PR itself follows the new convention as a live demonstration.

## 中文说明
- 在 `AGENTS.md` 顶部新增规则：每个 PR 的标题与描述除英文外必须包含简体中文版本 — 标题格式为 `<English title> / <中文标题>`，正文在英文内容之后附上对应的中文部分（例如 `## 中文说明`）。
- 本 PR 自身即遵循该新规范，作为实际示例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)