### PR TITLE
[Klaud Cold] Update kimik2.5-int4-mi325x-vllm vLLM ROCm image to v0.24.0 / 将 kimik2.5-int4-mi325x-vllm 的 vLLM ROCm 镜像 升级至 v0.24.0

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -727,7 +727,7 @@ kimik2.5-int4-mi355x-vllm:
       - { tp: 4, conc-start: 4, conc-end: 128 }
 
 kimik2.5-int4-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:v0.21.0
+  image: vllm/vllm-openai-rocm:v0.24.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,9 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - kimik2.5-int4-mi325x-vllm
+  description:
+    - "Update vLLM ROCm image from vllm/vllm-openai-rocm:v0.21.0 to vllm/vllm-openai-rocm:v0.24.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2071


### PR DESCRIPTION
## Summary
Update vLLM ROCm image from vllm/vllm-openai-rocm:v0.21.0 to vllm/vllm-openai-rocm:v0.24.0

Recipes touched: `kimik2.5-int4-mi325x-vllm`

## 中文说明
将 vLLM ROCm 镜像 从 vllm/vllm-openai-rocm:v0.21.0 升级至 vllm/vllm-openai-rocm:v0.24.0。涉及配置：`kimik2.5-int4-mi325x-vllm`。

## Test plan
- [ ] full-sweep-fail-fast sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)