### PR TITLE
[Klaud Cold] Add @hbarclay as codeowner for experimental/operatorx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@ configs/amd-master.yaml @billishyahao @chunfangamd @seungrokj @yctseng0211 @1am9
 
 # NVIDIA master config
 configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv @jgangani
+
+# OperatorX experimental
+experimental/operatorx/ @hbarclay


### PR DESCRIPTION
## Summary
- Adds `@hbarclay` as codeowner for `experimental/operatorx/` in `.github/CODEOWNERS`, following the existing path-specific entry style
- Follow-up to #2234 which imported operatorx into `experimental/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)