### PR TITLE
Use DeepGEMM-timeout vLLM setup for GB200 DSV4

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-high-tpt-megamoe.yaml
@@ -25,7 +25,7 @@ dynamo:
   install: true
   wheel: "1.3.0.dev1"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-deepgemm-timeout.sh
 
 slurm:
   time_limit: "8:00:00"
@@ -151,7 +151,7 @@ benchmark:
 identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
-    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+    revision: "b5968e9190ef611bbf34a7229255be88a0e937c1"
   container:
     image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-latency.yaml
@@ -24,7 +24,7 @@ dynamo:
   install: true
   wheel: "1.3.0.dev1"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-deepgemm-timeout.sh
 
 slurm:
   time_limit: "8:00:00"
@@ -146,6 +146,9 @@ benchmark:
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
 
 identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "b5968e9190ef611bbf34a7229255be88a0e937c1"
   container:
     image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-low-middle-curve.yaml
@@ -25,7 +25,7 @@ dynamo:
   install: true
   wheel: "1.3.0.dev1"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-deepgemm-timeout.sh
 
 slurm:
   time_limit: "8:00:00"
@@ -148,6 +148,9 @@ benchmark:
   custom_tokenizer: "sa_bench_tokenizers.vllm_deepseek_v4.VLLMDeepseekV4Tokenizer"
 
 identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4-Pro"
+    revision: "b5968e9190ef611bbf34a7229255be88a0e937c1"
   container:
     image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-max-tpt-megamoe.yaml
@@ -25,7 +25,7 @@ dynamo:
   install: true
   wheel: "1.3.0.dev1"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-deepgemm-timeout.sh
 
 slurm:
   time_limit: "8:00:00"
@@ -151,7 +151,7 @@ benchmark:
 identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
-    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+    revision: "b5968e9190ef611bbf34a7229255be88a0e937c1"
   container:
     image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-gb200-mid-curve-megamoe.yaml
@@ -25,7 +25,7 @@ dynamo:
   install: true
   wheel: "1.3.0.dev1"
 
-setup_script: vllm-container-deps.sh
+setup_script: vllm-container-deps-deepgemm-timeout.sh
 
 slurm:
   time_limit: "8:00:00"
@@ -151,7 +151,7 @@ benchmark:
 identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
-    revision: "0366e4e064385807ea86b088a5c6c878ff23343b"
+    revision: "b5968e9190ef611bbf34a7229255be88a0e937c1"
   container:
     image: "vllm/vllm-openai:dsv4-megamoe-mxfp4-arm64-cu130-4ba0a72"
   frameworks:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4800,3 +4800,10 @@
     - "Use the DeepSeek-V4-Pro MXFP4 checkpoint for the five GB200 STP recipes"
     - "Align recipe identity metadata with Dynamo 1.3.0.dev1 and vLLM 0.1.dev18219+g4ba0a72a4"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2139
+
+- config-keys:
+    - dsv4-fp4-gb200-dynamo-vllm
+  description:
+    - "Use NVIDIA/srt-slurm branch vllm-gb200-v0.1.dev18219+g4ba0a72a4 for the GB200 Dynamo-vLLM DeepSeek-V4-Pro recipes"
+    - "Run vllm-container-deps-deepgemm-timeout.sh before each vLLM worker starts"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2139

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -307,7 +307,7 @@ if [[ "$IS_AGENTIC" == "1" ]]; then
 elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv4" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
-    git checkout aflowers/vllm-gb200-v0.20.0
+    git checkout vllm-gb200-v0.1.dev18219+g4ba0a72a4
     # Use `cp -rT` so if the upstream branch ever ships a stub
     # `recipes/vllm/deepseek-v4/` directory, we overlay our recipes onto
     # it rather than nesting (`cp -r src dst` would create


### PR DESCRIPTION
## Summary

- Pin all five GB200 DeepSeek-V4-Pro STP recipe identities to `b5968e9190ef611bbf34a7229255be88a0e937c1`.
- Keep cloning `NVIDIA/srt-slurm`, but check out `vllm-gb200-v0.1.dev18219+g4ba0a72a4` for the DSV4 GB200 Dynamo-vLLM path.
- Run `vllm-container-deps-deepgemm-timeout.sh` on all five standard GB200 STP recipes.
- Append the corresponding benchmark changelog entry linked to #2139.

## Validation

- Verified the five identity mappings and setup scripts, and compared each recipe with those fields excluded to confirm no other recipe behavior changed.
- Generated the targeted GB200 8k/1k Dynamo-vLLM matrix.
- Ran `python -m pytest utils/matrix_logic/ -q` (221 passed), `bash -n runners/launch_gb200-nv.sh`, and the changelog validator against the PR 2139 head.

## Runtime validation

`vllm-gb200-v0.1.dev18219+g4ba0a72a4` has not been published on `NVIDIA/srt-slurm` yet, so no launch or benchmark was attempted. This PR remains draft and intentionally has no sweep label until that upstream branch provides `vllm-container-deps-deepgemm-timeout.sh`.