### PR TITLE
[DSv4] Refresh stale H200 FP8 submissions / 刷新过期的 H200 FP8 数据

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3078,7 +3078,7 @@ dsr1-fp8-h200-sglang-mtp:
 # Uses the cu129 image. H200 has no FP4 path, so the FP4 indexer cache
 # flag is omitted. Max-model-len is pinned at 800k per the recipe.
 dsv4-fp8-h200-vllm:
-  image: vllm/vllm-openai:v0.25.0
+  image: vllm/vllm-openai:v0.25.1
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200
@@ -3101,7 +3101,7 @@ dsv4-fp8-h200-vllm:
 # MTP variant of dsv4-fp8-h200-vllm. Mirrors the non-MTP image and adds
 # --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.
 dsv4-fp8-h200-vllm-mtp:
-  image: vllm/vllm-openai:v0.25.0
+  image: vllm/vllm-openai:v0.25.1
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3078,7 +3078,7 @@ dsr1-fp8-h200-sglang-mtp:
 # Uses the cu129 image. H200 has no FP4 path, so the FP4 indexer cache
 # flag is omitted. Max-model-len is pinned at 800k per the recipe.
 dsv4-fp8-h200-vllm:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.25.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200
@@ -3098,11 +3098,10 @@ dsv4-fp8-h200-vllm:
       - { tp: 8, ep: 1, dp-attn: false, conc-start: 1, conc-end: 256 }
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 1, conc-end: 256 }
 
-# MTP variant of dsv4-fp8-h200-vllm. Uses the canonical v0.20.1 image
-# (the non-MTP entry above is still on the deepseekv4-cu129 tag) and adds
+# MTP variant of dsv4-fp8-h200-vllm. Mirrors the non-MTP image and adds
 # --speculative-config '{"method":"mtp","num_speculative_tokens":2}'.
 dsv4-fp8-h200-vllm-mtp:
-  image: vllm/vllm-openai:v0.21.0
+  image: vllm/vllm-openai:v0.25.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200
@@ -3143,7 +3142,7 @@ dsv4-fp8-h200-vllm-agentic:
 # runner pool, search space) and adds EAGLE speculative decoding via
 # --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
 dsv4-fp8-h200-sglang:
-  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
+  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:1bf5d508ab110cc0fe1659a5f21d1be02a7f0d7ca8f58cea7e7f4e11f6ae208f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200-dgxc
@@ -3167,7 +3166,7 @@ dsv4-fp8-h200-sglang:
 # runner pool, search space) and adds EAGLE speculative decoding via
 # --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
 dsv4-fp8-h200-sglang-mtp:
-  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:7f19c6dc092e47a10fac2e41f47eab78970280d06648b8e50d312a82f0ae722f
+  image: lmsysorg/sglang:deepseek-v4-hopper@sha256:1bf5d508ab110cc0fe1659a5f21d1be02a7f0d7ca8f58cea7e7f4e11f6ae208f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: h200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4750,3 +4750,19 @@
     - "Image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928"
     - "6 topologies across 1k/1k and 8k/1k: 1P1D TP4 STP + wide-EP (DEP4 prefill / DEP16 decode) from 1P1D up to 8P1D, recipes under benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2137
+
+- config-keys:
+    - dsv4-fp8-h200-vllm
+    - dsv4-fp8-h200-vllm-mtp
+  description:
+    - "Bump vLLM image from v0.21.0 to v0.25.0 for DeepSeek-V4-Pro FP8 on H200, matching the B200/B300 dsv4 vLLM bump (#2169)"
+    - "Refresh stale H200 dsv4 submissions (last run 2026-05-21)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2191
+
+- config-keys:
+    - dsv4-fp8-h200-sglang
+    - dsv4-fp8-h200-sglang-mtp
+  description:
+    - "Bump the pinned lmsysorg/sglang:deepseek-v4-hopper digest from the 2026-05-02 push (7f19c6dc) to the current 2026-05-13 push (1bf5d508)"
+    - "Refresh stale H200 dsv4 SGLang submissions (last run 2026-05-04)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2191


### PR DESCRIPTION
## Summary

Split out of the closed #2189 — H200 only, one PR per SKU.

DSv4 (DeepSeek-V4-Pro) FP8 on H200 was stale (last run 2026-05-21). Pure image refresh, no search-space change:

- `dsv4-fp8-h200-vllm(+mtp)`: bump vLLM image `v0.21.0` → `v0.25.0`, matching the B200/B300 dsv4 vLLM bump (#2169). No script change — the H200 recipe is the FP8/Hopper path and doesn't use the fp4/mega_moe flags that needed `--prefill-schedule-interval` on B200/B300.
- `dsv4-fp8-h200-sglang(+mtp)`: bump the pinned `lmsysorg/sglang:deepseek-v4-hopper` digest from the 2026-05-02 push (`7f19c6dc`) to the current 2026-05-13 push (`1bf5d508`).

Validation: `generate_sweep_configs.py --model-prefix dsv4 --runner-type h200` resolves to the v0.25.0 image; `validate_perf_changelog.py --base-ref main` passes.

## 中文说明

从已关闭的 #2189 拆分而来——仅 H200，按 SKU 拆分为独立 PR。

H200 上的 DSv4（DeepSeek-V4-Pro）FP8 数据已过期（最后一次运行 2026-05-21）。仅刷新镜像，不改动扫描空间：

- `dsv4-fp8-h200-vllm(+mtp)`：vLLM 镜像从 `v0.21.0` 升级到 `v0.25.0`，与 B200/B300 的 dsv4 vLLM 升级（#2169）一致。无需修改脚本——H200 走 FP8/Hopper 路径，不使用 B200/B300 上需要 `--prefill-schedule-interval` 的 fp4/mega_moe 参数。
- `dsv4-fp8-h200-sglang(+mtp)`：将固定的 `lmsysorg/sglang:deepseek-v4-hopper` 镜像摘要从 2026-05-02 推送（`7f19c6dc`）更新为当前 2026-05-13 推送（`1bf5d508`）。

验证：`generate_sweep_configs.py --model-prefix dsv4 --runner-type h200` 解析到 v0.25.0 镜像；`validate_perf_changelog.py --base-ref main` 通过。