### PR TITLE
[WIP] MiniMax-M3 B300: use FlashInfer split-K nightly

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
@@ -3,7 +3,9 @@
 # MiniMax-M3 NVFP4 B300 single-node vLLM recipe.
 # Same shape as minimaxm3_fp8_b300.sh but uses the nvidia/MiniMax-M3-NVFP4
 # checkpoint. MiniMax-M3 modelopt NVFP4 support (vllm-project/vllm PR #46380) is
-# baked into the perf container image, so no runtime patch is needed.
+# baked into the perf container image. The FlashInfer runtime is pinned to the
+# first nightly containing the upstream SM100 low-M MXFP8 split-K kernel
+# (flashinfer-ai/flashinfer#3847).
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -18,6 +20,23 @@ check_env_vars \
     MAX_MODEL_LEN \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
+
+FLASHINFER_VERSION=0.6.15.dev20260710
+FLASHINFER_RELEASE_URL="https://github.com/flashinfer-ai/flashinfer/releases/download/nightly-v0.6.15-20260710"
+
+python3 -m pip uninstall -y flashinfer-python flashinfer-cubin flashinfer-jit-cache
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_python-${FLASHINFER_VERSION}-py3-none-any.whl" \
+    || { echo "FlashInfer ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_cubin-${FLASHINFER_VERSION}-py3-none-any.whl" \
+    || { echo "FlashInfer cubin ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_jit_cache-${FLASHINFER_VERSION}+cu130-cp39-abi3-manylinux_2_28_x86_64.whl" \
+    || { echo "FlashInfer JIT cache ${FLASHINFER_VERSION}+cu130 install failed" >&2; exit 1; }
 
 if [[ -n "${MODEL_PATH:-}" ]]; then
     if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
@@ -39,6 +58,7 @@ SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_FLOAT32_MATMUL_PRECISION=high
 export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -57,6 +77,7 @@ start_gpu_monitor
 set -x
 vllm serve "$MODEL_PATH" --served-model-name "$MODEL" --host 0.0.0.0 --port $PORT \
 $PARALLEL_ARGS \
+--attention_config.indexer_kv_dtype fp8 \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --kv-cache-dtype fp8 \

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -13559,7 +13559,7 @@ minimaxm3-fp8-b300-vllm:
 # weights are pre-staged read-only at /scratch/models/MiniMax-M3-NVFP4 (added to
 # the STAGED_MODELS allow-list in launch_b300-nv.sh).
 minimaxm3-fp4-b300-vllm:
-  image: vllm/vllm-openai:nightly-93d8f834dd8acf33eb0e2a75b2711b628cb6e226
+  image: vllm/vllm-openai:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: b300
@@ -13575,15 +13575,12 @@ minimaxm3-fp4-b300-vllm:
       - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 2, conc-start: 4, conc-end: 256 }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 4096, conc-end: 4096 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, conc-start: 1, conc-end: 2 }
       - { tp: 4, conc-start: 1, conc-end: 2 }
       - { tp: 2, conc-start: 4, conc-end: 256 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of MiniMax-M3 NVFP4
 # (nvidia/MiniMax-M3-NVFP4) B300 single-node vLLM, pairing the target with the

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4699,3 +4699,11 @@
     - "Clean the export envs"
     - "Enable two batch overlap"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2093
+
+- config-keys:
+    - minimaxm3-fp4-b300-vllm
+  description:
+    - "Bump the vLLM image to nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9"
+    - "Install FlashInfer 0.6.15.dev20260710 with upstream SM100 low-M MXFP8 split-K support"
+    - "Use FP8 indexer KV cache, extend the model execution timeout, and remove DP-attention sweep points"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2148


### PR DESCRIPTION
## Summary
- bump the MiniMax-M3 NVFP4 B300 vLLM image
- install the July 10 FlashInfer nightly containing upstream SM100 low-M MXFP8 split-K support
- use FP8 indexer KV cache and extend the model execution timeout
- remove DP-attention points from the non-MTP sweep

## Validation
- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh`
- generated 31 non-MTP B300 rows with `dp-attn=false`
- `pytest utils/matrix_logic/ -q` (189 passed)
- verified all three pinned FlashInfer release assets resolve