### PR TITLE
chore: allow core CODEOWNER sign-off [skip-sweep]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 configs/amd-master.yaml @billishyahao @chunfangamd @seungrokj @yctseng0211 @1am9trash
 
 # NVIDIA master config
-configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv
+configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv @InferenceX/core
 
 # OperatorX experimental
 experimental/operatorx/ @hbarclay


### PR DESCRIPTION
## Summary

- Add `@InferenceX/core` as an owner of `configs/nvidia-master.yaml`.
- Preserve the existing individual NVIDIA CODEOWNERS.
- Allow core maintainers to provide valid sign-offs for PRs that change the NVIDIA master config.

## Validation

- `git diff --check`
- Confirmed the PR changes only `.github/CODEOWNERS`.