### PR TITLE
fix: split staging workflow tokens

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -19,26 +19,41 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/stage-results')
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: Authorize request and resolve source run
         id: request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_TOKEN: ${{ secrets.REPO_PAT }}
         with:
-          github-token: ${{ secrets.INFX_FRONTEND_PAT }}
+          github-token: ${{ github.token }}
           script: |
-            const body = context.payload.comment.body.trim();
-            const command = /^\/stage-results(?:\s+(?<runId>\d+))?$/u.exec(body);
-            if (!command) {
-              await github.rest.issues.createComment({
+            const createComment = async (body) => github.request(
+              'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
+              {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: [
+                body,
+                headers: { authorization: `Bearer ${process.env.COMMENT_TOKEN}` },
+              },
+            );
+
+            const body = context.payload.comment.body.trim();
+            const command = /^\/stage-results(?:\s+(?<runId>\d+))?$/u.exec(body);
+            if (!command) {
+              await createComment(
+                [
                   'Usage: `/stage-results` or `/stage-results <run-id>`.',
                   '',
                   '用法：`/stage-results` 或 `/stage-results <run-id>`。',
                 ].join('\n'),
-              });
+              );
               core.setFailed('Unsupported /stage-results syntax');
               return;
             }
@@ -51,16 +66,13 @@ jobs:
             });
             const permission = permissionResponse.data.permission;
             if (!['admin', 'maintain', 'write'].includes(permission)) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: [
+              await createComment(
+                [
                   `@${actor} \`/stage-results\` requires write access to this repository.`,
                   '',
                   `@${actor} 只有具备本仓库写入权限的成员才能运行 \`/stage-results\`。`,
                 ].join('\n'),
-              });
+              );
               core.setFailed(`Actor ${actor} has ${permission} permission`);
               return;
             }
@@ -84,16 +96,13 @@ jobs:
             );
             const fullSweepLabel = fullSweepLabels.find((label) => pullLabels.has(label));
             if (!fullSweepLabel) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: [
+              await createComment(
+                [
                   `@${actor} \`/stage-results\` requires a completed run from a PR using one of: ${fullSweepLabels.map((label) => `\`${label}\``).join(', ')}.`,
                   '',
                   `@${actor} \`/stage-results\` 只能用于已完成完整 sweep 的 PR；请使用以下标签之一：${fullSweepLabels.map((label) => `\`${label}\``).join('、')}。`,
                 ].join('\n'),
-              });
+              );
               core.setFailed('PR does not have a full-sweep label');
               return;
             }
@@ -257,7 +266,7 @@ jobs:
           RUN_URL: ${{ steps.request.outputs.run-url }}
           REQUESTED_BY: ${{ steps.request.outputs.requested-by }}
         with:
-          github-token: ${{ secrets.INFX_FRONTEND_PAT }}
+          github-token: ${{ secrets.REPO_PAT }}
           script: |
             const body = [
               `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). The shared staging slot is serialized; a completion link will be posted here.`,


### PR DESCRIPTION
## Summary

- use the scoped Actions token for collaborator authorization and read-only PR, workflow-run, and artifact queries
- use REPO_PAT only for PR comments
- keep INFX_FRONTEND_PAT limited to the cross-repository staging dispatch

## Root cause

The cross-repository dispatch PAT cannot call the collaborator-permission endpoint in InferenceX. The original Actions token can perform that read, but GitHub prevents it from creating comments in this issue_comment PR context. Each token now performs only the operation it supports.

## Validation

- actionlint .github/workflows/stage-results.yml
- git diff --check
- zizmor .github/workflows/stage-results.yml