### PR TITLE
[Klaud Cold] Remove disallowed --hf-overrides indexer override from DSV4 ATOM disagg / 移除 DSV4 ATOM disagg 中不允许的 --hf-overrides indexer 覆盖

### DIFF
--- a/benchmarks/multi_node/amd_utils/server_atom.sh
+++ b/benchmarks/multi_node/amd_utils/server_atom.sh
@@ -151,9 +151,6 @@ fi
 
 # HF overrides (single-quoted JSON preserved through eval)
 HF_OVERRIDES_ARG=""
-if [[ "$MODEL_NAME" == "DeepSeek-V4-Pro" ]]; then
-    HF_OVERRIDES_ARG="--hf-overrides '{\"use_index_cache\":true,\"index_topk_freq\":4}'"
-fi
 
 # KV cache dtype (skip if unset or 'auto')
 KV_CACHE_ARG=""

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4433,3 +4433,9 @@
     - "Add --online_quant_config with ptpc_fp8 and MoE layer exclusions (*block_sparse_moe) to all scripts."
     - "Replace deprecated AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0 and ATOM_M3_SPARSE_USE_ASM_PA=1 with ATOM_FORCE_ATTN_TRITON=1."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2001
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-disagg
+  description:
+    - "Remove --hf-overrides use_index_cache/index_topk_freq indexer-skipping override for DeepSeek-V4-Pro from the ATOM disagg server launcher (not allowed: reduces model architecture FLOPs per PR_REVIEW_CHECKLIST.md)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- Removes the DeepSeek-V4-Pro conditional in `benchmarks/multi_node/amd_utils/server_atom.sh` that set `HF_OVERRIDES_ARG="--hf-overrides '{\"use_index_cache\":true,\"index_topk_freq\":4}'"` — this indexer-skipping override reduces model-architecture FLOPs, which [PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) disallows. `HF_OVERRIDES_ARG=""` remains as an empty extension point so the three expansion sites are untouched.
- Appends the required `perf-changelog.yaml` entry for `dsv4-fp4-mi355x-atom-disagg`.
- `full-sweep-fail-fast` label applied for PR validation.
- Companion to #2037, which removes the same override from the single-node DSV4 FP4 MI355X ATOM recipe.

## 中文说明
- 移除 `benchmarks/multi_node/amd_utils/server_atom.sh` 中针对 DeepSeek-V4-Pro 的条件分支（设置 `HF_OVERRIDES_ARG="--hf-overrides '{\"use_index_cache\":true,\"index_topk_freq\":4}'"`）— 该覆盖跳过部分层的 indexer，减少了模型架构 FLOPs，[PR_REVIEW_CHECKLIST.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/docs/PR_REVIEW_CHECKLIST.md) 禁止此类优化。保留 `HF_OVERRIDES_ARG=""` 作为空扩展点，三处展开位置不受影响。
- 为 `dsv4-fp4-mi355x-atom-disagg` 追加所需的 `perf-changelog.yaml` 条目。
- 已添加 `full-sweep-fail-fast` 标签用于 PR 验证。
- 与 #2037（移除单节点 DSV4 FP4 MI355X ATOM recipe 中的同一覆盖）配套。

🤖 Generated with [Claude Code](https://claude.com/claude-code)