### PR TITLE
[AgentX] Fix trace selection for 1M-context models

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1340,17 +1340,20 @@ resolve_trace_source() {
     # unfiltered corpus and switches to the 256k-capped variant), or
     # by recipes that want to pin an older corpus generation.
     #
-    # Default (no override): the 062126 v7 corpus, selected by model family.
-    # DSv4 (full context) rides the unfiltered base corpus; every non-DSv4
-    # recipe defaults to the 256k-capped variant because those servers run at
-    # max_model_len ~256k and would reject >256k requests. Any recipe can still
-    # pin a specific corpus via WEKA_LOADER_OVERRIDE.
+    # Default (no override): the 062126 v7 corpus, selected by the model
+    # family's native context length. Models with a 1M-token default context
+    # use the unfiltered corpus; shorter-context families use the 256k-capped
+    # variant. Any recipe can still pin a specific corpus via
+    # WEKA_LOADER_OVERRIDE.
     local default_loader
-    if [[ "${MODEL_PREFIX:-}" == dsv4* ]]; then
-        default_loader="semianalysis_cc_traces_weka_062126"
-    else
-        default_loader="semianalysis_cc_traces_weka_062126_256k"
-    fi
+    case "${MODEL_PREFIX:-}" in
+        dsv4*|minimaxm3*)
+            default_loader="semianalysis_cc_traces_weka_062126"
+            ;;
+        *)
+            default_loader="semianalysis_cc_traces_weka_062126_256k"
+            ;;
+    esac
     local loader="${WEKA_LOADER_OVERRIDE:-$default_loader}"
     local dataset
     case "$loader" in


### PR DESCRIPTION
## Summary

- Select the uncapped `semianalysis_cc_traces_weka_062126` corpus by default for AgentX model families with a native 1M-token context.
- Add MiniMax-M3 alongside DeepSeek-V4 to the full-context model allowlist.
- Preserve the 256K-capped default for shorter-context model families and preserve explicit `WEKA_LOADER_OVERRIDE` behavior.

## Root cause

`resolve_trace_source` treated every model family other than DeepSeek-V4 as a 256K-context model. MiniMax-M3 has a native 1M-token context, so it was incorrectly assigned the capped corpus unless each recipe manually overrode the loader.

## Validation

- `bash -n benchmarks/benchmark_lib.sh`
- `git diff --check`
- Focused shell assertions for `dsv4`, `minimaxm3`, shorter-context families, prefix matching, and explicit override precedence

## 中文说明

- AgentX 默认根据模型原生上下文长度选择数据集：DeepSeek-V4 和 MiniMax-M3 使用未裁剪的 062126 语料。
- 较短上下文模型继续默认使用 256K 裁剪版本。
- 每个 recipe 显式设置的 `WEKA_LOADER_OVERRIDE` 仍然优先。