### PR TITLE
[codex] Dispatch reused sources directly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -186,12 +186,13 @@ Remove and re-add the sweep label to force one.
 It merges `main`, preserves changelog bytes, fixes an appended `XXX` PR link,
 pushes a synchronization commit, waits for checks, then merges.
 
-The main run verifies the source, validates and uploads its ingest artifacts,
-then ingests them with merge-run changelog metadata. Source coverage is
-authoritative, so later matrix/eval policy changes do not invalidate reuse.
-Validation rejects duplicate fixed rows, missing run stats, inconsistent
-agentic artifacts, malformed eval metadata, and raw/aggregate eval mismatches.
-Batched evals use only `completed_eval_concs`.
+The main run passes the source and merge run IDs to the ingest workflow. That
+workflow downloads the source artifacts once, validates them, and ingests them
+with merge-run changelog metadata. Source coverage is authoritative, so later
+matrix/eval policy changes do not invalidate reuse. Validation rejects
+duplicate fixed rows, missing run stats, inconsistent agentic artifacts,
+malformed eval metadata, and raw/aggregate eval mismatches. Batched evals use
+only `completed_eval_concs`.
 
 Reuse fails closed when authorized but ineligible or invalid; without
 authorization, `main` runs the normal full sweep.

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -681,89 +681,6 @@ jobs:
         uses: ./.github/workflows/collect-evals.yml
         secrets: inherit
 
-    reuse-ingest-artifacts:
-        needs: setup
-        # Agentic reuse is downloaded and validated directly by the AgentX
-        # ingest workflow. Keep this relay only for production/non-agentic
-        # ingests until that workflow adopts the same direct-source path.
-        # `setup` runs via always() and depends on `check-changelog` and
-        # `reuse-sweep-gate`, which are skipped on every push-to-main. Without
-        # always() here, those skipped jobs poison this job's implicit
-        # success() check and it is skipped even when setup succeeded with
-        # reuse-enabled=true — silently breaking the merge-time ingest. Guard
-        # explicitly on setup success instead (same pattern as
-        # comment-unofficial-run-visualizer).
-        if: >-
-            always() &&
-            needs.setup.result == 'success' &&
-            needs.setup.outputs.reuse-enabled == 'true' &&
-            (
-              toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == 'null' ||
-              toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == '[]'
-            ) &&
-            (
-              toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == 'null' ||
-              toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == '[]'
-            )
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-            - name: Download reusable source artifacts
-              env:
-                  GH_TOKEN: ${{ secrets.REPO_PAT || github.token }}
-                  SOURCE_RUN_ID: ${{ needs.setup.outputs.reuse-source-run-id }}
-              run: |
-                  gh run download "$SOURCE_RUN_ID" \
-                    --repo "${{ github.repository }}" \
-                    -D source-artifacts
-
-                  # Keep only artifacts consumed by the official ingest path.
-                  # The merge run uploads its own changelog metadata; reusable
-                  # benchmark/eval rows are attributed to the source PR sweep.
-                  rm -rf source-artifacts/changelog-metadata
-                  for artifact_dir in source-artifacts/*; do
-                      [ -e "$artifact_dir" ] || continue
-                      name=$(basename "$artifact_dir")
-                      case "$name" in
-                          results_bmk|eval_results_all|run-stats|bmk_*|eval_*|agentic_*|server_logs_*|multinode_server_logs_*)
-                              ;;
-                          *)
-                              rm -rf "$artifact_dir"
-                              ;;
-                      esac
-                  done
-
-                  mkdir -p source-artifacts/reused-ingest-metadata
-                  cat > source-artifacts/reused-ingest-metadata/reuse_source_run.json <<'JSON'
-                  {
-                    "source_run_id": "${{ needs.setup.outputs.reuse-source-run-id }}",
-                    "source_run_attempt": "${{ needs.setup.outputs.reuse-source-run-attempt }}",
-                    "source_run_url": "${{ needs.setup.outputs.reuse-source-run-url }}",
-                    "source_pr_number": "${{ needs.setup.outputs.reuse-source-pr-number }}",
-                    "source_head_sha": "${{ needs.setup.outputs.reuse-source-head-sha }}",
-                    "ingest_run_id": "${{ github.run_id }}",
-                    "ingest_run_attempt": "${{ github.run_attempt }}",
-                    "ingest_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  }
-                  JSON
-
-                  echo "Reusing artifacts from $SOURCE_RUN_ID:"
-                  find source-artifacts -maxdepth 1 -mindepth 1 -type d -printf '  %f\n' | sort
-
-            - name: Validate reusable artifacts
-              # Collapses reran (flaky) eval duplicates to the latest result
-              # per identity, then validates consistency for ingest.
-              run: |
-                  python3 utils/validate_reusable_sweep_artifacts.py \
-                    --artifacts-dir source-artifacts
-
-            - name: Upload reusable ingest artifacts
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              with:
-                  name: reused-ingest-artifacts
-                  path: source-artifacts/*
-
     upload-changelog-metadata:
         needs: [setup, collect-results]
         if: ${{ always() && needs.setup.result == 'success' }}
@@ -854,7 +771,6 @@ jobs:
                 calc-success-rate,
                 setup,
                 upload-changelog-metadata,
-                reuse-ingest-artifacts,
             ]
         if: >-
             always() &&
@@ -874,7 +790,7 @@ jobs:
             (
               needs.collect-results.result != 'skipped' ||
               needs.collect-evals.result != 'skipped' ||
-              needs.reuse-ingest-artifacts.result == 'success'
+              needs.setup.outputs.reuse-enabled == 'true'
             )
         runs-on: ubuntu-latest
         steps:
@@ -887,8 +803,13 @@ jobs:
                     -d '{
                       "event_type": "ingest-results",
                       "client_payload": {
-                        "run-id": "${{ github.run_id }}",
-                        "run-attempt": "${{ github.run_attempt }}"
+                        "run-id": "${{ needs.setup.outputs.reuse-enabled == 'true' && needs.setup.outputs.reuse-source-run-id || github.run_id }}",
+                        "run-attempt": "${{ needs.setup.outputs.reuse-enabled == 'true' && needs.setup.outputs.reuse-source-run-attempt || github.run_attempt }}",
+                        "ingest-run-id": "${{ github.run_id }}",
+                        "ingest-run-attempt": "${{ github.run_attempt }}",
+                        "source-pr-number": "${{ needs.setup.outputs.reuse-source-pr-number }}",
+                        "source-head-sha": "${{ needs.setup.outputs.reuse-source-head-sha }}",
+                        "validation-ref": "${{ github.sha }}"
                       }
                     }'
 
@@ -899,7 +820,6 @@ jobs:
                 sweep-agentic,
                 sweep-multi-node-agentic,
                 upload-changelog-metadata,
-                reuse-ingest-artifacts,
             ]
         if: >-
             always() &&

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -683,6 +683,9 @@ jobs:
 
     reuse-ingest-artifacts:
         needs: setup
+        # Agentic reuse is downloaded and validated directly by the AgentX
+        # ingest workflow. Keep this relay only for production/non-agentic
+        # ingests until that workflow adopts the same direct-source path.
         # `setup` runs via always() and depends on `check-changelog` and
         # `reuse-sweep-gate`, which are skipped on every push-to-main. Without
         # always() here, those skipped jobs poison this job's implicit
@@ -693,7 +696,15 @@ jobs:
         if: >-
             always() &&
             needs.setup.result == 'success' &&
-            needs.setup.outputs.reuse-enabled == 'true'
+            needs.setup.outputs.reuse-enabled == 'true' &&
+            (
+              toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == 'null' ||
+              toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) == '[]'
+            ) &&
+            (
+              toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == 'null' ||
+              toJson(fromJson(needs.setup.outputs.search-space-config).multi_node['agentic']) == '[]'
+            )
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -898,7 +909,7 @@ jobs:
             needs.upload-changelog-metadata.result == 'success' &&
             (
               (
-                needs.reuse-ingest-artifacts.result == 'success' &&
+                needs.setup.outputs.reuse-enabled == 'true' &&
                 (
                   (
                     toJson(fromJson(needs.setup.outputs.search-space-config).single_node['agentic']) != 'null' &&
@@ -936,8 +947,13 @@ jobs:
                     -d '{
                       "ref": "feat/agentx",
                       "inputs": {
-                        "run-id": "${{ github.run_id }}",
-                        "run-attempt": "${{ github.run_attempt }}",
+                        "run-id": "${{ needs.setup.outputs.reuse-enabled == 'true' && needs.setup.outputs.reuse-source-run-id || github.run_id }}",
+                        "run-attempt": "${{ needs.setup.outputs.reuse-enabled == 'true' && needs.setup.outputs.reuse-source-run-attempt || github.run_attempt }}",
+                        "ingest-run-id": "${{ github.run_id }}",
+                        "ingest-run-attempt": "${{ github.run_attempt }}",
+                        "source-pr-number": "${{ needs.setup.outputs.reuse-source-pr-number }}",
+                        "source-head-sha": "${{ needs.setup.outputs.reuse-source-head-sha }}",
+                        "validation-ref": "${{ github.sha }}",
                         "database-target": "agentx-v1"
                       }
                     }'


### PR DESCRIPTION
## Summary

For reused sweeps, send the original source run directly to the ingest workflow instead of downloading and re-uploading its artifacts on the merge run.

This removes the merge-side artifact relay for fixed-sequence, eval, and agentic ingestion while preserving merge-run changelog metadata and source-run links.

Companion workflow change: https://github.com/SemiAnalysisAI/InferenceX-app/pull/539

Merge #539 into `master`, merge `master` into `feat/agentx`, then merge this PR.

## Validation

- `actionlint .github/workflows/run-sweep.yml`
- Verified fixed-sequence source run `28999997980` selects 80 ingest artifacts
- Verified agentic source run `28955639528` selects 201 ingest artifacts
- Verified merge run `29031436674` provides downstream changelog metadata
