### PR TITLE
ci: route agentic ingests to the production database / 将 agentic 入库路由至生产数据库

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -391,10 +391,10 @@ jobs:
                     -H "Accept: application/vnd.github+v3+json" \
                     https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
                     -d '{
-                      "ref": "feat/agentx",
+                      "ref": "master",
                       "inputs": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
-                        "database-target": "agentx-v1"
+                        "database-target": "production"
                       }
                     }'

--- a/.github/workflows/recover-reused-ingest.yml
+++ b/.github/workflows/recover-reused-ingest.yml
@@ -158,17 +158,17 @@ jobs:
         needs: package-reused-artifacts
         runs-on: ubuntu-latest
         steps:
-            - name: Trigger AgentX database ingest
+            - name: Trigger agentic database ingest
               run: |
                   curl -sSf -X POST \
                     -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
                     -H "Accept: application/vnd.github+v3+json" \
                     https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
                     -d '{
-                      "ref": "feat/agentx",
+                      "ref": "master",
                       "inputs": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
-                        "database-target": "agentx-v1"
+                        "database-target": "production"
                       }
                     }'

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -933,11 +933,11 @@ jobs:
                     -H "Accept: application/vnd.github+v3+json" \
                     https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
                     -d '{
-                      "ref": "feat/agentx",
+                      "ref": "master",
                       "inputs": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
-                        "database-target": "agentx-v1"
+                        "database-target": "production"
                       }
                     }'
 


### PR DESCRIPTION
## Summary

The agentx-v1 staging Neon database is retired: its agentic-traces data was migrated into the main production DB on **2026-07-10**, and from now on all results — including agentic — are ingested directly into production.

This updates the three agentic ingest dispatches (`run-sweep.yml` single/multi-node sweep path, `e2e-tests.yml` test-sweep path, `recover-reused-ingest.yml` reused-artifact recovery path) to run `SemiAnalysisAI/InferenceX-app`'s `ingest-agentic-results.yml` from **`master`** with **`database-target=production`** — previously `ref=feat/agentx` with `database-target=agentx-v1` (#2130). Agentic runs keep using the dedicated agentic ingest workflow (blob-heavy artifacts need its longer timeout); only the target DB and workflow ref change.

**Intentionally kept:** the "skip the regular production ingest when the sweep contains agentic matrices" gating from #2131. The agentic ingest workflow downloads *all* artifacts for the run and executes the same ingest script, so it fully ingests such runs into production on its own. Re-enabling the regular `ingest-results` dispatch for agentic-containing runs would double-ingest the same run now that both paths write to one database. Please don't "simplify" that condition away.

Companion PR in `InferenceX-app` (removing the `agentx-v1` target from `ingest-agentic-results.yml`) merges first, so the workflow state referenced here is already live on `master`.

### Follow-ups requiring settings changes (not possible in code)

- Delete the `DATABASE_AGENTX_V1_WRITE_URL` secret in `InferenceX-app`'s Actions secrets.
- Decommission the agentx-v1 Neon project and retire the `feat/agentx` branch + Vercel preview of `InferenceX-app`.

## 中文说明

agentx-v1 暂存 Neon 数据库已退役：其 agentic-traces 数据已于 **2026-07-10** 迁移至主生产数据库，此后所有结果（包括 agentic）均直接写入生产数据库。

本 PR 更新三处 agentic 入库调度（`run-sweep.yml` 单/多节点扫描路径、`e2e-tests.yml` 测试扫描路径、`recover-reused-ingest.yml` 产物复用恢复路径），改为从 **`master`** 分支运行 `InferenceX-app` 的 `ingest-agentic-results.yml`，并设置 **`database-target=production`**（此前为 `ref=feat/agentx` + `agentx-v1`，见 #2130）。agentic run 仍使用专用入库工作流（大体积产物需要更长超时），仅目标数据库与工作流 ref 变更。

**有意保留** #2131 引入的"扫描包含 agentic 矩阵时跳过常规生产入库"逻辑：agentic 入库工作流会下载该 run 的全部产物并执行同一入库脚本，可独立完成生产入库；两条路径现共用一个数据库，若恢复常规入库将导致同一 run 重复写入。请勿将该条件"简化"移除。

`InferenceX-app` 的配套 PR（移除 `ingest-agentic-results.yml` 中的 `agentx-v1` 目标）先行合并，本 PR 引用的工作流状态届时已在 `master` 上生效。

**后续人工操作**：删除 `InferenceX-app` 的 `DATABASE_AGENTX_V1_WRITE_URL` secret；下线 agentx-v1 Neon 项目；退役 `InferenceX-app` 的 `feat/agentx` 分支及 Vercel 预览部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)