### PR TITLE
[codex] Skip production ingest for agentic runs / agentic 运行跳过 production 入库

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -841,6 +841,7 @@ jobs:
                 collect-results,
                 collect-evals,
                 calc-success-rate,
+                setup,
                 upload-changelog-metadata,
                 reuse-ingest-artifacts,
             ]
@@ -848,6 +849,17 @@ jobs:
             always() &&
             github.event_name == 'push' &&
             github.ref == 'refs/heads/main' &&
+            needs.setup.result == 'success' &&
+            (
+              (
+                toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == 'null' ||
+                toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == '[]'
+              ) &&
+              (
+                toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == 'null' ||
+                toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == '[]'
+              )
+            ) &&
             (
               needs.collect-results.result != 'skipped' ||
               needs.collect-evals.result != 'skipped' ||


### PR DESCRIPTION
## Summary

Follow-up to #2130: skip the generic production ingest when a single-node or multi-node agentic matrix is present. Non-agentic runs continue ingesting into production; agentic runs use `agentx-v1`.

## 中文说明

这是 #2130 的后续修复：当存在单节点或多节点 agentic 矩阵时，跳过通用 production 入库。非 agentic 运行继续写入 production，agentic 运行写入 `agentx-v1`。