### PR TITLE
[Klaud Cold] Add /debug-mi300-enroot-pyxis command / 新增 /debug-mi300-enroot-pyxis 命令

### DIFF
--- a/.claude/commands/debug-mi300-enroot-pyxis.md
+++ b/.claude/commands/debug-mi300-enroot-pyxis.md
@@ -1,0 +1,77 @@
+---
+description: Debug enroot/pyxis container-start failures on the MI300X Vultr cluster (chi-mi300x-*) — userns sysctl drift survey via the slurm controller, approved fix, and sweep reruns
+argument-hint: [failed-run-or-job-url ...]
+---
+
+Debug `pyxis: couldn't start container` failures on the MI300X runners
+(`mi300x-amds_*`, nodes `chi-mi300x-*`). The canonical signature in the job log:
+
+```
+error: pyxis:     enroot-nsenter: failed to create user namespace: Permission denied
+error: pyxis: couldn't start container
+error: spank: required plugin spank_pyxis.so: task_init() failed with rc=-1
+srun: error: chi-mi300x-0XX: task 0: Exited with exit code 1
+```
+
+Known root cause (July 2026): **provisioning drift** — nodes run Ubuntu 24.04,
+and freshly (re)provisioned nodes carry the distro default
+`kernel.apparmor_restrict_unprivileged_userns=1`, which blocks pyxis's
+`enroot-nsenter` from creating user namespaces. Nodes with the flag at `0`
+work; jobs pass or fail by node lottery. Plain `unshare -U` still works even
+on broken nodes (Ubuntu ships an AppArmor profile for `unshare`), so don't let
+that mislead you — test the actual enroot path or check the sysctl directly.
+
+## Access
+
+`ssh amd-vultr-mi300` lands as **root on the slurm controller**
+(`slurm-sa-mi300-controller-01...`). Compute nodes do NOT accept direct root
+SSH — reach them with `srun`:
+
+```bash
+ssh amd-vultr-mi300 'srun -w chi-mi300x-043 -N1 --immediate=30 bash -c "<cmd>"'
+```
+
+## Procedure
+
+1. **Confirm the signature** from the failing GitHub job log(s) in `$ARGUMENTS`
+   (or via `gh run view --log-failed`), and note the failing node names from
+   the `srun: error: chi-mi300x-0XX` lines.
+
+2. **Read-only survey** of every `idle`/`mixed`/`alloc` node
+   (`sinfo -N` for the list):
+
+   ```bash
+   ssh amd-vultr-mi300 'for n in $(sinfo -N -h -o "%N" | sort -u); do
+     v=$(srun -w $n -N1 --immediate=20 sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>&1 | tail -1)
+     echo "$n: $v"
+   done'
+   ```
+
+   Expect a split: failing nodes at `1`, working nodes at `0`. If ALL nodes are
+   at `0` and failures persist, this is a different bug — check the enroot
+   AppArmor profile coverage of `/usr/local/bin/enroot-nsenter`, enroot
+   versions, and pyxis plugin state instead.
+
+3. **Fix only with explicit user approval** (this disables a kernel security
+   mitigation — AskUserQuestion first, always). On each drifted node, set the
+   flag to the cluster's working baseline and persist it:
+
+   ```bash
+   ssh amd-vultr-mi300 'for n in <drifted nodes>; do
+     srun -w $n -N1 --immediate=30 bash -c \
+       "sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 && \
+        echo kernel.apparmor_restrict_unprivileged_userns=0 > /etc/sysctl.d/99-enroot-userns.conf"
+   done'
+   ```
+
+   Verify each node reads back `0` and the sysctl.d file exists (survives
+   reboot).
+
+4. **Rerun the affected sweeps**: `gh run rerun <id> --failed` for each failed
+   run; full `gh run rerun` if a cancelled run refuses partial rerun.
+
+5. **Flag the durable fix**: the sysctl belongs in the node provisioning image
+   — any node that gets (re)provisioned without it will regress (watch nodes
+   listed as down with "provisioning incomplete" in `sinfo`; they'll likely
+   come up drifted). Ping the cluster owners rather than treating step 3 as
+   permanent.


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/debug-mi300-enroot-pyxis.md`, encoding today's MI300X debugging session: the `enroot-nsenter: failed to create user namespace: Permission denied` signature, root-on-controller access via `ssh amd-vultr-mi300` with `srun` to reach compute nodes (no direct root SSH), a read-only survey of `kernel.apparmor_restrict_unprivileged_userns` across nodes, and the approval-gated fix (`sysctl -w` + `/etc/sysctl.d/99-enroot-userns.conf`) matching the cluster's working baseline.
- Documents the gotcha that plain `unshare -U` works even on broken nodes (Ubuntu's stock AppArmor profile), the rerun step, and the durable fix (bake the sysctl into the provisioning image — freshly provisioned nodes regress otherwise).
- Fix was validated live today: nodes chi-mi300x-043/049/057/058 were drifted at flag=1; after the fix, the three failed canaries (#2062, #2063, #2069) were rerun.

## 中文说明
- 新增 `.claude/commands/debug-mi300-enroot-pyxis.md`，沉淀今日 MI300X 调试过程：`enroot-nsenter` 用户命名空间 Permission denied 的错误签名、通过 `ssh amd-vultr-mi300`（控制器 root）加 `srun` 访问计算节点（节点不接受直接 root SSH）、对 `kernel.apparmor_restrict_unprivileged_userns` 的只读全节点巡检，以及需用户批准的修复（`sysctl -w` + `/etc/sysctl.d/99-enroot-userns.conf`，对齐集群自身的正常基线）。
- 记录了易误导点：即使在故障节点上 `unshare -U` 也能成功（Ubuntu 自带 AppArmor profile 覆盖 unshare）；并包含重跑步骤与长期修复建议（将该 sysctl 写入节点供应镜像，否则新供应节点会回退）。
- 修复已于今日实测验证：chi-mi300x-043/049/057/058 四节点漂移为 flag=1；修复后已重跑三个失败的 canary（#2062、#2063、#2069）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)