### PR TITLE
feat: add /stage-results PR command / 添加 /stage-results PR 命令

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -1,0 +1,205 @@
+name: Stage PR Results
+
+run-name: Stage results for PR #${{ github.event.issue.number }}
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: stage-results-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Authorize and dispatch staging
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/stage-results')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Authorize request and resolve source run
+        id: request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const body = context.payload.comment.body.trim();
+            const command = /^\/stage-results(?:\s+(?<runId>\d+))?$/u.exec(body);
+            if (!command) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  'Usage: `/stage-results` or `/stage-results <run-id>`.',
+                  '',
+                  '用法：`/stage-results` 或 `/stage-results <run-id>`。',
+                ].join('\n'),
+              });
+              core.setFailed('Unsupported /stage-results syntax');
+              return;
+            }
+
+            const actor = context.payload.comment.user.login;
+            const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: actor,
+            });
+            const permission = permissionResponse.data.permission;
+            if (!['admin', 'maintain', 'write'].includes(permission)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `@${actor} \`/stage-results\` requires write access to this repository.`,
+                  '',
+                  `@${actor} 只有具备本仓库写入权限的成员才能运行 \`/stage-results\`。`,
+                ].join('\n'),
+              });
+              core.setFailed(`Actor ${actor} has ${permission} permission`);
+              return;
+            }
+
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const belongsToPullRequest = async (run) => {
+              if (run.pull_requests?.some((pr) => pr.number === context.issue.number)) return true;
+              const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: run.head_sha,
+                per_page: 100,
+              });
+              return associated.data.some((pr) => pr.number === context.issue.number);
+            };
+
+            let run;
+            const requestedRunId = command.groups?.runId;
+            if (requestedRunId) {
+              const response = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: Number(requestedRunId),
+              });
+              run = response.data;
+              if (!(await belongsToPullRequest(run))) {
+                core.setFailed(`Run ${requestedRunId} does not belong to PR #${context.issue.number}`);
+                return;
+              }
+            } else {
+              const response = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'run-sweep.yml',
+                event: 'pull_request',
+                head_sha: pull.data.head.sha,
+                status: 'completed',
+                per_page: 30,
+              });
+              for (const candidate of response.data.workflow_runs) {
+                if (candidate.conclusion === 'success' && (await belongsToPullRequest(candidate))) {
+                  run = candidate;
+                  break;
+                }
+              }
+              if (!run) {
+                core.setFailed(
+                  `No successful completed run-sweep.yml run found for current PR head ${pull.data.head.sha}`,
+                );
+                return;
+              }
+            }
+
+            if (run.path !== '.github/workflows/run-sweep.yml' || run.event !== 'pull_request') {
+              core.setFailed(`Run ${run.id} is not a pull-request run of run-sweep.yml`);
+              return;
+            }
+            if (run.status !== 'completed' || run.conclusion !== 'success') {
+              core.setFailed(`Run ${run.id} must be completed successfully (found ${run.status}/${run.conclusion})`);
+              return;
+            }
+
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id,
+              per_page: 100,
+            });
+            const usableNames = artifacts
+              .filter((artifact) => !artifact.expired)
+              .map((artifact) => artifact.name);
+            const hasBenchmarkData = usableNames.some(
+              (name) =>
+                name === 'results_bmk' ||
+                name === 'eval_results_all' ||
+                name.startsWith('bmk_agentic_'),
+            );
+            if (!hasBenchmarkData) {
+              core.setFailed(`Run ${run.id} has no unexpired benchmark result artifacts`);
+              return;
+            }
+
+            core.setOutput('run-id', String(run.id));
+            core.setOutput('run-attempt', String(run.run_attempt ?? 1));
+            core.setOutput('run-date', run.created_at.slice(0, 10));
+            core.setOutput('requested-by', actor);
+            core.setOutput('run-url', run.html_url);
+
+      - name: Dispatch InferenceX-app staging workflow
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ID: ${{ steps.request.outputs.run-id }}
+          RUN_ATTEMPT: ${{ steps.request.outputs.run-attempt }}
+          RUN_DATE: ${{ steps.request.outputs.run-date }}
+          REQUESTED_BY: ${{ steps.request.outputs.requested-by }}
+        with:
+          github-token: ${{ secrets.INFX_FRONTEND_PAT }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'SemiAnalysisAI',
+              repo: 'InferenceX-app',
+              event_type: 'stage-results',
+              client_payload: {
+                'source-repository': `${context.repo.owner}/${context.repo.repo}`,
+                'pr-number': String(context.issue.number),
+                'run-id': process.env.RUN_ID,
+                'run-attempt': process.env.RUN_ATTEMPT,
+                'run-date': process.env.RUN_DATE,
+                'requested-by': process.env.REQUESTED_BY,
+              },
+            });
+
+      - name: Acknowledge staging request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ID: ${{ steps.request.outputs.run-id }}
+          RUN_URL: ${{ steps.request.outputs.run-url }}
+          REQUESTED_BY: ${{ steps.request.outputs.requested-by }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const body = [
+              `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). The shared staging slot is serialized; a completion link will be posted here.`,
+              '',
+              `@${process.env.REQUESTED_BY} 正在将[运行 ${process.env.RUN_ID}](${process.env.RUN_URL})发布到预发布环境。共享预发布环境会按顺序处理请求；完成后将在此处发布链接。`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -76,6 +76,55 @@ jobs:
               pull_number: context.issue.number,
             });
 
+            const fullSweepLabels = [
+              'full-sweep-enabled',
+              'non-canary-full-sweep-enabled',
+              'full-sweep-fail-fast',
+              'full-sweep-fail-fast-no-canary',
+            ];
+            const pullLabels = new Set(
+              pull.data.labels
+                .map((label) => (typeof label === 'string' ? label : label.name))
+                .filter(Boolean),
+            );
+            const fullSweepLabel = fullSweepLabels.find((label) => pullLabels.has(label));
+            if (!fullSweepLabel) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `@${actor} \`/stage-results\` requires a completed run from a PR using one of: ${fullSweepLabels.map((label) => `\`${label}\``).join(', ')}.`,
+                  '',
+                  `@${actor} \`/stage-results\` 只能用于已完成完整 sweep 的 PR；请使用以下标签之一：${fullSweepLabels.map((label) => `\`${label}\``).join('、')}。`,
+                ].join('\n'),
+              });
+              core.setFailed('PR does not have a full-sweep label');
+              return;
+            }
+
+            const timelineEvents = await github.paginate(
+              github.rest.issues.listEventsForTimeline,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const fullSweepLabelAppliedAt = timelineEvents
+              .filter(
+                (event) => event.event === 'labeled' && event.label?.name === fullSweepLabel,
+              )
+              .reduce(
+                (latest, event) => Math.max(latest, Date.parse(event.created_at ?? '')),
+                Number.NEGATIVE_INFINITY,
+              );
+            if (!Number.isFinite(fullSweepLabelAppliedAt)) {
+              core.setFailed(`Could not verify when ${fullSweepLabel} was applied to the PR`);
+              return;
+            }
+
             const belongsToPullRequest = async (run) => {
               if (run.pull_requests?.some((pr) => pr.number === context.issue.number)) return true;
               const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -128,6 +177,26 @@ jobs:
               core.setFailed(`Run ${run.id} is not a pull-request run of run-sweep.yml`);
               return;
             }
+            if (run.head_sha !== pull.data.head.sha) {
+              core.setFailed(`Run ${run.id} is not for the current PR head ${pull.data.head.sha}`);
+              return;
+            }
+            if (Date.parse(run.created_at) < fullSweepLabelAppliedAt) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `@${actor} run ${run.id} predates the current \`${fullSweepLabel}\` label. Wait for the full sweep triggered by that label to complete successfully.`,
+                  '',
+                  `@${actor} 运行 ${run.id} 早于当前 \`${fullSweepLabel}\` 标签。请等待该标签触发的完整 sweep 成功完成。`,
+                ].join('\n'),
+              });
+              core.setFailed(
+                `Run ${run.id} predates the current ${fullSweepLabel} label application`,
+              );
+              return;
+            }
             if (run.status !== 'completed' || run.conclusion !== 'success') {
               core.setFailed(`Run ${run.id} must be completed successfully (found ${run.status}/${run.conclusion})`);
               return;
@@ -142,6 +211,20 @@ jobs:
             const usableNames = artifacts
               .filter((artifact) => !artifact.expired)
               .map((artifact) => artifact.name);
+            if (!usableNames.includes('changelog-metadata')) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `@${actor} run ${run.id} cannot be staged because it has no unexpired \`changelog-metadata\` artifact.`,
+                  '',
+                  `@${actor} 无法发布运行 ${run.id}：该运行没有未过期的 \`changelog-metadata\` 产物。`,
+                ].join('\n'),
+              });
+              core.setFailed(`Run ${run.id} has no unexpired changelog-metadata artifact`);
+              return;
+            }
             const hasBenchmarkData = usableNames.some(
               (name) =>
                 name === 'results_bmk' ||


### PR DESCRIPTION
## Summary

- Add `/stage-results` and `/stage-results <run-id>` support on InferenceX pull requests.
- Restrict the command to collaborators with `write`, `maintain`, or `admin` repository permission.
- Require one of the full-sweep labels: `full-sweep-enabled`, `non-canary-full-sweep-enabled`, `full-sweep-fail-fast`, or `full-sweep-fail-fast-no-canary`.
- Require the selected successful `run-sweep.yml` run to target the current PR head and to have started after the current full-sweep label was applied.
- Require unexpired `changelog-metadata` plus benchmark result artifacts before dispatch.
- Dispatch the isolated InferenceX-app staging workflow and post bilingual acknowledgement, rejection, and completion messages on the source PR.

## Flow

1. A writer comments `/stage-results` on a full-sweep InferenceX PR.
2. This workflow authorizes the commenter and resolves a completed successful full-sweep run with changelog metadata.
3. InferenceX-app refreshes its shared Git and Neon staging branches from `master`/production, ingests the selected artifacts, and invalidates only staging caches.
4. The PR receives a run-pinned staging dashboard link, or a failure link if a downstream staging step fails. The shared staging slot remains available until the next request.

## Dependency

Merge [InferenceX-app PR #565](https://github.com/SemiAnalysisAI/InferenceX-app/pull/565) first. The comment command dispatches the workflow introduced there.

## Validation

- `actionlint .github/workflows/stage-results.yml`
- `git diff --check`
- Permission, full-sweep label history, current head SHA, PR association, workflow identity, successful completion, artifact expiry, and changelog metadata checks are enforced before dispatch.

## 中文说明

### 变更概述

- 在 InferenceX PR 评论中支持 `/stage-results` 和 `/stage-results <run-id>`。
- 仅允许仓库权限为 `write`、`maintain` 或 `admin` 的协作者执行该命令。
- PR 必须使用以下完整 sweep 标签之一：`full-sweep-enabled`、`non-canary-full-sweep-enabled`、`full-sweep-fail-fast` 或 `full-sweep-fail-fast-no-canary`。
- 所选的成功 `run-sweep.yml` 必须针对 PR 当前提交，并且必须在当前完整 sweep 标签应用后启动。
- 触发预发布前，必须存在未过期的 `changelog-metadata` 和基准测试结果产物。
- 触发隔离的 InferenceX-app 预发布工作流，并在源 PR 中发布中英双语的受理、拒绝和完成消息。

### 执行流程

1. 具备写入权限的协作者在启用完整 sweep 的 InferenceX PR 中评论 `/stage-results`。
2. 本工作流验证评论者权限，并解析包含 changelog 元数据且已成功完成的完整 sweep 运行。
3. InferenceX-app 从 `master` 和生产数据库刷新共享 Git/Neon staging 分支，写入指定产物，并仅刷新 staging 缓存。
4. PR 会收到绑定该运行的预发布仪表板链接；如果下游预发布步骤失败，则会收到失败工作流链接。共享预发布槽位会保留到下一次请求。

### 依赖关系

请先合并 [InferenceX-app PR #565](https://github.com/SemiAnalysisAI/InferenceX-app/pull/565)。本评论命令会触发该 PR 新增的工作流。

### 验证

- `actionlint .github/workflows/stage-results.yml`
- `git diff --check`
- 触发前会强制检查用户权限、完整 sweep 标签历史、当前提交 SHA、PR 关联、工作流身份、成功结论、产物有效期和 changelog 元数据。
