### PR TITLE
[WIP][AMD][MI355x] dsv4-fp4-mi355x-vllm-agentic, install latest lmcache

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm.sh
@@ -274,14 +274,7 @@ EOF
         { set +x; } 2>/dev/null
         unset VLLM_USE_SIMPLE_KV_OFFLOAD
 
-        git clone https://github.com/LMCache/LMCache.git
-        cd LMCache
-        # https://github.com/LMCache/LMCache/pull/3853
-        git checkout 9229067cec0b3a63bb8a39368d101db7ac0bc3c1
-        pip install -r requirements/build.txt
-        pip install grpcio==1.78.0
-        CXX=hipcc BUILD_WITH_HIP=1 pip install -e .   --no-build-isolation
-        cd ..
+        pip install lmcache==0.5.1
 
         python3 -c "import lmcache.integration.vllm.lmcache_mp_connector" >/dev/null
 
@@ -330,6 +323,7 @@ EOF
             --max-workers "$LMCACHE_MAX_WORKERS"
             --eviction-policy LRU
             --supported-transfer-mode "$LMCACHE_TX_MODE"
+            --no-separate-object-group
         )
         printf '%q ' "${LMCACHE_CMD[@]}" > "$RESULT_DIR/lmcache_command.txt"
         printf '\n' >> "$RESULT_DIR/lmcache_command.txt"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4781,3 +4781,10 @@
     - "Bump image to lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260708"
     - "Clean the export envs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2198
+
+- config-keys:
+    - dsv4-fp4-mi355x-vllm-agentic
+  description:
+    - "Replace pinned-commit LMCache source build (CXX=hipcc BUILD_WITH_HIP=1) with pip install lmcache==0.5.1"
+    - "Add --no-separate-object-group to the LMCache MP server launch command"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2214


### PR DESCRIPTION
## Summary
- Replace pinned-commit LMCache source build (`CXX=hipcc BUILD_WITH_HIP=1`) with `pip install lmcache==0.5.1`
- Add `--no-separate-object-group` to the LMCache MP server launch command