### PR TITLE
[Klaud Cold] README: add Chinese translation to the title line / README：标题行加入中文翻译

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  InferenceX™, Open Source Continuous Inference Standard and Research Platform 
+#  InferenceX™, Open Source Continuous Inference Standard and Research Platform / 开源持续推理标准与研究平台
 <p align="center">
   <a href="https://github.com/SemiAnalysisAI/InferenceX/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://github.com/SemiAnalysisAI/InferenceX/pulls"><img alt="PRs Welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>


### PR DESCRIPTION
## Summary
- Adds the Chinese platform name directly to the `README.md` H1: `InferenceX™, Open Source Continuous Inference Standard and Research Platform / 开源持续推理标准与研究平台`, using the same translation as `README_zh.md`'s title.
- Per explicit request, this change is in `README.md` only — `README_zh.md` already carries the Chinese title, so no mirror edit is needed.

## 中文说明
- 在 `README.md` 的一级标题中直接加入平台名称的中文翻译：`InferenceX™, Open Source Continuous Inference Standard and Research Platform / 开源持续推理标准与研究平台`，与 `README_zh.md` 的标题译名一致。
- 按明确要求，本次仅修改 `README.md` — `README_zh.md` 已有中文标题，无需镜像修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)