### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-b300-sglang (+mtp) SGLang image to v0.5.14-cu130 / 将 qwen3.5-fp8-b300-sglang（+mtp） 的 SGLang 镜像 升级至 v0.5.14-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2656,7 +2656,7 @@ qwen3.5-fp8-b200-sglang-mtp:
 
 
 qwen3.5-fp8-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.14-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: b300
@@ -2675,7 +2675,7 @@ qwen3.5-fp8-b300-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.14-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,10 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - qwen3.5-fp8-b300-sglang
+    - qwen3.5-fp8-b300-sglang-mtp
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.12-cu130 to lmsysorg/sglang:v0.5.14-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2059


### PR DESCRIPTION
## Summary
Update SGLang image from lmsysorg/sglang:v0.5.12-cu130 to lmsysorg/sglang:v0.5.14-cu130

Recipes touched: `qwen3.5-fp8-b300-sglang`, `qwen3.5-fp8-b300-sglang-mtp`

## 中文说明
将 SGLang 镜像 从 lmsysorg/sglang:v0.5.12-cu130 升级至 lmsysorg/sglang:v0.5.14-cu130。涉及配置：`qwen3.5-fp8-b300-sglang`、`qwen3.5-fp8-b300-sglang-mtp`。

## Test plan
- [ ] full-sweep-fail-fast sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)