### PR TITLE
chore(agentic): rerun DSV4 SGLang with standard warmup

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4750,3 +4750,10 @@
     - "Image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928"
     - "6 topologies across 1k/1k and 8k/1k: 1P1D TP4 STP + wide-EP (DEP4 prefill / DEP16 decode) from 1P1D up to 8P1D, recipes under benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2137
+
+- config-keys:
+    - dsv4-fp4-b200-sglang-agentic-hicache
+    - dsv4-fp4-b300-sglang-agentic-hicache
+  description:
+    - "Rerun after standardizing agentic warmup to the regular trajectory warmup plus a 600-second accelerated cache-pressure warmup."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2179

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -270,7 +270,7 @@ def main():
 
     # Validate final results structure
     validated = ChangelogMatrixEntry.model_validate(final_results)
-    print(validated.model_dump_json(by_alias=True))
+    print(validated.model_dump_json(by_alias=True, exclude_none=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR #2112 ran these SGLang agentic configs without the accelerated warmup stage.

This changelog-only PR reruns B200 and B300 with the standard regular warmup followed by the 600-second accelerated warmup.

Tests:
- `python utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD`
- 32 targeted changelog tests passed
