### PR TITLE
[Klaud Cold] Update qwen3.5-bf16-mi355x-sglang (+mtp) SGLang ROCm image to v0.5.14-rocm720-mi35x / 将 qwen3.5-bf16-mi355x-sglang（+mtp） 的 SGLang ROCm 镜像 升级至 v0.5.14-rocm720-mi35x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -159,7 +159,7 @@ dsr1-fp8-mi355x-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
 qwen3.5-bf16-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi355x
@@ -178,7 +178,7 @@ qwen3.5-bf16-mi355x-sglang:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-bf16-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B
   model-prefix: qwen3.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,10 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - qwen3.5-bf16-mi355x-sglang
+    - qwen3.5-bf16-mi355x-sglang-mtp
+  description:
+    - "Update SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 to lmsysorg/sglang:v0.5.14-rocm720-mi35x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2066


### PR DESCRIPTION
## Summary
Update SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 to lmsysorg/sglang:v0.5.14-rocm720-mi35x

Recipes touched: `qwen3.5-bf16-mi355x-sglang`, `qwen3.5-bf16-mi355x-sglang-mtp`

## 中文说明
将 SGLang ROCm 镜像 从 lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517 升级至 lmsysorg/sglang:v0.5.14-rocm720-mi35x。涉及配置：`qwen3.5-bf16-mi355x-sglang`、`qwen3.5-bf16-mi355x-sglang-mtp`。

## Test plan
- [ ] full-sweep-fail-fast sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)