### PR TITLE
[Klaud Cold] Update kimik2.5-int4-h200-vllm vLLM image to v0.24.0 / 将 kimik2.5-int4-h200-vllm 的 vLLM 镜像 升级至 v0.24.0

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2838,7 +2838,7 @@ kimik2.5-int4-b300-vllm:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-h200-vllm:
-  image: vllm/vllm-openai:v0.22.0
+  image: vllm/vllm-openai:v0.24.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4448,3 +4448,9 @@
     - "Employ the AITER MLA attention backend for the DeepSeek-V4 MLA path."
     - "Switch the MoE backend from triton_unfused to AITER MoE (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter) for the FP4 experts."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1980
+
+- config-keys:
+    - kimik2.5-int4-h200-vllm
+  description:
+    - "Update vLLM image from vllm/vllm-openai:v0.22.0 to vllm/vllm-openai:v0.24.0"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2072


### PR DESCRIPTION
## Summary
Update vLLM image from vllm/vllm-openai:v0.22.0 to vllm/vllm-openai:v0.24.0

Recipes touched: `kimik2.5-int4-h200-vllm`

## 中文说明
将 vLLM 镜像 从 vllm/vllm-openai:v0.22.0 升级至 vllm/vllm-openai:v0.24.0。涉及配置：`kimik2.5-int4-h200-vllm`。

## Test plan
- [ ] full-sweep-fail-fast sweep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)