### PR TITLE
agentic(sibling): write result JSON to /workspace so the result guard finds it

### DIFF
--- a/benchmarks/multi_node/amd_utils/server_sglang.sh
+++ b/benchmarks/multi_node/amd_utils/server_sglang.sh
@@ -812,7 +812,10 @@ if [ "$NODE_RANK" -eq 0 ]; then
                 if [[ -n "${!_v+x}" ]]; then printf '%s=%s\n' "$_v" "${!_v}"; fi
             done
             echo "INFMAX_CONTAINER_WORKSPACE=/workspace"
-            echo "AGENTIC_OUTPUT_DIR=/run_logs/slurm_job-${SLURM_JOB_ID}"
+            # Do NOT pin AGENTIC_OUTPUT_DIR: it must default to /workspace (the
+            # host repo mount == GITHUB_WORKSPACE) so the aggregated
+            # ${RESULT_FILENAME}_conc<N>.json lands where the workflow guard globs
+            # it. /workspace is bind-mounted writable, same as the co-located path.
             echo "HF_HOME=/run_logs/hf_cache"
             echo "MODEL_DIR=/models"
             # A pre-baked client image ships aiperf at CLIENT_AIPERF_VENV; when


### PR DESCRIPTION
## Summary
Fixes the DSv4 agentic sibling-client run failing at the end with
`Run failed: expected 1 agentic results, found 0.` (e.g. run 29095134929, `dsv4 ... c32`).

Root cause: the node-0 sibling client set `AGENTIC_OUTPUT_DIR=/run_logs/slurm_job-*` (host `/tmp`), so `process_agentic_result.py` saved the aggregated `${RESULT_FILENAME}_conc<N>.json` **outside** `GITHUB_WORKSPACE`. The workflow guard globs `${RESULT_FILENAME}_conc*.json` in `GITHUB_WORKSPACE` and found 0.

The **co-located** path leaves `AGENTIC_OUTPUT_DIR` unset, so it defaults to `INFMAX_CONTAINER_WORKSPACE=/workspace` — which is the host repo bind-mount (`== GITHUB_WORKSPACE`). Dropping the override makes the sibling match: raw artifacts still go under the trace_replay log dir (`/run_logs`), only the top-level result JSON moves to `/workspace` where the guard and upload steps expect it. `/workspace` is bind-mounted writable in the sibling `docker run`, same as the co-located server container.

## Changes
- `benchmarks/multi_node/amd_utils/server_sglang.sh`: remove the `AGENTIC_OUTPUT_DIR=/run_logs/...` line from the sibling `client.env` (single line + explanatory comment).

## Test plan
- [ ] Re-dispatch `dsv4-fp4-mi355x-sglang-disagg-agentic-hicache`; confirm `Saved aggregated agentic result to /workspace/${RESULT_FILENAME}_conc<N>.json` and the result-count guard passes.
- [ ] Confirm artifacts (`LOGS/agentic/**`) still upload.