### PR TITLE
[Klaud Cold] AGENTS.md: add CONTRIBUTING.md as mandatory reading / 将 CONTRIBUTING.md 列为必读文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Guidance for AI agents working with InferenceX.
 
+> **Mandatory reading: [`CONTRIBUTING.md`](CONTRIBUTING.md)** — read it before opening or reviewing any PR. It covers the full PR review flow, the CODEOWNER sign-off process, the `/reuse-sweep-run` merge path, post-merge responsibilities, and critical cluster rules (e.g. never leaving root-owned files on AMD runners).
+
 > **PR titles & PR descriptions must be bilingual — include a Simplified Chinese version in addition to English.** Title format: `<English title> / <中文标题>`. In the PR body, follow the English content with its Chinese translation (e.g. a `## 中文说明` section mirroring the summary). This applies to every PR, matching the bilingual docs rule in Code Conventions.
 
 > **Translation quality bar:** write natural technical Chinese as used by ML infra engineers, not word-for-word machine translation. Follow the style of [`vllm-project/vllm-ascend` `README.zh.md`](https://github.com/vllm-project/vllm-ascend/blob/main/README.zh.md): translate concepts into idiomatic Chinese while preserving model names, hardware SKUs (MI355X, B300, GB200 ...), framework names (vLLM, SGLang, ATOM ...), flags, and CLI/env-var identifiers in English. Use parenthetical English clarification for acronyms on first use, e.g. 混合专家(MOE), 专家并行(EP). Preferred term mappings:


### PR DESCRIPTION
## Summary

Adds a blockquote near the top of `AGENTS.md` directing agents to read `CONTRIBUTING.md` before opening or reviewing any PR. Covers the PR review flow, CODEOWNER sign-off, `/reuse-sweep-run` merge path, post-merge responsibilities, and critical cluster rules (e.g. root-owned files on AMD runners).

## Test plan

- [x] `AGENTS.md` is English-only per existing convention (no `_zh` pairing needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 中文说明

在 `AGENTS.md` 顶部新增必读指引，要求 agent 在开启或审阅任何 PR 之前先阅读 `CONTRIBUTING.md`。