### PR TITLE
fix(agentic): standardize replay warmup

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1475,14 +1475,10 @@ build_replay_cmd() {
     # least one profile turn after warmup.
     REPLAY_CMD+=" --trajectory-start-min-ratio 0.25"
     REPLAY_CMD+=" --trajectory-start-max-ratio 0.75"
-    # Optional cache-pressure warmup for long agentic traces. AIPerf first
-    # completes its normal t* snapshot warmup, then continues those exact
-    # trajectories with one-token outputs and no idle delays for this many
-    # seconds. Profiling begins only after those requests drain and resumes
-    # from the resulting live trajectory state.
-    if [ -n "${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-}" ]; then
-        REPLAY_CMD+=" --agentic-cache-warmup-duration $AIPERF_AGENTIC_CACHE_WARMUP_DURATION"
-    fi
+    # After the normal t* snapshot warmup, continue those exact trajectories
+    # with one-token outputs and no idle delays for 10 minutes. Profiling begins
+    # only after those requests drain and resumes from the resulting live state.
+    REPLAY_CMD+=" --agentic-cache-warmup-duration 600"
     # Use server-reported usage fields (prompt_tokens / completion_tokens) for
     # ISL/OSL instead of client-side tokenizer.encode(). Auto-enables
     # stream_options.include_usage on the OpenAI chat endpoint. Skips the

--- a/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm.sh
@@ -65,8 +65,6 @@ nvidia-smi
 resolve_trace_source
 install_agentic_deps
 
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
-
 # vLLM v0.22.1 can ship CUTLASS DSL 4.5.2 with stale native MLIR bindings,
 # which fails DSV4 indexer compilation with mlir_global_dtors(..., data).
 # Reinstall the matching native wheel until NVIDIA/cutlass#3259 is resolved.

--- a/benchmarks/single_node/agentic/dsv4_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b300_vllm.sh
@@ -68,8 +68,6 @@ nvidia-smi
 resolve_trace_source
 install_agentic_deps
 
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
-
 # vLLM v0.22.1 can ship CUTLASS DSL 4.5.2 with stale native MLIR bindings,
 # which fails DSV4 indexer compilation with mlir_global_dtors(..., data).
 # Reinstall the matching native wheel until NVIDIA/cutlass#3259 is resolved.

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -58,12 +58,6 @@ install_agentic_deps
 # Nightly ROCm image may be missing runtime deps; ensure they are present.
 agentic_pip_install --quiet Pillow fastapi uvicorn
 
-# default
-export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=600
-# tune
-#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=60
-#export AIPERF_AGENTIC_CACHE_WARMUP_DURATION=1200
-# tune
 export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
 
 # vllm-project/router expands the one HTTP backend into one logical worker per


### PR DESCRIPTION
Agentic replay warmup was optional and configured in individual recipes.

- Always run the normal trajectory warmup followed by a fixed 10-minute accelerated warmup.
- Remove recipe-specific duration overrides.

Tests:
- `bash -n benchmarks/benchmark_lib.sh benchmarks/single_node/agentic/*.sh benchmarks/multi_node/agentic_srt.sh`
- `python -m pytest utils/matrix_logic/ -v` (198 passed)
