### PR TITLE
Use MXFP4 weights for PR 2139 GB200 vLLM recipes

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
@@ -8,8 +8,8 @@ name: "svf-vllm-disagg-gb200-high-tpt-megamoe"
 # 4096 with no CPU/NVMe offload.
 #
 # Local deltas vs upstream:
-#   * model.path alias renamed deepseekv4-fp4 -> deepseek-v4-pro to match
-#     SRT_SLURM_MODEL_PREFIX in runners/launch_gb200-nv.sh.
+#   * model.path uses the deepseek-v4-pro-mxfp4 alias from
+#     runners/launch_gb200-nv.sh.
 #   * model.container set to vllm/vllm-openai:v0.20.0-ubuntu2404 to
 #     match nvidia-master.yaml image (which the launch script registers as
 #     the alias key in srtslurm.yaml). Upstream variants ship either the
@@ -17,7 +17,7 @@ name: "svf-vllm-disagg-gb200-high-tpt-megamoe"
 #   * slurm.time_limit + health_check set to 8h / 1440 attempts to
 #     absorb cold-cache /mnt/numa1 model loads.
 model:
-  path: "deepseek-v4-pro"
+  path: "deepseek-v4-pro-mxfp4"
   container: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   precision: "fp4"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
@@ -7,8 +7,8 @@ name: "svf-vllm-disagg-gb200-low-latency"
 # dedicated NATS/etcd infra node. Single-concurrency point for low latency.
 #
 # Local deltas vs upstream:
-#   * model.path alias renamed deepseekv4-fp4 -> deepseek-v4-pro to match
-#     SRT_SLURM_MODEL_PREFIX in runners/launch_gb200-nv.sh.
+#   * model.path uses the deepseek-v4-pro-mxfp4 alias from
+#     runners/launch_gb200-nv.sh.
 #   * model.container set to vllm/vllm-openai:v0.20.0-ubuntu2404 to
 #     match nvidia-master.yaml image (which the launch script registers as
 #     the alias key in srtslurm.yaml). Upstream variants ship either the
@@ -16,7 +16,7 @@ name: "svf-vllm-disagg-gb200-low-latency"
 #   * slurm.time_limit + health_check set to 8h / 1440 attempts to
 #     absorb cold-cache /mnt/numa1 model loads.
 model:
-  path: "deepseek-v4-pro"
+  path: "deepseek-v4-pro-mxfp4"
   container: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   precision: "fp4"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
@@ -8,8 +8,8 @@ name: "svf-vllm-disagg-gb200-low-middle-curve"
 # 256 and 512.
 #
 # Local deltas vs upstream:
-#   * model.path alias renamed deepseekv4-fp4 -> deepseek-v4-pro to match
-#     SRT_SLURM_MODEL_PREFIX in runners/launch_gb200-nv.sh.
+#   * model.path uses the deepseek-v4-pro-mxfp4 alias from
+#     runners/launch_gb200-nv.sh.
 #   * model.container set to vllm/vllm-openai:v0.20.0-ubuntu2404 to
 #     match nvidia-master.yaml image (which the launch script registers as
 #     the alias key in srtslurm.yaml). Upstream variants ship either the
@@ -17,7 +17,7 @@ name: "svf-vllm-disagg-gb200-low-middle-curve"
 #   * slurm.time_limit + health_check set to 8h / 1440 attempts to
 #     absorb cold-cache /mnt/numa1 model loads.
 model:
-  path: "deepseek-v4-pro"
+  path: "deepseek-v4-pro-mxfp4"
   container: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   precision: "fp4"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
@@ -8,8 +8,8 @@ name: "svf-vllm-disagg-gb200-max-tpt-megamoe"
 # 4096 with no CPU/NVMe offload.
 #
 # Local deltas vs upstream:
-#   * model.path alias renamed deepseekv4-fp4 -> deepseek-v4-pro to match
-#     SRT_SLURM_MODEL_PREFIX in runners/launch_gb200-nv.sh.
+#   * model.path uses the deepseek-v4-pro-mxfp4 alias from
+#     runners/launch_gb200-nv.sh.
 #   * model.container set to vllm/vllm-openai:v0.20.0-ubuntu2404 to
 #     match nvidia-master.yaml image (which the launch script registers as
 #     the alias key in srtslurm.yaml). Upstream variants ship either the
@@ -17,7 +17,7 @@ name: "svf-vllm-disagg-gb200-max-tpt-megamoe"
 #   * slurm.time_limit + health_check set to 8h / 1440 attempts to
 #     absorb cold-cache /mnt/numa1 model loads.
 model:
-  path: "deepseek-v4-pro"
+  path: "deepseek-v4-pro-mxfp4"
   container: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   precision: "fp4"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
@@ -8,8 +8,8 @@ name: "svf-vllm-disagg-gb200-mid-curve-megamoe"
 # 256/512/1024 with no CPU/NVMe offload.
 #
 # Local deltas vs upstream:
-#   * model.path alias renamed deepseekv4-fp4 -> deepseek-v4-pro to match
-#     SRT_SLURM_MODEL_PREFIX in runners/launch_gb200-nv.sh.
+#   * model.path uses the deepseek-v4-pro-mxfp4 alias from
+#     runners/launch_gb200-nv.sh.
 #   * model.container set to vllm/vllm-openai:v0.20.0-ubuntu2404 to
 #     match nvidia-master.yaml image (which the launch script registers as
 #     the alias key in srtslurm.yaml). Upstream variants ship either the
@@ -17,7 +17,7 @@ name: "svf-vllm-disagg-gb200-mid-curve-megamoe"
 #   * slurm.time_limit + health_check set to 8h / 1440 attempts to
 #     absorb cold-cache /mnt/numa1 model loads.
 model:
-  path: "deepseek-v4-pro"
+  path: "deepseek-v4-pro-mxfp4"
   container: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   precision: "fp4"
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4725,4 +4725,5 @@
     - "Use MessagePack encoding for the Dynamo request plane on frontends and workers"
     - "Reduce the 1P4D TP8 decode GPU memory utilization from 0.9 to 0.85"
     - "Update the vLLM image from v0.20.0-ubuntu2404 to dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
+    - "Use the DeepSeek-V4-Pro MXFP4 checkpoint for the five GB200 STP recipes"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2139

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -90,6 +90,7 @@ fi
 # MODEL_PATH: Override with pre-downloaded paths on GB200 runner
 # The yaml files specify HuggingFace model IDs for portability, but we use
 # local paths to avoid repeated downloading on the shared GB200 cluster.
+MODEL_PATHS_EXTRA=""
 if [[ $FRAMEWORK == "dynamo-sglang" ]]; then
     export CONFIG_DIR="/mnt/lustre01/artifacts/sglang-configs/1k1k"
     if [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp8" ]]; then
@@ -156,6 +157,7 @@ elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
         # NVFP4 path explicit here.
         export MODEL_PATH="/mnt/lustre01/models/DeepSeek-V4-Pro-NVFP4/"
         export SRT_SLURM_MODEL_PREFIX="deepseek-v4-pro"
+        MODEL_PATHS_EXTRA='  "deepseek-v4-pro-mxfp4": "/mnt/lustre01/models/DeepSeek-V4-Pro"'
     elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/MiniMax-M2.5-NVFP4"
         export SRT_SLURM_MODEL_PREFIX="minimax-m2.5-nvfp4"
@@ -434,6 +436,7 @@ srtctl_root: "${SRTCTL_ROOT}"
 # Model path aliases
 model_paths:
   "${SRT_SLURM_MODEL_PREFIX}": "${MODEL_PATH}"
+${MODEL_PATHS_EXTRA}
 containers:
   dynamo-trtllm: ${SQUASH_FILE}
   dynamo-sglang: ${SQUASH_FILE}


### PR DESCRIPTION
## Summary

- Add a dedicated `deepseek-v4-pro-mxfp4` model-path alias for `/mnt/lustre01/models/DeepSeek-V4-Pro`.
- Switch only PR 2139's five standard GB200 Dynamo-vLLM recipes to the MXFP4 alias.
- Preserve the existing `deepseek-v4-pro` to `DeepSeek-V4-Pro-NVFP4` mapping for MTP2, agentic, and every other configuration.

## Validation

- `bash -n runners/launch_gb200-nv.sh`
- Parsed `perf-changelog.yaml`, `configs/nvidia-master.yaml`, and all DeepSeek-V4 vLLM recipe YAML files (29 files total).
- Generated the targeted GB200 DSV4 FP4 Dynamo-vLLM 8K/1K matrix; all five standard STP rows and four unchanged MTP rows were emitted.
- `python -m pytest utils/matrix_logic/ -q` — 198 passed.
- `utils/validate_perf_changelog.py` passed against PR 2139's current main merge-base.

## Parent PR state

PR 2139 currently has a pre-existing merge conflict with `main`, so validation directly against the latest `origin/main` remains blocked until the parent branch is synchronized. This child PR intentionally does not rebase or otherwise modify the parent branch.
