### PR TITLE
[AMD] MiniMax-M3 FP4 MI355X vLLM STP: close gap vs ATOM (INT4 all-reduce + index-sharing), TP4 sweep / MiniMax-M3 FP4 MI355X vLLM STP：缩小与 ATOM 的性能差距（INT4 all-reduce + 跨层索引共享），TP4 扫描

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
@@ -4,6 +4,16 @@
 # https://huggingface.co/amd/MiniMax-M3-MXFP4#reproduction
 # Block size 128 is mandatory for MSA. This fixed-sequence benchmark uses the
 # text-only language-model path with AITER MoE (vllm-project/vllm#46419).
+#
+# High-concurrency parity with the ATOM recipe comes from three levers:
+#   * INT4 quantized all-reduce (env knobs below) -- reduces the all-reduce
+#     cost (the biggest decode kernel); measured ~-12% to -17% TPOT at conc
+#     64/128/256. Works on any nightly.
+#   * fp8 KV cache (--kv-cache-dtype fp8).
+#   * cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4) --
+#     requires vllm-project/vllm#47269 (merged).
+# Pin the image (configs/amd-master.yaml) to a nightly containing #47269
+# before sweeping for the full curve.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -35,6 +45,13 @@ export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+# INT4 quantized all-reduce for the (~1.5 MB) decode all-reduces, which are the
+# single biggest decode kernel at high concurrency. The MIN_SIZE_KB override is
+# required: vLLM's default INT4 quick-reduce size gate for (bf16, TP4) is 16 MB,
+# so it never fires for decode-sized tensors without it.
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context
@@ -63,6 +80,8 @@ vllm serve "$MODEL" --port "$PORT" \
     --max-model-len "$MAX_MODEL_LEN" \
     --attention-backend TRITON_ATTN \
     --moe-backend aiter \
+    --kv-cache-dtype fp8 \
+    --hf-overrides '{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}' \
     --tool-call-parser minimax_m3 \
     --enable-auto-tool-choice \
     --reasoning-parser minimax_m3 > "$SERVER_LOG" 2>&1 &

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2576,7 +2576,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
 # language-model path and mirror the MXFP8 MI355X search space for a direct
 # precision comparison.
 minimaxm3-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
+  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x
@@ -2588,19 +2588,11 @@ minimaxm3-fp4-mi355x-vllm:
     - isl: 1024
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 64 }
-      - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
-      - { tp: 2, ep: 2, conc-start: 16, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
+      - { tp: 4, conc-start: 1, conc-end: 512 }
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
+      - { tp: 4, conc-start: 1, conc-end: 512 }
 
 # EAGLE3 speculative-decoding variant of minimaxm3-fp4-mi355x-vllm. Pair the
 # amd/MiniMax-M3-MXFP4 target with Inferact/MiniMax-M3-EAGLE3 and three draft

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2576,7 +2576,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
 # language-model path and mirror the MXFP8 MI355X search space for a direct
 # precision comparison.
 minimaxm3-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
+  image: vllm/vllm-openai-rocm:nightly-69715823df89b11ee684b84066390cbb9092d5c1
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4578,7 +4578,7 @@
 - config-keys:
     - minimaxm3-fp4-mi355x-vllm
   description:
-    - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM STP. Bump image to nightly-09663abde (vllm-project/vllm#47269 for index_topk_freq). Add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
+    - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM STP. Bump image to latest nightly vllm/vllm-openai-rocm:nightly-69715823df89b11ee684b84066390cbb9092d5c1 (includes vllm-project/vllm#47269 for index_topk_freq). Add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
     - "Simplify search space to a single TP4 conc 1-512 sweep for 1k1k and 8k1k (drop TP8, TP4/EP4, TP2/EP2, and dp-attn variants), matching minimaxm3-fp8-mi355x-vllm (#2003)."
     - "Local (ATOM's benchmark): conc32 17.21ms / conc64 25.13ms vs ATOM ref 16.74 / 25.00 (matched); GSM8K limit100=0.95."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4581,4 +4581,4 @@
     - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM STP. Bump image to nightly-09663abde (vllm-project/vllm#47269 for index_topk_freq). Add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
     - "Simplify search space to a single TP4 conc 1-512 sweep for 1k1k and 8k1k (drop TP8, TP4/EP4, TP2/EP2, and dp-attn variants), matching minimaxm3-fp8-mi355x-vllm (#2003)."
     - "Local (ATOM's benchmark): conc32 17.21ms / conc64 25.13ms vs ATOM ref 16.74 / 25.00 (matched); GSM8K limit100=0.95."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4581,4 +4581,4 @@
     - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM STP. Bump image to latest nightly vllm/vllm-openai-rocm:nightly-69715823df89b11ee684b84066390cbb9092d5c1 (includes vllm-project/vllm#47269 for index_topk_freq). Add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
     - "Simplify search space to a single TP4 conc 1-512 sweep for 1k1k and 8k1k (drop TP8, TP4/EP4, TP2/EP2, and dp-attn variants), matching minimaxm3-fp8-mi355x-vllm (#2003)."
     - "Local (ATOM's benchmark): conc32 17.21ms / conc64 25.13ms vs ATOM ref 16.74 / 25.00 (matched); GSM8K limit100=0.95."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2102

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4574,3 +4574,11 @@
   description:
     - "Add high concurrency configs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1994
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm
+  description:
+    - "Close the high-concurrency gap vs the ATOM recipe on MiniMax-M3 MXFP4 MI355X single-node vLLM STP. Bump image to nightly-09663abde (vllm-project/vllm#47269 for index_topk_freq). Add INT4 quantized all-reduce (VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0, VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB=256), fp8 KV cache (--kv-cache-dtype fp8), and cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4)."
+    - "Simplify search space to a single TP4 conc 1-512 sweep for 1k1k and 8k1k (drop TP8, TP4/EP4, TP2/EP2, and dp-attn variants), matching minimaxm3-fp8-mi355x-vllm (#2003)."
+    - "Local (ATOM's benchmark): conc32 17.21ms / conc64 25.13ms vs ATOM ref 16.74 / 25.00 (matched); GSM8K limit100=0.95."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD


### PR DESCRIPTION
## Summary

Revives the closed #1969 recipe tuning for `minimaxm3-fp4-mi355x-vllm` (single-node STP) and narrows the sweep to the TP4-only search space from merged #2003:

1. **INT4 quantized all-reduce** — `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4` + `..._CAST_BF16_TO_FP16=0` + `..._QUANTIZATION_MIN_SIZE_KB=256`. Reduces the all-reduce cost (the biggest decode kernel).
2. **fp8 KV cache** (`--kv-cache-dtype fp8`).
3. **Cross-layer indexer top-k sharing** (`--hf-overrides index_topk_freq=4`) — requires vllm-project/vllm#47269 (merged); image bumped to latest `nightly-69715823`.
4. **Search space** — single TP4 conc 1–512 sweep for 1k1k and 8k1k (drops TP8, TP4/EP4, TP2/EP2, and dp-attn variants), matching `minimaxm3-fp8-mi355x-vllm` (#2003).

Supersedes the closed #1969, which was marked superseded but had no linked replacement for FP4 STP.

## Measured (local, amd/MiniMax-M3-MXFP4, MI355X gfx950, TP4, 8k1k)

| conc | vLLM (this config) | ATOM ref | gap |
| --- | --- | --- | --- |
| 32 | 17.21 ms | 16.74 ms | +2.8% |
| 64 | 25.13 ms | 25.00 ms | +0.2% (matched) |

GSM8K limit=100 = 0.95 (above ATOM's 0.9363).

## Test plan

- [ ] CI changelog validation passes
- [ ] `full-sweep-fail-fast` sweep on `minimaxm3-fp4-mi355x-vllm` (TP4, 1k1k + 8k1k)
- [ ] Eval lane GSM8K passes on 8k1k subset

## 中文说明

恢复已关闭的 #1969 对 `minimaxm3-fp4-mi355x-vllm` 单节点 STP 的 recipe 调优，并将扫描范围收窄为已合并 #2003 的 TP4-only 配置：

1. **INT4 量化 all-reduce** — 降低解码阶段 all-reduce 开销（最大 decode kernel）。
2. **fp8 KV 缓存**（`--kv-cache-dtype fp8`）。
3. **跨层索引 top-k 共享**（`--hf-overrides index_topk_freq=4`）— 镜像升级至最新 `nightly-69715823`（含 vllm-project/vllm#47269）。
4. **搜索空间** — 1k1k/8k1k 均为 TP4、并发 1–512 单条扫描（去掉 TP8、TP4/EP4、TP2/EP2 及 dp-attn 变体），与 `minimaxm3-fp8-mi355x-vllm`（#2003）一致。

本地测试（MI355X TP4, 8k1k）并发 64 时 TPOT 与 ATOM 基本持平；GSM8K 精度 0.95，高于 ATOM 的 0.9363。

Made with [Cursor](https://cursor.com)