### PR TITLE
Add Kimi K2.6 NVFP4 B300 EAGLE3 AgentX benchmark / 新增 Kimi K2.6 NVFP4 B300 EAGLE3 AgentX 基准测试

### DIFF
--- a/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+DRAFT_MODEL="lightseekorg/kimi-k2.6-eagle3-mla"
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+    DRAFT_MODEL_PATH="/data/models/${DRAFT_MODEL##*/}"
+    if [[ ! -d "$DRAFT_MODEL_PATH" || -z "$(ls -A "$DRAFT_MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$DRAFT_MODEL" --local-dir "$DRAFT_MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+    hf download "$DRAFT_MODEL"
+    DRAFT_MODEL_PATH="$DRAFT_MODEL"
+fi
+nvidia-smi
+
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+SERVER_PID=""
+
+cleanup_agentic_services() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "vLLM server" 60
+    exit "$exit_code"
+}
+trap cleanup_agentic_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+DCP_SIZE="${DCP_SIZE:-1}"
+DCP_ARGS=()
+if [[ "$DCP_SIZE" -gt 1 ]]; then
+    DCP_ARGS+=(--decode-context-parallel-size "$DCP_SIZE")
+fi
+
+SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":4,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":3.24}")
+ATTN_BACKEND_ARGS=(--attention-backend TOKENSPEED_MLA)
+
+OFFLOAD_ARGS=()
+
+if agentic_kv_offload_enabled; then
+    case "$KV_OFFLOAD_BACKEND" in
+    native)
+        export VLLM_USE_SIMPLE_KV_OFFLOAD=1
+        CPU_OFFLOAD_BYTES=$((TOTAL_CPU_DRAM_GB * 1024 * 1024 * 1024))
+        OFFLOAD_ARGS=(
+            --disable-hybrid-kv-cache-manager
+            --kv-transfer-config
+            "{\"kv_connector\":\"SimpleCPUOffloadConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":$CPU_OFFLOAD_BYTES,\"lazy_offload\":false}}"
+        )
+        ;;
+    *) echo "Error: unsupported KV_OFFLOAD_BACKEND value '$KV_OFFLOAD_BACKEND' with EAGLE3 (expected: native)" >&2; exit 1 ;;
+    esac
+fi
+
+
+echo "Starting vllm server..."
+export PYTHONNOUSERSITE=1
+
+export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+
+{ set +x; } 2>/dev/null
+VLLM_CMD=(
+    vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --kv-cache-dtype fp8
+    --trust-remote-code
+    --block-size 64
+    --language-model-only
+    --gpu-memory-utilization 0.90
+    --max-num-seqs "$CONC"
+    "${ATTN_BACKEND_ARGS[@]}"
+    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+    --max-cudagraph-capture-size 2048
+    --max-num-batched-tokens 16384
+    --stream-interval 10
+    --enable-prefix-caching
+    --tensor-parallel-size "$TP"
+    "${SPEC_ARGS[@]}"
+    "${DCP_ARGS[@]}"
+    "${OFFLOAD_ARGS[@]}"
+)
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+build_replay_cmd "$RESULT_DIR"
+
+run_agentic_replay_and_write_outputs "$RESULT_DIR"

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
@@ -54,7 +54,14 @@ if [[ "$DCP_SIZE" -gt 1 ]]; then
     DCP_ARGS+=(--decode-context-parallel-size "$DCP_SIZE")
 fi
 
-SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":4,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":3.24}")
+if [[ "$DCP_SIZE" -gt 1 ]]; then
+    NUM_SPEC_TOKENS=3
+    SYNTHETIC_ACCEPT_LEN=2.88
+else
+    NUM_SPEC_TOKENS=4
+    SYNTHETIC_ACCEPT_LEN=3.24
+fi
+SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":$NUM_SPEC_TOKENS,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":$SYNTHETIC_ACCEPT_LEN}")
 ATTN_BACKEND_ARGS=(--attention-backend TOKENSPEED_MLA)
 
 OFFLOAD_ARGS=()

--- a/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh
@@ -51,17 +51,19 @@ trap 'exit 143' TERM
 DCP_SIZE="${DCP_SIZE:-1}"
 DCP_ARGS=()
 if [[ "$DCP_SIZE" -gt 1 ]]; then
-    DCP_ARGS+=(--decode-context-parallel-size "$DCP_SIZE")
-fi
-
-if [[ "$DCP_SIZE" -gt 1 ]]; then
+    DCP_ARGS+=(--decode-context-parallel-size "$DCP_SIZE" --dcp-comm-backend a2a)
     NUM_SPEC_TOKENS=3
     SYNTHETIC_ACCEPT_LEN=2.88
+    SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":$NUM_SPEC_TOKENS,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":$SYNTHETIC_ACCEPT_LEN,\"attention_backend\":\"TOKENSPEED_MLA\"}")
+    ATTN_CONFIG='{"mla_prefill_backend":"TOKENSPEED_MLA"}'
+    COMPILATION_CONFIG='{"pass_config":{"fuse_allreduce_rms":false}}'
 else
     NUM_SPEC_TOKENS=4
     SYNTHETIC_ACCEPT_LEN=3.24
+    SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":$NUM_SPEC_TOKENS,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":$SYNTHETIC_ACCEPT_LEN}")
+    ATTN_CONFIG='{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
+    COMPILATION_CONFIG='{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
 fi
-SPEC_ARGS=(--speculative-config "{\"method\":\"eagle3\",\"model\":\"$DRAFT_MODEL_PATH\",\"num_speculative_tokens\":$NUM_SPEC_TOKENS,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":$SYNTHETIC_ACCEPT_LEN}")
 ATTN_BACKEND_ARGS=(--attention-backend TOKENSPEED_MLA)
 
 OFFLOAD_ARGS=()
@@ -99,8 +101,8 @@ VLLM_CMD=(
     --gpu-memory-utilization 0.90
     --max-num-seqs "$CONC"
     "${ATTN_BACKEND_ARGS[@]}"
-    --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":true}'
-    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+    --attention-config "$ATTN_CONFIG"
+    --compilation-config "$COMPILATION_CONFIG"
     --max-cudagraph-capture-size 2048
     --max-num-batched-tokens 16384
     --stream-interval 10

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2989,6 +2989,24 @@ kimik2.5-fp4-b300-vllm-agentic:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
       - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [1, 2, 4, 8, 16, 32, 40, 48, 56, 64] }
 
+kimik2.5-fp4-b300-vllm-agentic-mtp:
+  image: vllm/vllm-openai:nightly-94c0ef300180f8fd1071d9cbe7270a8348155f94
+  model: Kimi-K2.6-NVFP4
+  model-prefix: kimik2.5
+  runner: cluster:b300-nv
+  precision: fp4
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [2, 4, 8] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [8, 16, 32] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, dcp-size: 4, kv-offloading: none, conc-list: [32, 64, 80, 96, 112, 128] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, dcp-size: 4, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [64, 80, 96, 112, 128, 144, 160] }
+
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14
   model: deepseek-ai/DeepSeek-R1-0528

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4765,3 +4765,10 @@
     - "Bump image to lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260708"
     - "Clean the export envs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2198
+
+- config-keys:
+    - kimik2.5-fp4-b300-vllm-agentic-mtp
+  description:
+    - "Add EAGLE3 speculative-decoding arm for the Kimi K2.6 NVFP4 B300 AgentX recipe (draft lightseekorg/kimi-k2.6-eagle3-mla, TOKENSPEED_MLA attention backend with TRT-LLM ragged MLA kernel)."
+    - "TP8/TP4 GPU-only KV points plus a TP4 native CPU-offload ladder via SimpleCPUOffloadConnector with lazy_offload off; TP4/DCP4 high-concurrency points (conc 32/64) using num_speculative_tokens=3 and synthetic_acceptance_length=2.88."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2158

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -352,6 +352,7 @@ else
         Kimi-K2.5
         Kimi-K2.5-NVFP4
         Kimi-K2.6
+        Kimi-K2.6-NVFP4
         MiniMax-M2.5
         MiniMax-M2.5-NVFP4
         MiniMax-M2.7

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -270,7 +270,7 @@ def main():
 
     # Validate final results structure
     validated = ChangelogMatrixEntry.model_validate(final_results)
-    print(validated.model_dump_json(by_alias=True))
+    print(validated.model_dump_json(by_alias=True, exclude_none=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds an EAGLE3 speculative-decoding AgentX (agentic-coding) benchmark for Kimi K2.6 NVFP4 on B300, served with upstream vLLM (`vllm/vllm-openai:nightly-94c0ef30…`).

### Changes
- **New config** `kimik2.5-fp4-b300-vllm-agentic-mtp` (`configs/nvidia-master.yaml`), runner `cluster:b300-nv`. Search space: TP8, TP4, TP4 + native CPU KV offload (`SimpleCPUOffloadConnector`, `dram-utilization: 0.80`), and TP4/DCP4 with and without offload at high concurrency.
- **New script** `benchmarks/single_node/agentic/kimik2.5_fp4_b300_mtp.sh`: EAGLE3 draft `lightseekorg/kimi-k2.6-eagle3-mla` with simulated synthetic acceptance — non-DCP arms use `num_speculative_tokens=4` / AL 3.24; DCP4 arms use `num_speculative_tokens=3` / AL 2.88. `TOKENSPEED_MLA` attention backend, `TRTLLM_RAGGED` MLA prefill (non-DCP), fp8 KV cache.
- **Launcher**: add `Kimi-K2.6-NVFP4` to the b300-nv model allowlist.
- **Changelog tooling**: `process_changelog.py` now emits JSON with `exclude_none=True`; perf-changelog entry added.

### Validation
- PR sweep: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29359203708 (staged via `/stage-results`)
- Upstream vLLM recipe PRs: vllm-project/recipes#626, vllm-project/recipes#634

---

为 B300 上的 Kimi K2.6 NVFP4 新增 EAGLE3 投机解码 AgentX（agentic-coding）基准测试，使用上游 vLLM 镜像。新增 `kimik2.5-fp4-b300-vllm-agentic-mtp` 配置（TP8 / TP4 / TP4+CPU KV offload / TP4+DCP4 组合）、基准脚本（EAGLE3 草稿模型 `lightseekorg/kimi-k2.6-eagle3-mla`，非 DCP 使用 spec4/AL 3.24，DCP4 使用 spec3/AL 2.88）、b300-nv 模型白名单及 perf-changelog 条目。
