### PR TITLE
Fix reusable artifact validation for nested metadata / 修复嵌套元数据的可复用产物校验

### DIFF
--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -266,6 +266,40 @@ def test_multinode_agentic_identity_fields_match() -> None:
             assert identity({**default_row, field: 2}) != identity(default_row)
 
 
+def test_agentic_identity_freezes_nested_kv_offload_backend() -> None:
+    row = {
+        **agentic_result(),
+        "kv_offloading": "dram",
+        "kv_offload_backend": {
+            "name": "native",
+            "options": {"layers": ["cpu", "gpu"]},
+        },
+    }
+    row.pop("offloading")
+
+    identity = agentic_key(row)
+
+    assert isinstance(hash(identity), int)
+    assert identity == agentic_key(
+        {
+            **row,
+            "kv_offload_backend": {
+                "options": {"layers": ["cpu", "gpu"]},
+                "name": "native",
+            },
+        }
+    )
+    assert identity != agentic_key(
+        {
+            **row,
+            "kv_offload_backend": {
+                "name": "native",
+                "options": {"layers": ["cpu"]},
+            },
+        }
+    )
+
+
 def write_agentic_artifacts(
     root: Path,
     conc: int = 16,
@@ -513,6 +547,25 @@ def test_agentic_validation_rejects_duplicate_point_identity(
     result_path.write_text(
         json.dumps([agentic_result(), agentic_result()])
     )
+
+    errors = validate_agentic_artifacts(tmp_path)
+
+    assert "agentic point artifacts contain 1 duplicate row(s)" in errors
+
+
+def test_agentic_validation_handles_mapping_kv_offload_backend(
+    tmp_path: Path,
+) -> None:
+    row = {
+        **agentic_result(),
+        "kv_offloading": "dram",
+        "kv_offload_backend": {"name": "native"},
+    }
+    row.pop("offloading")
+    point_dir = tmp_path / "bmk_agentic_native_offload"
+    point_dir.mkdir()
+    (point_dir / "result.json").write_text(json.dumps([row, row]))
+    (tmp_path / "agentic_native_offload").mkdir()
 
     errors = validate_agentic_artifacts(tmp_path)
 

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -110,13 +110,27 @@ def actual_benchmark_keys(artifacts_dir: Path) -> set[tuple[Any, ...]]:
     return set(actual_benchmark_key_rows(artifacts_dir))
 
 
+def freeze_identity_value(value: Any) -> Any:
+    """Convert nested JSON values into deterministic, hashable identities."""
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (key, freeze_identity_value(item))
+                for key, item in value.items()
+            )
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_identity_value(item) for item in value)
+    return value
+
+
 def agentic_key(row: dict[str, Any]) -> tuple[Any, ...]:
     """Build an agentic identity from one point result."""
     if "kv_offloading" in row:
         kv_offloading = row.get("kv_offloading") or "none"
         offload_key: Any = (
             kv_offloading,
-            (row.get("kv_offload_backend") or "")
+            freeze_identity_value(row.get("kv_offload_backend") or "")
             if kv_offloading != "none"
             else "",
         )


### PR DESCRIPTION
## Summary

- canonicalize nested JSON values before using them in reusable-artifact identities
- preserve KV offload backend name/version/options while making mappings and lists hashable
- add regression tests for the exact `{"name": "native"}` failure and deeper nested metadata
- verify duplicate detection still reports duplicates instead of crashing

Root cause: [post-merge run 29425167775](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29425167775) passed a dict-valued `kv_offload_backend` into `Counter`, which raised `TypeError: unhashable type: 'dict'` while reusing PR #2158's staged artifacts.

## Validation

- `python -m pytest utils/test_validate_reusable_sweep_artifacts.py -v` — 26 passed
- complete `test-changelog-gate.yml` pytest command — 140 passed
- replayed the exact failing artifact from run 29359203708; its identity is now hashable

## 中文说明

- 在构造可复用产物标识前，递归规范化嵌套 JSON 值
- 保留 KV 卸载后端的名称、版本和选项，同时将映射与列表转换为可哈希形式
- 为本次 `{"name": "native"}` 故障以及更深层的嵌套元数据添加回归测试
- 验证重复产物检测会正确报告重复项，而不会崩溃

根因：[合并后运行 29425167775](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29425167775) 在复用 PR #2158 的暂存产物时，将字典类型的 `kv_offload_backend` 传入 `Counter`，触发 `TypeError: unhashable type: 'dict'`。

## 验证

- `python -m pytest utils/test_validate_reusable_sweep_artifacts.py -v` — 26 项通过
- 完整执行 `test-changelog-gate.yml` 中的 pytest 命令 — 140 项通过
- 使用运行 29359203708 中触发故障的原始产物复测；其标识现在可正常哈希
