### PR TITLE
[DSv4] Re-run GB300 dynamo-trt configs / 重跑 GB300 dynamo-trt 配置

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4750,3 +4750,10 @@
     - "Image: lmsysorg/sglang:nightly-dev-cu13-20260709-074bb928"
     - "6 topologies across 1k/1k and 8k/1k: 1P1D TP4 STP + wide-EP (DEP4 prefill / DEP16 decode) from 1P1D up to 8P1D, recipes under benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2137
+
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-trt
+    - dsv4-fp4-gb300-dynamo-trt-mtp
+  description:
+    - "Re-run GB300 dsv4 dynamo-trt configs (no config change): the only GB300 dsv4 1k1k submissions are from a single 2026-06-15 run"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2193


### PR DESCRIPTION
## Summary

Split out of the closed #2189 — GB300 only, one PR per SKU.

The only GB300 dsv4 (DeepSeek-V4-Pro) 1k1k submissions come from a single 2026-06-15 run. Re-run `dsv4-fp4-gb300-dynamo-trt(+mtp)` — no config change, changelog-only trigger.

Validation: `validate_perf_changelog.py --base-ref main` passes.

## 中文说明

从已关闭的 #2189 拆分而来——仅 GB300，按 SKU 拆分为独立 PR。

GB300 dsv4（DeepSeek-V4-Pro）1k1k 目前仅有 2026-06-15 单日数据。重跑 `dsv4-fp4-gb300-dynamo-trt(+mtp)`——配置不变，仅通过 changelog 触发。

验证：`validate_perf_changelog.py --base-ref main` 通过。