### PR TITLE
[DSv4] Refresh H200/B300/GB300 submissions, densify B300 1k1k sweep / 刷新 H200/B300/GB300 DSv4 基准数据并加密 B300 1k1k 扫描

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
@@ -53,7 +53,7 @@ start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 # SWA ratio: 1k inputs need more SWA cache headroom than 8k inputs; 0.5 was
 # tuned empirically for the 1k1k recipe, while 0.1 is the cookbook default.
 
-if [ "$CONC" = "1" ] || [ "$CONC" = "32" ]; then
+if [ "$CONC" -le 32 ]; then
     # TP-only, no DP attention
     MEM_FRACTION_STATIC=0.90
     SWA_FULL_TOKENS_RATIO=$([[ "$ISL" == "1024" ]] && echo 0.5 || echo 0.1)
@@ -63,7 +63,7 @@ if [ "$CONC" = "1" ] || [ "$CONC" = "32" ]; then
         --disable-flashinfer-autotune
     )
 
-elif [ "$CONC" = "512" ]; then
+elif [ "$CONC" -ge 64 ] && [ "$CONC" -le 512 ]; then
     # DP attention, flashinfer_mxfp4
     export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     MEM_FRACTION_STATIC=0.94

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2002,8 +2002,8 @@ dsv4-fp4-b300-sglang:
   multinode: false
   # Recipes are selected inside benchmarks/single_node/dsv4_fp4_b300_sglang.sh
   # by CONC:
-  #   CONC 1|32:         TP-only, flashinfer_mxfp4
-  #   CONC 512:          DP-attn, flashinfer_mxfp4
+  #   CONC <=32:         TP-only, flashinfer_mxfp4
+  #   CONC 64-512:       DP-attn, flashinfer_mxfp4
   #   CONC 2048-8192:    DP-attn, megamoe
   # ep is implicit in sglang: --moe-a2a-backend megamoe forces ep_size=tp_size,
   # while low-latency leaves ep_size at the default of 1.
@@ -2014,8 +2014,12 @@ dsv4-fp4-b300-sglang:
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 1 }
       - { tp: 4, ep: 1, conc-start: 32, conc-end: 32 }
-      - { tp: 4, ep: 1, dp-attn: true, conc-start: 512, conc-end: 512 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 8192, conc-end: 8192 }
+      # Densified mid band: the previous single conc-512 point left the
+      # ~50 tok/s/user frontier region (conc 64-256) unsampled at 1k1k.
+      - { tp: 4, ep: 1, dp-attn: true, conc-start: 64, conc-end: 512 }
+      # Megamoe band extended down to the script's existing 2048/4096 profiles
+      # (previously only 8192 at 1k1k).
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 2048, conc-end: 8192 }
     - isl: 8192
       osl: 1024
       search-space:
@@ -3078,7 +3082,7 @@ dsr1-fp8-h200-sglang-mtp:
 # Uses the cu129 image. H200 has no FP4 path, so the FP4 indexer cache
 # flag is omitted. Max-model-len is pinned at 800k per the recipe.
 dsv4-fp8-h200-vllm:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.25.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200
@@ -3098,11 +3102,10 @@ dsv4-fp8-h200-vllm:
       - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256 }
 
-# MTP variant of dsv4-fp8-h200-vllm. Uses the canonical v0.20.1 image
-# (the non-MTP entry above is still on the deepseekv4-cu129 tag) and adds
+# MTP variant of dsv4-fp8-h200-vllm. Mirrors the non-MTP image and adds
 # --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.
 dsv4-fp8-h200-vllm-mtp:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.25.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200
@@ -3143,7 +3146,7 @@ dsv4-fp8-h200-vllm-agentic:
 # runner pool, search space) and adds EAGLE speculative decoding via
 # --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
 dsv4-fp8-h200-sglang:
-  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
+  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:1bf5d508ab110cc0fe1659a5f21d1be02a7f0d7ca8f58cea7e7f4e11f6ae208f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200-dgxc
@@ -3167,7 +3170,7 @@ dsv4-fp8-h200-sglang:
 # runner pool, search space) and adds EAGLE speculative decoding via
 # --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
 dsv4-fp8-h200-sglang-mtp:
-  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
+  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:1bf5d508ab110cc0fe1659a5f21d1be02a7f0d7ca8f58cea7e7f4e11f6ae208f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4750,3 +4750,41 @@
     - "Image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928"
     - "6 topologies across 1k/1k and 8k/1k: 1P1D TP4 STP + wide-EP (DEP4 prefill / DEP16 decode) from 1P1D up to 8P1D, recipes under benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2137
+
+- config-keys:
+    - dsv4-fp8-h200-vllm
+    - dsv4-fp8-h200-vllm-mtp
+  description:
+    - "Bump vLLM image from v0.21.0 to v0.25.0 for DeepSeek-V4-Pro FP8 on H200, matching the B200/B300 dsv4 vLLM bump (#2169)"
+    - "Refresh stale H200 dsv4 submissions (last run 2026-05-21)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2189
+
+- config-keys:
+    - dsv4-fp8-h200-sglang
+    - dsv4-fp8-h200-sglang-mtp
+  description:
+    - "Bump the pinned lmsysorg/sglang:deepseek-v4-hopper digest from the 2026-05-02 push (7f19c6dc) to the current 2026-05-13 push (1bf5d508)"
+    - "Refresh stale H200 dsv4 SGLang submissions (last run 2026-05-04)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2189
+
+- config-keys:
+    - dsv4-fp4-b300-sglang
+  description:
+    - "Densify the 1k1k sweep: the previous search space sampled only conc {1, 32, 512, 8192}, leaving the ~50 tok/s/user frontier region unsampled and noisy (933 tok/s/GPU vs B200's 1359 at 50 tok/s/user)"
+    - "Add the DP-attn flashinfer_mxfp4 band conc 64-512 (was a single 512 point) and extend the megamoe band down to conc 2048-8192 (was a single 8192 point), reusing the existing CONC 2048/4096 launch profiles in dsv4_fp4_b300_sglang.sh"
+    - "dsv4_fp4_b300_sglang.sh: select launch profiles by CONC range (<=32 TP-only, 64-512 DP-attn flashinfer) instead of exact match; megamoe profiles unchanged"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2189
+
+- config-keys:
+    - dsv4-fp4-b300-trt
+    - dsv4-fp4-b300-trt-mtp
+  description:
+    - "Re-run B300 dsv4 TRT-LLM configs (no config change, last run 2026-06-11) so the 1k1k frontier density check around 50 tok/s/user compares same-pass data across frameworks"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2189
+
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-trt
+    - dsv4-fp4-gb300-dynamo-trt-mtp
+  description:
+    - "Re-run GB300 dsv4 dynamo-trt configs (no config change): the only GB300 dsv4 1k1k submissions are from a single 2026-06-15 run"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2189


### PR DESCRIPTION
## Summary

Part of the DSv4 (DeepSeek-V4-Pro) submission refresh pass — stale/noisy SKUs only (the GB200 1k1k restore and the missing H100/MI300X/MI325X FP8 recipes will follow in separate PRs).

- **H200 FP8 (stale, last run 2026-05-21):**
  - `dsv4-fp8-h200-vllm(+mtp)`: bump vLLM image `v0.21.0` → `v0.25.0`, matching the B200/B300 dsv4 vLLM bump (#2169). No script changes needed — the H200 recipe is the FP8/Hopper path and doesn't use the fp4/mega_moe flags that needed `--prefill-schedule-interval` on B200/B300.
  - `dsv4-fp8-h200-sglang(+mtp)`: bump the pinned `lmsysorg/sglang:deepseek-v4-hopper` digest from the 2026-05-02 push (`7f19c6dc`) to the current 2026-05-13 push (`1bf5d508`).
- **B300 1k1k sweep density:** `dsv4-fp4-b300-sglang` sampled only conc {1, 32, 512, 8192} at 1k1k, leaving the ~50 tok/s/user frontier region unsampled (site reads 933 tok/s/GPU vs B200's 1,359 at 50 tok/s/user while B300 wins at 30 and 100 — likely a density artifact). Added the DP-attn flashinfer_mxfp4 band conc 64–512 and extended the megamoe band to 2048–8192 (reusing the script's existing 2048/4096 launch profiles). `dsv4_fp4_b300_sglang.sh` now selects launch profiles by CONC range instead of exact match. `dsv4-fp4-b300-trt(+mtp)` re-run entries (no config change, last run 2026-06-11) so the density check compares same-pass data.
  - Deliberately **not** touched: `dsv4-fp4-b300-sglang-mtp` stays capped at conc ≤32 (B300 EAGLE draft CUDA-graph crash at bs≥128, see KLAUD_DEBUG.md), and the TRT 1k1k conc-2048 point stays dropped (MLA-overlap crash, #1703).
- **GB300 1k1k (single date 2026-06-15):** re-run entries for `dsv4-fp4-gb300-dynamo-trt(+mtp)` (no config change) — currently the only GB300 dsv4 1k1k submissions.

Validation: `generate_sweep_configs.py` produces the expected densified 1k1k matrix (conc 1, 32, 64, 128, 256, 512, 2048, 4096, 8192); `validate_perf_changelog.py --base-ref main` passes.

## 中文说明

本 PR 属于 DeepSeek-V4-Pro（DSv4）基准数据刷新批次，仅覆盖数据过期/噪声较大的 SKU（GB200 1k1k 恢复以及 H100/MI300X/MI325X 缺失的 FP8 配方将在后续 PR 中单独提交）。

- **H200 FP8（数据过期，最后一次运行 2026-05-21）：**
  - `dsv4-fp8-h200-vllm(+mtp)`：vLLM 镜像从 `v0.21.0` 升级到 `v0.25.0`，与 B200/B300 的 dsv4 vLLM 升级（#2169）保持一致。无需修改脚本——H200 配方走 FP8/Hopper 路径，不使用 B200/B300 上需要 `--prefill-schedule-interval` 的 fp4/mega_moe 参数。
  - `dsv4-fp8-h200-sglang(+mtp)`：将固定的 `lmsysorg/sglang:deepseek-v4-hopper` 镜像摘要从 2026-05-02 推送（`7f19c6dc`）更新为当前 2026-05-13 推送（`1bf5d508`）。
- **B300 1k1k 扫描密度：** `dsv4-fp4-b300-sglang` 在 1k1k 下只采样 conc {1, 32, 512, 8192}，导致约 50 tok/s/user 交互性区域完全未采样（官网显示 933 tok/s/GPU，低于 B200 的 1,359，而 B300 在 30 和 100 处均领先——大概率是采样密度问题）。新增 DP-attn flashinfer_mxfp4 频段 conc 64–512，并将 megamoe 频段扩展为 2048–8192（复用脚本中已有的 2048/4096 启动配置）。`dsv4_fp4_b300_sglang.sh` 改为按 CONC 区间选择启动配置。同时为 `dsv4-fp4-b300-trt(+mtp)` 追加重跑条目（配置不变，最后一次运行 2026-06-11），保证密度检查基于同一批次数据。
  - 特意未改动：`dsv4-fp4-b300-sglang-mtp` 保持 conc ≤32 上限（B300 EAGLE 草稿模型在 bs≥128 时 CUDA graph 崩溃，见 KLAUD_DEBUG.md）；TRT 1k1k conc-2048 采样点保持移除状态（MLA-overlap 崩溃，#1703）。
- **GB300 1k1k（仅有 2026-06-15 单日数据）：** 为 `dsv4-fp4-gb300-dynamo-trt(+mtp)` 追加重跑条目（配置不变）——这是目前 GB300 dsv4 仅有的 1k1k 提交来源。

验证：`generate_sweep_configs.py` 生成的 1k1k 矩阵符合预期（conc 1, 32, 64, 128, 256, 512, 2048, 4096, 8192）；`validate_perf_changelog.py --base-ref main` 通过。