### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-mi355x-sglang (+mtp) SGLang ROCm image to v0.5.14-rocm720-mi35x / 将 qwen3.5-fp4-mi355x-sglang（+mtp） 的 SGLang ROCm 镜像 升级至 v0.5.14-rocm720-mi35x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -414,7 +414,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
           - "DECODE_MTP_SIZE=0"
 
 qwen3.5-fp4-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x
@@ -456,7 +456,7 @@ qwen3.5-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 16 }
 
 qwen3.5-fp4-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,10 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang
+    - qwen3.5-fp4-mi355x-sglang-mtp
+  description:
+    - "Update SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612 to lmsysorg/sglang:v0.5.14-rocm720-mi35x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2068


### PR DESCRIPTION
## Summary
Update SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612 to lmsysorg/sglang:v0.5.14-rocm720-mi35x

Recipes touched: `qwen3.5-fp4-mi355x-sglang`, `qwen3.5-fp4-mi355x-sglang-mtp`

## 中文说明
将 SGLang ROCm 镜像 从 lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612 升级至 lmsysorg/sglang:v0.5.14-rocm720-mi35x。涉及配置：`qwen3.5-fp4-mi355x-sglang`、`qwen3.5-fp4-mi355x-sglang-mtp`。

## Test plan
- [ ] full-sweep-fail-fast sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)