### PR TITLE
perf(dsv4-fp4-mi355x-vllm): use ATOM plugin native FlyDSL W4A4 MoE / 改用 ATOM 插件原生 FlyDSL W4A4 MoE

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_vllm.sh
@@ -12,12 +12,6 @@ set -eo pipefail
 # same ROCm recipe while switching parallelism to vLLM's DP+EP form.
 # Image-pin details live in amd-master.yaml.
 #
-# Use the AITER MoE backend (VLLM_ROCM_USE_AITER_MOE=1 + --moe-backend aiter)
-# for the FP4 MoE expert weights of deepseek-ai/DeepSeek-V4-Pro. The AITER
-# MXFP4 path registers the FP4 scale parameters (w13_weight_scale /
-# w2_weight_scale), so safetensors loads correctly and decode runs on the
-# fused AITER experts instead of triton_unfused.
-#
 # --compilation-config mode=3 with FULL_AND_PIECEWISE cudagraph mode
 # enables full CUDA graph capture for improved throughput on MI355X.
 
@@ -45,7 +39,8 @@ if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
 fi
 
 export VLLM_ROCM_USE_AITER=1
-export VLLM_ROCM_USE_AITER_MOE=1
+export ATOM_MOE_GU_ITLV=1
+export AITER_BF16_FP8_MOE_BOUND=0
 
 SERVER_LOG=/workspace/server.log
 
@@ -76,7 +71,6 @@ vllm serve $MODEL --port $PORT \
     --gpu-memory-utilization 0.8 \
     --kv-cache-dtype fp8 \
     --trust-remote-code \
-    --moe-backend aiter \
     --tokenizer-mode deepseek_v4 \
     --reasoning-parser deepseek_v4 \
     --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}' > $SERVER_LOG 2>&1 &

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1912,7 +1912,7 @@ dsv4-fp4-mi355x-sglang-mtp:
 # gpu-mem-util=0.6. TP8 sweeps conc 4-64; DEP8 has a single conc=64
 # probe to validate the ROCm DP+EP path.
 dsv4-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
+  image: rocm/atom-dev:vllm-v0.22.0-nightly_20260704
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x


### PR DESCRIPTION
## Summary
- Replace the a16w4 (AITER_MXFP4_BF16) MoE path — which produces garbled output on DeepSeek-V4-Pro — with the ATOM vLLM out-of-tree plugin's native FlyDSL W4A4 (MXFP4×MXFP4) kernel.
- Correct output and **2.34× baseline**: 2287 vs 979 output tok/s (c64 1k/1k, TP=8, CUDA graph).
- Pin image to the dated immutable ATOM OOT tag `rocm/atom-dev:vllm-v0.22.0-nightly_20260704` (vLLM 0.22.1 + atom plugin + flydsl); set `ATOM_MOE_GU_ITLV=1` and `AITER_BF16_FP8_MOE_BOUND=0`.

## Why
a16w4 loads and is fast but numerically wrong (multi-expert layout bug). Correct native W4A4 depends on Atom's FlyDSL JIT kernel (matched shuffle layout + `gate_mode=INTERLEAVE` + fp4x2 activation), which vLLM's bundled aiter can't reproduce — so we use Atom's official vLLM plugin instead.

## Test plan
- [x] Smoke test: "48+24"→72, "capital of France"→Paris, "capital of Italy"→Rome
- [x] Benchmark c64 1k/1k: 2287 tok/s (vs baseline 979 same-config)
- [ ] Full sweep CI green

## 中文说明
将会产生乱码输出的 a16w4 (AITER_MXFP4_BF16) 路线,替换为 ATOM vLLM 外挂插件(out-of-tree plugin)的原生 FlyDSL W4A4 (MXFP4×MXFP4) MoE kernel。
- 输出正确,且为 baseline 的 **2.34 倍**:c64 1k/1k、TP=8、CUDA graph 下 2287 vs 979 output tok/s。
- 镜像 pin 到带日期的不可变 ATOM OOT tag `rocm/atom-dev:vllm-v0.22.0-nightly_20260704`(含 vLLM 0.22.1 + atom plugin + flydsl);设置 `ATOM_MOE_GU_ITLV=1` 与 `AITER_BF16_FP8_MOE_BOUND=0`。

### 为什么
a16w4 能加载且快,但数值错误(多专家布局 bug)。正确的原生 W4A4 依赖 Atom 的 FlyDSL JIT kernel(配对的 shuffle 布局 + `gate_mode=INTERLEAVE` + fp4x2 激活量化),vLLM 自带的 aiter 无法复现,故改用 Atom 官方 vLLM plugin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)