### PR TITLE
[Klaud Cold] Job names: hide /DCP1 and /PCP1 when default / 任务名：DCP/PCP 为 1 时隐藏 /DCP1 与 /PCP1

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 500
     name: >-
       ${{ inputs.model-prefix }} ${{ inputs.precision }} ${{ inputs.runner }} ${{ inputs.framework == 'sglang' && 'sgl' || inputs.framework == 'dynamo-sglang' && 'dyn-sgl' || inputs.framework == 'sglang-disagg' && 'sgl-disagg' || inputs.framework }}
-      TP${{ inputs.tp }}/DCP${{ inputs.dcp-size }}/PCP${{ inputs.pcp-size }}${{ inputs.ep != '' && inputs.ep != '1' && format('/EP{0}', inputs.ep) || '' }}${{ inputs.dp-attn && '/DPA' || '' }}
+      TP${{ inputs.tp }}${{ inputs.dcp-size != '' && inputs.dcp-size != '1' && format('/DCP{0}', inputs.dcp-size) || '' }}${{ inputs.pcp-size != '' && inputs.pcp-size != '1' && format('/PCP{0}', inputs.pcp-size) || '' }}${{ inputs.ep != '' && inputs.ep != '1' && format('/EP{0}', inputs.ep) || '' }}${{ inputs.dp-attn && '/DPA' || '' }}
       ${{ inputs.spec-decoding != 'none' && inputs.spec-decoding || '' }}
       ${{ inputs.kv-offloading != '' && inputs.kv-offloading != 'none' && format('{0} KV offload', inputs.kv-offloading) || '' }}
       ${{ inputs.kv-offload-backend != '' && inputs.kv-offload-backend != 'none' && inputs.kv-offload-backend != 'default' && inputs.kv-offload-backend || '' }}

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -100,7 +100,7 @@ jobs:
         config: ${{ fromJson(needs.get-jobs.outputs.filtered-matrix) }}
     name: >-
       ${{ matrix.config.model-prefix }} ${{ matrix.config.precision }} ${{ matrix.config.runner }} ${{ matrix.config.framework }}
-      TP${{ matrix.config.tp }}/DCP${{ matrix.config.dcp-size }}/PCP${{ matrix.config.pcp-size }} c${{ matrix.config.conc }}
+      TP${{ matrix.config.tp }}${{ matrix.config.dcp-size != '' && matrix.config.dcp-size != '1' && format('/DCP{0}', matrix.config.dcp-size) || '' }}${{ matrix.config.pcp-size != '' && matrix.config.pcp-size != '1' && format('/PCP{0}', matrix.config.pcp-size) || '' }} c${{ matrix.config.conc }}
     runs-on: ${{ matrix.config.runner }}
     env:
       EXP_NAME: ${{ matrix.config.exp-name }}


### PR DESCRIPTION
## Summary
- Hides the `/DCP{n}` and `/PCP{n}` segments from benchmark job names when the value is the default `1`, using the exact same conditional mechanism that already hides `/EP1` (#2041). Each segment is hidden independently:
  - `TP8/DCP1/PCP1` → `TP8`
  - `TP8/DCP8/PCP1` → `TP8/DCP8`
  - `TP8/DCP1/PCP2` → `TP8/PCP2`
- Example: `dsv4 fp4 mi355x sgl TP8/DCP1/PCP1 mtp c16` becomes `dsv4 fp4 mi355x sgl TP8 mtp c16`.
- Applies to both places that render the parallelism segment: `benchmark-tmpl.yml` (single-node benchmark/eval jobs) and `profile.yml`. The multinode template never rendered DCP/PCP. Display-only — `RESULT_FILENAME` and all env plumbing are untouched. Same proven mechanism as #2041/#2046/#2082.

## 中文说明
- 当 DCP/PCP 为默认值 `1` 时，基准任务名中隐藏 `/DCP{n}` 与 `/PCP{n}` 段，复用已有的 `/EP1` 隐藏机制（#2041）。两段各自独立判断：
  - `TP8/DCP1/PCP1` → `TP8`
  - `TP8/DCP8/PCP1` → `TP8/DCP8`
  - `TP8/DCP1/PCP2` → `TP8/PCP2`
- 示例：`dsv4 fp4 mi355x sgl TP8/DCP1/PCP1 mtp c16` 变为 `dsv4 fp4 mi355x sgl TP8 mtp c16`。
- 覆盖渲染并行段的两处：`benchmark-tmpl.yml`（单节点基准/评测任务）和 `profile.yml`；多节点模板本就不显示 DCP/PCP。仅影响显示，`RESULT_FILENAME` 及环境变量传递均未改动。与 #2041/#2046/#2082 相同的成熟机制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)