### PR TITLE
[AMD][MI355X] Qwen3.5 FP8 agentic: switch to dsv4 mlpnopad image

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2179,8 +2179,7 @@ glm5-fp8-mi325x-sglang-mtp:
 # ============================================================================
 
 qwen3.5-fp8-mi355x-sglang-agentic-hicache:
-  # (srok) TODO: pub img
-  image: rocm/pytorch-private:sglang-rocm720-mi35x_dsv4_mlpnopad
+  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260521
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi355x-amds
@@ -2191,7 +2190,7 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      #- { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the
@@ -2451,7 +2450,8 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
           - "DECODE_MTP_SIZE=1"
 
 dsv4-fp4-mi355x-sglang-agentic-hicache:
-  image: lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260710
+  # (srok) TODO: pub img
+  image: rocm/pytorch-private:sglang-rocm720-mi35x_dsv4_mlpnopad
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds
@@ -2462,9 +2462,9 @@ dsv4-fp4-mi355x-sglang-agentic-hicache:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8] }
+      #- { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8] }
       - { tp: 8, dp-attn: true, kv-offloading: none, conc-list: [16, 32, 48, 64] }
-      - { tp: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64] }
+      #- { tp: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64] }
 
 # MiniMax-M3 MXFP8 MI355X recipe:
 # https://github.com/vllm-project/recipes/commit/2a3728ed9892debfd767a72a58ebc90b33f186e5

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2179,7 +2179,8 @@ glm5-fp8-mi325x-sglang-mtp:
 # ============================================================================
 
 qwen3.5-fp8-mi355x-sglang-agentic-hicache:
-  image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260521
+  # (srok) TODO: pub img
+  image: rocm/pytorch-private:sglang-rocm720-mi35x_dsv4_mlpnopad
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi355x-amds
@@ -2190,7 +2191,7 @@ qwen3.5-fp8-mi355x-sglang-agentic-hicache:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      #- { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 # DSv4-Pro FP4 on MI355X via SGLang. Uses a rocm720 mi35x image built off the

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4918,3 +4918,9 @@
     - "Image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-904e4ec"
     - "B300: GPU-resident TP4/TP8 at conc [1,2,4,6,8,12,16,20,24,28,32] and DEP8 at conc [32,64,96,128,160,192,196,224,228] (max-num-batched-tokens 16384, long-prefill-token-threshold 4096, gpu-memory-utilization 0.92); TP4 SimpleCPU lazy-offload at conc [28,32,36,40]; DEP4 at conc [8,16,24,32,40,48,56,64,72] with both SimpleCPU and Mooncake 0.3.11.post1."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2241
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang-agentic-hicache
+  description:
+    - "Switch image to rocm/pytorch-private:sglang-rocm720-mi35x_dsv4_mlpnopad for MLP no-pad kernel evaluation"
+    - "Disable non-offload sweep (TP8 conc 1-32), keep HiCache dram-offload sweep (TP8 conc 16-64)"


### PR DESCRIPTION
## Summary
- Switch `qwen3.5-fp8-mi355x-sglang-agentic-hicache` image to `rocm/pytorch-private:sglang-rocm720-mi35x_dsv4_mlpnopad` for MLP no-pad kernel evaluation
- Disable non-offload sweep (TP8 conc 1-32), keep HiCache dram-offload sweep (TP8 conc 16-64)

## Test plan
- [ ] Full sweep on MI355X cluster with HiCache dram-offload conc [16, 32, 48, 64]
- [ ] Verify mlpnopad image loads and serves Qwen3.5 correctly
- [ ] TODO: publish public image once validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)