### PR TITLE
[WIP] Comparison branch for #2148: BF16 gate on main

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
@@ -3,7 +3,9 @@
 # MiniMax-M3 NVFP4 B300 single-node vLLM recipe.
 # Same shape as minimaxm3_fp8_b300.sh but uses the nvidia/MiniMax-M3-NVFP4
 # checkpoint. MiniMax-M3 modelopt NVFP4 support (vllm-project/vllm PR #46380) is
-# baked into the perf container image, so no runtime patch is needed.
+# baked into the perf container image. The FlashInfer runtime is pinned to the
+# first nightly containing the upstream SM100 low-M MXFP8 split-K kernel
+# (flashinfer-ai/flashinfer#3847).
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -18,6 +20,23 @@ check_env_vars \
     MAX_MODEL_LEN \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
+
+FLASHINFER_VERSION=0.6.15.dev20260710
+FLASHINFER_RELEASE_URL="https://github.com/flashinfer-ai/flashinfer/releases/download/nightly-v0.6.15-20260710"
+
+python3 -m pip uninstall -y flashinfer-python flashinfer-cubin flashinfer-jit-cache
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_python-${FLASHINFER_VERSION}-py3-none-any.whl" \
+    || { echo "FlashInfer ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_cubin-${FLASHINFER_VERSION}-py3-none-any.whl" \
+    || { echo "FlashInfer cubin ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
+
+python3 -m pip install --no-deps \
+    "${FLASHINFER_RELEASE_URL}/flashinfer_jit_cache-${FLASHINFER_VERSION}+cu130-cp39-abi3-manylinux_2_28_x86_64.whl" \
+    || { echo "FlashInfer JIT cache ${FLASHINFER_VERSION}+cu130 install failed" >&2; exit 1; }
 
 if [[ -n "${MODEL_PATH:-}" ]]; then
     if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
@@ -39,6 +58,7 @@ SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_FLOAT32_MATMUL_PRECISION=high
 export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -57,6 +77,7 @@ start_gpu_monitor
 set -x
 vllm serve "$MODEL_PATH" --served-model-name "$MODEL" --host 0.0.0.0 --port $PORT \
 $PARALLEL_ARGS \
+--attention_config.indexer_kv_dtype fp8 \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --kv-cache-dtype fp8 \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
@@ -3,9 +3,7 @@
 # MiniMax-M3 NVFP4 B300 single-node vLLM recipe.
 # Same shape as minimaxm3_fp8_b300.sh but uses the nvidia/MiniMax-M3-NVFP4
 # checkpoint. MiniMax-M3 modelopt NVFP4 support (vllm-project/vllm PR #46380) is
-# baked into the perf container image. The FlashInfer runtime is pinned to the
-# first nightly containing the upstream SM100 low-M MXFP8 split-K kernel
-# (flashinfer-ai/flashinfer#3847).
+# baked into the perf container image, so no runtime patch is needed.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -21,24 +19,7 @@ check_env_vars \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 
-FLASHINFER_VERSION=0.6.15.dev20260710
-FLASHINFER_RELEASE_URL="https://github.com/flashinfer-ai/flashinfer/releases/download/nightly-v0.6.15-20260710"
-
-python3 -m pip uninstall -y flashinfer-python flashinfer-cubin flashinfer-jit-cache
-
-python3 -m pip install --no-deps \
-    "${FLASHINFER_RELEASE_URL}/flashinfer_python-${FLASHINFER_VERSION}-py3-none-any.whl" \
-    || { echo "FlashInfer ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
-
-python3 -m pip install --no-deps \
-    "${FLASHINFER_RELEASE_URL}/flashinfer_cubin-${FLASHINFER_VERSION}-py3-none-any.whl" \
-    || { echo "FlashInfer cubin ${FLASHINFER_VERSION} install failed" >&2; exit 1; }
-
-python3 -m pip install --no-deps \
-    "${FLASHINFER_RELEASE_URL}/flashinfer_jit_cache-${FLASHINFER_VERSION}+cu130-cp39-abi3-manylinux_2_28_x86_64.whl" \
-    || { echo "FlashInfer JIT cache ${FLASHINFER_VERSION}+cu130 install failed" >&2; exit 1; }
-
-# Test the BF16 MiniMax-M3 routing gate with the upstream FlashInfer nightly.
+# Test the BF16 MiniMax-M3 routing gate against the main branch runtime.
 VLLM_GATE_PATCH="$(dirname "$0")/patches/vllm-minimaxm3-gate-bf16.patch"
 if ! command -v patch >/dev/null 2>&1; then
     apt-get update -y && apt-get install -y --no-install-recommends patch \
@@ -72,7 +53,6 @@ SERVER_LOG=/workspace/server.log
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_FLOAT32_MATMUL_PRECISION=high
 export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
-export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -91,7 +71,6 @@ start_gpu_monitor
 set -x
 vllm serve "$MODEL_PATH" --served-model-name "$MODEL" --host 0.0.0.0 --port $PORT \
 $PARALLEL_ARGS \
---attention_config.indexer_kv_dtype fp8 \
 --gpu-memory-utilization 0.95 \
 --max-model-len $MAX_MODEL_LEN \
 --kv-cache-dtype fp8 \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh
@@ -38,6 +38,20 @@ python3 -m pip install --no-deps \
     "${FLASHINFER_RELEASE_URL}/flashinfer_jit_cache-${FLASHINFER_VERSION}+cu130-cp39-abi3-manylinux_2_28_x86_64.whl" \
     || { echo "FlashInfer JIT cache ${FLASHINFER_VERSION}+cu130 install failed" >&2; exit 1; }
 
+# Test the BF16 MiniMax-M3 routing gate with the upstream FlashInfer nightly.
+VLLM_GATE_PATCH="$(dirname "$0")/patches/vllm-minimaxm3-gate-bf16.patch"
+if ! command -v patch >/dev/null 2>&1; then
+    apt-get update -y && apt-get install -y --no-install-recommends patch \
+        || { echo "Failed to install patch(1)" >&2; exit 1; }
+fi
+VLLM_PACKAGE_DIR=$(python3 -c "import importlib.util; print(importlib.util.find_spec('vllm').submodule_search_locations[0])") \
+    || { echo "Could not locate the installed vllm package" >&2; exit 1; }
+VLLM_SITE_PACKAGES=$(dirname "$VLLM_PACKAGE_DIR")
+patch --dry-run -p1 -d "$VLLM_SITE_PACKAGES" < "$VLLM_GATE_PATCH" >/dev/null \
+    || { echo "vLLM MiniMax-M3 GateLinear BF16 patch does not apply" >&2; exit 1; }
+patch -p1 -d "$VLLM_SITE_PACKAGES" < "$VLLM_GATE_PATCH" \
+    || { echo "vLLM MiniMax-M3 GateLinear BF16 patch failed" >&2; exit 1; }
+
 if [[ -n "${MODEL_PATH:-}" ]]; then
     if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
         hf download "$MODEL" --local-dir "$MODEL_PATH"

--- a/benchmarks/single_node/fixed_seq_len/patches/vllm-minimaxm3-gate-bf16.patch
+++ b/benchmarks/single_node/fixed_seq_len/patches/vllm-minimaxm3-gate-bf16.patch
@@ -1,0 +1,11 @@
+--- a/vllm/models/minimax_m3/nvidia/model.py
++++ b/vllm/models/minimax_m3/nvidia/model.py
+@@ -228,7 +228,7 @@
+             config.hidden_size,
+             config.num_local_experts,
+             bias=False,
+-            params_dtype=torch.float32,
++            params_dtype=torch.bfloat16,
+             out_dtype=torch.float32,
+             prefix=f"{prefix}.gate",
+         )

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -13559,7 +13559,7 @@ minimaxm3-fp8-b300-vllm:
 # weights are pre-staged read-only at /scratch/models/MiniMax-M3-NVFP4 (added to
 # the STAGED_MODELS allow-list in launch_b300-nv.sh).
 minimaxm3-fp4-b300-vllm:
-  image: vllm/vllm-openai:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
+  image: vllm/vllm-openai:nightly-93d8f834dd8acf33eb0e2a75b2711b628cb6e226
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: b300

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -13559,7 +13559,7 @@ minimaxm3-fp8-b300-vllm:
 # weights are pre-staged read-only at /scratch/models/MiniMax-M3-NVFP4 (added to
 # the STAGED_MODELS allow-list in launch_b300-nv.sh).
 minimaxm3-fp4-b300-vllm:
-  image: vllm/vllm-openai:nightly-93d8f834dd8acf33eb0e2a75b2711b628cb6e226
+  image: vllm/vllm-openai:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: b300
@@ -13575,15 +13575,12 @@ minimaxm3-fp4-b300-vllm:
       - { tp: 4, conc-start: 1, conc-end: 64 }
       - { tp: 2, conc-start: 4, conc-end: 256 }
       - { tp: 4, ep: 4, conc-start: 64, conc-end: 512 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 4096, conc-end: 4096 }
     - isl: 8192
       osl: 1024
       search-space:
       - { tp: 8, conc-start: 1, conc-end: 2 }
       - { tp: 4, conc-start: 1, conc-end: 2 }
       - { tp: 2, conc-start: 4, conc-end: 256 }
-      - { tp: 2, ep: 2, dp-attn: true, conc-start: 512, conc-end: 512 }
 
 # EAGLE3 speculative-decoding (spec-decoding: mtp) variant of MiniMax-M3 NVFP4
 # (nvidia/MiniMax-M3-NVFP4) B300 single-node vLLM, pairing the target with the

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4711,8 +4711,6 @@
 - config-keys:
     - minimaxm3-fp4-b300-vllm
   description:
-    - "Bump the vLLM image to nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9"
-    - "Install FlashInfer 0.6.15.dev20260710 with upstream SM100 low-M MXFP8 split-K support"
-    - "Use FP8 indexer KV cache, extend the model execution timeout, and remove DP-attention sweep points"
-    - "Test the BF16 MiniMax-M3 routing gate as a branch of PR #2148"
+    - "Test the BF16 MiniMax-M3 routing gate against the main branch image and bundled FlashInfer runtime"
+    - "Keep the existing non-DP serving configuration and omit DP-attention sweep points"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2149

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4707,4 +4707,4 @@
     - "Install FlashInfer 0.6.15.dev20260710 with upstream SM100 low-M MXFP8 split-K support"
     - "Use FP8 indexer KV cache, extend the model execution timeout, and remove DP-attention sweep points"
     - "Test the BF16 MiniMax-M3 routing gate as a branch of PR #2148"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2149

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4706,4 +4706,5 @@
     - "Bump the vLLM image to nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9"
     - "Install FlashInfer 0.6.15.dev20260710 with upstream SM100 low-M MXFP8 split-K support"
     - "Use FP8 indexer KV cache, extend the model execution timeout, and remove DP-attention sweep points"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2148
+    - "Test the BF16 MiniMax-M3 routing gate as a branch of PR #2148"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4699,3 +4699,11 @@
     - "Clean the export envs"
     - "Enable two batch overlap"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2093
+
+- config-keys:
+    - minimaxm3-fp4-b300-vllm
+  description:
+    - "Bump the vLLM image to nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9"
+    - "Install FlashInfer 0.6.15.dev20260710 with upstream SM100 low-M MXFP8 split-K support"
+    - "Use FP8 indexer KV cache, extend the model execution timeout, and remove DP-attention sweep points"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2148


### PR DESCRIPTION
## Summary

This is a comparison branch for #2148 that tests the MiniMax-M3 BF16 routing gate directly against `main`.

It keeps `main`'s vLLM image, bundled FlashInfer runtime, and serving configuration unchanged. The only runtime difference is a vLLM MiniMax-M3 gate patch that changes the routing gate parameter dtype from FP32 to BF16 while preserving FP32 output. DP-attention rows are omitted from the sweep.

## Motivation

PR #2148's latest-nightly TP2 c256 result regressed despite effectively identical available memory and KV-cache capacity. Since `main` is already faster, this PR measures the BF16 gate change on the `main` runtime without carrying over #2148's FlashInfer nightly, image, FP8 indexer-KV, or timeout changes.

## Validation

- `bash -n benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b300.sh`
- `utils/validate_perf_changelog.py` against `origin/main`
- Generated matrix: 20 single-node 1k/1k rows, 11 single-node 8k/1k rows, and 2 eval rows
- Confirmed 8k/1k TP2 includes concurrency 4 through 256 on main's `nightly-93d8f834dd8acf33eb0e2a75b2711b628cb6e226` image with DP attention disabled
