### PR TITLE
[DSv4] Densify B300 SGLang 1k1k sweep, re-run B300 TRT / 加密 B300 SGLang 1k1k 扫描并重跑 B300 TRT

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_b300_sglang.sh
@@ -53,7 +53,7 @@ start_gpu_monitor --output "$PWD/gpu_metrics.csv"
 # SWA ratio: 1k inputs need more SWA cache headroom than 8k inputs; 0.5 was
 # tuned empirically for the 1k1k recipe, while 0.1 is the cookbook default.
 
-if [ "$CONC" = "1" ] || [ "$CONC" = "32" ]; then
+if [ "$CONC" -le 32 ]; then
     # TP-only, no DP attention
     MEM_FRACTION_STATIC=0.90
     SWA_FULL_TOKENS_RATIO=$([[ "$ISL" == "1024" ]] && echo 0.5 || echo 0.1)
@@ -63,7 +63,7 @@ if [ "$CONC" = "1" ] || [ "$CONC" = "32" ]; then
         --disable-flashinfer-autotune
     )
 
-elif [ "$CONC" = "512" ]; then
+elif [ "$CONC" -ge 64 ] && [ "$CONC" -le 512 ]; then
     # DP attention, flashinfer_mxfp4
     export SGLANG_OPT_SWA_EVICT_DROP_PAGE_MARGIN=1
     MEM_FRACTION_STATIC=0.94

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2002,8 +2002,8 @@ dsv4-fp4-b300-sglang:
   multinode: false
   # Recipes are selected inside benchmarks/single_node/dsv4_fp4_b300_sglang.sh
   # by CONC:
-  #   CONC 1|32:         TP-only, flashinfer_mxfp4
-  #   CONC 512:          DP-attn, flashinfer_mxfp4
+  #   CONC <=32:         TP-only, flashinfer_mxfp4
+  #   CONC 64-512:       DP-attn, flashinfer_mxfp4
   #   CONC 2048-8192:    DP-attn, megamoe
   # ep is implicit in sglang: --moe-a2a-backend megamoe forces ep_size=tp_size,
   # while low-latency leaves ep_size at the default of 1.
@@ -2014,8 +2014,12 @@ dsv4-fp4-b300-sglang:
       search-space:
       - { tp: 8, ep: 1, conc-start: 1, conc-end: 1 }
       - { tp: 4, ep: 1, conc-start: 32, conc-end: 32 }
-      - { tp: 4, ep: 1, dp-attn: true, conc-start: 512, conc-end: 512 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 8192, conc-end: 8192 }
+      # Densified mid band: the previous single conc-512 point left the
+      # ~50 tok/s/user frontier region (conc 64-256) unsampled at 1k1k.
+      - { tp: 4, ep: 1, dp-attn: true, conc-start: 64, conc-end: 512 }
+      # Megamoe band extended down to the script's existing 2048/4096 profiles
+      # (previously only 8192 at 1k1k).
+      - { tp: 8, ep: 8, dp-attn: true, conc-start: 2048, conc-end: 8192 }
     - isl: 8192
       osl: 1024
       search-space:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4750,3 +4750,18 @@
     - "Image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928"
     - "6 topologies across 1k/1k and 8k/1k: 1P1D TP4 STP + wide-EP (DEP4 prefill / DEP16 decode) from 1P1D up to 8P1D, recipes under benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2137
+
+- config-keys:
+    - dsv4-fp4-b300-sglang
+  description:
+    - "Densify the 1k1k sweep: the previous search space sampled only conc {1, 32, 512, 8192}, leaving the ~50 tok/s/user frontier region unsampled and noisy (933 tok/s/GPU vs B200's 1359 at 50 tok/s/user)"
+    - "Add the DP-attn flashinfer_mxfp4 band conc 64-512 (was a single 512 point) and extend the megamoe band down to conc 2048-8192 (was a single 8192 point), reusing the existing CONC 2048/4096 launch profiles in dsv4_fp4_b300_sglang.sh"
+    - "dsv4_fp4_b300_sglang.sh: select launch profiles by CONC range (<=32 TP-only, 64-512 DP-attn flashinfer) instead of exact match; megamoe profiles unchanged"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2192
+
+- config-keys:
+    - dsv4-fp4-b300-trt
+    - dsv4-fp4-b300-trt-mtp
+  description:
+    - "Re-run B300 dsv4 TRT-LLM configs (no config change, last run 2026-06-11) so the 1k1k frontier density check around 50 tok/s/user compares same-pass data across frameworks"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2192


### PR DESCRIPTION
## Summary

Split out of the closed #2189 — B300 only, one PR per SKU.

**Problem:** `dsv4-fp4-b300-sglang` sampled only conc {1, 32, 512, 8192} at 1k1k, leaving the ~50 tok/s/user frontier region unsampled (site reads 933 tok/s/GPU vs B200's 1,359 at 50 tok/s/user while B300 wins at 30 and 100 — a density artifact, not a real loss).

**Change:**
- Add the DP-attn flashinfer_mxfp4 band conc 64–512 (was a single 512 point) and extend the megamoe band to conc 2048–8192 (was a single 8192 point), reusing the script's existing 2048/4096 launch profiles.
- `dsv4_fp4_b300_sglang.sh` now selects launch profiles by CONC range (`<=32` TP-only, `64-512` DP-attn flashinfer) instead of exact match; megamoe profiles unchanged.
- `dsv4-fp4-b300-trt(+mtp)` re-run (no config change, last run 2026-06-11) so the density check compares same-pass data across frameworks.

Deliberately **not** touched: `dsv4-fp4-b300-sglang-mtp` stays capped at conc ≤32 (B300 EAGLE draft CUDA-graph crash at bs≥128, see KLAUD_DEBUG.md), and the TRT 1k1k conc-2048 point stays dropped (MLA-overlap crash, #1703).

Validation: `generate_sweep_configs.py` produces the densified 1k1k matrix (conc 1, 32, 64, 128, 256, 512, 2048, 4096, 8192); `validate_perf_changelog.py --base-ref main` passes; script passes `bash -n`.

## 中文说明

从已关闭的 #2189 拆分而来——仅 B300，按 SKU 拆分为独立 PR。

**问题：** `dsv4-fp4-b300-sglang` 在 1k1k 下只采样 conc {1, 32, 512, 8192}，导致约 50 tok/s/user 交互性区域未采样（官网显示 933 tok/s/GPU，低于 B200 的 1,359，而 B300 在 30 和 100 处均领先——是采样密度问题，并非真实劣势）。

**改动：**
- 新增 DP-attn flashinfer_mxfp4 频段 conc 64–512（原为单点 512），并将 megamoe 频段扩展为 conc 2048–8192（原为单点 8192），复用脚本已有的 2048/4096 启动配置。
- `dsv4_fp4_b300_sglang.sh` 改为按 CONC 区间选择启动配置（`<=32` TP-only、`64-512` DP-attn flashinfer），不再精确匹配；megamoe 配置不变。
- `dsv4-fp4-b300-trt(+mtp)` 重跑（配置不变，最后一次运行 2026-06-11），保证密度检查基于同一批次数据。

特意未改动：`dsv4-fp4-b300-sglang-mtp` 保持 conc ≤32 上限（B300 EAGLE 草稿模型在 bs≥128 时 CUDA graph 崩溃，见 KLAUD_DEBUG.md）；TRT 1k1k conc-2048 采样点保持移除状态（MLA-overlap 崩溃，#1703）。

验证：`generate_sweep_configs.py` 生成加密后的 1k1k 矩阵（conc 1, 32, 64, 128, 256, 512, 2048, 4096, 8192）；`validate_perf_changelog.py --base-ref main` 通过；脚本通过 `bash -n`。