### PR TITLE
[Klaud Cold] add-model-hardware: finish fail-fast label switch / 补齐 add-model-hardware 的 fail-fast 标签替换

### DIFF
--- a/.claude/commands/add-model-hardware.md
+++ b/.claude/commands/add-model-hardware.md
@@ -1,5 +1,5 @@
 ---
-description: Add a new model+hardware single-node benchmark recipe (script + master-config entry + perf-changelog + launcher routing), open a [Klaud Cold] PR, label full-sweep-enabled, and monitor CI
+description: Add a new model+hardware single-node benchmark recipe (script + master-config entry + perf-changelog + launcher routing), open a [Klaud Cold] PR, label full-sweep-fail-fast, and monitor CI
 argument-hint: <model-link> <gpu-sku> [recipes-link] [draft-model-link] [mtp]
 ---
 
@@ -164,7 +164,7 @@ git push -u origin feat/<model>-<sku>[-mtp]-dayzero
 gh pr create --repo SemiAnalysisAI/InferenceX --base main \
   --title "[Klaud Cold] <key>: day-zero <MODEL> <SKU> recipe" --body "<summary>"
 # fill perf-changelog pr-link with the real URL → commit → push
-gh api -X POST repos/SemiAnalysisAI/InferenceX/issues/<PR>/labels -f "labels[]=full-sweep-enabled" --jq '.[].name'
+gh api -X POST repos/SemiAnalysisAI/InferenceX/issues/<PR>/labels -f "labels[]=full-sweep-fail-fast" --jq '.[].name'
 ```
 Wait for the sweep run to register on the head SHA, then monitor to a conclusion and report
 the job breakdown (e.g. 24 success / 6 skipped / 0 fail). If the **canary** fails, pull its log


### PR DESCRIPTION
## Summary
- Follow-up to #2079: two spots in `/add-model-hardware` still referenced `full-sweep-enabled` — the frontmatter description and the REST label example. Both now use `full-sweep-fail-fast`.

## 中文说明
- #2079 的补充：`/add-model-hardware` 中仍有两处引用 `full-sweep-enabled`（frontmatter 描述与 REST 打标签示例），现均改为 `full-sweep-fail-fast`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)