### PR TITLE
Fix agentic ingest dispatch authorization / 修复 Agentic 摄取分发授权

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -424,10 +424,10 @@ jobs:
                   curl -sSf -X POST \
                     -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
                     -H "Accept: application/vnd.github+v3+json" \
-                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
                     -d '{
-                      "ref": "master",
-                      "inputs": {
+                      "event_type": "ingest-agentic-results",
+                      "client_payload": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
                         "database-target": "production"

--- a/.github/workflows/recover-reused-ingest.yml
+++ b/.github/workflows/recover-reused-ingest.yml
@@ -163,10 +163,10 @@ jobs:
                   curl -sSf -X POST \
                     -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
                     -H "Accept: application/vnd.github+v3+json" \
-                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
                     -d '{
-                      "ref": "master",
-                      "inputs": {
+                      "event_type": "ingest-agentic-results",
+                      "client_payload": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
                         "database-target": "production"

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -970,10 +970,10 @@ jobs:
                   curl -sSf -X POST \
                     -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
                     -H "Accept: application/vnd.github+v3+json" \
-                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/actions/workflows/ingest-agentic-results.yml/dispatches \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
                     -d '{
-                      "ref": "master",
-                      "inputs": {
+                      "event_type": "ingest-agentic-results",
+                      "client_payload": {
                         "run-id": "${{ github.run_id }}",
                         "run-attempt": "${{ github.run_attempt }}",
                         "database-target": "production"


### PR DESCRIPTION
## Summary

- Switch all agentic ingest triggers from `workflow_dispatch` to the `repository_dispatch` contract exposed by `InferenceX-app`.
- Cover main sweeps, E2E runs, and reused-ingest recovery runs.
- Preserve the existing production run ID and attempt payload.

## Root cause

The source workflows called the target workflow-dispatch endpoint with `INFX_FRONTEND_PAT`. GitHub rejected that endpoint with HTTP 403 because it requires Actions write authorization. The target workflow already documents and listens for the `ingest-agentic-results` repository-dispatch event, and the same PAT successfully dispatches repository events.

## Recovery

The failed production ingest for source run `29470515957` was manually re-dispatched through the supported repository-dispatch contract and is tracked by target run `29470850852`.

## Validation

- `actionlint` on all three changed workflows, excluding unrelated pre-existing baseline warnings
- YAML parsing for all three changed workflows
- `python -m pytest utils/changelog_gate_tests/test_run_sweep_gating.py -q` (27 passed)
- Verified all three agentic call sites use `event_type: ingest-agentic-results`

## 中文说明

### 摘要

- 将所有 Agentic 摄取触发器从 `workflow_dispatch` 切换为 `InferenceX-app` 已提供的 `repository_dispatch` 契约。
- 覆盖主分支扫描、E2E 运行以及复用产物摄取恢复流程。
- 保持现有的生产环境运行 ID 和尝试次数载荷不变。

### 根因

源工作流使用 `INFX_FRONTEND_PAT` 调用目标仓库的 workflow-dispatch 端点。该端点需要 Actions 写入权限，因此 GitHub 返回 HTTP 403。目标工作流本身已记录并监听 `ingest-agentic-results` repository-dispatch 事件，同一 PAT 也能成功发送 repository dispatch。

### 恢复

源运行 `29470515957` 的失败生产摄取已通过受支持的 repository-dispatch 契约重新触发，对应目标运行是 `29470850852`。

### 验证

- 对三个修改后的工作流运行 `actionlint`，仅排除与本次修改无关的既有基线告警
- 验证三个修改后的工作流均可正常解析 YAML
- `python -m pytest utils/changelog_gate_tests/test_run_sweep_gating.py -q`（27 项通过）
- 验证三个 Agentic 调用点均使用 `event_type: ingest-agentic-results`
