### PR TITLE
Reliability Fix: Raise container nofile ulimit to prevent FD exhaustion in AMD multi-node jobs

### DIFF
--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -573,6 +573,7 @@ fi
     --device=/dev/infiniband/uverbs7 \
     --ulimit memlock=-1 \
     --ulimit stack=67108864 \
+    --ulimit nofile=1048576:1048576 \
     --network host \
     --ipc host \
     --group-add video \


### PR DESCRIPTION
while doing DI optimization, found that some eval jobs failed.
The failed eval all have max concurrency 1024.

https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28959246164/job/85926289851 , https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28959246164/job/85926289806 , and https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28959246164/job/85926289736 , 

•	85926289851 (1P TP8 x 1D TP8): floods of Too many open files connecting to 10.24.112.105:2584 starting ~line 1341.
•	85926289806 (1P TP4 x 1D TP4): same, connecting to 10.24.112.101:2584 starting ~line 1322.
•	85926289736 (2P TP4 x 1D TP8): same, connecting to both prefill nodes 10.24.112.103/104:2584 starting ~line 1600.

tcp open error caused by: Too many open files (os error 24)

this is because the default ulimit  nofile 1024.
We can raise the ulimit nofile to make the high-concurrency eval jobs less error-prone.

