### PR TITLE
[Klaud Cold] CONTRIBUTING: warn against root-owned files on AMD runners / 贡献指南：警告勿在 AMD runner 工作区留下 root 所属文件

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,25 @@ A full benchmark sweep is expensive GPU time, and the runners are shared by ever
 - **This reduces CI queue time for everyone** — each reused merge frees hours of GPU runner time for other PRs, so please prefer the reuse path over merging without it. A green sweep alone is not enough: the `/reuse-sweep-run` comment must be on record (the sign-off verification checks for it), otherwise `main` silently re-runs the full sweep.
 - `utils/merge_with_reuse.sh <pr-number>` is the supported merge path; it posts the command, syncs the branch with `main`, waits for checks, and squash-merges. See the [workflows README](.github/workflows/README.md#reusing-an-approved-pr-full-sweep) for eligibility details.
 
+## AMD cluster: never leave root-owned files in runner workspaces
+
+Multi-node benchmarks on the AMD MI355X TW cluster submit Slurm jobs whose containers often run as **root**. If those containers write files (typically `benchmark_logs/logs/slurm_job-*`) into the GitHub Actions runner workspace and the job is **cancelled** before teardown runs, the root-owned directories are stranded. The runner user cannot delete them, so `actions/checkout` fails with:
+
+```
+Error: File was unable to be removed
+Error: EACCES: permission denied, rmdir '.../benchmark_logs/logs/slurm_job-<id>'
+```
+
+**This bricks every subsequent job on that runner** until someone with `sudo` on the shared `/it-share` storage manually removes the files. Because all AMD MI355X sweeps share the same runner pool, a single stranded root-owned directory blocks the entire queue for everyone.
+
+**Rules for benchmark scripts and Slurm containers:**
+
+1. **Never write as root into the runner workspace.** If your container must run as root, write outputs to a separate scratch directory outside `_work/` (e.g. `/tmp` or a dedicated staging path).
+2. **If root writes are unavoidable**, add a cleanup trap or teardown step that `chown`s or `rm`s all root-owned files under the workspace **before** the job exits — including on cancellation (`trap cleanup EXIT`).
+3. **Test your teardown path.** Cancel a running benchmark mid-flight and verify no root-owned files remain in the workspace.
+
+If you find a stranded root-owned file blocking runners, the recovery procedure is documented in [`.claude/commands/clean-amd-mi355-runner-root-files.md`](.claude/commands/clean-amd-mi355-runner-root-files.md): SSH into the hop host with `sudo`, scan the `_work` directories, and delete the offending files.
+
 ## After merging
 
 **PR authors are responsible for ensuring that after merging, all GitHub Action jobs fully pass.** A lot of the time, failures are just flakes and simply re-running the failed jobs will fix it. [See GitHub's docs on re-running failed jobs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow).

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -42,6 +42,25 @@ CODEOWNER 批准 PR 时，必须在批准评论中填写最新的 [PR_REVIEW_CHE
 - **这为每个人减少了 CI 排队时间** — 每次复用合并都会为其他 PR 释放数小时的 GPU runner 时间，因此请优先选择 reuse 路径，而不是不带它直接合并。仅有全绿 sweep 还不够：`/reuse-sweep-run` 评论必须在记录中（签署验证会检查这一点），否则 `main` 会静默地重新运行完整 sweep。
 - `utils/merge_with_reuse.sh <pr-number>` 是受支持的合并路径；它会发布命令、将分支与 `main` 同步、等待检查并 squash 合并。资格详情见 [workflows README](.github/workflows/README.md#reusing-an-approved-pr-full-sweep)。
 
+## AMD 集群：严禁在 runner 工作区留下 root 所属文件
+
+AMD MI355X TW 集群上的多节点基准测试通过 Slurm 提交容器化任务，这些容器通常以 **root** 身份运行。如果容器将文件（通常是 `benchmark_logs/logs/slurm_job-*`）写入 GitHub Actions runner 工作区，而任务在 teardown 执行前被**取消**，root 所属目录就会被遗留。runner 用户无法删除这些文件，导致 `actions/checkout` 失败：
+
+```
+Error: File was unable to be removed
+Error: EACCES: permission denied, rmdir '.../benchmark_logs/logs/slurm_job-<id>'
+```
+
+**这会阻塞该 runner 上的所有后续任务**，直到拥有 `sudo` 权限的人在共享 `/it-share` 存储上手动删除这些文件。由于所有 AMD MI355X 扫描共享同一个 runner 池，一个遗留的 root 所属目录就会阻塞整个队列，影响所有人。
+
+**基准测试脚本和 Slurm 容器规则：**
+
+1. **严禁以 root 身份写入 runner 工作区。** 如果容器必须以 root 运行，请将输出写入 `_work/` 之外的临时目录（例如 `/tmp` 或专用暂存路径）。
+2. **如果 root 写入不可避免**，请添加清理 trap 或 teardown 步骤，在任务退出前（包括取消时，使用 `trap cleanup EXIT`）`chown` 或 `rm` 工作区下所有 root 所属文件。
+3. **测试你的 teardown 路径。** 在运行中途取消基准测试，验证工作区中不会残留 root 所属文件。
+
+如果发现遗留的 root 所属文件阻塞了 runner，恢复流程参见 [`.claude/commands/clean-amd-mi355-runner-root-files.md`](.claude/commands/clean-amd-mi355-runner-root-files.md)：SSH 到中转主机，使用 `sudo` 扫描 `_work` 目录并删除问题文件。
+
 ## 合并之后
 
 **PR 作者有责任确保合并后所有 GitHub Action 任务完全通过。** 很多时候失败只是偶发抖动（flake），重新运行失败的任务即可解决。[参见 GitHub 关于重新运行失败任务的文档](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs#re-running-failed-jobs-in-a-workflow)。


### PR DESCRIPTION
## Summary

Adds a new section to `CONTRIBUTING.md` (and its `CONTRIBUTING_zh.md` counterpart) warning contributors not to leave root-owned files in GitHub Actions runner workspaces on the AMD MI355X TW cluster.

**Problem**: Multi-node Slurm containers run as root and write logs into the runner workspace. When a job is cancelled before teardown, root-owned directories get stranded. The runner user cannot delete them, causing `EACCES: permission denied` errors at `actions/checkout` that brick the runner for every subsequent job. Since all AMD MI355X sweeps share the same runner pool, one stranded directory blocks the entire queue for everyone.

**New rules documented**:
1. Never write as root into the runner workspace -- use `/tmp` or a dedicated staging path
2. If root writes are unavoidable, add a cleanup trap (`trap cleanup EXIT`) that removes root-owned files before exit
3. Test the teardown path by cancelling mid-flight and verifying no root files remain

Includes a pointer to the recovery procedure in `.claude/commands/clean-amd-mi355-runner-root-files.md`.

Motivated by recurring incidents on `gharunner06` -- most recently https://github.com/SemiAnalysisAI/InferenceX/pull/2003#issuecomment-4880683720.

## Test plan

- [x] Both `CONTRIBUTING.md` and `CONTRIBUTING_zh.md` updated in sync
- [x] No code, config, or workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 中文说明

在 `CONTRIBUTING.md` 及其中文版 `CONTRIBUTING_zh.md` 中新增章节，警告贡献者不要在 AMD MI355X TW 集群的 GitHub Actions runner 工作区中留下 root 所属文件。Slurm 容器以 root 运行时写入的日志文件如果在任务取消后未清理，会导致后续所有任务因 `EACCES: permission denied` 而失败，阻塞整个 runner 队列。新增三条规则：禁止以 root 写入工作区、必须添加清理 trap、测试 teardown 路径。