### PR TITLE
[Klaud Cold][DO NOT MERGE] Smoke-test verifier Check 10: agentic spec-decode golden synthetic AL / 验证器 Check 10 冒烟测试：agentic 投机解码黄金合成 AL

### DIFF
--- a/benchmarks/single_node/agentic/zz_check10_smoke_test_do_not_merge.sh
+++ b/benchmarks/single_node/agentic/zz_check10_smoke_test_do_not_merge.sh
@@ -6,7 +6,7 @@
 # name this file. The PR adding it will be closed without merging.
 set -euo pipefail
 
-vllm serve deepseek-ai/DeepSeek-V4-Pro-NVFP4 \\
-    --port 8000 \\
-    --tensor-parallel-size 8 \\
+vllm serve deepseek-ai/DeepSeek-V4-Pro-NVFP4 \
+    --port 8000 \
+    --tensor-parallel-size 8 \
     --speculative-config '{"method":"mtp","num_speculative_tokens":3}'

--- a/benchmarks/single_node/agentic/zz_check10_smoke_test_do_not_merge.sh
+++ b/benchmarks/single_node/agentic/zz_check10_smoke_test_do_not_merge.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# [DO NOT MERGE] Throwaway smoke test for codeowner-signoff-verify Check 10:
+# agentic spec-decode configs must simulate acceptance at the committed golden
+# AL from golden_al_distribution/. This script DELIBERATELY omits synthetic
+# acceptance (real rejection sampling) so the verifier should FAIL Check 10 and
+# name this file. The PR adding it will be closed without merging.
+set -euo pipefail
+
+vllm serve deepseek-ai/DeepSeek-V4-Pro-NVFP4 \\
+    --port 8000 \\
+    --tensor-parallel-size 8 \\
+    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'


### PR DESCRIPTION
## Summary

Throwaway test PR per the AGENTS.md verifier-validation flow, following #2160/#2161: this PR adds an agentic spec-decode benchmark script that **deliberately violates the new Check 10** — `--speculative-config` with MTP but **no** synthetic rejection sampling / golden acceptance length. A sign-off comment will be posted to trigger `codeowner-signoff-verify`; the expected verdict is REJECTED with **Check 10 explicitly FAILing and naming `benchmarks/single_node/agentic/zz_check10_smoke_test_do_not_merge.sh`** (Checks 1/2/4 will also fail — no sweep ran).

**This PR will be closed without merging once the verifier has responded.**

## 中文说明

按 AGENTS.md 验证流程创建的临时测试 PR（#2160/#2161 的后续）：本 PR 添加一个**故意违反新 Check 10** 的 agentic 投机解码脚本 —— `--speculative-config` 启用 MTP 但**未**启用合成拒绝采样 / 黄金接受长度。将发布签署评论触发 `codeowner-signoff-verify`；预期结论为 REJECTED，且 **Check 10 明确 FAIL 并指出该脚本**（Check 1/2/4 亦会失败——未运行 sweep）。

**验证器响应后，本 PR 将不合并直接关闭。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)