### PR TITLE
[Klaud Cold] Job names: dynamo-sglang→dyn-sgl, sglang-disagg→sgl-disagg / 任务名：dynamo-sglang→dyn-sgl、sglang-disagg→sgl-disagg

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 480
     name: >-
-      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework }}
+      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework == 'dynamo-sglang' && 'dyn-sgl' || inputs.framework == 'sglang-disagg' && 'sgl-disagg' || inputs.framework }}
       ${{ inputs.prefill-num-worker }}P (TP${{ inputs.prefill-tp }}${{ inputs.prefill-ep != '' && inputs.prefill-ep != '1' && format('/EP{0}', inputs.prefill-ep) || '' }}${{ inputs.prefill-dp-attn == 'true' && '/DPA' || '' }})
       x ${{ inputs.decode-num-worker }}D (TP${{ inputs.decode-tp }}${{ inputs.decode-ep != '' && inputs.decode-ep != '1' && format('/EP{0}', inputs.decode-ep) || '' }}${{ inputs.decode-dp-attn == 'true' && '/DPA' || '' }})
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 500
     name: >-
-      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework }}
+      ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework == 'dynamo-sglang' && 'dyn-sgl' || inputs.framework == 'sglang-disagg' && 'sgl-disagg' || inputs.framework }}
       TP${{ inputs.tp }}${{ inputs.ep != '' && inputs.ep != '1' && format('/EP{0}', inputs.ep) || '' }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}


### PR DESCRIPTION
## Summary
- Extends the framework shortening in both benchmark job-name templates (follow-up to #2041's `sglang`→`sgl`): `dynamo-sglang` now displays as `dyn-sgl` and `sglang-disagg` as `sgl-disagg`.
- Same chained-ternary mechanism as the already-tested `sglang`→`sgl` mapping; display-only, exact-match, all other framework values unchanged (`vllm`, `atom`, `trt`, `dynamo-trt`, ...).

## 中文说明
- 在两个基准任务名模板中扩展框架名缩写（继 #2041 的 `sglang`→`sgl` 之后）：`dynamo-sglang` 显示为 `dyn-sgl`，`sglang-disagg` 显示为 `sgl-disagg`。
- 与已实测验证的 `sglang`→`sgl` 映射采用相同的链式三元表达式机制；仅影响显示、精确匹配，其余框架值（`vllm`、`atom`、`trt`、`dynamo-trt` 等）保持不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)