### PR TITLE
[Klaud Cold] Re-introduce dsv4-fp8-mi355x-sglang on rocm/sgl-dev DSv4 image

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp8_mi355x_sglang.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp8_mi355x_sglang.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
+
+# Transformers in the container doesn't recognize the `deepseek_v4` model_type.
+# PR #23608's fallback in hf_transformers_utils.get_config tries to handle this
+# by writing a patched config to /tmp, but in practice isn't catching the error
+# in this image. Patch the cached config.json directly instead: set model_type
+# to `deepseek_v3` so AutoConfig.from_pretrained succeeds, and keep
+# architectures=['DeepseekV4ForCausalLM'] so SGLang dispatches to its native
+# DSv4 model class (python/sglang/srt/models/deepseek_v4.py).
+python3 << PYEOF
+import json
+from huggingface_hub import hf_hub_download
+path = hf_hub_download(repo_id="$MODEL", filename="config.json")
+with open(path) as f:
+    config = json.load(f)
+if config.get("model_type") == "deepseek_v4":
+    config["model_type"] = "deepseek_v3"
+    with open(path, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"Patched {path}: model_type deepseek_v4 -> deepseek_v3")
+else:
+    print(f"No patch needed: model_type is {config.get('model_type')!r}")
+PYEOF
+
+# DSv4-specific SGLang env vars (from sgl-project/sglang#23608)
+export SGLANG_OPT_USE_FUSED_COMPRESS=false
+export SGLANG_OPT_USE_OLD_COMPRESSOR=true
+export SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false
+export SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false
+export SGLANG_OPT_USE_FUSED_HASH_TOPK=false
+export SGLANG_HACK_FLASHMLA_BACKEND=torch
+export SGLANG_OPT_DEEPGEMM_HC_PRENORM=false
+export SGLANG_OPT_USE_TILELANG_MHC_PRE=false
+export SGLANG_OPT_USE_TILELANG_MHC_POST=false
+export SGLANG_ENABLE_THINKING=1
+export SGLANG_USE_AITER=1
+export SGLANG_USE_ROCM700A=1
+export SGLANG_TOPK_TRANSFORM_512_TORCH=1
+export SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1
+export SGLANG_DSV4_FP4_EXPERTS=false
+export SGLANG_OPT_DPSK_V4_RADIX=0
+export SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false
+export SGLANG_OPT_USE_FUSED_STORE_CACHE=false
+export SGLANG_FORCE_TRITON_MOE_FP8=1
+
+SERVER_LOG=/workspace/server.log
+PORT=${PORT:-8888}
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+# Start GPU monitoring (power, temperature, clocks every second)
+start_gpu_monitor
+
+python3 -m sglang.launch_server \
+    --model-path $MODEL \
+    --host=0.0.0.0 \
+    --port $PORT \
+    --tensor-parallel-size $TP \
+    --dp $TP \
+    --enable-dp-attention \
+    --trust-remote-code \
+    --disable-radix-cache \
+    --attention-backend compressed \
+    --max-running-request 256 \
+    --page-size 256 \
+    --chunked-prefill-size 8192 \
+    --disable-shared-experts-fusion \
+    --disable-cuda-graph \
+    --tool-call-parser deepseekv4 \
+    --reasoning-parser deepseek-v4 \
+    --watchdog-timeout 1800 $EVAL_CONTEXT_ARGS > $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+# Wait for server to be ready
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/
+
+# After throughput, run evaluation only if RUN_EVAL is true
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+# Stop GPU monitoring
+stop_gpu_monitor
+set +x

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1856,6 +1856,33 @@ dsv4-fp4-mi355x-sglang-mtp:
       - { tp: 8, dp-attn: true, conc-start: 64, conc-end: 2048, spec-decoding: mtp }
       - { tp: 8, dp-attn: false, conc-start: 1, conc-end: 32, spec-decoding: mtp }
 
+# DSv4-Pro FP8 on MI355X via SGLang. Re-introduced after removal in #1501.
+# The DSV4-Pro-FP8 checkpoint keeps some bf16 layers (shared-expert /
+# embedding), so generic lmsysorg/sglang-rocm releases fail at server boot
+# with a strict FP8 downcast check (ValueError: Downcasting not allowed:
+# target.dtype=torch.float8_e4m3fn, loaded_weight.dtype=torch.bfloat16).
+# Only the DSv4-specific rocm/sgl-dev custom builds tolerate this -- keep this
+# recipe pinned to a `...-DSv4` custom tag; do NOT bump it to a plain
+# sglang-rocm release (that is exactly what broke it and caused the removal).
+dsv4-fp8-mi355x-sglang:
+  image: rocm/sgl-dev:rocm720-mi35x-da28108-20260610-DSv4
+  model: sgl-project/DeepSeek-V4-Pro-FP8
+  model-prefix: dsv4
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, conc-start: 4, conc-end: 64 }
+
 # DSv4 on MI355X via vLLM, using the official vllm/vllm-openai-rocm
 # nightly image. DSv4 base ROCm support (vllm-project/vllm#40871) merged
 # on 2026-05-05, so any nightly built after that includes the

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4781,3 +4781,9 @@
     - "Bump image to lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260708"
     - "Clean the export envs"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2198
+
+- config-keys:
+    - dsv4-fp8-mi355x-sglang
+  description:
+    - "Re-introduce dsv4-fp8-mi355x-sglang benchmark (removed in #1501). Pins to DSv4-specific image rocm/sgl-dev:rocm720-mi35x-da28108-20260610-DSv4, which tolerates the DSV4-Pro-FP8 bf16 shared-expert/embedding layers; generic lmsysorg/sglang-rocm releases fail server boot with a strict FP8 downcast check. Restores launch script at benchmarks/single_node/fixed_seq_len/dsv4_fp8_mi355x_sglang.sh"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2220


### PR DESCRIPTION
## Summary
Re-introduces the `dsv4-fp8-mi355x-sglang` benchmark (DeepSeek-V4-Pro-FP8 on MI355X via SGLang), removed in #1501, with an updated DSv4-specific image.

## Why it was removed, and why this works
#1501 removed the recipe because bumping it off the custom `rocm/sgl-dev` build to a generic `lmsysorg/sglang-rocm` release broke server boot:
```
ValueError: Downcasting not allowed: target.dtype=torch.float8_e4m3fn, loaded_weight.dtype=torch.bfloat16
```
DSV4-Pro-FP8 keeps some bf16 layers (shared-expert / embedding); only the DSv4-specific `rocm/sgl-dev` custom builds tolerate this. This PR pins to `rocm/sgl-dev:rocm720-mi35x-da28108-20260610-DSv4` (a `-DSv4` custom build), **not** a plain release. A config comment records this so future bumps do not naively re-break it.

## Changes
- `configs/amd-master.yaml`: restore `dsv4-fp8-mi355x-sglang` block on the new image (tp8, 1k1k + 8k1k, conc 4–64).
- `benchmarks/single_node/fixed_seq_len/dsv4_fp8_mi355x_sglang.sh`: restore launch script under the current `fixed_seq_len/` layout + `_sglang` naming (the old flat `dsv4_fp8_mi355x.sh` no longer matches launcher routing). Serving flags/env carried over from the last-known-working version (config model_type patch, `--attention-backend compressed`, `--disable-cuda-graph`, DSv4 FP8 env vars).

## Test plan
- [ ] full-sweep-fail-fast sweep passes (server boots on the new image without the downcast error; GSM8K eval passes).

Note: serving flags/env were validated against the April `deepseek-v4-mi35x` build; the June `da28108-...-DSv4` build may need on-cluster tuning, which I will drive from the sweep results.