### PR TITLE
Align PR 2139 GB200 recipe identity versions

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
@@ -153,7 +153,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.0-ubuntu2404"
+    image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:
-    dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    dynamo: "1.3.0.dev1"
+    vllm: "0.1.dev18219+g4ba0a72a4"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
@@ -147,7 +147,7 @@ benchmark:
 
 identity:
   container:
-    image: "vllm/vllm-openai:v0.20.0-ubuntu2404"
+    image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:
-    dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    dynamo: "1.3.0.dev1"
+    vllm: "0.1.dev18219+g4ba0a72a4"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
@@ -149,7 +149,7 @@ benchmark:
 
 identity:
   container:
-    image: "vllm/vllm-openai:v0.20.0-ubuntu2404"
+    image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:
-    dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    dynamo: "1.3.0.dev1"
+    vllm: "0.1.dev18219+g4ba0a72a4"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
@@ -153,7 +153,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.0-ubuntu2404"
+    image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:
-    dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    dynamo: "1.3.0.dev1"
+    vllm: "0.1.dev18219+g4ba0a72a4"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
@@ -153,7 +153,7 @@ identity:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
     revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
   container:
-    image: "vllm/vllm-openai:v0.20.0-ubuntu2404"
+    image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:
-    dynamo: "1.2.0.dev20260426"
-    vllm: "0.20.0"
+    dynamo: "1.3.0.dev1"
+    vllm: "0.1.dev18219+g4ba0a72a4"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4775,4 +4775,5 @@
     - "Reduce the 1P4D TP8 decode GPU memory utilization from 0.9 to 0.85"
     - "Update the vLLM image from v0.20.0-ubuntu2404 to dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
     - "Use the DeepSeek-V4-Pro MXFP4 checkpoint for the five GB200 STP recipes"
+    - "Align recipe identity metadata with Dynamo 1.3.0.dev1 and vLLM 0.1.dev18219+g4ba0a72a4"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2139


### PR DESCRIPTION
## Summary

- Align the five standard GB200 Dynamo-vLLM recipe identity blocks with the active container image.
- Set the identity Dynamo version to `1.3.0.dev1`.
- Set the identity vLLM version to `0.1.dev18219+g4ba0a72a4`.
- Leave every non-identity recipe field unchanged.

## Validation

- Verified semantically that only each recipe's `identity` mapping changed.
- Parsed `perf-changelog.yaml`, `configs/nvidia-master.yaml`, and all DeepSeek-V4 vLLM recipe YAML files (29 files total).
- Generated the targeted GB200 DSV4 FP4 Dynamo-vLLM 8K/1K matrix; the same five STP and four MTP rows were emitted.
- `python -m pytest utils/matrix_logic/ -q` — 221 passed.
- `utils/validate_perf_changelog.py` passed against PR 2139's current main merge-base.

## Parent PR state

`main` has advanced since PR 2139 last synchronized its append-only changelog, so direct validation against the latest `origin/main` remains blocked until the parent branch is synchronized. This child PR intentionally does not modify that parent-branch state.
