### PR TITLE
Enable KV offloading for multi-node agentic sweeps / 为多节点 Agentic 扫描启用 KV 卸载

### DIFF
--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -604,8 +604,8 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     prefill = bmk[Fields.PREFILL.value]
                     decode = bmk[Fields.DECODE.value]
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
-                    kv_offloading = "none"
-                    kv_offload_backend = None
+                    kv_offloading = bmk.get(Fields.KV_OFFLOADING.value, "none")
+                    kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
                 else:
                     tp = bmk[Fields.TP.value]
                     dcp_size = bmk.get(Fields.DCP_SIZE.value, 1)
@@ -648,6 +648,13 @@ def generate_full_sweep(args, all_config_data, runner_data):
                 runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
 
                 if is_multinode:
+                    # Preserve historical exp-names for the default (no offload)
+                    # case; only append a suffix when KV offloading is active.
+                    offload_suffix = (
+                        f"_{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                        if kv_offloading != "none"
+                        else ""
+                    )
                     for runner_value in runners_for_entry:
                         for conc_batch in chunk_multinode_agentic_concurrencies(conc_values):
                             entry = {
@@ -661,16 +668,19 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 Fields.PREFILL.value: prefill,
                                 Fields.DECODE.value: decode,
                                 Fields.CONC.value: conc_batch,
-                                Fields.KV_OFFLOADING.value: "none",
+                                Fields.KV_OFFLOADING.value: kv_offloading,
                                 Fields.DURATION.value: duration,
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_p{prefill[Fields.NUM_WORKER.value]}x{prefill[Fields.TP.value]}"
                                     f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}"
                                     f"_conc{'x'.join(str(c) for c in conc_batch)}"
+                                    f"{offload_suffix}"
                                 ),
                                 Fields.DISAGG.value: disagg,
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
+                            if kv_offload_backend is not None:
+                                entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
                             validate_agentic_matrix_entry(entry)
                             matrix_values.append(entry)
                 else:
@@ -885,8 +895,8 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                     prefill = bmk[Fields.PREFILL.value]
                     decode = bmk[Fields.DECODE.value]
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
-                    kv_offloading = "none"
-                    kv_offload_backend = None
+                    kv_offloading = bmk.get(Fields.KV_OFFLOADING.value, "none")
+                    kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
                 else:
                     tp = bmk[Fields.TP.value]
                     dcp_size = bmk.get(Fields.DCP_SIZE.value, 1)
@@ -923,6 +933,13 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                     continue
 
                 if is_multinode:
+                    # Preserve historical exp-names for the default (no offload)
+                    # case; only append a suffix when KV offloading is active.
+                    offload_suffix = (
+                        f"_{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                        if kv_offloading != "none"
+                        else ""
+                    )
                     for runner_value in runners_for_entry:
                         for conc_batch in chunk_multinode_agentic_concurrencies(conc_values):
                             entry = {
@@ -936,16 +953,19 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.PREFILL.value: prefill,
                                 Fields.DECODE.value: decode,
                                 Fields.CONC.value: conc_batch,
-                                Fields.KV_OFFLOADING.value: "none",
+                                Fields.KV_OFFLOADING.value: kv_offloading,
                                 Fields.DURATION.value: duration,
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_p{prefill[Fields.NUM_WORKER.value]}x{prefill[Fields.TP.value]}"
                                     f"_d{decode[Fields.NUM_WORKER.value]}x{decode[Fields.TP.value]}"
                                     f"_conc{'x'.join(str(c) for c in conc_batch)}"
+                                    f"{offload_suffix}"
                                 ),
                                 Fields.DISAGG.value: disagg,
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
+                            if kv_offload_backend is not None:
+                                entry[Fields.KV_OFFLOAD_BACKEND.value] = kv_offload_backend
                             matrix_values.append(validate_agentic_matrix_entry(entry))
                 else:
                     for conc in conc_values:

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -2099,6 +2099,45 @@ class TestGenerateTestConfigSweep:
         assert result[1]["conc"] == [256]
         assert result[1]["exp-name"] == "dsv4_p2x8_d1x8_conc256"
 
+    def test_multinode_agentic_preserves_kv_offload_fields(self):
+        config = {
+            "dsv4-agentic-hicache": {
+                "image": "sglang-rocm",
+                "model": "deepseek-ai/DeepSeek-V4-Pro",
+                "model-prefix": "dsv4",
+                "precision": "fp4",
+                "framework": "sglang-disagg",
+                "runner": "cluster:mi355x-amds",
+                "multinode": True,
+                "disagg": True,
+                "scenarios": {
+                    "agentic-coding": [{
+                        "search-space": [{
+                            "conc-list": [16],
+                            "kv-offloading": "dram",
+                            "kv-offload-backend": "hicache",
+                            "prefill": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
+                            "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
+                        }],
+                    }],
+                },
+            },
+        }
+        args = argparse.Namespace(
+            config_keys=["dsv4-agentic-hicache"],
+            seq_lens=None,
+            conc=None,
+            scenario_type=["agentic-coding"],
+            runner_node_filter=None,
+        )
+
+        result = generate_test_config_sweep(args, config)
+
+        assert len(result) == 1
+        assert result[0]["kv-offloading"] == "dram"
+        assert result[0]["kv-offload-backend"] == "hicache"
+        assert result[0]["exp-name"] == "dsv4_p1x8_d1x8_conc16_kvdram-hicache"
+
 
 # =============================================================================
 # Test apply_node_type_defaults

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -240,7 +240,10 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
     prefill: WorkerConfig
     decode: WorkerConfig
     conc: list[int]
-    kv_offloading: Literal["none"] = Field(alias=Fields.KV_OFFLOADING.value)
+    kv_offloading: Literal["none", "dram"] = Field(alias=Fields.KV_OFFLOADING.value)
+    kv_offload_backend: Optional[str] = Field(
+        default=None, alias=Fields.KV_OFFLOAD_BACKEND.value
+    )
     duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     disagg: bool
@@ -249,6 +252,10 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
     @model_validator(mode='after')
     def validate_worker_hardware_pair(self):
         return _validate_worker_hardware_pair(self)
+
+    @model_validator(mode='after')
+    def validate_kv_offload_fields(self):
+        return _validate_kv_offload_fields(self)
 
 
 AgenticMatrixEntry = Union[SingleNodeAgenticMatrixEntry, MultiNodeAgenticMatrixEntry]


### PR DESCRIPTION
## Summary

Enable multi-node agentic sweep entries to preserve `kv-offloading` and `kv-offload-backend` from their benchmark search-space configuration instead of always forcing `kv-offloading: none`.

This PR is intentionally limited to the shared matrix infrastructure:

- read KV-offload mode and backend in both full-sweep and test-config generation;
- emit those fields in multi-node agentic matrix entries;
- append an offload suffix only for offloaded runs, preserving historical names for `none`;
- allow `dram` in the multi-node Agentic matrix schema and apply the existing KV-offload field-pair validation;
- add a focused regression test for `dram` + `hicache` propagation.

## Motivation

The original AgentX multi-node generator explicitly disabled KV offloading even when the YAML search-space supplied `kv-offloading: dram` and `kv-offload-backend: hicache`. As a result, multi-node disaggregated Agentic recipes could declare host KV offloading but the generated matrix silently replaced it with `none` and discarded the backend.

This separates that general capability from the DeepSeek-V4 MI355X recipe PR.

## Validation

- `PYTHONPATH=. pytest -q utils/matrix_logic/test_generate_sweep_configs.py` — 96 passed
- `python -m py_compile utils/matrix_logic/generate_sweep_configs.py utils/matrix_logic/validation.py`
- `git diff --check`

## 中文说明

本 PR 为多节点 Agentic 扫描补充通用的 KV 卸载配置透传能力。此前，多节点 Agentic 矩阵生成逻辑会无条件写入 `kv-offloading: none`，即使 YAML 搜索空间已经配置了 `kv-offloading: dram` 和 `kv-offload-backend: hicache`，生成结果仍会静默丢弃这些配置。

本 PR 的范围严格限定在共享矩阵基础设施：

- 在完整扫描和测试配置生成路径中读取 KV 卸载模式与后端；
- 将这些字段写入多节点 Agentic 矩阵项；
- 仅在启用卸载时为实验名称追加后缀，保持现有 `none` 配置的历史命名不变；
- 在多节点 Agentic 矩阵校验中允许 `dram`，并复用现有的 KV 卸载字段配对校验；
- 添加一个针对 `dram` + `hicache` 透传行为的回归测试。

这样可以把通用的多节点 Agentic KV 卸载能力与 DeepSeek-V4 MI355X 配方 PR 分离开来。

验证结果：矩阵逻辑测试 96 项全部通过，相关 Python 文件编译检查和 `git diff --check` 均通过。