### PR TITLE
fix(agentic): propagate speculative decoding to sweep jobs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -217,7 +217,7 @@ jobs:
             isl: '0'
             osl: '0'
             max-model-len: '0'
-            spec-decoding: 'none'
+            spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: 'false'
             run-eval: false
             scenario-type: agentic-coding

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -521,7 +521,7 @@ jobs:
             isl: '0'
             osl: '0'
             max-model-len: '0'
-            spec-decoding: 'none'
+            spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ 'false' }}
             run-eval: false
             scenario-type: agentic-coding

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -645,6 +645,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     pcp_size = bmk.get(Fields.PCP_SIZE.value, 1)
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
+                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
                     kv_offloading = bmk[Fields.KV_OFFLOADING.value]
                     kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
                 total_cpu_dram_gb = (
@@ -733,6 +734,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 Fields.PCP_SIZE.value: pcp_size,
                                 Fields.EP.value: ep if ep is not None else 1,
                                 Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
+                                Fields.SPEC_DECODING.value: spec_decoding,
                                 Fields.CONC.value: conc,
                                 Fields.KV_OFFLOADING.value: kv_offloading,
                                 Fields.TOTAL_CPU_DRAM_GB.value: total_cpu_dram_gb,
@@ -740,6 +742,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_tp{tp}_conc{conc}_"
                                     f"{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                                    + (f"_spec-{spec_decoding}" if spec_decoding != "none" else "")
                                 ),
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }
@@ -948,6 +951,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                     pcp_size = bmk.get(Fields.PCP_SIZE.value, 1)
                     ep = bmk.get(Fields.EP.value)
                     dp_attn = bmk.get(Fields.DP_ATTN.value)
+                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
                     kv_offloading = bmk[Fields.KV_OFFLOADING.value]
                     kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
                 total_cpu_dram_gb = (
@@ -1029,6 +1033,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.PCP_SIZE.value: pcp_size,
                                 Fields.EP.value: ep if ep is not None else 1,
                                 Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
+                                Fields.SPEC_DECODING.value: spec_decoding,
                                 Fields.CONC.value: conc,
                                 Fields.KV_OFFLOADING.value: kv_offloading,
                                 Fields.TOTAL_CPU_DRAM_GB.value: total_cpu_dram_gb,
@@ -1036,6 +1041,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                                 Fields.EXP_NAME.value: (
                                     f"{model_code}_tp{tp}_conc{conc}_"
                                     f"{agentic_kv_offload_suffix(kv_offloading, kv_offload_backend)}"
+                                    + (f"_spec-{spec_decoding}" if spec_decoding != "none" else "")
                                 ),
                                 Fields.SCENARIO_TYPE.value: "agentic-coding",
                             }

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -134,6 +134,39 @@ def sample_runner_config():
 
 
 @pytest.fixture
+def sample_single_node_agentic_config():
+    """Single-node agentic config with explicit and default spec decoding."""
+    return {
+        "kimik2.6-fp4-b300-trt-agentic": {
+            "image": "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc5",
+            "model": "moonshotai/Kimi-K2.5",
+            "model-prefix": "kimik2.6",
+            "precision": "fp4",
+            "framework": "trt",
+            "runner": "cluster:b300-nv",
+            "multinode": False,
+            "scenarios": {
+                "agentic-coding": [{
+                    "search-space": [
+                        {
+                            "tp": 8,
+                            "spec-decoding": "mtp",
+                            "kv-offloading": "none",
+                            "conc-list": [16],
+                        },
+                        {
+                            "tp": 8,
+                            "kv-offloading": "none",
+                            "conc-list": [32],
+                        },
+                    ],
+                }],
+            },
+        },
+    }
+
+
+@pytest.fixture
 def full_sweep_args_single_node():
     """Args for full-sweep single-node command."""
     args = argparse.Namespace()
@@ -688,6 +721,22 @@ class TestGenerateFullSweepSingleNode:
             (row["pp"], row["dcp-size"], row["pcp-size"])
             for row in explicit_result
         } == {(2, 2, 2)}
+
+    def test_agentic_spec_decoding_is_propagated(
+        self,
+        sample_single_node_agentic_config,
+        sample_runner_config,
+        full_sweep_args_single_node,
+    ):
+        result = generate_full_sweep(
+            full_sweep_args_single_node,
+            sample_single_node_agentic_config,
+            sample_runner_config,
+        )
+
+        assert [entry["spec-decoding"] for entry in result] == ["mtp", "none"]
+        assert result[0]["exp-name"].endswith("_kvnone_spec-mtp")
+        assert result[1]["exp-name"].endswith("_kvnone")
 
     def test_filter_by_model_prefix(self, sample_single_node_config, sample_runner_config, full_sweep_args_single_node):
         """Filter by model prefix should work."""
@@ -1913,6 +1962,29 @@ class TestGenerateTestConfigSweep:
             (row["pp"], row["dcp-size"], row["pcp-size"])
             for row in explicit_result
         ] == [(2, 2, 2)]
+
+    def test_single_node_agentic_spec_decoding_is_propagated(
+        self,
+        sample_single_node_agentic_config,
+        sample_runner_config,
+    ):
+        args = argparse.Namespace(
+            config_keys=["kimik2.6-fp4-b300-trt-agentic"],
+            seq_lens=None,
+            conc=None,
+            scenario_type=["agentic-coding"],
+            runner_node_filter=None,
+        )
+
+        result = generate_test_config_sweep(
+            args,
+            sample_single_node_agentic_config,
+            sample_runner_config,
+        )
+
+        assert [entry["spec-decoding"] for entry in result] == ["mtp", "none"]
+        assert result[0]["exp-name"].endswith("_kvnone_spec-mtp")
+        assert result[1]["exp-name"].endswith("_kvnone")
 
     def test_multinode_parallelism_fields_are_generated(
         self,

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -276,6 +276,9 @@ class SingleNodeAgenticMatrixEntry(BaseModel):
     pcp_size: int = Field(alias=Fields.PCP_SIZE.value, gt=0, strict=True)
     ep: int
     dp_attn: bool = Field(alias=Fields.DP_ATTN.value)
+    spec_decoding: Literal["mtp", "draft_model", "none"] = Field(
+        default="none", alias=Fields.SPEC_DECODING.value
+    )
     conc: int
     kv_offloading: Literal["none", "dram"] = Field(
         alias=Fields.KV_OFFLOADING.value


### PR DESCRIPTION
## What changed

- propagate `spec-decoding` from single-node agentic search-space entries into both generated sweep matrix formats
- pass the generated value through the agentic jobs in `run-sweep.yml` and `e2e-tests.yml`
- include non-default speculative-decoding modes in experiment names
- keep omitted values backward-compatible as `none`

## Why

Single-node agentic master configs already accept `spec-decoding`, but sweep generation dropped it and both workflow entrypoints hardcoded `none`. As a result, a config requesting `mtp` could run the STP launcher and be labeled incorrectly.

This reusable plumbing is split out from #2158 so the Kimi K2.6 benchmark PR can focus on its model-specific launcher and configuration.

## Validation

- `python -m pytest utils/matrix_logic/ -v` (221 passed)
