### PR TITLE
[codex] Run reused ingest artifacts on Blacksmith

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -694,7 +694,7 @@ jobs:
             always() &&
             needs.setup.result == 'success' &&
             needs.setup.outputs.reuse-enabled == 'true'
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-4vcpu-ubuntu-2404
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
## Summary

Run `reuse-ingest-artifacts` on the Blacksmith 4-vCPU Ubuntu runner so the reused sweep artifacts fit on its 80 GB disk.

No ingest or artifact-handling logic changes.

## Validation

- `actionlint .github/workflows/run-sweep.yml`
