### PR TITLE
[Klaud Cold] Remove disallowed --hf-overrides indexer override from DSV4 FP4 MI355X ATOM / 移除 DSV4 FP4 MI355X ATOM 中不允许的 --hf-overrides indexer 覆盖

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
@@ -54,7 +54,6 @@ export ATOM_DISABLE_MMAP=true
 export AITER_BF16_FP8_MOE_BOUND=0
 export ATOM_MOE_GU_ITLV=1
 MEM_FRAC_STATIC=0.9
-OPT_ARGS=(--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}')
 
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
@@ -65,7 +64,6 @@ python3 -m atom.entrypoints.openai_server \
     --gpu-memory-utilization $MEM_FRAC_STATIC \
     --no-enable_prefix_caching \
     --cudagraph-capture-sizes "${CUDAGRAPH_SIZES}" \
-    "${OPT_ARGS[@]}" \
     > "$SERVER_LOG" 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4433,3 +4433,9 @@
     - "Add --online_quant_config with ptpc_fp8 and MoE layer exclusions (*block_sparse_moe) to all scripts."
     - "Replace deprecated AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0 and ATOM_M3_SPARSE_USE_ASM_PA=1 with ATOM_FORCE_ATTN_TRITON=1."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2001
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom
+  description:
+    - "Remove --hf-overrides use_index_cache/index_topk_freq indexer-skipping override from the ATOM serve command (not allowed: reduces model architecture FLOPs per PR_REVIEW_CHECKLIST.md)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- Removes `OPT_ARGS=(--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}')` from `benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh` — this override reuses cached indices to skip the indexer on 3 of every 4 layers, reducing model-architecture FLOPs, which [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) explicitly disallows (and the signoff verifier's Check 7 now rejects).
- Appends the required `perf-changelog.yaml` entry for `dsv4-fp4-mi355x-atom`.
- `full-sweep-fail-fast` label applied for PR validation.

## 中文说明
- 从 `benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh` 中移除 `OPT_ARGS=(--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}')` — 该覆盖通过复用缓存索引使每 4 层中有 3 层跳过 indexer，减少了模型架构 FLOPs，[PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) 明确禁止此类优化（签署验证机器人的 Check 7 现在也会拒绝）。
- 为 `dsv4-fp4-mi355x-atom` 追加所需的 `perf-changelog.yaml` 条目。
- 已添加 `full-sweep-fail-fast` 标签用于 PR 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)