### PR TITLE
[AMD][MI355X] Update Kimi K2.5 FP4 vLLM recipe

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh
@@ -23,10 +23,60 @@ if [[ "$MODEL" != /* ]]; then hf download "$MODEL"; fi
 # https://github.com/vllm-project/vllm/issues/35633
 pip install amd-quark
 
+ensure_aiter_mxfp4_moe_backend() {
+  # Temporary bridge until vllm-project/vllm#48683 lands in the official ROCm
+  # nightly. AITER v0.1.16.post3 has Kimi FP4 tuning rows but lacks the
+  # RadeonFlow MXFP4 MoE backend files used by the best MI355X path.
+  if python3 - <<'PY'
+import site
+from pathlib import Path
+root = next(Path(p) for p in site.getsitepackages()
+            if p.endswith("dist-packages"))
+required = [
+    root / "aiter/ops/moe_mxfp4_aux.py",
+    root / "aiter/aot/flydsl/mxfp4_moe.py",
+]
+raise SystemExit(0 if all(p.exists() for p in required) else 1)
+PY
+  then
+    echo "AITER MXFP4 MoE backend already present; skipping runtime AITER bump."
+    return
+  fi
+
+  local aiter_branch="${AITER_RUNTIME_BUMP_VERSION:-v0.1.16.post4}"
+  local aiter_version="${aiter_branch#v}"
+  local aiter_repo="${AITER_RUNTIME_BUMP_REPO:-https://github.com/ROCm/aiter.git}"
+  local aiter_src="/tmp/aiter-${aiter_branch}"
+  local wheel_cache="${AITER_RUNTIME_WHEEL_CACHE:-/tmp/aiter-wheels}"
+
+  mkdir -p "$wheel_cache"
+  if compgen -G "$wheel_cache/amd_aiter-${aiter_version}-*.whl" >/dev/null; then
+    echo "Installing cached AITER ${aiter_branch} wheel from $wheel_cache."
+    python3 -m pip install flydsl==0.2.2
+    python3 -m pip install --force-reinstall --no-deps "$wheel_cache"/amd_aiter-"${aiter_version}"-*.whl
+    return
+  fi
+
+  echo "Building AITER ${aiter_branch} wheel for RadeonFlow MXFP4 MoE backend."
+  rm -rf "$aiter_src"
+  rm -rf /tmp/aiter-dist
+  git clone --recursive --depth 1 --branch "$aiter_branch" "$aiter_repo" "$aiter_src"
+  python3 -m pip install pyyaml flydsl==0.2.2
+  (
+    cd "$aiter_src"
+    AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=gfx950 \
+      python3 setup.py bdist_wheel --dist-dir=/tmp/aiter-dist
+  )
+  cp /tmp/aiter-dist/*.whl "$wheel_cache"/
+  python3 -m pip install --force-reinstall --no-deps /tmp/aiter-dist/*.whl
+}
+
 # Set HIP_VISIBLE_DEVICES to match ROCR_VISIBLE_DEVICES for Ray compatibility in vLLM 0.14+
 if [ -n "$ROCR_VISIBLE_DEVICES" ]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
+
+ensure_aiter_mxfp4_moe_backend
 
 SERVER_LOG=/workspace/server.log
 
@@ -46,12 +96,14 @@ if [[ "$version" == "" || $version -lt 177 ]]; then
 fi
 
 export VLLM_ROCM_USE_AITER=1
+export VLLM_ROCM_USE_AITER_LINEAR=true
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=true
+export AITER_MXFP4_INTERMEDIATE=1
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
 
-# Disable AITER RMSNorm for TP < 8 due to accuracy issues
-if [ "${TP}" -lt 8 ]; then
-  export VLLM_ROCM_USE_AITER_RMSNORM=0
-fi
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-16384}"
 
 if [ "${EP_SIZE:-0}" -gt 1 ]; then
   EP=" --enable-expert-parallel"
@@ -71,8 +123,10 @@ vllm serve $MODEL --port $PORT \
 $EP \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
---block-size=1 \
---no-enable-prefix-caching \
+--max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
+--kv-cache-dtype fp8 \
+--block-size=16 \
+--moe-backend aiter \
 --trust-remote-code \
 --no-enable-prefix-caching \
 --mm-encoder-tp-mode data > $SERVER_LOG 2>&1 &

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -621,8 +621,10 @@ kimik2.5-int4-mi300x-vllm:
       search-space:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
+# Temporary AITER v0.1.16.post4 bridge until vllm-project/vllm#48683 reaches
+# the official ROCm nightly.
 kimik2.5-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:v0.24.0
+  image: vllm/vllm-openai-rocm:nightly-67fe73b2b47e2927af1e5ec6fb91e16e3b075940
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4933,3 +4933,11 @@
   description:
     - "Add MiniMax M3 NVFP4 B300 Dynamo-vLLM disaggregated EAGLE3 recipes"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2182
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-vllm
+  description:
+    - "Pin image to vllm/vllm-openai-rocm:nightly-67fe73b2b47e2927af1e5ec6fb91e16e3b075940"
+    - "Add temporary AITER v0.1.16.post4 bridge with flydsl==0.2.2 until vllm-project/vllm#48683 reaches the official ROCm nightly"
+    - "Enable validated MI355X vLLM settings: AITER linear, FSE, INT4 quick-reduce, MXFP4 intermediate, KV FP8, block size 16, and --moe-backend aiter"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2266


### PR DESCRIPTION
## Summary

Update the Kimi K2.5 MXFP4 MI355X vLLM fixed-sequence recipe to use the validated AITER/RadeonFlow MXFP4 MoE path without relying on a private vLLM image.

- Pin the recipe image to the validated official ROCm nightly tag:
  `vllm/vllm-openai-rocm:nightly-67fe73b2b47e2927af1e5ec6fb91e16e3b075940`
- Add a temporary AITER `v0.1.16.post4` bridge until `vllm-project/vllm#48683` reaches the official nightly.
- Cache the locally built AITER wheel under `/workspace/.cache/aiter-wheels` and install `flydsl==0.2.2` for the post4 backend.
- Update serving flags/envs for the validated Kimi K2.5 FP4 MI355X vLLM path: AITER linear, FSE, INT4 quick-reduce, MXFP4 intermediate, KV FP8, block size 16, and `--moe-backend aiter`.

## Validation

- `bash -n benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_mi355x.sh`
- `yaml.safe_load(configs/amd-master.yaml)`
- Runtime bump smoke on MI355X official nightly:
  - before: `amd-aiter 0.1.16.post3`
  - after: `amd-aiter 0.1.16.post4`, `flydsl 0.2.2`
  - verified `moe_mxfp4_aux.py`, `mxfp4_moe.py`, and `kimik2_fp4_tuned_fmoe.csv`
  - cached install path: ~6 seconds
- Manual 8k/1k TP4 e2e sweep run completed successfully: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29599920100

## 中文说明

更新 Kimi K2.5 MXFP4 在 MI355X 上的 vLLM fixed-seq recipe，使用已验证的 AITER/RadeonFlow MXFP4 MoE 路径，且不依赖私有 vLLM 镜像。
