### PR TITLE
[Klaud Cold] Shorten benchmark job names: hide /EP1, sglang→sgl, conc=→c= / 精简基准任务名：隐藏 /EP1、sglang→sgl、conc=→c=

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -177,13 +177,13 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 480
     name: >-
-      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
+      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework }}
       ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}${{ inputs.prefill-ep != '' && inputs.prefill-ep != '1' && format('/EP{0}', inputs.prefill-ep) || '' }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
       x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}${{ inputs.decode-ep != '' && inputs.decode-ep != '1' && format('/EP{0}', inputs.decode-ep) || '' }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
       ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}
-      conc=${{ inputs.conc != '' && inputs.conc || join(fromJson(inputs.conc-list), 'x') }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
+      c=${{ inputs.conc != '' && inputs.conc || join(fromJson(inputs.conc-list), 'x') }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
 
     steps:
       - name: Slurm cleanup (pre-run)

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -178,8 +178,8 @@ jobs:
     timeout-minutes: 480
     name: >-
       ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
-      ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}/EP${{ inputs.prefill-ep }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
-      x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}/EP${{ inputs.decode-ep }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
+      ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}${{ inputs.prefill-ep != '' && inputs.prefill-ep != '1' && format('/EP{0}', inputs.prefill-ep) || '' }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
+      x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}${{ inputs.decode-ep != '' && inputs.decode-ep != '1' && format('/EP{0}', inputs.decode-ep) || '' }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
       ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 500
     name: >-
       ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
-      TP${{ inputs.tp }}/EP${{ inputs.ep }}${{ inputs.dp-attn && '/DPA' || '' }}
+      TP${{ inputs.tp }}${{ inputs.ep != '' && inputs.ep != '1' && format('/EP{0}', inputs.ep) || '' }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
       ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -133,12 +133,12 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 500
     name: >-
-      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework }}
+      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework }}
       TP${{ inputs.tp }}${{ inputs.ep != '' && inputs.ep != '1' && format('/EP{0}', inputs.ep) || '' }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
       ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}
-      conc=${{ inputs.conc }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
+      c=${{ inputs.conc }}${{ inputs.eval-only && ' | eval-only' || (inputs.run-eval && ' | eval' || '') }}
     steps:
       - name: Resource cleanup (pre-run)
         run: &resource-cleanup |


### PR DESCRIPTION
## Summary
Shortens the benchmark job display names in both templates (`benchmark-tmpl.yml` single-node, `benchmark-multinode-tmpl.yml` prefill/decode sides):
- `/EP<n>` renders only when `ep` is non-empty and ≠ 1 — `TP8/EP1` becomes `TP8`, while `TP8/EP8`/`/DPA` render unchanged.
- Framework `sglang` displays as `sgl` (exact match; composite values like `dynamo-sglang`, `sglang-disagg` unchanged).
- `conc=` shortened to `c=`.

Before: `dsv4 fp4 mi355x atom TP8/EP1 conc=1`, `1P (TP8/EP1) x 1D (TP8/EP1)`
After: `dsv4 fp4 mi355x atom TP8 c=1`, `1P (TP8) x 1D (TP8)`

Display-only: nothing parses these segments (reuse/signoff tooling keys off `single-node */` / `eval /` caller-job prefixes; results processing uses artifacts).

## Test
Verified live on H100 via `workflow_dispatch` from this branch ([run 28694634583](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28694634583), `qwen3.5-fp8-h100-sglang` with both lanes):
- ep=1 lane rendered `qwen3.5 fp8 h100 sgl TP8 c=4`
- ep=8 lane rendered `qwen3.5 fp8 h100 sgl TP8/EP8 c=16`

## 中文说明
精简两个模板中的基准任务显示名（单节点 `benchmark-tmpl.yml`，多节点 `benchmark-multinode-tmpl.yml` 的 prefill/decode 两侧）：
- 仅当 `ep` 非空且 ≠ 1 时显示 `/EP<n>` — `TP8/EP1` 变为 `TP8`，`TP8/EP8`、`/DPA` 保持不变。
- 框架 `sglang` 显示为 `sgl`（精确匹配；`dynamo-sglang`、`sglang-disagg` 等组合值不变）。
- `conc=` 缩短为 `c=`。

已在 H100 上实测验证（[run 28694634583](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28694634583)）：ep=1 显示 `qwen3.5 fp8 h100 sgl TP8 c=4`，ep=8 显示 `qwen3.5 fp8 h100 sgl TP8/EP8 c=16`。仅影响显示，无行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)