### PR TITLE
agentic: node-0 sibling benchmark-client container for DSv4 sweeps

### DIFF
--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -349,6 +349,8 @@ export DOCKER_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_${MODEL_NAME}_${S
 # dated tags are garbage-collected (manifest unknown)
 VLLM_ROUTER_IMAGE="${VLLM_ROUTER_IMAGE:-vllm/vllm-router:nightly-20260629-e667ebb}"
 ROUTER_CONT_NAME="router_vllm_${SANITIZED_USER}_${SLURM_JOB_ID}"
+# Separate agentic benchmark-client container (see CLIENT_IMAGE handling below).
+CLIENT_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_client_${SLURM_JOB_ID}"
 export RUN_FILE_FULL="$WS_PATH/${RUN_FILE}"
 
 SELECTED_NODELIST_SRUN=$(echo "$SELECTED_NODES" | paste -sd,)
@@ -518,6 +520,27 @@ echo "[config] wrote HiCache/Mooncake settings -> $HICACHE_MC_CONFIG"
 # Engine-specific container filter for pre-clean
 CONT_FILTER="name=^container_${ENGINE}_"
 
+# =============================================================================
+# Optional: separate benchmark-client image (agentic runs) — node-0 sibling
+# =============================================================================
+# When CLIENT_IMAGE is set, node 0 runs the aiperf trace replay in its own
+# sibling container built from CLIENT_IMAGE (which ships a pre-baked aiperf +
+# deps), instead of rebuilding the aiperf venv inside the server container every
+# run. Give the server container access to the host docker socket + CLI and the
+# host paths the sibling needs for its bind mounts. These fragments are expanded
+# at submit time and injected into the server `docker run` below; empty (no-op)
+# when CLIENT_IMAGE is unset, so the in-container aiperf path is unchanged.
+CLIENT_DOCKER_MOUNTS=""
+CLIENT_DOCKER_ENV=""
+if [[ -n "${CLIENT_IMAGE:-}" ]]; then
+    HOST_DOCKER_BIN="$(command -v docker || echo /usr/bin/docker)"
+    CLIENT_DOCKER_MOUNTS="-v /var/run/docker.sock:/var/run/docker.sock -v ${HOST_DOCKER_BIN}:/usr/bin/docker"
+    CLIENT_DOCKER_ENV="-e CLIENT_IMAGE=${CLIENT_IMAGE} -e HOST_REPO_DIR=${DI_REPO_DIR} -e HOST_MODEL_DIR=${MODEL_DIR} -e HOST_BENCH_LOGS=${BENCHMARK_LOGS_DIR} -e CLIENT_CONT_NAME=${CLIENT_CONT_NAME}"
+    echo "[client] node-0 sibling benchmark-client image enabled: ${CLIENT_IMAGE}"
+    # Best-effort pre-pull on all nodes so node 0's sibling launch doesn't stall.
+    srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c 'eval "$DOCKER_CMD_DETECT"; $DOCKER_CMD pull '"$CLIENT_IMAGE"' >/dev/null 2>&1 || true' 2>/dev/null || true
+fi
+
 srun \
   --nodelist="$SELECTED_NODELIST_SRUN" \
   --kill-on-bad-exit=1 \
@@ -678,9 +701,11 @@ fi
     -v ${DI_REPO_DIR}:${DOCKER_MOUNT_PATH} \
     -v ${HICACHE_MC_CONFIG}:/config/hicache_mc.env:ro \
     ${EXTRA_DOCKER_MOUNTS:-} \
+    ${CLIENT_DOCKER_MOUNTS} \
     \${RDMA_MOUNTS[@]+"\${RDMA_MOUNTS[@]}"} \
     ${DOCKER_ENV_COMMON[*]} \
     ${DOCKER_ENV_ENGINE[*]} \
+    ${CLIENT_DOCKER_ENV} \
     --name \"$DOCKER_CONT_NAME\" \
     --entrypoint \"\" \
     \"$DOCKER_IMAGE_NAME\" bash -lc '
@@ -697,7 +722,7 @@ exit \$DOCKER_EXIT_CODE
 "
 
 if [[ "${KEEP_CONTAINERS}" != "1" ]]; then
-    srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c 'eval "$DOCKER_CMD_DETECT"; $DOCKER_CMD rm -f '"$DOCKER_CONT_NAME"' 2>/dev/null || true'
+    srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c 'eval "$DOCKER_CMD_DETECT"; $DOCKER_CMD rm -f '"$DOCKER_CONT_NAME"' '"$CLIENT_CONT_NAME"' 2>/dev/null || true'
 
     # Clean up vLLM external router container on node 0
     if [[ "$ENGINE" == "vllm-disagg" && "$ROUTER_TYPE" == "vllm-router" ]]; then

--- a/benchmarks/multi_node/amd_utils/server_sglang.sh
+++ b/benchmarks/multi_node/amd_utils/server_sglang.sh
@@ -762,10 +762,65 @@ if [ "$NODE_RANK" -eq 0 ]; then
         echo "Benchmark runner: bench.sh (fixed-seq-len)"
     fi
 
+    IS_AGENTIC_RUN=0
+    if [[ "${IS_AGENTIC:-0}" == "1" || "${IS_AGENTIC:-}" == "true" ]]; then
+        IS_AGENTIC_RUN=1
+    fi
+
     if [[ "${EVAL_ONLY:-false}" == "true" ]]; then
         echo "EVAL_ONLY mode: skipping throughput benchmark"
     elif [[ "$DRY_RUN" -eq 1 ]]; then
         echo "DRY RUN: $BENCH_CMD"
+    elif [[ -n "${CLIENT_IMAGE:-}" && "$IS_AGENTIC_RUN" == "1" ]]; then
+        # Separate client image (node-0 sibling container): run the aiperf trace
+        # replay in its own sibling container built from CLIENT_IMAGE (which ships
+        # a pre-baked aiperf + deps) instead of rebuilding the aiperf venv inside
+        # this server container. The server/router stay up in this container while
+        # the client container drives the benchmark against the router on
+        # localhost (--network host). job.slurm mounts the host docker socket + CLI
+        # into this container and forwards HOST_REPO_DIR / HOST_MODEL_DIR /
+        # HOST_BENCH_LOGS / CLIENT_CONT_NAME so the sibling can be launched here.
+        CLIENT_ENV_FILE="/run_logs/slurm_job-${SLURM_JOB_ID}/client.env"
+        mkdir -p "/run_logs/slurm_job-${SLURM_JOB_ID}"
+        # Forward the benchmark-relevant env (incl. runtime-computed metrics/flush
+        # URLs) to the client container; override the few paths/flags that differ
+        # inside the pre-baked image. Unset vars are skipped, so the client keeps
+        # its own defaults for anything not exported here.
+        {
+            for _v in ENGINE MODEL_NAME MODEL_PREFIX PRECISION FRAMEWORK SPEC_DECODING \
+                      DURATION MAX_MODEL_LEN RESULT_FILENAME RUNNER_NAME \
+                      AIPERF_SERVER_METRICS_URLS SERVER_FLUSH_URLS_CSV \
+                      ENABLE_METRICS IS_AGENTIC CLEAR_CACHE_BETWEEN_CONC \
+                      KV_OFFLOADING KV_OFFLOAD_BACKEND TOTAL_CPU_DRAM_GB \
+                      WEKA_LOADER_OVERRIDE AIPERF_FAILED_REQUEST_THRESHOLD \
+                      AIPERF_AGENTIC_CACHE_WARMUP_DURATION AIPERF_UNSAFE_OVERRIDE \
+                      AIPERF_TRAJECTORY_START_MIN_RATIO AIPERF_TRAJECTORY_START_MAX_RATIO \
+                      AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES ROUTER_PORT TQDM_MININTERVAL; do
+                if [[ -n "${!_v+x}" ]]; then printf '%s=%s\n' "$_v" "${!_v}"; fi
+            done
+            echo "INFMAX_CONTAINER_WORKSPACE=/workspace"
+            echo "AGENTIC_OUTPUT_DIR=/run_logs/slurm_job-${SLURM_JOB_ID}"
+            echo "HF_HOME=/run_logs/hf_cache"
+            echo "AIPERF_USE_PREBUILT=1"
+            echo "AIPERF_VENV=/opt/venv"
+            echo "MODEL_DIR=/models"
+        } > "$CLIENT_ENV_FILE"
+
+        echo "Launching agentic benchmark in separate client container: ${CLIENT_IMAGE}"
+        docker rm -f "${CLIENT_CONT_NAME}" 2>/dev/null || true
+        set -x
+        docker run --rm --network host \
+            --name "${CLIENT_CONT_NAME}" \
+            --shm-size 32G \
+            -v "${HOST_REPO_DIR}:/workspace" \
+            -v "${HOST_MODEL_DIR}:/models" \
+            -v /tmp:/run_logs \
+            -v "${HOST_BENCH_LOGS}:/benchmark_logs" \
+            --env-file "${CLIENT_ENV_FILE}" \
+            --entrypoint "" \
+            "${CLIENT_IMAGE}" \
+            bash -lc "cd /workspace/benchmarks/multi_node/amd_utils && bash trace_replay.sh /models ${MODEL_NAME} \"${BENCH_MAX_CONCURRENCY}\" /run_logs/slurm_job-${SLURM_JOB_ID}"
+        set +x
     else
         set -x
         eval "$BENCH_CMD"

--- a/benchmarks/multi_node/amd_utils/server_sglang.sh
+++ b/benchmarks/multi_node/amd_utils/server_sglang.sh
@@ -801,9 +801,15 @@ if [ "$NODE_RANK" -eq 0 ]; then
             echo "INFMAX_CONTAINER_WORKSPACE=/workspace"
             echo "AGENTIC_OUTPUT_DIR=/run_logs/slurm_job-${SLURM_JOB_ID}"
             echo "HF_HOME=/run_logs/hf_cache"
-            echo "AIPERF_USE_PREBUILT=1"
-            echo "AIPERF_VENV=/opt/venv"
             echo "MODEL_DIR=/models"
+            # A pre-baked client image ships aiperf at CLIENT_AIPERF_VENV; when
+            # unset (e.g. reusing the server image, which carries no pre-baked
+            # venv), trace_replay builds aiperf on the fly from
+            # /workspace/utils/aiperf — same as the co-located path.
+            if [[ -n "${CLIENT_AIPERF_VENV:-}" ]]; then
+                echo "AIPERF_USE_PREBUILT=1"
+                echo "AIPERF_VENV=${CLIENT_AIPERF_VENV}"
+            fi
         } > "$CLIENT_ENV_FILE"
 
         echo "Launching agentic benchmark in separate client container: ${CLIENT_IMAGE}"

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -3054,6 +3054,12 @@ dsv4-fp4-mi355x-sglang-disagg-agentic-hicache:
           dp-attn: false
           additional-settings:
           - "PREFILL_NODES=1"
+          # Node-0 sibling client: run the aiperf trace-replay in its own
+          # pre-baked container on node 0 (via the host docker socket) instead of
+          # rebuilding the aiperf venv inside the server container, so the client
+          # does not steal CPU from the sglang scheduler + router. Setting only
+          # CLIENT_IMAGE (no CLIENT_NODES) selects the sibling-container mode.
+          - "CLIENT_IMAGE=rocm/pytorch-private:sglang-0.5.14-rocm720-mi35x-20260702-agentx-client-20260703-111826"
         decode:
           num-worker: 1
           tp: 8

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -3054,12 +3054,13 @@ dsv4-fp4-mi355x-sglang-disagg-agentic-hicache:
           dp-attn: false
           additional-settings:
           - "PREFILL_NODES=1"
-          # Node-0 sibling client: run the aiperf trace-replay in its own
-          # pre-baked container on node 0 (via the host docker socket) instead of
-          # rebuilding the aiperf venv inside the server container, so the client
-          # does not steal CPU from the sglang scheduler + router. Setting only
-          # CLIENT_IMAGE (no CLIENT_NODES) selects the sibling-container mode.
-          - "CLIENT_IMAGE=rocm/pytorch-private:sglang-0.5.14-rocm720-mi35x-20260702-agentx-client-20260703-111826"
+          # Node-0 sibling client: run the aiperf trace-replay in its own sibling
+          # container on node 0 (via the host docker socket) instead of inside the
+          # server container. Reuse the (publicly pullable) server image so
+          # upstream CI can fetch it; aiperf is built on the fly from
+          # /workspace/utils/aiperf. Setting only CLIENT_IMAGE (no CLIENT_NODES)
+          # selects the sibling-container mode.
+          - "CLIENT_IMAGE=lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260710"
         decode:
           num-worker: 1
           tp: 8


### PR DESCRIPTION
## Summary
Ports the **node-0 sibling benchmark-client container** mode from `ROCm/InferenceY` into this branch. When `CLIENT_IMAGE` is set (and `CLIENT_NODES` is **not**), node 0 launches the aiperf trace replay in its own pre-baked container via the host docker socket, instead of rebuilding the aiperf venv inside the server container and running it **co-located**.

Motivation: on the current DSv4 1P1D agentic sweep the aiperf client runs inside the server container on the single prefill node. Its CPU-heavy tokenize/aggregate work competes with the sglang scheduler + router, inflating TTFT/E2E and lowering throughput (heavy p99 tails observed in CI). Running the client as a sibling container isolates that load while keeping it on the same node (`--network host`, router on localhost).

Only the **sibling-container** mode is ported — the separate-client-**node** mode (`CLIENT_NODES`/`RUN_CLIENT_ON_SEPARATE_NODE`) is intentionally left out.

## Changes
- `benchmarks/multi_node/amd_utils/server_sglang.sh`: add `IS_AGENTIC_RUN` and a `CLIENT_IMAGE` sibling-container branch that writes `client.env` (forwarding the benchmark-relevant env + runtime-computed metrics/flush URLs) and `docker run`s the client against the local router.
- `benchmarks/multi_node/amd_utils/job.slurm`: define `CLIENT_CONT_NAME`; when `CLIENT_IMAGE` is set, mount the host docker socket + CLI into the server container, forward `HOST_REPO_DIR`/`HOST_MODEL_DIR`/`HOST_BENCH_LOGS`/`CLIENT_CONT_NAME`, pre-pull the client image, and clean up the client container on teardown. No-op when `CLIENT_IMAGE` is unset (in-container aiperf path unchanged).
- `configs/amd-master.yaml`: enable the sibling client on `dsv4-fp4-mi355x-sglang-disagg-agentic-hicache` via a single `CLIENT_IMAGE` additional-setting.

## Test plan
- [ ] `bash -n` on both scripts + YAML load (done locally).
- [ ] Dispatch `dsv4-fp4-mi355x-sglang-disagg-agentic-hicache`; confirm log shows `Launching agentic benchmark in separate client container: <CLIENT_IMAGE>` and NOT the co-located `trace_replay.sh` path.
- [ ] Confirm client container starts, drives the sweep against the localhost router, and results/artifacts land under the job's `/run_logs` + `benchmark_logs`.
- [ ] Confirm the client container is removed on normal exit and on scancel.
- [ ] Sanity vs a co-located baseline: TTFT/throughput/E2E should improve (esp. p99 tails).