### PR TITLE
[Klaud Cold] Fix benchmark_lib source paths broken by #1860 script move / 修复 #1860 移动脚本导致的 benchmark_lib 引用路径错误

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom_mtp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")/../benchmark_lib.sh"
+source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_sglang_mtp.sh
@@ -26,7 +26,7 @@
 # -DSv4 image that carries #26383, bump amd-master.yaml and the detect restores
 # the deep_gemm perf path. RUN_EVAL on the high-conc points gates accuracy.
 
-source "$(dirname "$0")/../benchmark_lib.sh"
+source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,10 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-mtp
+    - dsv4-fp4-mi355x-sglang-mtp
+  description:
+    - "Fix benchmark_lib.sh source path (../ to ../../) broken when PR #1860 moved the MTP scripts into fixed_seq_len/; both configs failed at launch with No such file or directory since then."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary
- PR #1860 moved `dsv4_fp4_mi355x_{atom,sglang,vllm}_mtp.sh` from `benchmarks/single_node/` into `fixed_seq_len/` as a pure `git mv`, leaving their `source "$(dirname "$0")/../benchmark_lib.sh"` one level short — all three configs have failed at launch with `No such file or directory` ever since (surfaced by [this #1981 sweep failure](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719706514/job/85167191887)).
- Fixes the `atom_mtp` and `sglang_mtp` scripts to `../../benchmark_lib.sh` (matching the other 151 `fixed_seq_len` scripts); the `vllm_mtp` copy is fixed on PR #1981's branch.
- Appends a `perf-changelog.yaml` entry for `dsv4-fp4-mi355x-atom-mtp` and `dsv4-fp4-mi355x-sglang-mtp` so both configs re-run and restore their data.

## 中文说明
- #1860 将 `dsv4_fp4_mi355x_{atom,sglang,vllm}_mtp.sh` 以纯 `git mv` 移入 `fixed_seq_len/`，其 `source "$(dirname "$0")/../benchmark_lib.sh"` 相对路径少了一级 - 自那以后三个配置全部在启动时报 `No such file or directory`（由 #1981 的 sweep 失败暴露）。
- 将 `atom_mtp` 与 `sglang_mtp` 脚本修正为 `../../benchmark_lib.sh`（与其余 151 个 `fixed_seq_len` 脚本一致）；`vllm_mtp` 已在 PR #1981 分支上修复。
- 为 `dsv4-fp4-mi355x-atom-mtp` 与 `dsv4-fp4-mi355x-sglang-mtp` 追加 `perf-changelog.yaml` 条目，重新运行这两个配置以恢复数据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)