### PR TITLE
fix(agentic): bound warmup drain to 10 minutes / 将 AgentX 预热排空限制为 10 分钟

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1479,9 +1479,9 @@ build_replay_cmd() {
     # with one-token outputs and no idle delays for 10 minutes. Profiling begins
     # only after those requests drain and resumes from the resulting live state.
     REPLAY_CMD+=" --agentic-cache-warmup-duration 600"
-    # Long-context warmup requests can take more than AIPerf's default 300s
-    # grace period to drain. Wait for every warmup request before profiling.
-    REPLAY_CMD+=" --warmup-grace-period inf"
+    # Give long-context warmup requests up to 10 minutes to drain before
+    # cancelling any remaining requests and starting profiling.
+    REPLAY_CMD+=" --warmup-grace-period 600"
     # Use server-reported usage fields (prompt_tokens / completion_tokens) for
     # ISL/OSL instead of client-side tokenizer.encode(). Auto-enables
     # stream_options.include_usage on the OpenAI chat endpoint. Skips the


### PR DESCRIPTION
Set the centralized AgentX warmup drain grace period from infinite to 600 seconds.

Tests: `bash -n benchmarks/benchmark_lib.sh`; `python -m pytest utils/matrix_logic/ -v` (221 passed).

## 中文说明

将集中配置的 AgentX 预热排空宽限期从无限改为 600 秒。

测试：`bash -n benchmarks/benchmark_lib.sh`；`python -m pytest utils/matrix_logic/ -v`（221 项通过）。