### PR TITLE
Extend AgentX warmup drain timeout to 30 minutes / 将 AgentX 预热排空超时延长至 30 分钟

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1479,9 +1479,9 @@ build_replay_cmd() {
     # with one-token outputs and no idle delays for 10 minutes. Profiling begins
     # only after those requests drain and resumes from the resulting live state.
     REPLAY_CMD+=" --agentic-cache-warmup-duration 600"
-    # Give long-context warmup requests up to 10 minutes to drain before
+    # Give long-context warmup requests up to 30 minutes to drain before
     # cancelling any remaining requests and starting profiling.
-    REPLAY_CMD+=" --warmup-grace-period 600"
+    REPLAY_CMD+=" --warmup-grace-period 1800"
     # Use server-reported usage fields (prompt_tokens / completion_tokens) for
     # ISL/OSL instead of client-side tokenizer.encode(). Auto-enables
     # stream_options.include_usage on the OpenAI chat endpoint. Skips the


### PR DESCRIPTION
## Summary

- increase the AgentX warmup drain grace period from 10 minutes to 30 minutes
- allow long-context warmup requests to finish before profiling instead of aborting the benchmark

## Root cause

The Kimi K2.6 non-offload concurrency-80 benchmark consistently had a small number of long-context warmup requests still in flight after the existing 600-second drain window, causing AIPerf to abort before profiling began.

## Validation

- `bash -n benchmarks/benchmark_lib.sh`
- `git diff --check`

## 中文说明

- 将 AgentX 预热排空宽限时间从 10 分钟延长至 30 分钟
- 允许长上下文预热请求在正式性能采集前完成，避免基准测试提前终止

## 根因

Kimi K2.6 无卸载、并发 80 的基准测试在原有 600 秒排空窗口结束后仍持续有少量长上下文预热请求未完成，导致 AIPerf 在正式性能采集开始前终止运行。

## 验证

- `bash -n benchmarks/benchmark_lib.sh`
- `git diff --check`
