### PR TITLE
perf(kimik2.5-fp4-mi355x): enable vLLM compile-time fusion passes / 为 kimik2.5-fp4-mi355x-vllm 启用 vLLM 编译期融合 pass

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh
@@ -74,7 +74,10 @@ $EP \
 --block-size=1 \
 --no-enable-prefix-caching \
 --trust-remote-code \
---no-enable-prefix-caching \
+--compilation_config.pass_config.fuse_norm_quant true \
+--compilation_config.pass_config.fuse_act_quant true \
+--compilation_config.pass_config.fuse_allreduce_rms true \
+--compilation_config.pass_config.fuse_mla_dual_rms_norm true \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4933,3 +4933,11 @@
   description:
     - "Add MiniMax M3 NVFP4 B300 Dynamo-vLLM disaggregated EAGLE3 recipes"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2182
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-vllm
+  description:
+    - 'Add vLLM compile-time fusion passes to benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh: --compilation_config.pass_config.{fuse_norm_quant,fuse_act_quant,fuse_allreduce_rms,fuse_mla_dual_rms_norm}=true (script previously set no --compilation_config)'
+    - "Motivated by two-trace torch-profiler triage: all-reduce ran fully serial (hid=0%) and residual-add+RMSNorm / RMSNorm+Quant families were un-collapsed"
+    - "Also removes a duplicate --no-enable-prefix-caching flag"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2264


### PR DESCRIPTION
## Summary
Enable four vLLM torch.compile fusion passes on the Kimi-K2.5-MXFP4 MI355X fixed-seq-len vLLM launch (`benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh`):

- `fuse_norm_quant`
- `fuse_act_quant`
- `fuse_allreduce_rms`
- `fuse_mla_dual_rms_norm`

This script previously passed **no** `--compilation_config` at all, so these passes were off. Sibling Kimi scripts already use this pattern (`kimik2.5_fp4_b300.sh`, the agentic Kimi scripts use `fuse_allreduce_rms`). Also drops a duplicate `--no-enable-prefix-caching` line.

## Motivation
Two-trace (mapping/formal) torch-profiler triage of Kimi-K2.5-MXFP4 @ TP8, c32, 8k/1k on MI355X showed:
- **all-reduce fully serial** (`excl 100% / hid 0%`) in both prefill (NCCL 33.5%) and decode (7.6%) → `fuse_allreduce_rms` target.
- un-collapsed **residual-add+RMSNorm** and **RMSNorm+Quant** kernel families → `fuse_norm_quant` / `fuse_act_quant` targets.

## Status: DRAFT — perf to be measured on CI runner
Local iteration used an **AITER-off** baseline, so the local +87% decode-throughput number does **not** isolate the fusion-pass delta on top of the real CI config (which already sets `VLLM_ROCM_USE_AITER=1`). Requesting a CI run to get the authoritative comparison of this script **with vs. without** the fusion passes.

Local accuracy check (AITER-on, GSM8K 100-sample 2-shot greedy) showed **no regression** (0.9500 with fusion passes; 0.9500 AITER-off baseline).

## Test plan
- [ ] CI: run `kimik2.5 fp4 mi355x vllm` single-node 8k1k @ conc 4–64 (tp4/tp8) — compare throughput vs. current main. (1k1k configs were deprecated in #2263.)
- [ ] CI: eval-only run to confirm GSM8K/accuracy parity.
- [ ] Confirm no server-startup regression from the added compile passes, and check the compile log shows the fusion passes actually fired (fusion counts) rather than silently no-op'ing.
- [ ] Confirm with the `kimik2.5_int4_mi355x.sh` author why `fuse_allreduce_rms` was explicitly disabled there on the same MI355X SKU.

---

## 中文说明

### 概述
在 Kimi-K2.5-MXFP4 MI355X 定长(fixed-seq-len)vLLM 启动脚本(`benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh`)上启用四个 vLLM torch.compile 融合 pass:

- `fuse_norm_quant`
- `fuse_act_quant`
- `fuse_allreduce_rms`
- `fuse_mla_dual_rms_norm`

该脚本此前完全没有传 `--compilation_config`,所以这些 pass 都是关闭的。同系列 Kimi 脚本已在用这个写法(`kimik2.5_fp4_b300.sh`,以及 agentic Kimi 脚本用了 `fuse_allreduce_rms`)。同时删掉了一处重复的 `--no-enable-prefix-caching`。

### 动机
对 Kimi-K2.5-MXFP4 @ TP8、c32、8k/1k 在 MI355X 上做的双 trace(mapping/formal)torch-profiler 分析显示:
- **all-reduce 完全串行**(`excl 100% / hid 0%`),prefill(NCCL 33.5%)和 decode(7.6%)都存在 → 对应 `fuse_allreduce_rms`。
- 未折叠的 **residual-add+RMSNorm** 与 **RMSNorm+Quant** kernel 族 → 对应 `fuse_norm_quant` / `fuse_act_quant`。

### 状态:DRAFT —— 性能待 CI runner 实测
本地迭代用的是 **AITER 关闭**的 baseline,所以本地 +87% 的 decode 吞吐数字**不能**单独归因于融合 pass 在真实 CI 配置(已开 `VLLM_ROCM_USE_AITER=1`)之上的增益。因此请求跑 CI,拿到这个脚本**开/关融合 pass** 的权威对比。

本地精度校验(AITER 开,GSM8K 100 样本 2-shot greedy)**无回退**(开融合 pass 为 0.9500;AITER 关闭 baseline 也是 0.9500)。

### 测试计划
- [ ] CI:跑 `kimik2.5 fp4 mi355x vllm` single-node 8k1k @ conc 4–64(tp4/tp8),与当前 main 对比吞吐。(1k1k 配置已在 #2263 废弃。)
- [ ] CI:eval-only 跑一遍,确认 GSM8K/精度持平。
- [ ] 确认新增的编译 pass 不引入 server 启动回退,并检查 compile 日志显示融合 pass 真正生效(有 fusion counts),而不是静默 no-op。
- [ ] 向 `kimik2.5_int4_mi355x.sh` 的作者确认:为什么在同样的 MI355X SKU 上那个脚本显式禁用了 `fuse_allreduce_rms`。