### PR TITLE
feat(config): separate P2P transfer and KV offload metadata

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -149,6 +149,18 @@ on:
         description: "KV offload backend for agentic scenarios when kv-offloading is not none"
         required: false
         type: string
+      kv-offload-backend-metadata:
+        description: "Optional KV offload backend name and version metadata as JSON"
+        required: false
+        type: string
+      router:
+        description: "Optional router name and version metadata as JSON"
+        required: false
+        type: string
+      kv-p2p-transfer:
+        description: "Optional multinode peer-to-peer KV transfer engine name"
+        required: false
+        type: string
       total-cpu-dram-gb:
         description: "Total CPU DRAM in GB for KV offloading"
         required: false
@@ -191,6 +203,9 @@ env:
   DURATION: ${{ inputs.duration }}
   KV_OFFLOADING: ${{ inputs.kv-offloading }}
   KV_OFFLOAD_BACKEND: ${{ inputs.kv-offload-backend }}
+  KV_OFFLOAD_BACKEND_METADATA: ${{ inputs.kv-offload-backend-metadata }}
+  ROUTER_METADATA: ${{ inputs.router }}
+  KV_P2P_TRANSFER: ${{ inputs.kv-p2p-transfer }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   PYTHONDONTWRITEBYTECODE: '1'
   PYTHONPYCACHEPREFIX: /tmp/inferencex-pycache

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -94,6 +94,18 @@ on:
         description: "KV offload backend for agentic scenarios when kv-offloading is not none"
         required: false
         type: string
+      kv-offload-backend-metadata:
+        description: "Optional KV offload backend name and version metadata as JSON"
+        required: false
+        type: string
+      router:
+        description: "Optional router name and version metadata as JSON"
+        required: false
+        type: string
+      kv-p2p-transfer:
+        description: "Optional multinode peer-to-peer KV transfer engine name"
+        required: false
+        type: string
       total-cpu-dram-gb:
         description: "Configured CPU DRAM capacity in GB for KV offloading"
         required: false
@@ -134,6 +146,9 @@ env:
   IS_AGENTIC: ${{ inputs.scenario-type == 'agentic-coding' && '1' || '0' }}
   KV_OFFLOADING: ${{ inputs.kv-offloading }}
   KV_OFFLOAD_BACKEND: ${{ inputs.kv-offload-backend }}
+  KV_OFFLOAD_BACKEND_METADATA: ${{ inputs.kv-offload-backend-metadata }}
+  ROUTER_METADATA: ${{ inputs.router }}
+  KV_P2P_TRANSFER: ${{ inputs.kv-p2p-transfer }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   DURATION: ${{ inputs.duration }}
   AIPERF_FAILED_REQUEST_THRESHOLD: '0.10'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -102,6 +102,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             exp-name: ${{ matrix.config.exp-name }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
@@ -149,6 +151,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             exp-name: ${{ matrix.config.exp-name }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
@@ -196,6 +200,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -204,7 +210,8 @@ jobs:
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
             kv-offloading: ${{ matrix.config.kv-offloading }}
-            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
+            kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
             total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             isl: '0'
@@ -237,6 +244,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
@@ -260,7 +269,8 @@ jobs:
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             conc: ${{ matrix.config.conc[0] }}
             kv-offloading: ${{ matrix.config.kv-offloading }}
-            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
+            kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
             duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
             run-eval: false
             scenario-type: agentic-coding
@@ -287,6 +297,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -320,6 +332,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -330,6 +330,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -368,6 +370,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             exp-name: ${{ matrix.config.exp-name }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
@@ -442,6 +446,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -498,6 +504,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -506,7 +514,8 @@ jobs:
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
             kv-offloading: ${{ matrix.config.kv-offloading }}
-            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
+            kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
             total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
             duration: ${{ matrix.config.duration }}
             isl: '0'
@@ -545,6 +554,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             conc-list: '[${{ matrix.config.conc }}]'
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
@@ -568,7 +579,8 @@ jobs:
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             conc: ${{ matrix.config.conc }}
             kv-offloading: ${{ matrix.config.kv-offloading }}
-            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
+            kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
             duration: ${{ matrix.config.duration }}
             run-eval: false
             scenario-type: agentic-coding
@@ -602,6 +614,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             tp: ${{ matrix.config.tp }}
             pp: ${{ matrix.config.pp }}
             dcp-size: ${{ matrix.config.dcp-size }}
@@ -643,6 +657,8 @@ jobs:
             model-prefix: ${{ matrix.config.model-prefix }}
             framework: ${{ matrix.config.framework }}
             precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}

--- a/benchmarks/single_node/agentic/README.md
+++ b/benchmarks/single_node/agentic/README.md
@@ -20,9 +20,14 @@ currently either `none` or `dram`; when it is `dram`, the backend must be set:
 ```yaml
 - dram-utilization: 0.80
   search-space:
-  - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [16, 32] }
+  - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [16, 32] }
   - { tp: 8, kv-offloading: none, conc-list: [16, 32] }
 ```
+
+`kv-offload-backend.name` is required when offloading is enabled. Its
+`version` is optional: omit it for framework-native implementations without an
+independent release, and include it for separately versioned packages such as
+LMCache or Mooncake.
 
 Agentic matrix generation uses a 3600-second default duration. Reusable
 workflow callers can still override the `duration` input explicitly.

--- a/benchmarks/single_node/agentic/README.md
+++ b/benchmarks/single_node/agentic/README.md
@@ -20,7 +20,7 @@ currently either `none` or `dram`; when it is `dram`, the backend must be set:
 ```yaml
 - dram-utilization: 0.80
   search-space:
-  - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [16, 32] }
+  - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: vllm-native }, conc-list: [16, 32] }
   - { tp: 8, kv-offloading: none, conc-list: [16, 32] }
 ```
 

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -22,7 +22,7 @@ set -x
 #   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
 #
 # KV_OFFLOADING=dram requires one of these. 
-#   KV_OFFLOAD_BACKEND=native.
+#   KV_OFFLOAD_BACKEND=vllm-native.
 #   KV_OFFLOAD_BACKEND=mooncake.
 #   KV_OFFLOAD_BACKEND=lmcache.
 #   KV_OFFLOAD_BACKEND=hicache.
@@ -102,8 +102,8 @@ OFFLOAD_ARGS=()
 
 if agentic_kv_offload_enabled; then
 case "${KV_OFFLOAD_BACKEND:-}" in
-  native)
-    require_agentic_kv_offload_backend native
+  vllm-native)
+    require_agentic_kv_offload_backend vllm-native
     # ---- vLLM native config ----------------------------------------------------------
     unset VLLM_USE_SIMPLE_KV_OFFLOAD
     # MI355X nodes have ~2.7 TiB of host DRAM available for offload;
@@ -111,7 +111,7 @@ case "${KV_OFFLOAD_BACKEND:-}" in
     # worker RSS / page cache / slurm cgroup).
     TOTAL_CPU_DRAM_PARTITION_GB="$((TOTAL_CPU_DRAM_GB / (8 / TP)))"
     # Use vLLM's regular native KV-offload path (OffloadingConnector),
-    # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+    # NOT the SimpleCPUOffloadConnector. The "vllm-native" backend resolves to
     # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
     # would switch it to SimpleCPUOffloadConnector. We intentionally leave
     # that env var UNSET here so the regular OffloadingConnector path is
@@ -277,7 +277,7 @@ EOF
         git clone https://github.com/LMCache/LMCache.git
         cd LMCache
         # https://github.com/LMCache/LMCache/pull/3853
-        git checkout dev
+        git checkout 9229067cec0b3a63bb8a39368d101db7ac0bc3c1
         pip install -r requirements/build.txt
         pip install grpcio==1.78.0
         CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
@@ -345,7 +345,7 @@ EOF
         )
     ;;
   *)
-    echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected: native, mooncake, lmcache)" >&2
+    echo "Error: unsupported KV_OFFLOAD_BACKEND '${KV_OFFLOAD_BACKEND:-}' (expected: vllm-native, mooncake, lmcache)" >&2
     exit 1
     ;;
 esac

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_b200.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_b200.sh
@@ -96,7 +96,7 @@ if require_agentic_kv_offload_backend lmcache; then
         { set +x; } 2>/dev/null
         unset VLLM_USE_SIMPLE_KV_OFFLOAD
 
-        agentic_pip_install --quiet --no-cache-dir lmcache
+        agentic_pip_install --quiet --no-cache-dir 'lmcache==0.5.1'
         python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 
         # MP mode owns the configured CPU pool in the external LMCache

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_b300.sh
@@ -7,7 +7,7 @@ set -x
 # Required env vars:
 #   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
 #
-# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=native.
+# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=vllm-simple.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -42,7 +42,7 @@ mkdir -p "$RESULT_DIR"
 OFFLOAD_ARGS=()
 PREFIX_CACHE_ARGS=()
 
-if require_agentic_kv_offload_backend native; then
+if require_agentic_kv_offload_backend vllm-simple; then
     export VLLM_USE_SIMPLE_KV_OFFLOAD=1
     OFFLOAD_ARGS=(
         --kv_offloading_backend native

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_mi355x.sh
@@ -7,7 +7,7 @@ set -x
 # Required env vars:
 #   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR
 #
-# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=native.
+# KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=vllm-native.
 
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
@@ -64,10 +64,10 @@ mkdir -p "$RESULT_DIR"
 OFFLOAD_ARGS=()
 PREFIX_CACHE_ARGS=()
 
-if require_agentic_kv_offload_backend native; then
+if require_agentic_kv_offload_backend vllm-native; then
     unset VLLM_USE_SIMPLE_KV_OFFLOAD
     # Use vLLM's regular native KV-offload path (OffloadingConnector),
-    # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+    # NOT the SimpleCPUOffloadConnector. The "vllm-native" backend resolves to
     # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
     # would switch it to SimpleCPUOffloadConnector. We intentionally leave
     # that env var UNSET here so the regular OffloadingConnector path is

--- a/benchmarks/single_node/agentic/kimik2.5_int4_b200.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_int4_b200.sh
@@ -38,7 +38,7 @@ SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 
 OFFLOAD_ARGS=""
-if require_agentic_kv_offload_backend native; then
+if require_agentic_kv_offload_backend vllm-simple; then
     export VLLM_USE_SIMPLE_KV_OFFLOAD=1
     OFFLOAD_ARGS="--kv_offloading_backend native --kv_offloading_size $TOTAL_CPU_DRAM_GB --disable-hybrid-kv-cache-manager"
 fi

--- a/benchmarks/single_node/agentic/kimik2.5_int4_h100.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_int4_h100.sh
@@ -38,7 +38,7 @@ SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 
 OFFLOAD_ARGS=""
-if require_agentic_kv_offload_backend native; then
+if require_agentic_kv_offload_backend vllm-simple; then
     export VLLM_USE_SIMPLE_KV_OFFLOAD=1
     OFFLOAD_ARGS="--kv_offloading_backend native --kv_offloading_size $TOTAL_CPU_DRAM_GB --disable-hybrid-kv-cache-manager"
 fi

--- a/benchmarks/single_node/agentic/kimik2.5_int4_h200.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_int4_h200.sh
@@ -38,7 +38,7 @@ SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 
 OFFLOAD_ARGS=""
-if require_agentic_kv_offload_backend native; then
+if require_agentic_kv_offload_backend vllm-simple; then
     # Kimi K2.5 is pure TP (no DP-attn): single engine, world_size=TP.
     # SimpleCPUOffloadConnector internally divides cpu_bytes_to_use by
     # world_size, so pass the full TOTAL_CPU_DRAM_GB; TP-shared mmap

--- a/configs/CONFIGS.md
+++ b/configs/CONFIGS.md
@@ -12,20 +12,33 @@ entry-name:
   runner: string
   precision: string
   framework: string
+  # Optional defaults for every search-space entry in this config.
+  router: { name: string, version: string }
+  kv-p2p-transfer: string
   scenarios:
     fixed-seq-len:
     - isl: int
       osl: int
       search-space:
       - { tp: int, conc-start: int, conc-end: int }
-      # Optionally, specify pipeline/expert/data-attention/context parallelism
+      # Optionally, specify pipeline/expert/data-attention/context parallelism.
       - { tp: int, pp: int, ep: int, dp-attn: bool, dcp-size: int, pcp-size: int, conc-start: int, conc-end: int }
+      # Optionally, declare router metadata and the P2P KV transfer engine.
+      - tp: int
+        router: { name: string, version: string }
+        kv-p2p-transfer: string
+        conc-start: int
+        conc-end: int
       - ...
     - ...
     agentic-coding:  # optional
     - trace-source: string
       search-space:
-      - { tp: int, conc-start: int, conc-end: int }
+      - tp: int
+        kv-offloading: dram
+        kv-offload-backend: { name: string, version: string } # version optional
+        conc-start: int
+        conc-end: int
       - ...
 ```
 
@@ -92,6 +105,8 @@ The below list describes what each field is:
       - Note: the step factor between `conc-start` and `conc-end` is 2, so if `conc-start` is 4 and `conc-end` is 128, all concurrencies `4, 8, 16, 32, ..., 128` will be run.
       - (Optional) `ep`: An integer representing the expert parallelism level that the configuration will be served at. Default is 1 (no expert parallelism) when not specified.
       - (Optional) `dp-attn`: A boolean representing whether or not to activate data parallel attention for the configuration. Default is false when not specified.
+      - (Optional) `router`: Router metadata containing exactly non-empty `name` and `version` strings.
+      - (Optional) `kv-p2p-transfer`: Non-empty name of the engine used to move KV state between workers. It is valid only for `multinode: true` configs and does not carry version metadata.
       - (Optional) `pp`: Pipeline parallelism level. Default is 1. It must be a positive integer.
       - (Optional) `dcp-size`: Decode context-parallel size. Default is 1. It must be a positive divisor of `tp`; DCP reuses the TP GPUs.
       - (Optional) `pcp-size`: Prefill context-parallel size. Default is 1. A topology consumes `tp * pp * pcp-size` GPUs per worker; DCP does not add GPUs.
@@ -100,6 +115,27 @@ The below list describes what each field is:
   - `agentic-coding`: Agentic trace replay benchmarks using real conversation traces. Each entry must have:
     - `trace-source`: Identifier for the trace dataset to use.
     - `search-space`: Same structure as `fixed-seq-len` search-space entries.
+
+`router` and `kv-p2p-transfer` may be omitted independently. Router metadata
+requires non-empty `name` and `version` strings. Its `version` must be the
+component's exact release, package or wheel version, or source commit. Do not
+copy a container image name or image tag into `version`; container image
+references are rejected. `kv-p2p-transfer` is intentionally
+name-only and is reserved for `multinode: true` configurations. It may describe
+an aggregated multinode topology, but every `disagg: true` config must declare
+it either at the top level or in every search-space entry.
+
+Top-level declarations apply to every scenario and search-space entry in that
+master config. For `router` and `kv-p2p-transfer`, choose exactly one scope:
+declaring a field both at the top level and in any search-space entry is
+rejected. Search-space values may differ between entries.
+
+`kv-offload-backend` is separate from peer-to-peer transfer. It requires a
+non-empty `name`; `version` is optional because framework-native implementations
+such as vLLM's built-in offload backends and SGLang HiCache do not have an
+independent component version. Supply `version` for independently versioned
+backends such as LMCache or Mooncake. Additional keys and image references in
+`version` are rejected.
 
 Agentic duration is not a master YAML field. Matrix generation defaults agentic
 jobs to 3600 seconds; reusable workflow callers may override the `duration`

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -355,6 +355,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -482,6 +483,7 @@ qwen3.5-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -595,6 +597,7 @@ glm5-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -800,13 +803,13 @@ kimik2.5-fp4-mi355x-vllm-agentic:
       # DRAM offload only above the KV cliff. Lower concurrencies fit
       # entirely on-GPU, so paying the offload-path overhead there would
       # just slow them down without measuring anything new.
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 40, 48, 56] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [32, 40, 48, 56] }
       # TP=4 probe: half-node layout doubles per-GPU weight footprint
       # (~62 GB on MI355X's 288 GB HBM, plenty of headroom). Restrict to
       # cliff-region concurrencies on both offload modes so we can directly
       # compare TP=4 vs TP=8 at the same conc points.
       - { tp: 4, kv-offloading: none, conc-list: [16, 24, 32, 40] }
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [16, 24, 32, 40] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [16, 24, 32, 40] }
 
 kimik2.5-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_202607091539
@@ -873,6 +876,7 @@ dsr1-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -1027,6 +1031,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -1181,6 +1186,7 @@ kimik2.5-fp4-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: vllm-disagg
+  kv-p2p-transfer: moriio
   multinode: true
   disagg: true
   scenarios:
@@ -1233,6 +1239,7 @@ dsr1-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -1461,6 +1468,7 @@ dsr1-fp4-mi355x-sglang-disagg-1k1k-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -1571,6 +1579,7 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -1739,6 +1748,7 @@ dsv4-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -2063,7 +2073,7 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 48, 64] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
 # amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
@@ -2084,7 +2094,7 @@ dsv4-fp4-mi355x-vllm-agentic:
       search-space:
       - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 4, 8, 16, 32, 40, 48] }
       - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [64, 72] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [32, 40, 48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [32, 40, 48] }
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
 # amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
@@ -2098,6 +2108,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  kv-p2p-transfer: mori
   multinode: true
   disagg: true
   scenarios:
@@ -2348,6 +2359,7 @@ dsv4-fp4-mi355x-atom-disagg:
   runner: mi355x
   precision: fp4
   framework: atom-disagg
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -2467,6 +2479,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: vllm-disagg
+  kv-p2p-transfer: moriio
   multinode: true
   disagg: true
   scenarios:
@@ -2655,6 +2668,7 @@ minimaxm3-fp8-mi355x-atom-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: atom-disagg
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -2725,6 +2739,7 @@ minimaxm3-fp4-mi355x-atom-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: atom-disagg
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -2928,6 +2943,7 @@ minimaxm3-fp8-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: vllm-disagg
+  kv-p2p-transfer: moriio
   multinode: true
   disagg: true
   scenarios:
@@ -3034,8 +3050,8 @@ minimaxm3-fp8-mi300x-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:
   image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
@@ -3059,6 +3075,6 @@ minimaxm3-fp8-mi325x-vllm-agentic:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80] }
-      - { tp: 4, ep: 4, kv-offloading: dram, kv-offload-backend: native, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: native, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96] }
+      - { tp: 4, ep: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96] }

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -355,6 +355,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -483,6 +484,7 @@ qwen3.5-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -597,6 +599,7 @@ glm5-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -803,13 +806,13 @@ kimik2.5-fp4-mi355x-vllm-agentic:
       # DRAM offload only above the KV cliff. Lower concurrencies fit
       # entirely on-GPU, so paying the offload-path overhead there would
       # just slow them down without measuring anything new.
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [32, 40, 48, 56] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-native }, conc-list: [32, 40, 48, 56] }
       # TP=4 probe: half-node layout doubles per-GPU weight footprint
       # (~62 GB on MI355X's 288 GB HBM, plenty of headroom). Restrict to
       # cliff-region concurrencies on both offload modes so we can directly
       # compare TP=4 vs TP=8 at the same conc points.
       - { tp: 4, kv-offloading: none, conc-list: [16, 24, 32, 40] }
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [16, 24, 32, 40] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: vllm-native }, conc-list: [16, 24, 32, 40] }
 
 kimik2.5-fp4-mi355x-atom:
   image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_202607091539
@@ -876,6 +879,7 @@ dsr1-fp8-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -1031,6 +1035,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
   runner: mi355x-disagg
   precision: fp8
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -1186,6 +1191,7 @@ kimik2.5-fp4-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: vllm-disagg
+  router: { name: vllm-router, version: "0.1.14" }
   kv-p2p-transfer: moriio
   multinode: true
   disagg: true
@@ -1239,6 +1245,7 @@ dsr1-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -1468,6 +1475,7 @@ dsr1-fp4-mi355x-sglang-disagg-1k1k-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -1579,6 +1587,7 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -1748,6 +1757,7 @@ dsv4-fp4-mi355x-sglang-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -2093,8 +2103,8 @@ dsv4-fp4-mi355x-vllm-agentic:
     - dram-utilization: 0.60
       search-space:
       - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 4, 8, 16, 32, 40, 48] }
-      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [64, 72] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [32, 40, 48] }
+      - { tp: 8, ep: 1, dp-attn: true, kv-offloading: none, conc-list: [64, 72], router: { name: vllm-router, version: "0.1.14" } }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "9229067cec0b3a63bb8a39368d101db7ac0bc3c1" }, conc-list: [32, 40, 48] }
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
 # amd/deepseek_v4 branch in sgl-project/sglang; the SHA is encoded in the
@@ -2108,6 +2118,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
   runner: mi355x-disagg
   precision: fp4
   framework: sglang-disagg
+  router: { name: sglang-router, version: "0.3.2" }
   kv-p2p-transfer: mori
   multinode: true
   disagg: true
@@ -2359,6 +2370,7 @@ dsv4-fp4-mi355x-atom-disagg:
   runner: mi355x
   precision: fp4
   framework: atom-disagg
+  router: { name: atomesh, version: "087b82d9c1f630e79149ba37e6213257ec9a76f8" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -2479,6 +2491,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: vllm-disagg
+  router: { name: vllm-router, version: "0.1.14" }
   kv-p2p-transfer: moriio
   multinode: true
   disagg: true
@@ -2668,6 +2681,7 @@ minimaxm3-fp8-mi355x-atom-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: atom-disagg
+  router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -2739,6 +2753,7 @@ minimaxm3-fp4-mi355x-atom-disagg:
   runner: mi355x-disagg
   precision: fp4
   framework: atom-disagg
+  router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -2943,6 +2958,7 @@ minimaxm3-fp8-mi355x-vllm-disagg:
   runner: mi355x-disagg
   precision: fp8
   framework: vllm-disagg
+  router: { name: vllm-router, version: "0.1.14" }
   kv-p2p-transfer: moriio
   multinode: true
   disagg: true
@@ -3050,8 +3066,8 @@ minimaxm3-fp8-mi300x-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:
   image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
@@ -3074,7 +3090,7 @@ minimaxm3-fp8-mi325x-vllm-agentic:
       - { tp: 4, ep: 4, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80] }
-      - { tp: 4, ep: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [16, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80], router: { name: vllm-router, version: "0.1.14" } }
+      - { tp: 4, ep: 4, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96], router: { name: vllm-router, version: "0.1.14" } }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -5,6 +5,7 @@ dsr1-fp4-b200-dynamo-trt:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -391,6 +392,7 @@ dsr1-fp8-b200-dynamo-trt:
   runner: b200-multinode
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -841,6 +843,7 @@ dsr1-fp4-b300-dynamo-trt:
   runner: b300
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -1254,6 +1257,7 @@ dsr1-fp8-b300-dynamo-trt:
   runner: b300
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -1778,10 +1782,10 @@ dsv4-fp4-b200-vllm-agentic:
       - { tp: 8, kv-offloading: none,  conc-list: [1, 2, 3, 4, 5] }
       # Sample the useful MooncakeStore range without repeating its collapsed
       # high-concurrency tail.
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [8, 10, 16] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [8, 10, 16] }
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [16, 32, 38, 44, 50] }
       # Retain the external-cache transition and peak-throughput region.
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [16, 38, 44, 56, 64, 66, 68] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [16, 38, 44, 56, 64, 66, 68] }
 
 dsv4-fp4-b200-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-c185066
@@ -2337,6 +2341,7 @@ glm5-fp4-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -2457,6 +2462,7 @@ glm5-fp4-gb300-dynamo-trt:
           tp: 16
           ep: 16
           dp-attn: true
+
       - conc-list: [ 2253 ]
         prefill:
           num-worker: 3
@@ -2809,7 +2815,7 @@ kimik2.5-int4-b200-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [32, 64, 96, 128] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [32, 64, 96, 128] }
 
 kimik2.5-int4-b300-vllm:
   image: vllm/vllm-openai:v0.24.0
@@ -2864,7 +2870,7 @@ kimik2.5-int4-h200-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -2976,7 +2982,7 @@ kimik2.5-fp4-b300-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: native, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
@@ -3220,12 +3226,12 @@ dsv4-fp4-b300-vllm-agentic:
       search-space:
       # Compare native GPU-cache and MooncakeStore CPU-offload cliffs.
       - { tp: 4, kv-offloading: none,  conc-list: [1, 2, 4, 6, 8, 16] }
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [16, 18, 20, 24] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [16, 18, 20, 24] }
       # TP8 remains cache-resident through conc 52.
       - { tp: 8, kv-offloading: none,  conc-list: [1, 2, 4, 6, 8, 16, 32, 40, 48, 52] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [52] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [52] }
       - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none,  conc-list: [8, 16] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [32] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [32] }
       # TP8 DEP retains representative low, peak, and transition points.
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [52, 72, 100, 128, 144] }
 
@@ -3429,6 +3435,7 @@ dsr1-fp8-h200-dynamo-trt:
   runner: h200-multinode
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -3973,6 +3980,7 @@ dsr1-fp8-h100-dynamo-trt:
   runner: h100-multinode
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -4444,6 +4452,7 @@ dsr1-fp8-h100-dynamo-sglang:
   runner: h100-multinode
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -4605,6 +4614,7 @@ dsr1-fp4-gb200-dynamo-trt:
   runner: gb200
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -4962,6 +4972,7 @@ dsr1-fp8-gb200-dynamo-trt:
   runner: gb200
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -5390,6 +5401,7 @@ dsr1-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -5519,6 +5531,7 @@ dsr1-fp8-gb300-dynamo-sglang:
   runner: gb300
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -5632,6 +5645,7 @@ dsr1-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -5747,6 +5761,7 @@ dsr1-fp4-gb300-dynamo-trt:
   runner: gb300
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -6174,6 +6189,7 @@ dsr1-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -6289,6 +6305,7 @@ dsr1-fp8-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -6701,6 +6718,7 @@ dsr1-fp8-h200-dynamo-sglang:
   runner: h200-multinode
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -6958,6 +6976,7 @@ dsr1-fp4-b200-dynamo-sglang:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -7094,6 +7113,7 @@ dsr1-fp8-b200-dynamo-sglang:
   runner: b200-multinode
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -7265,6 +7285,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
   runner: b200-multinode
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -7465,6 +7486,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -7675,6 +7697,7 @@ kimik2.5-fp4-gb200-dynamo-trt:
   runner: gb200
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8046,6 +8069,7 @@ kimik2.5-fp4-gb300-dynamo-trt:
   runner: gb300
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8389,6 +8413,7 @@ kimik2.5-fp4-gb200-dynamo-vllm:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8511,6 +8536,7 @@ dsv4-fp4-b200-dynamo-vllm:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8593,6 +8619,7 @@ dsv4-fp4-gb200-dynamo-vllm:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8693,6 +8720,7 @@ dsv4-fp4-gb200-llmd-vllm:
   runner: gb200
   precision: fp4
   framework: llmd-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8817,6 +8845,7 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -8897,6 +8926,7 @@ dsv4-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -9024,6 +9054,7 @@ qwen3.5-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -9133,6 +9164,7 @@ dsv4-fp4-gb200-dynamo-sglang-mtp:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -9269,6 +9301,7 @@ glm5-fp4-gb200-dynamo-sglang-mtp:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -9552,6 +9585,7 @@ dsv4-fp4-b300-dynamo-vllm:
   runner: b300
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -9608,6 +9642,7 @@ dsv4-fp4-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -9701,6 +9736,7 @@ dsv4-fp4-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -10097,6 +10133,7 @@ dsv4-fp4-gb300-dynamo-trt-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -10520,6 +10557,7 @@ dsv4-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -10634,6 +10672,7 @@ glm5-fp8-b200-dynamo-sglang:
   runner: b200-dgxc
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -10848,6 +10887,7 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
   scenarios:
@@ -10992,7 +11032,7 @@ kimik2.5-int4-h100-vllm:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 20] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: native, conc-list: [1, 2, 4, 8, 12, 16, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 2, 4, 8, 12, 16, 20] }
 
 qwen3.5-fp8-h100-sglang:
   image: lmsysorg/sglang:v0.5.14-cu130
@@ -11041,6 +11081,7 @@ glm5-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -11318,6 +11359,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
       # Pure tensor parallel (STP), 8k1k baseline-low-latency sweep.
       # Total: 8 GB300 GPUs.
       - spec-decoding: "none"
+        kv-p2p-transfer: mooncake
         conc-list: [1, 4, 8, 16, 32, 64, 256]
         prefill:
           num-worker: 1
@@ -11334,6 +11376,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
       # 5P1D wide-EP: 5 prefill workers @ DEP4 + 1 decode worker @ DEP16.
       # NIXL transfer. Total: 36 GB300 GPUs (5*4 + 4*4).
       - spec-decoding: "none"
+        kv-p2p-transfer: nixl
         conc-list: [2048]
         prefill:
           num-worker: 5
@@ -11350,6 +11393,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
       # 6P1D wide-EP: 6 prefill workers @ DEP4 + 1 decode worker @ DEP16.
       # Mooncake transfer. Total: 40 GB300 GPUs (6*4 + 4*4).
       - spec-decoding: "none"
+        kv-p2p-transfer: mooncake
         conc-list: [5120]
         prefill:
           num-worker: 6
@@ -11366,6 +11410,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
       # 7P1D wide-EP: 7 prefill workers @ DEP4 + 1 decode worker @ DEP16.
       # Mooncake transfer. Total: 44 GB300 GPUs (7*4 + 4*4).
       - spec-decoding: "none"
+        kv-p2p-transfer: mooncake
         conc-list: [5120]
         prefill:
           num-worker: 7
@@ -11387,6 +11432,7 @@ glm5-fp4-gb300-dynamo-sglang:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -11597,6 +11643,7 @@ glm5-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -11821,6 +11868,7 @@ glm5-fp4-gb300-dynamo-sglang-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -12089,6 +12137,7 @@ glm5-fp8-gb300-dynamo-sglang:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -12299,6 +12348,7 @@ glm5-fp8-gb300-dynamo-sglang-mtp:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-sglang
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -12494,7 +12544,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 48, 64] }
+      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0
@@ -12509,9 +12559,9 @@ kimik2.5-fp4-b200-vllm-agentic-lmcache:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 24] }
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [16, 24, 32, 36] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [16, 24, 32, 36] }
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [8, 12, 14, 16, 18, 20] }
-      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: lmcache, conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
+      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
 
 # CONC range conservative for H100's 80 GB HBM3 under the long-ISL with-
 # subagents corpus. hicache arm capped at conc 16 since high-conc + hicache
@@ -12524,6 +12574,7 @@ dsv4-fp4-gb300-dynamo-vllm-agentic:
   runner: cluster:gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -12594,7 +12645,7 @@ qwen3.5-fp8-h100-sglang-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 8, kv-offloading: none,    conc-list: [1, 2, 4, 8, 12, 14, 16] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [12, 14, 16, 20, 24, 28, 32, 42] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [12, 14, 16, 20, 24, 28, 32, 42] }
 
 # MiniMax-M3 NVFP4 disagg sweep on the same B300 topology matrix as the MXFP8
 # baseline above. The image includes vLLM PR #46380, so no runtime patch is
@@ -12606,6 +12657,7 @@ minimaxm3-fp8-b300-dynamo-vllm:
   runner: b300
   precision: fp8
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -12822,6 +12874,7 @@ minimaxm3-fp4-b300-dynamo-vllm:
   runner: b300
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -13038,6 +13091,7 @@ minimaxm3-fp8-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -13311,6 +13365,7 @@ minimaxm3-fp8-gb200-dynamo-vllm:
   runner: gb200
   precision: fp8
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -13877,6 +13932,7 @@ kimik2.5-fp4-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -14049,8 +14105,8 @@ minimaxm3-fp8-h100-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
 
 minimaxm3-fp8-h200-vllm-agentic:
   image: vllm/vllm-openai:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
@@ -14070,7 +14126,7 @@ minimaxm3-fp8-h200-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: mooncake, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
 
 dsv4-fp4-b200-sglang-agentic-hicache:
   image: lmsysorg/sglang:nightly-dev-cu13-20260707-b4155233
@@ -14085,11 +14141,11 @@ dsv4-fp4-b200-sglang-agentic-hicache:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none,     conc-list: [1, 2, 3, 4, 5] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [8, 10, 16, 32, 40, 44] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [8, 10, 16, 32, 40, 44] }
       # DEP without HiCache is already degraded at conc 52 (2,098 tok/s/GPU),
       # so resolve its pre-52 cliff instead of repeating the collapsed tail.
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,    conc-list: [16, 24, 32, 38, 44, 48, 50, 52] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [16, 32, 38, 44, 50, 56, 64, 66, 68] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 38, 44, 50, 56, 64, 66, 68] }
 
 # GB200 DeepSeek-V4 disaggregated AgentX frontier. The 3P/2D TEP8/TP8 curve
 # covers the middle/high-interactivity range omitted by the one-decode DEP
@@ -14109,7 +14165,7 @@ dsv4-fp4-b300-sglang-agentic-hicache:
       - { tp: 4, kv-offloading: none, conc-list: [1, 4, 8, 16, 20, 24, 32] }
       - { tp: 8, kv-offloading: none, conc-list: [1, 4, 8, 16, 32, 40, 48, 52, 56, 60, 64, 72] }
       - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [8, 16, 24, 32, 40, 64] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: hicache, conc-list: [32, 40, 48, 56, 64, 72, 80, 88, 96, 128] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 40, 48, 56, 64, 72, 80, 88, 96, 128] }
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [52, 72, 100, 128, 144, 196, 512] }
 
 # DEP8 prefill uses an 8K batch because 16K OOMs in the FP4 MoE intermediate;
@@ -14123,6 +14179,7 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-3p2d-tep8-tp8:
   runner: cluster:gb200-nv
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -14179,6 +14236,7 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-2p1d-dep8-dep8:
   runner: cluster:gb200-nv
   precision: fp4
   framework: dynamo-vllm
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -14235,6 +14293,7 @@ glm5-fp4-gb300-dynamo-trt-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  kv-p2p-transfer: nixl
   multinode: true
   disagg: true
   scenarios:
@@ -14562,8 +14621,6 @@ glm5-fp4-gb300-dynamo-trt-mtp:
           tp: 16
           ep: 16
           dp-attn: true
-
-
 qwen3.5-fp8-gb300-dynamo-sglang:
   image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928
   model: Qwen/Qwen3.5-397B-A17B-FP8
@@ -14573,6 +14630,7 @@ qwen3.5-fp8-gb300-dynamo-sglang:
   framework: dynamo-sglang
   multinode: true
   disagg: true
+  kv-p2p-transfer: mooncake
   scenarios:
     fixed-seq-len:
     - isl: 1024

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -5,6 +5,7 @@ dsr1-fp4-b200-dynamo-trt:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -392,6 +393,7 @@ dsr1-fp8-b200-dynamo-trt:
   runner: b200-multinode
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post2" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -843,6 +845,7 @@ dsr1-fp4-b300-dynamo-trt:
   runner: b300
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -1257,6 +1260,7 @@ dsr1-fp8-b300-dynamo-trt:
   runner: b300
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -1782,10 +1786,10 @@ dsv4-fp4-b200-vllm-agentic:
       - { tp: 8, kv-offloading: none,  conc-list: [1, 2, 3, 4, 5] }
       # Sample the useful MooncakeStore range without repeating its collapsed
       # high-concurrency tail.
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [8, 10, 16] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [16, 32, 38, 44, 50] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [8, 10, 16] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [16, 32, 38, 44, 50], router: { name: vllm-router, version: "0.1.14" } }
       # Retain the external-cache transition and peak-throughput region.
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [16, 38, 44, 56, 64, 66, 68] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [16, 38, 44, 56, 64, 66, 68], router: { name: vllm-router, version: "0.1.14" } }
 
 dsv4-fp4-b200-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-c185066
@@ -2341,6 +2345,7 @@ glm5-fp4-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -2815,7 +2820,7 @@ kimik2.5-int4-b200-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [32, 64, 96, 128] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [32, 64, 96, 128] }
 
 kimik2.5-int4-b300-vllm:
   image: vllm/vllm-openai:v0.24.0
@@ -2870,7 +2875,7 @@ kimik2.5-int4-h200-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [6, 7, 8, 9, 10, 11, 12, 13, 14] }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -2982,7 +2987,7 @@ kimik2.5-fp4-b300-vllm-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
@@ -3226,14 +3231,14 @@ dsv4-fp4-b300-vllm-agentic:
       search-space:
       # Compare native GPU-cache and MooncakeStore CPU-offload cliffs.
       - { tp: 4, kv-offloading: none,  conc-list: [1, 2, 4, 6, 8, 16] }
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [16, 18, 20, 24] }
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [16, 18, 20, 24] }
       # TP8 remains cache-resident through conc 52.
       - { tp: 8, kv-offloading: none,  conc-list: [1, 2, 4, 6, 8, 16, 32, 40, 48, 52] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [52] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none,  conc-list: [8, 16] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [32] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [52] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none,  conc-list: [8, 16], router: { name: vllm-router, version: "0.1.14" } }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [32], router: { name: vllm-router, version: "0.1.14" } }
       # TP8 DEP retains representative low, peak, and transition points.
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [52, 72, 100, 128, 144] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,  conc-list: [52, 72, 100, 128, 144], router: { name: vllm-router, version: "0.1.14" } }
 
 dsv4-fp4-b300-trt:
   image: ghcr.io#semianalysisai/trtllm-deepseek-v4:feat-deepseek_v4-c185066
@@ -3435,6 +3440,7 @@ dsr1-fp8-h200-dynamo-trt:
   runner: h200-multinode
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -3980,6 +3986,7 @@ dsr1-fp8-h100-dynamo-trt:
   runner: h100-multinode
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post3" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -4452,6 +4459,7 @@ dsr1-fp8-h100-dynamo-sglang:
   runner: h100-multinode
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -4614,6 +4622,7 @@ dsr1-fp4-gb200-dynamo-trt:
   runner: gb200
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post2" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -4972,6 +4981,7 @@ dsr1-fp8-gb200-dynamo-trt:
   runner: gb200
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post2" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -5401,6 +5411,7 @@ dsr1-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -5531,6 +5542,7 @@ dsr1-fp8-gb300-dynamo-sglang:
   runner: gb300
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -5645,6 +5657,7 @@ dsr1-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -5761,6 +5774,7 @@ dsr1-fp4-gb300-dynamo-trt:
   runner: gb300
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "0.8.1.post2" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -6189,6 +6203,7 @@ dsr1-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -6305,6 +6320,7 @@ dsr1-fp8-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -6718,6 +6734,7 @@ dsr1-fp8-h200-dynamo-sglang:
   runner: h200-multinode
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -6976,6 +6993,7 @@ dsr1-fp4-b200-dynamo-sglang:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -7130,6 +7148,7 @@ dsr1-fp8-b200-dynamo-sglang:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_stp_lowlat[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 8
@@ -7143,6 +7162,7 @@ dsr1-fp8-b200-dynamo-sglang:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_stp_lowlat[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 3
           tp: 8
@@ -7156,6 +7176,7 @@ dsr1-fp8-b200-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_stp_maxtpt[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 5
           tp: 8
@@ -7169,6 +7190,7 @@ dsr1-fp8-b200-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_stp_maxtpt[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 5
           tp: 8
@@ -7187,6 +7209,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_lowlat_0.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_0.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 3
           tp: 8
@@ -7201,6 +7224,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_lowlat_1.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_1.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 4
           tp: 8
@@ -7215,6 +7239,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_lowlat_2.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_lowlat_2.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 6
           tp: 8
@@ -7230,6 +7255,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_maxtpt_0.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_0.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 2
           tp: 8
@@ -7244,6 +7270,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_maxtpt_1.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_1.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7258,6 +7285,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_maxtpt_2.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_2.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7272,6 +7300,7 @@ dsr1-fp8-b200-dynamo-sglang:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_stp_maxtpt_3.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_stp_maxtpt_3.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7303,6 +7332,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_mtp_lowlat[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 8
@@ -7318,6 +7348,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_mtp_lowlat[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 3
           tp: 8
@@ -7333,6 +7364,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_mtp_maxtpt[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 5
           tp: 8
@@ -7348,6 +7380,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:zip_override_mtp_maxtpt[2]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 5
           tp: 8
@@ -7363,6 +7396,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/b200-fp8/1k1k.yaml:override_mtp_maxtpt_1p2d"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 2
           tp: 8
@@ -7382,6 +7416,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_lowlat_0.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_0.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 3
           tp: 8
@@ -7397,6 +7432,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_lowlat_1.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_1.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 4
           tp: 8
@@ -7412,6 +7448,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_lowlat_2.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_lowlat_2.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 6
           tp: 8
@@ -7428,6 +7465,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_0.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_0.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 2
           tp: 8
@@ -7443,6 +7481,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_1.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_1.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7458,6 +7497,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_2.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_2.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7473,6 +7513,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           additional-settings:
           # https://github.com/NVIDIA/srt-slurm/blob/sa-submission-q2-2026/recipes/b200-fp8/8k1k_mtp_maxtpt_3.yaml
           - "CONFIG_FILE=recipes/b200-fp8/8k1k_mtp_maxtpt_3.yaml"
+        router: { name: dynamo-router, version: "0.9.1" }
         decode:
           num-worker: 1
           tp: 8
@@ -7486,6 +7527,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "5b4bc1dd70965017a737c71b19db5a0aeaa88727" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -7697,6 +7739,7 @@ kimik2.5-fp4-gb200-dynamo-trt:
   runner: gb200
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8069,6 +8112,7 @@ kimik2.5-fp4-gb300-dynamo-trt:
   runner: gb300
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8413,6 +8457,7 @@ kimik2.5-fp4-gb200-dynamo-vllm:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8536,6 +8581,7 @@ dsv4-fp4-b200-dynamo-vllm:
   runner: b200-multinode
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8619,6 +8665,7 @@ dsv4-fp4-gb200-dynamo-vllm:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8720,6 +8767,7 @@ dsv4-fp4-gb200-llmd-vllm:
   runner: gb200
   precision: fp4
   framework: llmd-vllm
+  router: { name: llm-d-router, version: "0.9.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8845,6 +8893,7 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2:
   runner: gb200
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -8926,6 +8975,7 @@ dsv4-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "92f5b3b8d7dd5ab9179d4b1034bd2c1c0803693e" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -9054,6 +9104,7 @@ qwen3.5-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "46520ca59afe992fb5ef61b3197b2316f8df9b2b" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -9164,6 +9215,7 @@ dsv4-fp4-gb200-dynamo-sglang-mtp:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "92f5b3b8d7dd5ab9179d4b1034bd2c1c0803693e" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -9301,6 +9353,7 @@ glm5-fp4-gb200-dynamo-sglang-mtp:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.2.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -9585,6 +9638,7 @@ dsv4-fp4-b300-dynamo-vllm:
   runner: b300
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -9642,6 +9696,7 @@ dsv4-fp4-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -9736,6 +9791,7 @@ dsv4-fp4-gb300-dynamo-trt:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-deepseek-v4-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -10133,6 +10189,7 @@ dsv4-fp4-gb300-dynamo-trt-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-deepseek-v4-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -10557,6 +10614,7 @@ dsv4-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "81d0555ee23519cea80a42b4fe824e30368b7300" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -10672,6 +10730,7 @@ glm5-fp8-b200-dynamo-sglang:
   runner: b200-dgxc
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -10887,6 +10946,7 @@ dsv4-fp4-gb300-dynamo-sglang-mtp:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "81d0555ee23519cea80a42b4fe824e30368b7300" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
@@ -11032,7 +11092,7 @@ kimik2.5-int4-h100-vllm:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 20] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 2, 4, 8, 12, 16, 20] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [1, 2, 4, 8, 12, 16, 20] }
 
 qwen3.5-fp8-h100-sglang:
   image: lmsysorg/sglang:v0.5.14-cu130
@@ -11081,6 +11141,7 @@ glm5-fp4-gb200-dynamo-sglang:
   runner: gb200
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.2.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -11348,6 +11409,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.1.0" }
   multinode: true
   disagg: true
   scenarios:
@@ -11450,6 +11512,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_8k1k_hightpt[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11464,6 +11527,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_8k1k_hightpt[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11478,6 +11542,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_8k1k_hightpt[2]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11496,6 +11561,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_0.yaml"
+        router: { name: dynamo-router, version: "1.1.0" }
         decode:
           num-worker: 3
           tp: 4
@@ -11510,6 +11576,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_1.yaml"
+        router: { name: dynamo-router, version: "1.1.0" }
         decode:
           num-worker: 5
           tp: 4
@@ -11524,6 +11591,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_2.yaml"
+        router: { name: dynamo-router, version: "1.1.0" }
         decode:
           num-worker: 9
           tp: 4
@@ -11538,6 +11606,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_3.yaml"
+        router: { name: dynamo-router, version: "1.1.0" }
         decode:
           num-worker: 15
           tp: 4
@@ -11552,6 +11621,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_4.yaml"
+        router: { name: dynamo-router, version: "1.1.0" }
         decode:
           num-worker: 17
           tp: 4
@@ -11570,6 +11640,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_1k1k_hightpt[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11584,6 +11655,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_1k1k_hightpt[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11598,6 +11670,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_1k1k_hightpt[2]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 1
           tp: 32
@@ -11616,6 +11689,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_1k1k_lowlat[0]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 17
           tp: 4
@@ -11630,6 +11704,7 @@ glm5-fp4-gb300-dynamo-sglang:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/gb300-fp4/glm5.yaml:zip_override_1k1k_lowlat[1]"
+        router: { name: dynamo-router, version: "0.8.0" }
         decode:
           num-worker: 17
           tp: 4
@@ -11643,6 +11718,7 @@ glm5-fp8-gb200-dynamo-sglang:
   runner: gb200
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.2.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -11868,6 +11944,7 @@ glm5-fp4-gb300-dynamo-sglang-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -12137,6 +12214,7 @@ glm5-fp8-gb300-dynamo-sglang:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "0.8.0" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -12348,6 +12426,7 @@ glm5-fp8-gb300-dynamo-sglang-mtp:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.2.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -12559,9 +12638,9 @@ kimik2.5-fp4-b200-vllm-agentic-lmcache:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 24] }
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [16, 24, 32, 36] }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.1" }, conc-list: [16, 24, 32, 36] }
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [8, 12, 14, 16, 18, 20] }
-      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache }, conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
+      - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.1" }, conc-list: [12, 14, 16, 18, 20, 22, 24, 32] }
 
 # CONC range conservative for H100's 80 GB HBM3 under the long-ISL with-
 # subagents corpus. hicache arm capped at conc 16 since high-conc + hicache
@@ -12574,6 +12653,7 @@ dsv4-fp4-gb300-dynamo-vllm-agentic:
   runner: cluster:gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.2.0.dev20260426" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -12657,6 +12737,7 @@ minimaxm3-fp8-b300-dynamo-vllm:
   runner: b300
   precision: fp8
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260614" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -12874,6 +12955,7 @@ minimaxm3-fp4-b300-dynamo-vllm:
   runner: b300
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260614" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -13091,6 +13173,7 @@ minimaxm3-fp8-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp8
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260614" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -13365,6 +13448,7 @@ minimaxm3-fp8-gb200-dynamo-vllm:
   runner: gb200
   precision: fp8
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260614" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -13932,6 +14016,7 @@ kimik2.5-fp4-gb300-dynamo-vllm:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260601" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -14105,8 +14190,8 @@ minimaxm3-fp8-h100-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16] }
 
 minimaxm3-fp8-h200-vllm-agentic:
   image: vllm/vllm-openai:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
@@ -14126,7 +14211,7 @@ minimaxm3-fp8-h200-vllm-agentic:
       search-space:
       - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
       - { tp: 8, ep: 8, kv-offloading: none, conc-list: [2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20] }
 
 dsv4-fp4-b200-sglang-agentic-hicache:
   image: lmsysorg/sglang:nightly-dev-cu13-20260707-b4155233
@@ -14144,8 +14229,8 @@ dsv4-fp4-b200-sglang-agentic-hicache:
       - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [8, 10, 16, 32, 40, 44] }
       # DEP without HiCache is already degraded at conc 52 (2,098 tok/s/GPU),
       # so resolve its pre-52 cliff instead of repeating the collapsed tail.
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,    conc-list: [16, 24, 32, 38, 44, 48, 50, 52] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 38, 44, 50, 56, 64, 66, 68] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none,    conc-list: [16, 24, 32, 38, 44, 48, 50, 52], router: { name: sglang-router, version: "0.3.2" } }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 38, 44, 50, 56, 64, 66, 68], router: { name: sglang-router, version: "0.3.2" } }
 
 # GB200 DeepSeek-V4 disaggregated AgentX frontier. The 3P/2D TEP8/TP8 curve
 # covers the middle/high-interactivity range omitted by the one-decode DEP
@@ -14164,9 +14249,9 @@ dsv4-fp4-b300-sglang-agentic-hicache:
       search-space:
       - { tp: 4, kv-offloading: none, conc-list: [1, 4, 8, 16, 20, 24, 32] }
       - { tp: 8, kv-offloading: none, conc-list: [1, 4, 8, 16, 32, 40, 48, 52, 56, 60, 64, 72] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [8, 16, 24, 32, 40, 64] }
-      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 40, 48, 56, 64, 72, 80, 88, 96, 128] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [52, 72, 100, 128, 144, 196, 512] }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, conc-list: [8, 16, 24, 32, 40, 64], router: { name: sglang-router, version: "0.3.2" } }
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 40, 48, 56, 64, 72, 80, 88, 96, 128], router: { name: sglang-router, version: "0.3.2" } }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: none, conc-list: [52, 72, 100, 128, 144, 196, 512], router: { name: sglang-router, version: "0.3.2" } }
 
 # DEP8 prefill uses an 8K batch because 16K OOMs in the FP4 MoE intermediate;
 # decode uses FULL_DECODE_ONLY after the controlled graph test restored decode
@@ -14179,6 +14264,7 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-3p2d-tep8-tp8:
   runner: cluster:gb200-nv
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260618" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -14236,6 +14322,7 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-2p1d-dep8-dep8:
   runner: cluster:gb200-nv
   precision: fp4
   framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260618" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -14293,6 +14380,7 @@ glm5-fp4-gb300-dynamo-trt-mtp:
   runner: gb300-nv
   precision: fp4
   framework: dynamo-trt
+  router: { name: dynamo-router, version: "v1.3.0-dev.1" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true
@@ -14621,6 +14709,7 @@ glm5-fp4-gb300-dynamo-trt-mtp:
           tp: 16
           ep: 16
           dp-attn: true
+
 qwen3.5-fp8-gb300-dynamo-sglang:
   image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928
   model: Qwen/Qwen3.5-397B-A17B-FP8
@@ -14628,9 +14717,10 @@ qwen3.5-fp8-gb300-dynamo-sglang:
   runner: gb300
   precision: fp8
   framework: dynamo-sglang
+  router: { name: dynamo-router, version: "46520ca59afe992fb5ef61b3197b2316f8df9b2b" }
+  kv-p2p-transfer: mooncake
   multinode: true
   disagg: true
-  kv-p2p-transfer: mooncake
   scenarios:
     fixed-seq-len:
     - isl: 1024

--- a/utils/agentic/aggregation/process_agentic_result.py
+++ b/utils/agentic/aggregation/process_agentic_result.py
@@ -36,16 +36,63 @@ def required_env(name: str) -> str:
     return value
 
 
-def _validate_kv_offload_env() -> tuple[str, str]:
+def optional_component_metadata(env_name: str) -> dict[str, str] | None:
+    """Parse strict optional component metadata from a JSON environment value."""
+    raw_value = os.environ.get(env_name)
+    if raw_value in (None, "", "null"):
+        return None
+
+    try:
+        metadata = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{env_name} must contain valid JSON") from exc
+
+    if not isinstance(metadata, dict) or set(metadata) != {"name", "version"}:
+        raise SystemExit(f"{env_name} must contain exactly 'name' and 'version'")
+    if not all(isinstance(metadata[key], str) and metadata[key] for key in metadata):
+        raise SystemExit(f"{env_name} name and version must be non-empty strings")
+    return metadata
+
+
+def optional_kv_offload_backend_metadata(
+    env_name: str,
+) -> dict[str, str] | None:
+    """Parse KV offload backend metadata with an optional version."""
+    raw_value = os.environ.get(env_name)
+    if raw_value in (None, "", "null"):
+        return None
+
+    try:
+        metadata = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{env_name} must contain valid JSON") from exc
+
+    if not isinstance(metadata, dict) or not set(metadata) <= {"name", "version"}:
+        raise SystemExit(f"{env_name} may contain only 'name' and 'version'")
+    if set(metadata) not in ({"name"}, {"name", "version"}):
+        raise SystemExit(f"{env_name} must contain 'name' and optional 'version'")
+    if not all(isinstance(value, str) and value for value in metadata.values()):
+        raise SystemExit(f"{env_name} values must be non-empty strings")
+    return metadata
+
+
+def _validate_kv_offload_env() -> tuple[str, dict[str, str] | None]:
     kv_offloading = required_env("KV_OFFLOADING")
-    kv_offload_backend = os.environ.get("KV_OFFLOAD_BACKEND", "")
+    backend_name = os.environ.get("KV_OFFLOAD_BACKEND", "")
+    backend_metadata = optional_kv_offload_backend_metadata(
+        "KV_OFFLOAD_BACKEND_METADATA"
+    )
     if kv_offloading == "none":
-        if kv_offload_backend:
+        if backend_name or backend_metadata is not None:
             raise SystemExit("KV_OFFLOAD_BACKEND must be empty when KV_OFFLOADING=none")
     else:
-        if not kv_offload_backend or kv_offload_backend == "none":
+        if not backend_name or backend_name == "none" or backend_metadata is None:
             raise SystemExit("KV_OFFLOAD_BACKEND is required when KV_OFFLOADING is enabled")
-    return kv_offloading, kv_offload_backend
+        if backend_metadata["name"] != backend_name:
+            raise SystemExit(
+                "KV_OFFLOAD_BACKEND must match KV_OFFLOAD_BACKEND_METADATA.name"
+            )
+    return kv_offloading, backend_metadata
 
 
 def _gpu_shape() -> tuple[dict[str, Any], int, int, int, str]:
@@ -178,6 +225,14 @@ def build_agg(
         "request_accounting": request_accounting,
     }
     agg.update(multinode_fields)
+
+    router = optional_component_metadata("ROUTER_METADATA")
+    if router is not None:
+        agg["router"] = router
+
+    kv_p2p_transfer = os.environ.get("KV_P2P_TRANSFER")
+    if kv_p2p_transfer:
+        agg["kv_p2p_transfer"] = kv_p2p_transfer
 
     metadata = aggregate.get("metadata")
     if isinstance(metadata, dict):

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -385,6 +385,54 @@ def test_processor_preserves_dataset_provenance(tmp_path: Path):
     }
 
 
+def test_processor_emits_component_metadata_when_present(tmp_path: Path):
+    result_dir = _write_fixture(tmp_path)
+    agg = _run_processor(
+        result_dir,
+        tmp_path / "out",
+        env_overrides={
+            "ROUTER_METADATA": json.dumps({"name": "vllm-router", "version": "0.1.14"}),
+            "KV_P2P_TRANSFER": "mooncake",
+        },
+    )
+
+    assert agg["router"] == {"name": "vllm-router", "version": "0.1.14"}
+    assert agg["kv_p2p_transfer"] == "mooncake"
+
+
+def test_processor_omits_component_metadata_when_absent(tmp_path: Path):
+    result_dir = _write_fixture(tmp_path)
+    agg = _run_processor(result_dir, tmp_path / "out")
+
+    assert "router" not in agg
+    assert "kv_p2p_transfer" not in agg
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"name": "lmcache"},
+        {"name": "lmcache", "version": "0.5.1"},
+    ],
+)
+def test_processor_emits_kv_offload_backend_metadata(
+    tmp_path: Path,
+    metadata: dict[str, str],
+):
+    result_dir = _write_fixture(tmp_path)
+    agg = _run_processor(
+        result_dir,
+        tmp_path / "out",
+        env_overrides={
+            "KV_OFFLOADING": "dram",
+            "KV_OFFLOAD_BACKEND": "lmcache",
+            "KV_OFFLOAD_BACKEND_METADATA": json.dumps(metadata),
+        },
+    )
+
+    assert agg["kv_offload_backend"] == metadata
+
+
 def test_processor_latency_units_are_seconds(tmp_path: Path):
     """aiperf reports ms; legacy schema is seconds. Verify conversion."""
     result_dir = _write_fixture(tmp_path)

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -129,11 +129,24 @@ def agentic_dram_offload_gb(
     return int(proportional_bytes / BYTES_PER_GB)
 
 
-def agentic_kv_offload_suffix(kv_offloading: str, kv_offload_backend: str | None) -> str:
+def agentic_kv_offload_suffix(
+    kv_offloading: str,
+    kv_offload_backend: dict | None,
+) -> str:
     """Return a compact exp-name suffix for agentic KV offload settings."""
     if kv_offloading == "none":
         return "kvnone"
-    return f"kv{kv_offloading}-{kv_offload_backend}"
+    return f"kv{kv_offloading}-{kv_offload_backend['name']}"
+
+
+def component_metadata(benchmark: dict, config: dict) -> dict:
+    """Resolve optional component metadata from its validated scope."""
+    metadata = {}
+    for field in (Fields.ROUTER, Fields.KV_P2P_TRANSFER):
+        value = benchmark.get(field.value, config.get(field.value))
+        if value is not None:
+            metadata[field.value] = value
+    return metadata
 
 
 def chunk_multinode_agentic_concurrencies(conc_values: list[int]) -> list[list[int]]:
@@ -481,6 +494,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             Fields.DISAGG.value: disagg,
                             Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
                         }
+                        entry.update(component_metadata(bmk, val))
 
                         validate_matrix_entry(entry, is_multinode)
                         matrix_values.append(entry)
@@ -600,6 +614,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             if dp_attn is not None:
                                 entry[Fields.DP_ATTN.value] = dp_attn
 
+                            entry.update(component_metadata(bmk, val))
                             validate_matrix_entry(entry, is_multinode)
                             matrix_values.append(entry)
 
@@ -699,6 +714,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             }
                             if kv_offload_backend is not None:
                                 entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            entry.update(component_metadata(bmk, val))
                             validate_agentic_matrix_entry(entry)
                             matrix_values.append(entry)
                 else:
@@ -729,6 +745,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             }
                             if kv_offload_backend is not None:
                                 entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            entry.update(component_metadata(bmk, val))
                             validate_agentic_matrix_entry(entry)
                             matrix_values.append(entry)
 
@@ -847,6 +864,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                             Fields.DISAGG.value: disagg,
                             Fields.RUN_EVAL.value: False,
                         }
+                        entry.update(component_metadata(bmk, val))
                         matrix_values.append(validate_matrix_entry(entry, is_multinode=True))
                 else:
                     # Single-node config
@@ -905,6 +923,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.DISAGG.value: disagg,
                                 Fields.RUN_EVAL.value: False,
                             }
+                            entry.update(component_metadata(bmk, val))
                             matrix_values.append(validate_matrix_entry(entry, is_multinode=False))
 
         # ---- Agentic-coding scenarios ----
@@ -992,6 +1011,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                             }
                             if kv_offload_backend is not None:
                                 entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            entry.update(component_metadata(bmk, val))
                             matrix_values.append(validate_agentic_matrix_entry(entry))
                 else:
                     for conc in conc_values:
@@ -1021,6 +1041,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                             }
                             if kv_offload_backend is not None:
                                 entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
+                            entry.update(component_metadata(bmk, val))
                             matrix_values.append(validate_agentic_matrix_entry(entry))
 
     return matrix_values

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -68,6 +68,7 @@ def sample_multinode_config():
             "runner": "gb200",
             "multinode": True,
             "disagg": True,
+            "kv-p2p-transfer": "nixl",
             "scenarios": {
                 "fixed-seq-len": [
 
@@ -1946,6 +1947,9 @@ class TestGenerateTestConfigSweep:
 
     def test_runner_node_filter_expands_config_runner(self, sample_multinode_config, sample_runner_config):
         """test-config should allow targeting one concrete runner node."""
+        master_entry = sample_multinode_config["dsr1-fp4-gb200-dynamo-trt"]
+        master_entry["router"] = {"name": "trt-router", "version": "0.20.0"}
+        master_entry["kv-p2p-transfer"] = "nixl"
         args = argparse.Namespace(
             config_keys=["dsr1-fp4-gb200-dynamo-trt"],
             seq_lens=None,
@@ -1961,6 +1965,8 @@ class TestGenerateTestConfigSweep:
 
         assert len(result) == 1
         assert result[0]["runner"] == "gb200-nv_0"
+        assert result[0]["router"] == {"name": "trt-router", "version": "0.20.0"}
+        assert result[0]["kv-p2p-transfer"] == "nixl"
 
     def test_runner_node_filter_no_match_skips_config(self, sample_multinode_config, sample_runner_config):
         """Unmatched node filters should produce no entries."""
@@ -1990,6 +1996,7 @@ class TestGenerateTestConfigSweep:
                 "framework": "sglang",
                 "runner": "cluster:b300-nv",
                 "multinode": False,
+                "router": {"name": "default-router", "version": "1.0.0"},
                 "scenarios": {
                     "agentic-coding": [
                         {
@@ -1999,7 +2006,7 @@ class TestGenerateTestConfigSweep:
                                     "tp": 8,
                                     "ep": 1,
                                     "kv-offloading": "dram",
-                                    "kv-offload-backend": "hicache",
+                                    "kv-offload-backend": {"name": "hicache"},
                                     "conc-list": [64],
                                 }
                             ],
@@ -2023,6 +2030,7 @@ class TestGenerateTestConfigSweep:
         assert result[0]["scenario-type"] == "agentic-coding"
         assert result[0]["total-cpu-dram-gb"] == 2399
         assert result[0]["duration"] == 3600
+        assert result[0]["router"] == {"name": "default-router", "version": "1.0.0"}
 
     def test_agentic_node_dram_uses_explicit_gpu_count(self, sample_runner_config):
         config = {
@@ -2041,7 +2049,7 @@ class TestGenerateTestConfigSweep:
                             {
                                 "tp": 4,
                                 "kv-offloading": "dram",
-                                "kv-offload-backend": "native",
+                                "kv-offload-backend": {"name": "native"},
                                 "conc-list": [32],
                             },
                             {
@@ -2049,7 +2057,7 @@ class TestGenerateTestConfigSweep:
                                 "dcp-size": 2,
                                 "pcp-size": 1,
                                 "kv-offloading": "dram",
-                                "kv-offload-backend": "native",
+                                "kv-offload-backend": {"name": "native"},
                                 "conc-list": [32],
                             },
                             {
@@ -2057,14 +2065,14 @@ class TestGenerateTestConfigSweep:
                                 "dcp-size": 1,
                                 "pcp-size": 2,
                                 "kv-offloading": "dram",
-                                "kv-offload-backend": "native",
+                                "kv-offload-backend": {"name": "native"},
                                 "conc-list": [32],
                             },
                             {
                                 "tp": 4,
                                 "pp": 2,
                                 "kv-offloading": "dram",
-                                "kv-offload-backend": "native",
+                                "kv-offload-backend": {"name": "native"},
                                 "conc-list": [32],
                             },
                         ],
@@ -2111,7 +2119,7 @@ class TestGenerateTestConfigSweep:
                             {
                                 "tp": 4,
                                 "kv-offloading": "dram",
-                                "kv-offload-backend": "native",
+                                "kv-offload-backend": {"name": "native"},
                                 "conc-list": [32],
                             },
                         ],
@@ -2150,6 +2158,8 @@ class TestGenerateTestConfigSweep:
                             "search-space": [
                                 {
                                     "conc-list": [16, 32, 64, 128, 256],
+                                    "router": {"name": "dynamo-router", "version": "1.3.0"},
+                                    "kv-p2p-transfer": "nixl",
                                     "prefill": {"hardware": "gb200", "num-worker": 2, "tp": 4, "pp": 2, "dcp-size": 2, "pcp-size": 2, "ep": 4, "dp-attn": False},
                                     "decode": {"hardware": "h100", "num-worker": 1, "tp": 4, "pp": 2, "dcp-size": 2, "pcp-size": 1, "ep": 1, "dp-attn": False},
                                 }
@@ -2180,6 +2190,8 @@ class TestGenerateTestConfigSweep:
         assert result[0]["decode"]["pcp-size"] == 1
         assert result[1]["conc"] == [256]
         assert result[1]["exp-name"] == "dsv4_p2x4_d1x4_conc256"
+        assert all(entry["router"] == {"name": "dynamo-router", "version": "1.3.0"} for entry in result)
+        assert all(entry["kv-p2p-transfer"] == "nixl" for entry in result)
 
     def test_multinode_agentic_preserves_kv_offload_fields(self):
         config = {
@@ -2192,12 +2204,13 @@ class TestGenerateTestConfigSweep:
                 "runner": "cluster:mi355x-amds",
                 "multinode": True,
                 "disagg": True,
+                "kv-p2p-transfer": "mori",
                 "scenarios": {
                     "agentic-coding": [{
                         "search-space": [{
                             "conc-list": [16],
                             "kv-offloading": "dram",
-                            "kv-offload-backend": "hicache",
+                            "kv-offload-backend": {"name": "hicache"},
                             "prefill": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
                             "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
                         }],
@@ -2217,7 +2230,7 @@ class TestGenerateTestConfigSweep:
 
         assert len(result) == 1
         assert result[0]["kv-offloading"] == "dram"
-        assert result[0]["kv-offload-backend"] == "hicache"
+        assert result[0]["kv-offload-backend"] == {"name": "hicache"}
         assert result[0]["exp-name"] == "dsv4_p1x8_d1x8_conc16_kvdram-hicache"
 
 
@@ -2337,6 +2350,7 @@ class TestGenerateFullSweepMixed:
                 "runner": "cluster:gb200-nv",
                 "multinode": True,
                 "disagg": True,
+                "kv-p2p-transfer": "nixl",
                 "scenarios": {
                     "agentic-coding": [{
                         "search-space": [

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -1,6 +1,9 @@
 """Comprehensive tests for validation.py"""
+import copy
+
 import pytest
 from validation import (
+    ComponentMetadata,
     Fields,
     SingleNodeMatrixEntry,
     SingleNodeAgenticMatrixEntry,
@@ -95,6 +98,7 @@ def valid_multinode_matrix_entry():
         "max-model-len": 2248,
         "exp-name": "dsr1_1k1k",
         "disagg": True,
+        "kv-p2p-transfer": "nixl",
         "run-eval": False,
     }
 
@@ -137,6 +141,7 @@ def valid_multinode_master_config():
         "runner": "gb200",
         "multinode": True,
         "disagg": True,
+        "kv-p2p-transfer": "nixl",
         "scenarios": {
             "fixed-seq-len": [
 
@@ -390,31 +395,108 @@ class TestAgenticMatrixEntries:
             "dp-attn": False,
             "conc": 1,
             "kv-offloading": "dram",
-            "kv-offload-backend": "future-backend",
+            "kv-offload-backend": {"name": "future-backend"},
             "total-cpu-dram-gb": 2949,
             "duration": 3600,
             "exp-name": "dsv4_tp8_conc1_kvdram-future-backend",
             "scenario-type": "agentic-coding",
         })
         assert entry.kv_offloading == "dram"
-        assert entry.kv_offload_backend == "future-backend"
+        assert entry.kv_offload_backend.name == "future-backend"
+        assert entry.kv_offload_backend.version is None
 
     def test_arbitrary_backend_is_valid_for_agentic_search_space(self):
         entry = AgenticCodingSearchSpaceEntry(**{
             "tp": 8,
             "kv-offloading": "dram",
-            "kv-offload-backend": "future-backend",
+            "kv-offload-backend": {"name": "future-backend"},
+            "router": {"name": "vllm-router", "version": "0.1.14"},
+            "kv-p2p-transfer": "mooncake",
             "conc-list": [1, 2],
         })
         assert entry.kv_offloading == "dram"
-        assert entry.kv_offload_backend == "future-backend"
+        assert entry.kv_offload_backend.name == "future-backend"
+        assert entry.kv_offload_backend.version is None
+        assert entry.router.name == "vllm-router"
+        assert entry.router.version == "0.1.14"
+        assert entry.kv_p2p_transfer == "mooncake"
+
+    def test_router_metadata_is_optional_for_fixed_sequence_search_space(self):
+        entry = SingleNodeSearchSpaceEntry(**{
+            "tp": 8,
+            "router": {"name": "vllm-router", "version": "0.1.14"},
+            "conc-list": [1, 2],
+        })
+        assert entry.router.name == "vllm-router"
+
+    @pytest.mark.parametrize("metadata", [
+        {"name": "vllm-router"},
+        {"version": "0.1.14"},
+        {"name": "vllm-router", "version": "0.1.14", "mode": "round-robin"},
+        {"name": "", "version": "0.1.14"},
+        {"name": "vllm-router", "version": ""},
+    ])
+    def test_component_metadata_requires_exact_non_empty_fields(self, metadata):
+        with pytest.raises(Exception):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "none",
+                "router": metadata,
+                "conc-list": [1, 2],
+            })
+
+    @pytest.mark.parametrize("value", ["", {"name": "nixl"}])
+    def test_kv_p2p_transfer_requires_a_non_empty_name(self, value):
+        with pytest.raises(Exception):
+            MultiNodeSearchSpaceEntry(**{
+                "prefill": {
+                    "num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False,
+                },
+                "decode": {
+                    "num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False,
+                },
+                "kv-p2p-transfer": value,
+                "conc-list": [1],
+            })
+
+    def test_kv_offload_backend_accepts_optional_version(self):
+        entry = AgenticCodingSearchSpaceEntry(**{
+            "tp": 8,
+            "kv-offloading": "dram",
+            "kv-offload-backend": {"name": "lmcache", "version": "0.5.1"},
+            "conc-list": [1],
+        })
+
+        assert entry.kv_offload_backend.name == "lmcache"
+        assert entry.kv_offload_backend.version == "0.5.1"
+
+    def test_kv_offload_backend_rejects_unknown_metadata(self):
+        with pytest.raises(Exception):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "dram",
+                "kv-offload-backend": {"name": "lmcache", "mode": "cpu"},
+                "conc-list": [1],
+            })
+
+    def test_kv_offload_backend_rejects_image_as_version(self):
+        with pytest.raises(Exception, match="not an image reference"):
+            AgenticCodingSearchSpaceEntry(**{
+                "tp": 8,
+                "kv-offloading": "dram",
+                "kv-offload-backend": {
+                    "name": "lmcache",
+                    "version": "image:vllm/vllm-openai:v0.23.0",
+                },
+                "conc-list": [1],
+            })
 
     def test_kv_offload_backend_requires_dram_mode(self):
         with pytest.raises(Exception, match="kv-offload-backend"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "none",
-                "kv-offload-backend": "lmcache",
+                "kv-offload-backend": {"name": "lmcache"},
                 "conc-list": [1, 2],
             })
 
@@ -439,7 +521,7 @@ class TestAgenticMatrixEntries:
                 "search-space": [{
                     "tp": 4,
                     "kv-offloading": "dram",
-                    "kv-offload-backend": "native",
+                    "kv-offload-backend": {"name": "native"},
                     "conc-list": [16],
                 }],
             })
@@ -449,7 +531,7 @@ class TestAgenticMatrixEntries:
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "dram",
-                "kv-offload-backend": "native",
+                "kv-offload-backend": {"name": "native"},
                 "total-cpu-dram-gb": 1000,
                 "conc-list": [1, 2],
             })
@@ -460,7 +542,7 @@ class TestAgenticMatrixEntries:
             "search-space": [{
                 "tp": 4,
                 "kv-offloading": "dram",
-                "kv-offload-backend": "native",
+                "kv-offload-backend": {"name": "native"},
                 "conc-list": [16],
             }],
         })
@@ -474,7 +556,7 @@ class TestAgenticMatrixEntries:
                 "search-space": [{
                     "tp": 4,
                     "kv-offloading": "dram",
-                    "kv-offload-backend": "native",
+                    "kv-offload-backend": {"name": "native"},
                     "conc-list": [16],
                 }],
             })
@@ -487,7 +569,7 @@ class TestAgenticMatrixEntries:
                 "search-space": [{
                     "tp": 4,
                     "kv-offloading": "dram",
-                    "kv-offload-backend": "native",
+                    "kv-offload-backend": {"name": "native"},
                     "conc-list": [16],
                 }],
             })
@@ -949,6 +1031,137 @@ class TestMasterConfigEntries:
         config = SingleNodeMasterConfigEntry(**valid_single_node_master_config)
         assert config.disagg is False
 
+    def test_single_node_rejects_kv_p2p_transfer(
+        self,
+        valid_single_node_master_config,
+    ):
+        """P2P KV transfer is reserved for multinode configurations."""
+        valid_single_node_master_config["kv-p2p-transfer"] = "nixl"
+
+        with pytest.raises(Exception, match="kv-p2p-transfer"):
+            SingleNodeMasterConfigEntry(**valid_single_node_master_config)
+
+    def test_aggregated_multinode_allows_kv_p2p_transfer(
+        self,
+        valid_multinode_master_config,
+    ):
+        """P2P transfer is not restricted to disaggregated multinode serving."""
+        valid_multinode_master_config["disagg"] = False
+
+        config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+        assert config.kv_p2p_transfer == "nixl"
+
+    def test_component_metadata_rejects_image_as_version(self):
+        """Component versions identify the component, not its container."""
+        with pytest.raises(Exception, match="not an image reference"):
+            ComponentMetadata(
+                name="nixl",
+                version="image:vllm/vllm-openai:v0.23.0",
+            )
+
+    @pytest.mark.parametrize(("field", "value"), [
+        ("router", {"name": "component", "version": "1.0.0"}),
+        ("kv-p2p-transfer", "nixl"),
+    ])
+    def test_component_metadata_rejects_mixed_scopes(
+        self,
+        valid_multinode_master_config,
+        field,
+        value,
+    ):
+        """One metadata field cannot be declared at both supported scopes."""
+        valid_multinode_master_config[field] = value
+        search_space = valid_multinode_master_config[
+            "scenarios"
+        ]["fixed-seq-len"][0]["search-space"]
+        search_space[0][field] = value
+
+        with pytest.raises(Exception, match=f"{field} must be declared either"):
+            MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+    def test_component_metadata_allows_different_field_scopes(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Router and KV transfer may independently choose their scope."""
+        valid_multinode_master_config.pop("kv-p2p-transfer")
+        valid_multinode_master_config["router"] = {
+            "name": "dynamo-router",
+            "version": "1.0.0",
+        }
+        search_space = valid_multinode_master_config[
+            "scenarios"
+        ]["fixed-seq-len"][0]["search-space"]
+        search_space[0]["kv-p2p-transfer"] = "nixl"
+
+        config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+        assert config.router.name == "dynamo-router"
+        kv_p2p_transfer = config.scenarios.fixed_seq_len[0].search_space[0].kv_p2p_transfer
+        assert kv_p2p_transfer == "nixl"
+
+    def test_component_metadata_allows_different_search_space_values(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Different search-space entries may use different components."""
+        valid_multinode_master_config.pop("kv-p2p-transfer")
+        search_space = valid_multinode_master_config[
+            "scenarios"
+        ]["fixed-seq-len"][0]["search-space"]
+        search_space.append(copy.deepcopy(search_space[0]))
+        search_space[0]["kv-p2p-transfer"] = "nixl"
+        search_space[1]["kv-p2p-transfer"] = "mooncake"
+
+        config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+        values = config.scenarios.fixed_seq_len[0].search_space
+        assert values[0].kv_p2p_transfer == "nixl"
+        assert values[1].kv_p2p_transfer == "mooncake"
+
+    def test_disagg_requires_kv_p2p_transfer(self, valid_multinode_master_config):
+        """A disaggregated config cannot omit KV transfer metadata."""
+        valid_multinode_master_config.pop("kv-p2p-transfer")
+
+        with pytest.raises(Exception, match="disagg=true requires kv-p2p-transfer"):
+            MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+    def test_disagg_accepts_kv_p2p_transfer_on_every_search_space_entry(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Per-entry KV transfer metadata is valid when every entry has it."""
+        valid_multinode_master_config.pop("kv-p2p-transfer")
+        search_space = valid_multinode_master_config[
+            "scenarios"
+        ]["fixed-seq-len"][0]["search-space"]
+        search_space.append(copy.deepcopy(search_space[0]))
+        for entry in search_space:
+            entry["kv-p2p-transfer"] = "nixl"
+
+        config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+        assert all(
+            entry.kv_p2p_transfer == "nixl"
+            for entry in config.scenarios.fixed_seq_len[0].search_space
+        )
+
+    def test_disagg_rejects_partial_search_space_kv_p2p_transfer(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Per-entry KV transfer metadata cannot leave any entry unspecified."""
+        valid_multinode_master_config.pop("kv-p2p-transfer")
+        search_space = valid_multinode_master_config[
+            "scenarios"
+        ]["fixed-seq-len"][0]["search-space"]
+        search_space.append(copy.deepcopy(search_space[0]))
+        search_space[0]["kv-p2p-transfer"] = "nixl"
+
+        with pytest.raises(Exception, match="disagg=true requires kv-p2p-transfer"):
+            MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
     def test_disagg_requires_multinode(self, valid_single_node_master_config):
         """Single-node master configs cannot enable disaggregation."""
         valid_single_node_master_config["disagg"] = True
@@ -993,6 +1206,7 @@ class TestMasterConfigEntries:
             "runner": "b200-multinode",
             "multinode": True,
             "disagg": True,
+            "kv-p2p-transfer": "nixl",
             "scenarios": {
                 "agentic-coding": [
                     {

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -1,4 +1,11 @@
-from pydantic import BaseModel, Field, ValidationError, ConfigDict, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from typing import List, Optional, Union, Literal, Dict
 from enum import Enum
 
@@ -59,6 +66,8 @@ class Fields(Enum):
     # Agentic coding fields
     KV_OFFLOADING = 'kv-offloading'
     KV_OFFLOAD_BACKEND = 'kv-offload-backend'
+    ROUTER = 'router'
+    KV_P2P_TRANSFER = 'kv-p2p-transfer'
     TOTAL_CPU_DRAM_GB = 'total-cpu-dram-gb'
     AVAILABLE_CPU_DRAM_MIB = 'available-cpu-dram-mib'
     DRAM_UTILIZATION = 'dram-utilization'
@@ -87,6 +96,44 @@ class Fields(Enum):
     are valid. Threfore, there should not be any default values set in these Pydantic models. Any missing value
     should raise a validation error.
 """
+
+
+class ComponentMetadata(BaseModel):
+    """Strict name and version metadata for an optional runtime component."""
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+
+    @field_validator('version')
+    @classmethod
+    def validate_component_version(cls, version: str) -> str:
+        """Require the component's own version rather than its image provenance."""
+        if version.startswith('image:'):
+            raise ValueError(
+                "component version must be a release, package version, or "
+                "source commit, not an image reference"
+            )
+        return version
+
+
+class KVOffloadBackendMetadata(BaseModel):
+    """KV offload backend metadata with an optional independent version."""
+    model_config = ConfigDict(extra='forbid')
+
+    name: str = Field(min_length=1)
+    version: Optional[str] = Field(default=None, min_length=1)
+
+    @field_validator('version')
+    @classmethod
+    def validate_component_version(cls, version: Optional[str]) -> Optional[str]:
+        """Reject image provenance when an independent version is available."""
+        if version is not None and version.startswith('image:'):
+            raise ValueError(
+                "component version must be a release, package version, or "
+                "source commit, not an image reference"
+            )
+        return version
 
 
 def _validate_tp_context_topology(self):
@@ -127,6 +174,7 @@ class SingleNodeMatrixEntry(BaseModel):
     disagg: Literal[False]
     run_eval: bool = Field(alias=Fields.RUN_EVAL.value)
     eval_only: bool = Field(alias=Fields.EVAL_ONLY.value, default=False)
+    router: Optional[ComponentMetadata] = None
 
     @model_validator(mode='after')
     def validate_single_node_topology(self):
@@ -193,10 +241,23 @@ class MultiNodeMatrixEntry(BaseModel):
     eval_all_concs: bool = Field(
         default=False, alias=Fields.EVAL_ALL_CONCS.value
     )
+    router: Optional[ComponentMetadata] = None
+    kv_p2p_transfer: Optional[str] = Field(
+        default=None, alias=Fields.KV_P2P_TRANSFER.value, min_length=1
+    )
 
     @model_validator(mode='after')
     def validate_worker_hardware_pair(self):
         return _validate_worker_hardware_pair(self)
+
+    @model_validator(mode='after')
+    def validate_disagg_transfer(self):
+        if self.disagg and self.kv_p2p_transfer is None:
+            raise ValueError(
+                f"{Fields.DISAGG.value}=true requires "
+                f"{Fields.KV_P2P_TRANSFER.value}"
+            )
+        return self
 
 
 class SingleNodeAgenticMatrixEntry(BaseModel):
@@ -219,9 +280,10 @@ class SingleNodeAgenticMatrixEntry(BaseModel):
     kv_offloading: Literal["none", "dram"] = Field(
         alias=Fields.KV_OFFLOADING.value
     )
-    kv_offload_backend: Optional[str] = Field(
+    kv_offload_backend: Optional[KVOffloadBackendMetadata] = Field(
         default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
     )
+    router: Optional[ComponentMetadata] = None
     total_cpu_dram_gb: int = Field(alias=Fields.TOTAL_CPU_DRAM_GB.value, ge=0)
     duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
@@ -253,8 +315,12 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
     decode: WorkerConfig
     conc: list[int]
     kv_offloading: Literal["none", "dram"] = Field(alias=Fields.KV_OFFLOADING.value)
-    kv_offload_backend: Optional[str] = Field(
+    kv_offload_backend: Optional[KVOffloadBackendMetadata] = Field(
         default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
+    )
+    router: Optional[ComponentMetadata] = None
+    kv_p2p_transfer: Optional[str] = Field(
+        default=None, alias=Fields.KV_P2P_TRANSFER.value, min_length=1
     )
     duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
@@ -268,6 +334,15 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
     @model_validator(mode='after')
     def validate_kv_offload_fields(self):
         return _validate_kv_offload_fields(self)
+
+    @model_validator(mode='after')
+    def validate_disagg_transfer(self):
+        if self.disagg and self.kv_p2p_transfer is None:
+            raise ValueError(
+                f"{Fields.DISAGG.value}=true requires "
+                f"{Fields.KV_P2P_TRANSFER.value}"
+            )
+        return self
 
 
 AgenticMatrixEntry = Union[SingleNodeAgenticMatrixEntry, MultiNodeAgenticMatrixEntry]
@@ -368,20 +443,20 @@ def _validate_agentic_runner_is_cluster(runner: str, scenarios) -> None:
 def _validate_kv_offload_fields(self):
     backend = getattr(self, "kv_offload_backend", None)
     if self.kv_offloading is None:
-        if backend not in (None, ""):
+        if backend is not None:
             raise ValueError(
                 f"{Fields.KV_OFFLOAD_BACKEND.value} requires "
                 f"{Fields.KV_OFFLOADING.value}"
             )
         return self
     if self.kv_offloading == "none":
-        if backend not in (None, ""):
+        if backend is not None:
             raise ValueError(
                 f"{Fields.KV_OFFLOAD_BACKEND.value} can only be set when "
                 f"{Fields.KV_OFFLOADING.value} is not 'none'"
             )
         return self
-    if backend is None or not backend.strip():
+    if backend is None:
         raise ValueError(
             f"{Fields.KV_OFFLOAD_BACKEND.value} is required when "
             f"{Fields.KV_OFFLOADING.value} is '{self.kv_offloading}'"
@@ -404,6 +479,7 @@ class SingleNodeSearchSpaceEntry(BaseModel):
         default="none", alias=Fields.SPEC_DECODING.value)
     dp_attn: Optional[bool] = Field(
         default=None, alias=Fields.DP_ATTN.value)
+    router: Optional[ComponentMetadata] = None
     conc_start: Optional[int] = Field(
         default=None, alias=Fields.CONC_START.value)
     conc_end: Optional[int] = Field(
@@ -428,6 +504,10 @@ class MultiNodeSearchSpaceEntry(BaseModel):
         default="none", alias=Fields.SPEC_DECODING.value)
     prefill: WorkerConfig
     decode: WorkerConfig
+    router: Optional[ComponentMetadata] = None
+    kv_p2p_transfer: Optional[str] = Field(
+        default=None, alias=Fields.KV_P2P_TRANSFER.value, min_length=1
+    )
     conc_start: Optional[int] = Field(
         default=None, alias=Fields.CONC_START.value)
     conc_end: Optional[int] = Field(
@@ -483,8 +563,12 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
     kv_offloading: Optional[Literal["none", "dram"]] = Field(
         default=None, alias=Fields.KV_OFFLOADING.value
     )
-    kv_offload_backend: Optional[str] = Field(
+    kv_offload_backend: Optional[KVOffloadBackendMetadata] = Field(
         default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
+    )
+    router: Optional[ComponentMetadata] = None
+    kv_p2p_transfer: Optional[str] = Field(
+        default=None, alias=Fields.KV_P2P_TRANSFER.value, min_length=1
     )
     conc_start: Optional[int] = Field(default=None, alias=Fields.CONC_START.value)
     conc_end: Optional[int] = Field(default=None, alias=Fields.CONC_END.value)
@@ -592,6 +676,55 @@ class MultiNodeScenarios(BaseModel):
         return self
 
 
+def _validate_component_metadata_scope(self: BaseModel) -> BaseModel:
+    """Require unambiguous component metadata across a master config."""
+    search_space_entries = [
+        entry
+        for scenario_configs in (
+            self.scenarios.fixed_seq_len,
+            self.scenarios.agentic_coding,
+        )
+        for scenario_config in scenario_configs or []
+        for entry in scenario_config.search_space
+    ]
+
+    for field in (Fields.ROUTER, Fields.KV_P2P_TRANSFER):
+        attribute = field.value.replace("-", "_")
+        top_level_value = getattr(self, attribute, None)
+        has_search_space_value = any(
+            getattr(entry, attribute, None) is not None
+            for entry in search_space_entries
+        )
+        if top_level_value is not None and has_search_space_value:
+            raise ValueError(
+                f"{field.value} must be declared either at the top level or "
+                "in search-space entries, not both"
+            )
+
+    has_search_space_transfer = any(
+        getattr(entry, "kv_p2p_transfer", None) is not None
+        for entry in search_space_entries
+    )
+    if not self.multinode and has_search_space_transfer:
+        raise ValueError(
+            f"{Fields.KV_P2P_TRANSFER.value} is only valid when "
+            f"{Fields.MULTINODE.value}=true"
+        )
+
+    top_level_transfer = getattr(self, "kv_p2p_transfer", None)
+    if self.disagg and top_level_transfer is None:
+        if not search_space_entries or any(
+            entry.kv_p2p_transfer is None for entry in search_space_entries
+        ):
+            raise ValueError(
+                f"{Fields.DISAGG.value}=true requires "
+                f"{Fields.KV_P2P_TRANSFER.value} at the top level or in every "
+                "search-space entry"
+            )
+
+    return self
+
+
 class SingleNodeMasterConfigEntry(BaseModel):
     """Top-level single node master configuration entry."""
     model_config = ConfigDict(extra='forbid', populate_by_name=True)
@@ -604,12 +737,17 @@ class SingleNodeMasterConfigEntry(BaseModel):
     runner: str
     multinode: Literal[False]
     disagg: Literal[False] = Field(default=False)
+    router: Optional[ComponentMetadata] = None
     scenarios: SingleNodeScenarios
 
     @model_validator(mode='after')
     def validate_agentic_runner(self):
         _validate_agentic_runner_is_cluster(self.runner, self.scenarios)
         return self
+
+    @model_validator(mode='after')
+    def validate_component_metadata_scope(self):
+        return _validate_component_metadata_scope(self)
 
 
 class MultiNodeMasterConfigEntry(BaseModel):
@@ -624,12 +762,20 @@ class MultiNodeMasterConfigEntry(BaseModel):
     runner: str
     multinode: Literal[True]
     disagg: bool = Field(default=False)
+    router: Optional[ComponentMetadata] = None
+    kv_p2p_transfer: Optional[str] = Field(
+        default=None, alias=Fields.KV_P2P_TRANSFER.value, min_length=1
+    )
     scenarios: MultiNodeScenarios
 
     @model_validator(mode='after')
     def validate_agentic_runner(self):
         _validate_agentic_runner_is_cluster(self.runner, self.scenarios)
         return self
+
+    @model_validator(mode='after')
+    def validate_component_metadata_scope(self):
+        return _validate_component_metadata_scope(self)
 
 
 def validate_master_config(master_configs: dict) -> List[dict]:

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -22,6 +22,24 @@ def get_required_env_vars(required_vars):
     return env_values
 
 
+def get_optional_component_metadata(env_var):
+    """Parse strict optional component metadata from a JSON environment value."""
+    raw_value = os.environ.get(env_var)
+    if raw_value in (None, "", "null"):
+        return None
+
+    try:
+        metadata = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{env_var} must contain valid JSON") from exc
+
+    if not isinstance(metadata, dict) or set(metadata) != {"name", "version"}:
+        raise ValueError(f"{env_var} must contain exactly 'name' and 'version'")
+    if not all(isinstance(metadata[key], str) and metadata[key] for key in metadata):
+        raise ValueError(f"{env_var} name and version must be non-empty strings")
+    return metadata
+
+
 # Base required env vars
 base_env = get_required_env_vars([
     'RUNNER_TYPE', 'FRAMEWORK', 'PRECISION', 'SPEC_DECODING',
@@ -55,6 +73,14 @@ data = {
     'isl': int(isl),
     'osl': int(osl),
 }
+
+router = get_optional_component_metadata('ROUTER_METADATA')
+if router is not None:
+    data['router'] = router
+
+kv_p2p_transfer = os.environ.get('KV_P2P_TRANSFER')
+if kv_p2p_transfer:
+    data['kv_p2p_transfer'] = kv_p2p_transfer
 
 is_multinode = os.environ.get('IS_MULTINODE', 'false').lower() == 'true'
 

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -243,6 +243,36 @@ class TestProcessResultScript:
         assert output_data["output_tput_per_gpu"] == pytest.approx(12000.0 / 8)  # decode gpus
         assert output_data["input_tput_per_gpu"] == pytest.approx((15000.5 - 12000.0) / 20)  # prefill gpus
 
+    def test_component_metadata_is_emitted_when_present(
+        self, tmp_path, sample_benchmark_result, multinode_env_vars
+    ):
+        env = {
+            **multinode_env_vars,
+            "ROUTER_METADATA": json.dumps({"name": "vllm-router", "version": "0.1.14"}),
+            "KV_P2P_TRANSFER": "mooncake",
+        }
+
+        result = run_script(tmp_path, env, sample_benchmark_result)
+
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+        output_data = json.loads(result.stdout)
+        assert output_data["router"] == {"name": "vllm-router", "version": "0.1.14"}
+        assert output_data["kv_p2p_transfer"] == "mooncake"
+
+    @pytest.mark.parametrize("metadata", [
+        {"name": "vllm-router"},
+        {"name": "vllm-router", "version": "0.1.14", "mode": "round-robin"},
+    ])
+    def test_component_metadata_rejects_partial_or_extra_fields(
+        self, tmp_path, sample_benchmark_result, single_node_env_vars, metadata
+    ):
+        env = {**single_node_env_vars, "ROUTER_METADATA": json.dumps(metadata)}
+
+        result = run_script(tmp_path, env, sample_benchmark_result)
+
+        assert result.returncode != 0
+        assert "must contain exactly 'name' and 'version'" in result.stderr
+
     def test_homogeneous_multinode_omits_hardware_fields(
         self, tmp_path, sample_benchmark_result, multinode_env_vars
     ):


### PR DESCRIPTION
## Summary

- add strict `{name, version}` router metadata
- rename KV transfer metadata to name-only `kv-p2p-transfer` and reserve it for `multinode: true` configurations
- require every disaggregated config to identify its P2P transfer engine while allowing the field on aggregated multinode configurations
- represent `kv-offload-backend` as `{name, version?}`, keeping versions optional for framework-native implementations
- reject ambiguous top-level plus per-search-space declarations and carry the metadata into aggregate results

## Validation

- `python -m pytest utils/matrix_logic/ -q`
- process-result and agentic aggregation tests
- full NVIDIA and AMD master-config generation
