### PR TITLE
[codex] Route agentic ingests to agentx-v1 / 将 agentic 入库路由至 agentx-v1

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -395,6 +395,6 @@ jobs:
                       "inputs": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
-                        "database-target": "production"
+                        "database-target": "agentx-v1"
                       }
                     }'

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -926,7 +926,7 @@ jobs:
                       "inputs": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
-                        "database-target": "production"
+                        "database-target": "agentx-v1"
                       }
                     }'
 


### PR DESCRIPTION
## Summary

Temporarily route single-node and multi-node agentic ingests to `agentx-v1`. Non-agentic ingests continue using production.

This will be changed back to production on Friday, July 10, 2026.

## 中文说明

临时将单节点和多节点 agentic 数据写入 `agentx-v1`，非 agentic 数据继续写入 production。

该配置将在 2026 年 7 月 10 日（星期五）切回 production。