### PR TITLE
[AMD] Qwen3.5-FP8 MI355X SGLang disagg perf tuning: Docker image update / Qwen3.5-FP8 MI355X SGLang disagg 性能调优 更新Docker image

### DIFF
--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -373,27 +373,27 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   disagg: true
   scenarios:
     fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
-      - spec-decoding: "none"
-        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=0"
+    # - isl: 1024
+    #   osl: 1024
+    #   search-space:
+    #   # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
+    #   - spec-decoding: "none"
+    #     conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+    #     prefill:
+    #       num-worker: 1
+    #       tp: 8
+    #       ep: 1
+    #       dp-attn: false
+    #       additional-settings:
+    #       - "PREFILL_NODES=1"
+    #     decode:
+    #       num-worker: 1
+    #       tp: 8
+    #       ep: 1
+    #       dp-attn: false
+    #       additional-settings:
+    #       - "DECODE_NODES=1"
+    #       - "DECODE_MTP_SIZE=0"
 
     - isl: 8192
       osl: 1024
@@ -409,7 +409,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       # MoRI is added to is_deepep_class_backend() or shared-slot
       # accounting is reconciled.
       - spec-decoding: "none"
-        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
         prefill:
           num-worker: 1
           tp: 8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -383,7 +383,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       search-space:
       # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
       - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128 ]
+        conc-list: [ 8, 16, 32, 64, 128 ]
         prefill:
           num-worker: 1
           tp: 8
@@ -405,7 +405,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       search-space:
       # 1P+1D TP8/EP1 low-concurrency sweep.
       - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128 ]
+        conc-list: [ 8, 16, 32, 64, 128 ]
         prefill:
           num-worker: 1
           tp: 8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -363,7 +363,7 @@ qwen3.5-fp8-mi355x-atom-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-mi355x-sglang-disagg:
-  image: lmsysorg/sglang-rocm:v0.5.11-rocm700-mi35x-20260511
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x-disagg

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -368,7 +368,7 @@ qwen3.5-fp8-mi355x-atom-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-mi355x-sglang-disagg:
-  image: lmsysorg/sglang-rocm:v0.5.11-rocm700-mi35x-20260511
+  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x-disagg

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -16,7 +16,6 @@ dsr1-fp4-mi355x-sglang:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, conc-start: 4, conc-end: 64 }
       - { tp: 8, conc-start: 4, conc-end: 64 }
     # Agentic-coding sweep commented out for this image-bump PR — the
     # 10-conc agentic matrix amplifies sweep cost and the bump validation
@@ -262,7 +261,7 @@ qwen3.5-fp8-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x
@@ -274,14 +273,17 @@ qwen3.5-fp8-mi355x-sglang:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 32 }
+      - { tp: 8, ep: 8, conc-start: 64, conc-end: 256 }
+      - { tp: 2, ep: 2, conc-start: 128, conc-end: 256 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
+      - { tp: 2, ep: 2, conc-start: 4, conc-end: 32 }
+      - { tp: 4, ep: 1, conc-start: 32, conc-end: 256 }
 
 qwen3.5-fp8-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260528
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x
@@ -293,11 +295,14 @@ qwen3.5-fp8-mi355x-sglang-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 32, spec-decoding: mtp }
+      - { tp: 8, ep: 8, conc-start: 64, conc-end: 256, spec-decoding: mtp }
+      - { tp: 2, ep: 2, conc-start: 128, conc-end: 256, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+      - { tp: 2, ep: 2, conc-start: 4, conc-end: 32, spec-decoding: mtp }
+      - { tp: 4, ep: 1, conc-start: 32, conc-end: 256, spec-decoding: mtp }
 
 # Diverged from qwen3.5-fp8-mi355x-sglang (agentic-coding sibling). Metadata is
 # identical to origin/main's qwen3.5-fp8-mi355x-sglang; the split exists because this
@@ -363,7 +368,7 @@ qwen3.5-fp8-mi355x-atom-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-mi355x-sglang-disagg:
-  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.11-rocm700-mi35x-20260511
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x-disagg
@@ -373,43 +378,12 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   disagg: true
   scenarios:
     fixed-seq-len:
-    # - isl: 1024
-    #   osl: 1024
-    #   search-space:
-    #   # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
-    #   - spec-decoding: "none"
-    #     conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
-    #     prefill:
-    #       num-worker: 1
-    #       tp: 8
-    #       ep: 1
-    #       dp-attn: false
-    #       additional-settings:
-    #       - "PREFILL_NODES=1"
-    #     decode:
-    #       num-worker: 1
-    #       tp: 8
-    #       ep: 1
-    #       dp-attn: false
-    #       additional-settings:
-    #       - "DECODE_NODES=1"
-    #       - "DECODE_MTP_SIZE=0"
-
-    - isl: 8192
+    - isl: 1024
       osl: 1024
       search-space:
-      # 1P+1D TP8/EP1 low-concurrency sweep.
-      # dp-attn intentionally false (matches the 1k1k row): with
-      # --enable-dp-attention + --moe-a2a-backend mori, sglang auto-promotes
-      # moe_ep_size=tp_size=8, but is_deepep_class_backend() excludes MoRI,
-      # so num_shared_slots stays at the global value (1) and the
-      # (num_experts - num_shared_slots) % moe_ep_size assertion in
-      # fused_moe_triton/layer.py fires for Qwen3.5 (512 routed + 1 shared).
-      # Track upstream sglang for a fix; flip back to dp-attn=true once
-      # MoRI is added to is_deepep_class_backend() or shared-slot
-      # accounting is reconciled.
+      # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
       - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
         prefill:
           num-worker: 1
           tp: 8
@@ -426,8 +400,58 @@ qwen3.5-fp8-mi355x-sglang-disagg:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=0"
 
+    - isl: 8192
+      osl: 1024
+      search-space:
+      # 1P+1D TP8/EP1 low-concurrency sweep.
+      # dp-attn intentionally false (matches the 1k1k row): with
+      # --enable-dp-attention + --moe-a2a-backend mori, sglang auto-promotes
+      # moe_ep_size=tp_size=8, but is_deepep_class_backend() excludes MoRI,
+      # so num_shared_slots stays at the global value (1) and the
+      # (num_experts - num_shared_slots) % moe_ep_size assertion in
+      # fused_moe_triton/layer.py fires for Qwen3.5 (512 routed + 1 shared).
+      # Track upstream sglang for a fix; flip back to dp-attn=true once
+      # MoRI is added to is_deepep_class_backend() or shared-slot
+      # accounting is reconciled.
+      - spec-decoding: "none"
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "DECODE_MTP_SIZE=0"
+
+qwen3.5-fp8-mi355x-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.10.post1-rocm700-mi35x
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
+
 qwen3.5-fp4-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612
+  image: lmsysorg/sglang:v0.5.12-rocm720-mi35x
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x
@@ -469,7 +493,7 @@ qwen3.5-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 16 }
 
 qwen3.5-fp4-mi355x-sglang-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260517
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: mi355x
@@ -481,12 +505,12 @@ qwen3.5-fp4-mi355x-sglang-mtp:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 2, conc-start: 4, conc-end: 128, spec-decoding: mtp }
+      - { tp: 2, conc-start: 4, conc-end: 256, spec-decoding: mtp }
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
 
 qwen3.5-fp4-mi355x-sglang-disagg:
@@ -739,7 +763,7 @@ glm5.1-fp4-mi355x-atom:
       - { tp: 4, conc-start: 4, conc-end: 256 }
 
 kimik2.5-int4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-b8336c3c7c298e0878f22a7bf70f4e295b2f4e01
+  image: vllm/vllm-openai-rocm:v0.21.0
   model: moonshotai/Kimi-K2.5
   model-prefix: kimik2.5
   runner: mi355x
@@ -751,13 +775,11 @@ kimik2.5-int4-mi355x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 128 }
-      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 64 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 4, conc-end: 128 }
-      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 64 }
 
 kimik2.5-int4-mi325x-vllm:
   image: vllm/vllm-openai-rocm:v0.21.0
@@ -871,6 +893,214 @@ kimik2.5-fp4-mi355x-atom:
       - { tp: 8, conc-start: 4, conc-end: 128 }
       - { tp: 4, conc-start: 4, conc-end: 128 }
 
+minimaxm2.5-fp8-mi355x-vllm:
+  image: vllm/vllm-openai-rocm:v0.22.0
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 2, ep: 2, conc-start: 2, conc-end: 512 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 256 }
+      - { tp: 8, ep: 8, conc-start: 2, conc-end: 2 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 2, ep: 2, conc-start: 2, conc-end: 256 }
+      - { tp: 4, ep: 4, conc-start: 4, conc-end: 512 }
+      - { tp: 8, ep: 8, conc-start: 2, conc-end: 2 }
+
+# Diverged from minimaxm2.5-fp8-mi355x-vllm (agentic-coding sibling). Reasons below;
+# the original minimaxm2.5-fp8-mi355x-vllm entry is left identical to origin/main so
+# its fixed-seq-len sweep is unaffected.
+#   - image: 'vllm/vllm-openai-rocm:v0.19.0' -> 'vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf'
+minimaxm2.5-fp8-mi355x-vllm-agentic:
+  # Nightly carrying vllm-project/vllm@20cac26b ("[Bug fix][KV Connector]
+  # add cpu_offload_blocks > 0 check before maybe_run_layer_kv_offload"),
+  # which enables SimpleCPUOffloadConnector on ROCm. Required for the
+  # cpu-offload sweep points to use the same offload path as the NVIDIA
+  # agentic-coding configs.
+  image: vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # MI355X tp=4 ep=4: compute ceiling ~60 (empirical), KV cliff ~91 (analytical).
+    # Compute saturates first; cpu offload likely won't help, but worth confirming.
+    # AMD uses native OffloadingConnector (NOT SimpleCPUOffloadConnector).
+    - duration: 1800
+      search-space:
+      - { tp: 4, ep: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 48, 56, 64, 72, 96] }
+      - { tp: 4, ep: 4, offloading: cpu,  conc-list: [48, 56, 64, 72, 96] }
+
+minimaxm2.5-fp8-mi355x-atom:
+  image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp8
+  framework: atom
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 256 }
+      - { tp: 4, conc-start: 4, conc-end: 256 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 256 }
+      - { tp: 4, conc-start: 4, conc-end: 256 }
+
+minimaxm2.5-fp4-mi355x-atom:
+  image: rocm/atom:rocm7.2.2_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.2.post
+  model: amd/MiniMax-M2.5-MXFP4
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp4
+  framework: atom
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 1, conc-start: 4, conc-end: 1024 }
+      - { tp: 2, conc-start: 4, conc-end: 1024 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 16 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 1, conc-start: 4, conc-end: 1024 }
+      - { tp: 2, conc-start: 4, conc-end: 1024 }
+      - { tp: 4, conc-start: 4, conc-end: 128 }
+      - { tp: 8, conc-start: 4, conc-end: 16 }
+
+minimaxm2.5-fp4-mi355x-vllm:
+  image: vllm/vllm-openai-rocm:v0.22.0
+  model: amd/MiniMax-M2.5-MXFP4
+  model-prefix: minimaxm2.5
+  runner: mi355x
+  precision: fp4
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 1, conc-start: 4, conc-end: 32 }
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 1, conc-start: 4, conc-end: 32 }
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+
+minimaxm2.5-fp8-mi300x-vllm:
+  image: vllm/vllm-openai-rocm:v0.21.0
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi300x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 4, conc-start: 4, conc-end: 64 }
+
+# Diverged from minimaxm2.5-fp8-mi300x-vllm (agentic-coding sibling). Reasons below;
+# the original minimaxm2.5-fp8-mi300x-vllm entry is left identical to origin/main so
+# its fixed-seq-len sweep is unaffected.
+#   - image: 'vllm/vllm-openai-rocm:v0.16.0' -> 'vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf'
+minimaxm2.5-fp8-mi300x-vllm-agentic:
+  # Nightly carrying vllm-project/vllm@20cac26b — see mi355x config above.
+  image: vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi300x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # MI300X tp=4: compute ceiling ~25 (estimated, between H100 and H200);
+    # KV cliff ~52. Compute saturates first.
+    # AMD uses native OffloadingConnector (NOT SimpleCPUOffloadConnector).
+    - duration: 1800
+      search-space:
+      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 20, 24, 28, 32, 40, 48] }
+      - { tp: 4, offloading: cpu,  conc-list: [16, 20, 24, 28, 32] }
+
+minimaxm2.5-fp8-mi325x-vllm:
+  image: vllm/vllm-openai-rocm:v0.22.0
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi325x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 512 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 2, conc-start: 4, conc-end: 64 }
+      - { tp: 8, ep: 8, conc-start: 4, conc-end: 256 }
+
+# Diverged from minimaxm2.5-fp8-mi325x-vllm (agentic-coding sibling). Reasons below;
+# the original minimaxm2.5-fp8-mi325x-vllm entry is left identical to origin/main so
+# its fixed-seq-len sweep is unaffected.
+#   - image: 'vllm/vllm-openai-rocm:v0.18.0' -> 'vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf'
+minimaxm2.5-fp8-mi325x-vllm-agentic:
+  # Nightly carrying vllm-project/vllm@20cac26b — see mi355x config above.
+  image: vllm/vllm-openai-rocm:nightly-51f22dcfd068fe8f1e3192da2a1e825b930223cf
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi325x
+  precision: fp8
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    # MI325X tp=4: cloned from MI300X recipe (slightly faster compute,
+    # similar HBM profile). Compute saturates first; cpu-offload window
+    # exercises the SimpleCPUOffloadConnector path enabled by the rocm
+    # nightly. Mirror MI300X conc grid for cross-vendor comparability.
+    - duration: 1800
+      search-space:
+      - { tp: 4, offloading: none, conc-list: [1, 2, 4, 8, 16, 20, 24, 28, 32, 40, 48] }
+      - { tp: 4, offloading: cpu,  conc-list: [16, 20, 24, 28, 32] }
+
 gptoss-fp4-mi300x-vllm:
   image: vllm/vllm-openai-rocm:v0.17.0
   model: openai/gpt-oss-120b
@@ -923,7 +1153,7 @@ gptoss-fp4-mi325x-vllm:
 
 gptoss-fp4-mi355x-vllm:
   image: vllm/vllm-openai-rocm:v0.22.0
-  model: openai/gpt-oss-120b
+  model: amd/gpt-oss-120b-w-mxfp4-a-fp8
   model-prefix: gptoss
   runner: mi355x
   precision: fp4
@@ -1354,6 +1584,62 @@ kimik2.5-fp4-mi355x-vllm-disagg:
           num-worker: 1
           tp: 8
           ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "VLLM_MORIIO_CONNECTOR_READ_MODE=1"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=2"
+
+minimaxm2.5-fp8-mi355x-vllm-disagg:
+  image: vllm/vllm-openai-rocm:nightly-a6682d1d259cca69a9ae737ea5608fbbe7520031
+  model: MiniMaxAI/MiniMax-M2.5
+  model-prefix: minimaxm2.5
+  runner: mi355x-disagg
+  precision: fp8
+  framework: vllm-disagg
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      # 1P2D: 1 prefill node (co-located with proxy) + 2 decode nodes = 3 nodes total
+      # Prefill also needs EP=8: MiniMax M2.5 expert intermediate_size=1536,
+      # TP8 shards to 192 which is not divisible by FP8 block_n=128.
+      - spec-decoding: "none"
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "VLLM_MORIIO_CONNECTOR_READ_MODE=1"
+        decode:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=2"
+
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - spec-decoding: "none"
+        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
           dp-attn: false
           additional-settings:
           - "PREFILL_NODES=1"
@@ -1873,8 +2159,13 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=1"
 
+
+# DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
+# amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
+# image tag, so bumping sglang is just an image tag bump here. Sweeps
+# DP-attention on/off and EP=8.
 dsv4-fp4-mi355x-sglang:
-  image: lmsysorg/sglang-rocm:v0.5.13.post1-rocm720-mi35x-20260618
+  image: rocm/sgl-dev:rocm720-mi35x-f96ac98-20260526-DSv4
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1887,15 +2178,12 @@ dsv4-fp4-mi355x-sglang:
       osl: 1024
       search-space:
       - { tp: 8, dp-attn: true, conc-start: 64, conc-end: 2048 }
-      - { tp: 4, dp-attn: true, conc-start: 16, conc-end: 128 }
-      - { tp: 4, dp-attn: false, conc-start: 1 , conc-end: 32 }
+      - { tp: 8, dp-attn: false, conc-start: 1 , conc-end: 32 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, dp-attn: true, conc-start: 64, conc-end: 2048 }
-      - { tp: 4, dp-attn: true, conc-start: 16, conc-end: 128 }
-      - { tp: 4, dp-attn: false, conc-start: 1, conc-end: 32 }
-
+      - { tp: 8, dp-attn: false, conc-start: 1, conc-end: 32 }
 
 # MTP variant of dsv4-fp4-mi355x-sglang. Mirrors the base search space and adds
 # spec-decoding: mtp, which routes to dsv4_fp4_mi355x_sglang_mtp.sh (EAGLE
@@ -1997,8 +2285,15 @@ dsv4-fp4-mi355x-vllm-mtp:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 512, spec-decoding: mtp }
 
+# Day-0 single-sequence marker for DeepSeek-V4 on ATOM (ROCm/ATOM#650).
+# PR1 of the ATOM DSv4 series still uses torch sparse-attention fallbacks
+# that OOM once warmup/prefill batches multiple requests; keep CONC=1 until
+# the AITER sparse-attention kernel / multi-request path lands upstream.
+# --enforce-eager and ATOM_USE_TRITON_MOE=1 are required on gfx950. Image is
+# the standard atom0.1.2.post MI355X base (matching qwen3.5-fp8-mi355x-atom);
+# the DSv4 PR is overlaid at runtime by dsv4_fp4_mi355x_atom.sh at a pinned SHA.
 dsv4-fp4-mi355x-atom:
-  image: rocm/atom-dev:nightly_202606161823
+  image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -2010,20 +2305,13 @@ dsv4-fp4-mi355x-atom:
     - isl: 1024
       osl: 1024
       search-space:
-        # conc4-64, TP8
-        # conc128-512, DPA
-        # conc1024-2048, DPA TBO
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 2048 }
+      - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 1024 }
     - isl: 8192
       osl: 1024
       search-space:
-        # conc4-64, TP8
-        # conc128, DPA
-        # conc256-2048, DPA TBO
-      - { tp: 4, ep: 1, conc-list: [8, 16, 32, 64] }
-      - { tp: 8, ep: 1, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, ep: 1, dp-attn: true, conc-start: 128, conc-end: 2048 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 64 }
+      - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 512 }
 
 dsv4-fp4-mi355x-atom-mtp:
   image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3
@@ -2453,712 +2741,3 @@ dsv4-fp4-mi355x-sglang-agentic:
 # async scheduling, max-num-seqs=128, max-num-batched-tokens=8192,
 # gpu-mem-util=0.6. TP8 sweeps conc 4-64; DEP8 has a single conc=64
 # probe to validate the ROCm DP+EP path.
-
-dsv4-fp4-mi355x-atom-disagg:
-  image: rocm/atom-dev:nightly_202606101403
-  model: deepseek-ai/DeepSeek-V4-Pro
-  model-prefix: dsv4
-  runner: mi355x
-  precision: fp4
-  framework: atom-disagg
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-      # 1P1D DPA+TP8
-    - isl: 8192
-      osl: 1024
-      search-space:
-      # 2P1D DPA+TP8 
-      - conc-list: [ 256, 512, 768, 1024, 2048 ]
-        prefill:
-          num-worker: 2
-          tp: 8
-          ep: 1
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=2"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 1P1D TP8 
-      - conc-list: [ 4, 8, 16, 32, 64, 128 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 1P1D TP8
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - conc-list: [ 4, 8, 16, 32, 64, 128, 256, 512, 1024 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-
-# MiniMax-M3 MXFP8 MI355X recipe:
-# https://github.com/vllm-project/recipes/commit/2a3728ed9892debfd767a72a58ebc90b33f186e5
-# MXFP8 runs from TP=4 on gfx950; block size 128 is mandatory for MSA.
-minimaxm3-fp8-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 64 }
-      - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
-      - { tp: 2, ep: 2, conc-start: 16, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
-
-# EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
-# minimaxm3-fp8-mi355x-vllm, pairing MiniMaxAI/MiniMax-M3-MXFP8 with the
-# Inferact/MiniMax-M3-EAGLE3 draft head (3 speculative tokens). No
-# attention_backend override is needed — the server runs on TRITON_ATTN, so
-# the FlashInfer page-128/MHA limitation that forced FLASH_ATTN on Blackwell
-# does not apply here. Search space mirrors the non-MTP entry trimmed at the
-# extreme-concurrency end, identical to the minimaxm3-fp8-b300-vllm-mtp /
-# b200-vllm-mtp precedent: spec decode pays off at low/mid concurrency while
-# acceptance dilutes in big batches, and the draft weights + draft KV shave
-# headroom — tp2-ep2 is dropped since its KV headroom was already thin.
-minimaxm3-fp8-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
-
-# MiniMax-M3 MXFP4 MI355X vLLM disaggregated (prefill/decode) config.
-minimaxm3-fp4-mi355x-vllm-disagg:
-  image: rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x-disagg
-  precision: fp4
-  framework: vllm-disagg
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-    - isl: 8192
-      osl: 1024
-      search-space:
-      # 1P TP4 + 1D TP4 (2 nodes total), conc sweep 1..512 (single job, looped)
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 2P TP4 + 1D TP4 (3 nodes total), conc 128/256/512 (single job, looped)
-      - spec-decoding: "none"
-        conc-list: [ 128, 256, 512 ]
-        prefill:
-          num-worker: 2
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=2"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-# MiniMax-M3 MXFP4 MI355X vLLM recipe. The pinned nightly includes upstream
-# MiniMax-M3 Quark MXFP4 support (vllm-project/vllm#45794). Use the text-only
-# language-model path and mirror the MXFP8 MI355X search space for a direct
-# precision comparison.
-minimaxm3-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp4
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 64 }
-      - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
-      - { tp: 2, ep: 2, conc-start: 16, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
-
-# EAGLE3 speculative-decoding variant of minimaxm3-fp4-mi355x-vllm. Pair the
-# amd/MiniMax-M3-MXFP4 target with Inferact/MiniMax-M3-EAGLE3 and three draft
-# tokens. Search space mirrors the MI355X MXFP8 MTP entry, trimming the base
-# FP4 sweep at extreme concurrency where speculative decoding loses value.
-minimaxm3-fp4-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-3f5a1e1733200760169ff31ebe60a271072b199e
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp4
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 4, ep: 4, conc-start: 64, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 256, spec-decoding: mtp }
-
-# MiniMax-M3 MXFP4 MI355X atom recipe:
-# https://github.com/ROCm/ATOM/blob/5d42d49f9e4292e5b61475917e92e7ec1b1dacb7/recipes/MiniMax-M3.md
-# block size 128 is mandatory for MSA. TP4 on a single gfx950 node, per the recipe.
-minimaxm3-fp4-mi355x-atom:
-  image: rocm/atom-dev:MiniMax-M3-20260623
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp4
-  framework: atom
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256 }
-
-minimaxm3-fp4-mi355x-atom-mtp:
-  image: rocm/atom-dev:MiniMax-M3-20260623
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp4
-  framework: atom
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256, spec-decoding: mtp  }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256, spec-decoding: mtp  }
-
-minimaxm3-fp8-mi355x-atom:
-  image: rocm/atom-dev:MiniMax-M3-20260623
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp8
-  framework: atom
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256 }
-
-minimaxm3-fp8-mi355x-atom-mtp:
-  image: rocm/atom-dev:MiniMax-M3-20260623
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x
-  precision: fp8
-  framework: atom
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 256, spec-decoding: mtp }
-
-minimaxm3-fp8-mi355x-atom-disagg:
-  image: rocm/atom-dev:MiniMax-M3-20260622
-  model: amd/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x-disagg
-  precision: fp8
-  framework: atom-disagg
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-    - isl: 8192
-      osl: 1024
-      search-space:
-      # 1P1D TP4
-      - conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 1P1D TP4
-    - isl: 1024
-      osl: 1024
-      search-space:
-      # 1P1D TP4
-      - conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-
-minimaxm3-fp4-mi355x-atom-disagg:
-  image: rocm/atom-dev:MiniMax-M3-20260622
-  model: amd/MiniMax-M3-MXFP4
-  model-prefix: minimaxm3
-  runner: mi355x-disagg
-  precision: fp4
-  framework: atom-disagg
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-    - isl: 8192
-      osl: 1024
-      search-space:
-      # 1P1D TP4
-      - conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 1P1D TP4
-    - isl: 1024
-      osl: 1024
-      search-space:
-      # 1P1D TP4
-      - conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-
-# MiniMax-M3 MXFP8 MI300X day-zero recipe. Reuse the dedicated ROCm image and
-# MI355X serving shape, but retain the default BF16 KV cache because this
-# checkpoint lacks calibrated ROCm FP8 attention scales. Use the TP8-only H100
-# search space: TP8 for latency and TP8+EP8 (TEP) at high concurrency.
-minimaxm3-fp8-mi300x-vllm:
-  image: vllm/vllm-openai-rocm:minimax-m3
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi300x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256 }
-
-# EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
-# minimaxm3-fp8-mi300x-vllm, pairing MiniMaxAI/MiniMax-M3-MXFP8 with the
-# Inferact/MiniMax-M3-EAGLE3 draft head (3 speculative tokens). Same TP8-only
-# search space as the non-MTP MI300X entry (gfx942 192 GB is memory-tight, like
-# H100), with the TP8 latency rows started at conc 1 to capture single-request
-# latency — matching the H100/MI355X MTP recipes. The pinned ROCm nightly
-# includes upstream SupportsEagle3 support for the AMD MiniMax-M3 model.
-minimaxm3-fp8-mi300x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-b53b1c7ffe7aebdafd0876350f30e51d1226c92a
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi300x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 128, conc-end: 256, spec-decoding: mtp }
-
-# MiniMax-M3 MXFP8 MI325X day-zero recipe. Reuse the dedicated ROCm image
-# and serving flags validated on MI355X, with the H200 search space: TP4 and
-# TP8 latency, TP4/TP8 expert parallelism, and TP8 data-parallel attention.
-minimaxm3-fp8-mi325x-vllm:
-  image: vllm/vllm-openai-rocm:minimax-m3
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi325x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 64 }
-      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256 }
-      - { tp: 8, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 512 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 32 }
-      - { tp: 8, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512 }
-
-# EAGLE3 speculative-decoding (spec-decoding: mtp) variant of
-# minimaxm3-fp8-mi325x-vllm, pairing MiniMaxAI/MiniMax-M3-MXFP8 with the
-# Inferact/MiniMax-M3-EAGLE3 draft head (3 speculative tokens). Same H200-style
-# search space as the non-MTP MI325X entry, trimmed at the extreme-concurrency
-# end with TP-only latency rows started at conc 1 (matching the H200/MI355X MTP
-# recipes). Runs with CUDA graphs (no --enforce-eager, VLLM_USE_BREAKABLE_CUDAGRAPH=0,
-# BF16 KV on gfx942). The shipped ROCm image lacks SupportsEagle3 on the AMD
-# MiniMax-M3 model, so the recipe applies that fix in-place at runtime
-# (functionstackx/vllm#1, upstream vllm-project/vllm#45546; validated green on
-# MI355X/MI300X) before serving.
-minimaxm3-fp8-mi325x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:minimax-m3
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi325x
-  precision: fp8
-  framework: vllm
-  multinode: false
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 64, spec-decoding: mtp }
-      - { tp: 4, ep: 4, conc-start: 128, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - { tp: 4, conc-start: 1, conc-end: 32, spec-decoding: mtp }
-      - { tp: 8, conc-start: 1, conc-end: 128, spec-decoding: mtp }
-      - { tp: 8, ep: 8, conc-start: 256, conc-end: 256, spec-decoding: mtp }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 256, spec-decoding: mtp }
-
-# MiniMax-M3 MXFP8 MI355X vLLM disaggregated (prefill/decode) smoke test on the
-# day-zero ROCm image. Minimal 1 prefill (TP8) + 1 decode (TP8) at conc 1 to
-# validate the MoRI-IO KV-transfer disagg pipeline end-to-end for M3. Layered on
-# the MoRI-patch-removal infra (#1585). No EP (TP8 only); MoE experts are
-# TP-sharded as in the single-node M3 TP8 recipe. Per-worker serve flags live in
-# benchmarks/multi_node/amd_utils/models_vllm.yaml (MiniMax-M3-MXFP8).
-minimaxm3-fp8-mi355x-vllm-disagg:
-  image: vllm/vllm-openai-rocm:nightly-556bc4e3a089378e9df2482659898192da18db15
-  model: MiniMaxAI/MiniMax-M3-MXFP8
-  model-prefix: minimaxm3
-  runner: mi355x-disagg
-  precision: fp8
-  framework: vllm-disagg
-  multinode: true
-  disagg: true
-  scenarios:
-    fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # Asymmetric 1P TP4 + 1D TP8 (smaller prefill, full-node decode) across
-      # conc 1,2,4,8,16,32,64,128,256.
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # Balanced half-node 1P TP4 + 1D TP4 at high conc 64,128,256,512,1024.
-      - spec-decoding: "none"
-        conc-list: [ 64, 128, 256, 512, 1024 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 2P TP4 + 1D TP8: two half-node TP4 prefill workers (PREFILL_NODES=2)
-      # feeding one full-node TP8 decode, at high conc 256,512,768,1024.
-      - spec-decoding: "none"
-        conc-list: [ 256, 512, 768, 1024 ]
-        prefill:
-          num-worker: 2
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=2"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-    # 8k1k disagg sweep across four P/D layouts (1P TP8 + 1D TP8 conc 1..1024;
-    # 1P TP4 + 1D TP8 conc 1..256; 1P TP4 + 1D TP4 conc 64..1024; 2P TP4 + 1D TP8
-    # conc 256..1024). The multi-node eval policy (8k1k + conc >= 16) marks one
-    # lm-eval on the highest-max-conc layout (TP8+TP8, eval-conc=median=128) —
-    # validating the M3 MoRI-IO disagg pipeline's correctness end-to-end.
-    - isl: 8192
-      osl: 1024
-      search-space:
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # Asymmetric 1P TP4 + 1D TP8 (smaller prefill, full-node decode) across
-      # conc 1,2,4,8,16,32,64,128,256.
-      - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # Balanced half-node 1P TP4 + 1D TP4 at high conc 64,128,256,512,1024.
-      - spec-decoding: "none"
-        conc-list: [ 64, 128, 256, 512, 1024 ]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-      # 2P TP4 + 1D TP8: two half-node TP4 prefill workers (PREFILL_NODES=2)
-      # feeding one full-node TP8 decode, at high conc 256,512,768,1024.
-      - spec-decoding: "none"
-        conc-list: [ 256, 512, 768, 1024 ]
-        prefill:
-          num-worker: 2
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=2"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -378,27 +378,27 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   disagg: true
   scenarios:
     fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
-      - spec-decoding: "none"
-        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
-        prefill:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "PREFILL_NODES=1"
-        decode:
-          num-worker: 1
-          tp: 8
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "DECODE_MTP_SIZE=0"
+    # - isl: 1024
+    #   osl: 1024
+    #   search-space:
+    #   # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
+    #   - spec-decoding: "none"
+    #     conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+    #     prefill:
+    #       num-worker: 1
+    #       tp: 8
+    #       ep: 1
+    #       dp-attn: false
+    #       additional-settings:
+    #       - "PREFILL_NODES=1"
+    #     decode:
+    #       num-worker: 1
+    #       tp: 8
+    #       ep: 1
+    #       dp-attn: false
+    #       additional-settings:
+    #       - "DECODE_NODES=1"
+    #       - "DECODE_MTP_SIZE=0"
 
     - isl: 8192
       osl: 1024
@@ -414,7 +414,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       # MoRI is added to is_deepep_class_backend() or shared-slot
       # accounting is reconciled.
       - spec-decoding: "none"
-        conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
+        conc-list: [8] #[ 8, 16, 32, 64, 128, 256, 512 ]
         prefill:
           num-worker: 1
           tp: 8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -414,7 +414,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       # MoRI is added to is_deepep_class_backend() or shared-slot
       # accounting is reconciled.
       - spec-decoding: "none"
-        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
+        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128 ]
         prefill:
           num-worker: 1
           tp: 8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -414,7 +414,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
       # MoRI is added to is_deepep_class_backend() or shared-slot
       # accounting is reconciled.
       - spec-decoding: "none"
-        conc-list: [8] #[ 8, 16, 32, 64, 128, 256, 512 ]
+        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 ]
         prefill:
           num-worker: 1
           tp: 8

--- a/.github/configs/amd-master.yaml
+++ b/.github/configs/amd-master.yaml
@@ -378,41 +378,32 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   disagg: true
   scenarios:
     fixed-seq-len:
-    # - isl: 1024
-    #   osl: 1024
-    #   search-space:
-    #   # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
-    #   - spec-decoding: "none"
-    #     conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
-    #     prefill:
-    #       num-worker: 1
-    #       tp: 8
-    #       ep: 1
-    #       dp-attn: false
-    #       additional-settings:
-    #       - "PREFILL_NODES=1"
-    #     decode:
-    #       num-worker: 1
-    #       tp: 8
-    #       ep: 1
-    #       dp-attn: false
-    #       additional-settings:
-    #       - "DECODE_NODES=1"
-    #       - "DECODE_MTP_SIZE=0"
+    - isl: 1024
+      osl: 1024
+      search-space:
+      # Matches qwen3.5-fp8-mi355x-sglang TP8/EP1 low-concurrency sweep
+      - spec-decoding: "none"
+        conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "DECODE_MTP_SIZE=0"
 
     - isl: 8192
       osl: 1024
       search-space:
       # 1P+1D TP8/EP1 low-concurrency sweep.
-      # dp-attn intentionally false (matches the 1k1k row): with
-      # --enable-dp-attention + --moe-a2a-backend mori, sglang auto-promotes
-      # moe_ep_size=tp_size=8, but is_deepep_class_backend() excludes MoRI,
-      # so num_shared_slots stays at the global value (1) and the
-      # (num_experts - num_shared_slots) % moe_ep_size assertion in
-      # fused_moe_triton/layer.py fires for Qwen3.5 (512 routed + 1 shared).
-      # Track upstream sglang for a fix; flip back to dp-attn=true once
-      # MoRI is added to is_deepep_class_backend() or shared-slot
-      # accounting is reconciled.
       - spec-decoding: "none"
         conc-list: [ 1, 2, 4, 8, 16, 32, 64, 128 ]
         prefill:

--- a/.github/configs/runners.yaml
+++ b/.github/configs/runners.yaml
@@ -141,6 +141,12 @@ mi355x-disagg:
 - 'mi355x-amds_06'
 - 'mi355x-amds_07'
 - 'mi355x-amds_08'
+- 'mi355x-amds_12'
+- 'mi355x-amds_14'
+- 'mi355x-amds_16'
+- 'mi355x-amds_17'
+- 'mi355x-amds_18'
+- 'mi355x-amds_19'
 gb200:
 - gb200-nv_0
 - gb200-nv_1

--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -156,7 +156,7 @@ fi
 # Optional: exclude specific nodes (e.g. nodes with broken Docker sockets).
 # Set SLURM_EXCLUDE_NODES env var to a comma-separated list of hostnames.
 EXCLUDE_OPT=()
-SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15}"
+SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g09,mia1-p01-g11,mia1-p01-g12,mia1-p01-g15}"
 if [[ -n "${SLURM_EXCLUDE_NODES:-}" ]]; then
     EXCLUDE_OPT=(--exclude "$SLURM_EXCLUDE_NODES")
 fi

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4323,3 +4323,12 @@
     - "Enable AITER MoE on MiniMax-M3 MXFP4 MI355X single-node vLLM STP: export VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1; pass --moe-backend aiter."
     - "Pin vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1 (from nightly-3f5a1e1733200760169ff31ebe60a271072b199e) for AITER MoE and shared-expert fusion support (vllm-project/vllm#46419, vllm-project/vllm#46545)."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1954
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang-disagg
+  description:
+    - "Bump Qwen3.5-FP8 MI355X SGLang disagg image from lmsysorg/sglang-rocm:v0.5.11-rocm700-mi35x-20260511 to lmsysorg/sglang:v0.5.14-rocm720-mi35x (ROCm 7.0 → 7.2, sglang v0.5.11 → v0.5.14)."
+    - "Fix disagg SLURM exclude list: add mia1-p01-g09 (broken pyxis) to submit.sh — was missing from multi-node path, causing prefill worker 503 failures."
+    - "Expand mi355x-disagg runner pool from 3 to 9 nodes."
+    - "8K1K concurrency sweep: [ 1, 2, 4, 8, 16, 32, 64, 128 ]; 1K1K commented out for this tuning round."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2092


### PR DESCRIPTION
### Changes
- **Docker image bump**: update `qwen3.5-fp8-mi355x-sglang-disagg` image from `lmsysorg/sglang-rocm:v0.5.11-rocm700-mi35x-20260511` to `lmsysorg/sglang:v0.5.14-rocm720-mi35x` (ROCm 7.0 → 7.2, sglang v0.5.11 → v0.5.14).
- **Concurrency sweep**: concurrency `[ 1, 2, 4, 8, 16, 32, 64, 128 ]`

### Authors
@ChangLiu0709 
@chunfangamd 

## 中文说明
Qwen3.5-FP8 MI355X SGLang 分离式推理性能调优：
- 升级 Docker 镜像至 `lmsysorg/sglang:v0.5.14-rocm720-mi35x`（ROCm 7.0 → 7.2，sglang v0.5.11 → v0.5.14）。
- 并发扫描：并发 `[ 1, 2, 4, 8, 16, 32, 64, 128 ]`。

Made with [Cursor](https://cursor.com)