### PR TITLE
fix: bump vllm-router image to nightly-20260708-b93cbcb / 升级 vllm-router 镜像至 nightly-20260708-b93cbcb

### DIFF
--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -317,7 +317,7 @@ export DOCKER_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_${MODEL_NAME}_${S
 # vLLM external router container.
 # NOTE: vllm/vllm-router only retains ~16 recent nightlies on Docker Hub; older
 # dated tags are garbage-collected (manifest unknown)
-VLLM_ROUTER_IMAGE="${VLLM_ROUTER_IMAGE:-vllm/vllm-router:nightly-20260629-e667ebb}"
+VLLM_ROUTER_IMAGE="${VLLM_ROUTER_IMAGE:-vllm/vllm-router:nightly-20260708-b93cbcb}"
 ROUTER_CONT_NAME="router_vllm_${SANITIZED_USER}_${SLURM_JOB_ID}"
 export RUN_FILE_FULL="$WS_PATH/${RUN_FILE}"
 


### PR DESCRIPTION
## Summary
- Bump the disagg `VLLM_ROUTER_IMAGE` default in `benchmarks/multi_node/amd_utils/job.slurm` from `nightly-20260629-e667ebb` to `nightly-20260708-b93cbcb`.
- **Why:** `vllm/vllm-router` retains only ~15 dated nightlies on Docker Hub (one added daily). `nightly-20260629-e667ebb` is currently the second-oldest retained tag, so it will be garbage-collected within ~1-2 days — after which every multi-node `vllm-disagg` job would fail to pull the router container (a 404, the same class of failure previously seen with the expired `nightly-20260617` tag).
- `nightly-20260708-b93cbcb` was already exercised in a green disagg run, so it's a known-good router build.

This is a small, config-independent infra fix affecting all AMD `vllm-disagg` configs; no `perf-changelog.yaml` change (no benchmark-config change).

## Test plan
- [ ] Confirm `nightly-20260708-b93cbcb` resolves on Docker Hub (HTTP 200).
- [ ] A subsequent multi-node `vllm-disagg` run pulls the router container successfully.

## 中文说明
- 将 `benchmarks/multi_node/amd_utils/job.slurm` 中分离式(disagg)的 `VLLM_ROUTER_IMAGE` 默认值从 `nightly-20260629-e667ebb` 升级为 `nightly-20260708-b93cbcb`。
- **原因：** `vllm/vllm-router` 在 Docker Hub 上仅保留约 15 个每日 nightly 标签（每天新增一个）。`nightly-20260629-e667ebb` 目前是倒数第二个仍保留的标签，一两天内即会被回收；届时所有多节点 `vllm-disagg` 任务都将无法拉取路由器容器（404，与此前 `nightly-20260617` 标签过期时同类的故障）。
- `nightly-20260708-b93cbcb` 已在一次通过的 disagg 运行中验证，是已知可用的路由器构建。

这是一个与具体配置无关的小型基础设施修复，影响所有 AMD `vllm-disagg` 配置；不涉及 `perf-changelog.yaml`（未改动基准配置）。

Made with [Cursor](https://cursor.com)