### PR TITLE
Fix agentic SWE-bench eval dispatch: dedicated agentic_evals bucket + sweep job / 修复 agentic SWE-bench 评估调度：新增 agentic_evals 独立分桶与扫描任务

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -628,6 +628,58 @@ jobs:
             run-eval: true
             eval-only: true
 
+    # Agentic (SWE-bench) eval rows carry the agentic input shape, so they are
+    # dispatched with sweep-agentic's inputs rather than sweep-evals' fixed-seq-len
+    # inputs (isl/osl/max-model-len, which agentic rows don't have).
+    sweep-agentic-evals:
+        needs: [setup, canary-select, canary-sweep]
+        if: >-
+            ${{
+              !cancelled() &&
+              needs.setup.result == 'success' &&
+              needs.setup.outputs.reuse-enabled != 'true' &&
+              (needs.canary-sweep.result == 'success' || needs.canary-sweep.result == 'skipped') &&
+              toJson(fromJson(needs.setup.outputs.search-space-config).agentic_evals) != '[]' &&
+              toJson(fromJson(needs.setup.outputs.search-space-config).agentic_evals) != 'null'
+            }}
+        uses: ./.github/workflows/benchmark-tmpl.yml
+        name: agentic eval /
+        strategy:
+            fail-fast: ${{ contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast') || contains(github.event.pull_request.labels.*.name, 'full-sweep-fail-fast-no-canary') }}
+            matrix:
+                config: ${{ fromJson(needs.setup.outputs.search-space-config).agentic_evals }}
+        secrets: inherit
+        with:
+            exp-name: ${{ matrix.config.exp-name }}
+            runner: ${{ matrix.config.runner }}
+            image: ${{ matrix.config.image }}
+            model: ${{ matrix.config.model }}
+            model-prefix: ${{ matrix.config.model-prefix }}
+            framework: ${{ matrix.config.framework }}
+            precision: ${{ matrix.config.precision }}
+            router: ${{ matrix.config.router && toJson(matrix.config.router) || '' }}
+            kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
+            tp: ${{ matrix.config.tp }}
+            pp: ${{ matrix.config.pp }}
+            dcp-size: ${{ matrix.config.dcp-size }}
+            pcp-size: ${{ matrix.config.pcp-size }}
+            ep: ${{ matrix.config.ep }}
+            dp-attn: ${{ matrix.config.dp-attn }}
+            conc: ${{ matrix.config.conc }}
+            kv-offloading: ${{ matrix.config.kv-offloading }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
+            kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
+            total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
+            duration: ${{ matrix.config.duration }}
+            isl: '0'
+            osl: '0'
+            max-model-len: '0'
+            spec-decoding: ${{ matrix.config.spec-decoding }}
+            disagg: ${{ 'false' }}
+            run-eval: true
+            eval-only: true
+            scenario-type: agentic-coding
+
     sweep-multi-node-evals:
         needs: [setup, canary-select, canary-sweep]
         if: >-
@@ -714,8 +766,8 @@ jobs:
             result-prefix: "bmk"
 
     collect-evals:
-        needs: [sweep-evals, sweep-multi-node-evals, setup]
-        if: ${{ always() && needs.setup.result != 'skipped' && (needs.sweep-evals.result != 'skipped' || needs.sweep-multi-node-evals.result != 'skipped') }}
+        needs: [sweep-evals, sweep-agentic-evals, sweep-multi-node-evals, setup]
+        if: ${{ always() && needs.setup.result != 'skipped' && (needs.sweep-evals.result != 'skipped' || needs.sweep-agentic-evals.result != 'skipped' || needs.sweep-multi-node-evals.result != 'skipped') }}
         uses: ./.github/workflows/collect-evals.yml
         secrets: inherit
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4933,12 +4933,3 @@
   description:
     - "Add MiniMax M3 NVFP4 B300 Dynamo-vLLM disaggregated EAGLE3 recipes"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2182
-
-- config-keys:
-    - dsv4-fp4-b300-vllm-agentic
-  description:
-    - "Validate the agentic SWE-bench eval dispatch path (agentic_evals bucket + sweep-agentic-evals job, fixing the eval-only failures first seen on #2258/#2259): re-run only the DEP8 top-concurrency SWE-bench eval; no throughput re-run."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2267
-  evals-only: true
-  scenario-type:
-    - agentic-coding

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4933,3 +4933,12 @@
   description:
     - "Add MiniMax M3 NVFP4 B300 Dynamo-vLLM disaggregated EAGLE3 recipes"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2182
+
+- config-keys:
+    - dsv4-fp4-b300-vllm-agentic
+  description:
+    - "Validate the agentic SWE-bench eval dispatch path (agentic_evals bucket + sweep-agentic-evals job, fixing the eval-only failures first seen on #2258/#2259): re-run only the DEP8 top-concurrency SWE-bench eval; no throughput re-run."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2267
+  evals-only: true
+  scenario-type:
+    - agentic-coding

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -1405,107 +1405,43 @@ class TestChangelogEntry:
 # Test ChangelogMatrixEntry
 # =============================================================================
 
-@pytest.fixture
-def valid_agentic_eval_row():
-    """Agentic SWE-bench eval row as emitted by generate_sweep_configs --evals-only."""
-    return {
-        "image": "vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-904e4ec",
-        "model": "deepseek-ai/DeepSeek-V4-Pro",
-        "model-prefix": "dsv4",
-        "precision": "fp4",
-        "framework": "vllm",
-        "runner": "cluster:b300-nv",
-        "tp": 8,
-        "pp": 1,
-        "dcp-size": 1,
-        "pcp-size": 1,
-        "ep": 8,
-        "dp-attn": True,
-        "spec-decoding": "mtp",
-        "conc": 224,
-        "kv-offloading": "none",
-        "router": {"name": "vllm-router", "version": "0.1.14"},
-        "total-cpu-dram-gb": 0,
-        "duration": 3600,
-        "exp-name": "dsv4_tp8_conc224_kvnone_spec-mtp",
-        "scenario-type": "agentic-coding",
-        "run-eval": True,
-        "eval-only": True,
-    }
+AGENTIC_EVAL_ROW = {
+    "image": "vllm/vllm-openai:nightly", "model": "deepseek-ai/DeepSeek-V4-Pro",
+    "model-prefix": "dsv4", "precision": "fp4", "framework": "vllm",
+    "runner": "cluster:b300-nv", "tp": 8, "pp": 1, "dcp-size": 1,
+    "pcp-size": 1, "ep": 8, "dp-attn": True, "spec-decoding": "mtp",
+    "conc": 224, "kv-offloading": "none", "total-cpu-dram-gb": 0,
+    "duration": 3600, "exp-name": "dsv4_tp8_conc224_kvnone_spec-mtp",
+    "scenario-type": "agentic-coding", "run-eval": True, "eval-only": True,
+}
 
-
-@pytest.fixture
-def valid_changelog_metadata():
-    return {
-        "base_ref": "base",
-        "head_ref": "head",
-        "entries": [{
-            "config-keys": ["test-config"],
-            "description": ["Test entry"],
-            "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
-        }],
-    }
+CHANGELOG_METADATA = {
+    "base_ref": "base", "head_ref": "head",
+    "entries": [{
+        "config-keys": ["test-config"], "description": ["Test entry"],
+        "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+    }],
+}
 
 
 class TestChangelogMatrixEntry:
     """Tests for the final search-space contract consumed by run-sweep.yml."""
 
-    def test_agentic_eval_rows_validate_in_agentic_evals(
-        self, valid_agentic_eval_row, valid_changelog_metadata,
-    ):
+    def test_agentic_eval_rows_live_in_agentic_evals_only(self):
+        """`evals` is dispatched with fixed-seq-len inputs (isl/osl/
+        max-model-len), so agentic rows must only validate in agentic_evals."""
         entry = ChangelogMatrixEntry.model_validate({
-            "agentic_evals": [valid_agentic_eval_row],
-            "changelog_metadata": valid_changelog_metadata,
+            "agentic_evals": [AGENTIC_EVAL_ROW],
+            "changelog_metadata": CHANGELOG_METADATA,
         })
-
-        assert entry.agentic_evals[0].scenario_type == "agentic-coding"
         assert entry.agentic_evals[0].run_eval is True
         assert entry.agentic_evals[0].eval_only is True
 
-    def test_evals_bucket_rejects_agentic_rows(
-        self, valid_agentic_eval_row, valid_changelog_metadata,
-    ):
-        """The `evals` bucket is dispatched with fixed-seq-len inputs
-        (isl/osl/max-model-len), so agentic rows must never validate there."""
         with pytest.raises(ValueError):
             ChangelogMatrixEntry.model_validate({
-                "evals": [valid_agentic_eval_row],
-                "changelog_metadata": valid_changelog_metadata,
+                "evals": [AGENTIC_EVAL_ROW],
+                "changelog_metadata": CHANGELOG_METADATA,
             })
-
-    def test_evals_bucket_accepts_fixed_seq_len_rows(
-        self, valid_single_node_matrix_entry, valid_changelog_metadata,
-    ):
-        eval_row = {
-            **valid_single_node_matrix_entry,
-            "run-eval": True,
-            "eval-only": True,
-        }
-        entry = ChangelogMatrixEntry.model_validate({
-            "evals": [eval_row],
-            "changelog_metadata": valid_changelog_metadata,
-        })
-
-        assert entry.evals[0].run_eval is True
-        assert entry.evals[0].eval_only is True
-
-    def test_agentic_benchmark_rows_dump_without_eval_flags(
-        self, valid_agentic_eval_row, valid_changelog_metadata,
-    ):
-        """Benchmark rows omit run-eval/eval-only, and exclude_none must keep
-        them out of the dump so the dispatched row shape is unchanged."""
-        benchmark_row = {
-            k: v for k, v in valid_agentic_eval_row.items()
-            if k not in ("run-eval", "eval-only")
-        }
-        entry = ChangelogMatrixEntry.model_validate({
-            "single_node": {"agentic": [benchmark_row]},
-            "changelog_metadata": valid_changelog_metadata,
-        })
-        dumped = entry.model_dump(by_alias=True, exclude_none=True)
-
-        assert "run-eval" not in dumped["single_node"]["agentic"][0]
-        assert "eval-only" not in dumped["single_node"]["agentic"][0]
 
 
 # =============================================================================

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -18,6 +18,7 @@ from validation import (
     SingleNodeMasterConfigEntry,
     MultiNodeMasterConfigEntry,
     ChangelogEntry,
+    ChangelogMatrixEntry,
     validate_matrix_entry,
     validate_master_config,
     validate_runner_config,
@@ -1398,6 +1399,113 @@ class TestChangelogEntry:
                 "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
                 "scenario-type": scenario_type,
             })
+
+
+# =============================================================================
+# Test ChangelogMatrixEntry
+# =============================================================================
+
+@pytest.fixture
+def valid_agentic_eval_row():
+    """Agentic SWE-bench eval row as emitted by generate_sweep_configs --evals-only."""
+    return {
+        "image": "vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-904e4ec",
+        "model": "deepseek-ai/DeepSeek-V4-Pro",
+        "model-prefix": "dsv4",
+        "precision": "fp4",
+        "framework": "vllm",
+        "runner": "cluster:b300-nv",
+        "tp": 8,
+        "pp": 1,
+        "dcp-size": 1,
+        "pcp-size": 1,
+        "ep": 8,
+        "dp-attn": True,
+        "spec-decoding": "mtp",
+        "conc": 224,
+        "kv-offloading": "none",
+        "router": {"name": "vllm-router", "version": "0.1.14"},
+        "total-cpu-dram-gb": 0,
+        "duration": 3600,
+        "exp-name": "dsv4_tp8_conc224_kvnone_spec-mtp",
+        "scenario-type": "agentic-coding",
+        "run-eval": True,
+        "eval-only": True,
+    }
+
+
+@pytest.fixture
+def valid_changelog_metadata():
+    return {
+        "base_ref": "base",
+        "head_ref": "head",
+        "entries": [{
+            "config-keys": ["test-config"],
+            "description": ["Test entry"],
+            "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+        }],
+    }
+
+
+class TestChangelogMatrixEntry:
+    """Tests for the final search-space contract consumed by run-sweep.yml."""
+
+    def test_agentic_eval_rows_validate_in_agentic_evals(
+        self, valid_agentic_eval_row, valid_changelog_metadata,
+    ):
+        entry = ChangelogMatrixEntry.model_validate({
+            "agentic_evals": [valid_agentic_eval_row],
+            "changelog_metadata": valid_changelog_metadata,
+        })
+
+        assert entry.agentic_evals[0].scenario_type == "agentic-coding"
+        assert entry.agentic_evals[0].run_eval is True
+        assert entry.agentic_evals[0].eval_only is True
+
+    def test_evals_bucket_rejects_agentic_rows(
+        self, valid_agentic_eval_row, valid_changelog_metadata,
+    ):
+        """The `evals` bucket is dispatched with fixed-seq-len inputs
+        (isl/osl/max-model-len), so agentic rows must never validate there."""
+        with pytest.raises(ValueError):
+            ChangelogMatrixEntry.model_validate({
+                "evals": [valid_agentic_eval_row],
+                "changelog_metadata": valid_changelog_metadata,
+            })
+
+    def test_evals_bucket_accepts_fixed_seq_len_rows(
+        self, valid_single_node_matrix_entry, valid_changelog_metadata,
+    ):
+        eval_row = {
+            **valid_single_node_matrix_entry,
+            "run-eval": True,
+            "eval-only": True,
+        }
+        entry = ChangelogMatrixEntry.model_validate({
+            "evals": [eval_row],
+            "changelog_metadata": valid_changelog_metadata,
+        })
+
+        assert entry.evals[0].run_eval is True
+        assert entry.evals[0].eval_only is True
+
+    def test_agentic_benchmark_rows_dump_without_eval_flags(
+        self, valid_agentic_eval_row, valid_changelog_metadata,
+    ):
+        """Benchmark rows omit run-eval/eval-only, and exclude_none must keep
+        them out of the dump so the dispatched row shape is unchanged."""
+        benchmark_row = {
+            k: v for k, v in valid_agentic_eval_row.items()
+            if k not in ("run-eval", "eval-only")
+        }
+        entry = ChangelogMatrixEntry.model_validate({
+            "single_node": {"agentic": [benchmark_row]},
+            "changelog_metadata": valid_changelog_metadata,
+        })
+        dumped = entry.model_dump(by_alias=True, exclude_none=True)
+
+        assert "run-eval" not in dumped["single_node"]["agentic"][0]
+        assert "eval-only" not in dumped["single_node"]["agentic"][0]
 
 
 # =============================================================================

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -291,6 +291,10 @@ class SingleNodeAgenticMatrixEntry(BaseModel):
     duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     scenario_type: str = Field(alias=Fields.SCENARIO_TYPE.value)
+    # Agentic eval rows (SWE-bench) carry run-eval/eval-only; benchmark rows
+    # omit them, and exclude_none keeps them out of dumped benchmark output.
+    run_eval: Optional[bool] = Field(default=None, alias=Fields.RUN_EVAL.value)
+    eval_only: Optional[bool] = Field(default=None, alias=Fields.EVAL_ONLY.value)
 
     @model_validator(mode='after')
     def validate_kv_offload_fields(self):
@@ -890,6 +894,13 @@ class ChangelogMatrixEntry(BaseModel):
     multi_node: dict[str, list[Union[MultiNodeMatrixEntry, MultiNodeAgenticMatrixEntry]]
                      ] = Field(default_factory=dict)
     evals: list[SingleNodeMatrixEntry] = Field(default_factory=list)
+    # Agentic (SWE-bench) eval rows live in their own bucket rather than a
+    # union inside `evals`: each bucket maps 1:1 to a run-sweep.yml job with a
+    # static input block, so an agentic row can never reach the fixed-seq-len
+    # eval dispatch (which reads isl/osl/max-model-len and would launch the
+    # wrong benchmark script).
+    agentic_evals: list[SingleNodeAgenticMatrixEntry] = Field(
+        default_factory=list)
     multinode_evals: list[MultiNodeMatrixEntry] = Field(default_factory=list)
     changelog_metadata: ChangelogMetadata
 

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -137,6 +137,7 @@ def main():
         "single_node": defaultdict(list),
         "multi_node": defaultdict(list),
         "evals": [],
+        "agentic_evals": [],
         "multinode_evals": [],
         "changelog_metadata": {
             "base_ref": args.base_ref,
@@ -271,7 +272,18 @@ def main():
             seq_len_str = seq_len_to_str(result["isl"], result["osl"])
             final_results["single_node"][seq_len_str].append(result)
 
-    final_results["evals"] = [e for e in all_eval_results if e.get("prefill") is None]
+    # Agentic eval rows go to their own bucket so run-sweep.yml can dispatch
+    # them with agentic inputs (scenario-type, kv-offloading, ...) instead of
+    # the fixed-seq-len inputs (isl/osl/max-model-len) they don't have.
+    single_node_evals = [e for e in all_eval_results if e.get("prefill") is None]
+    final_results["evals"] = [
+        e for e in single_node_evals
+        if e.get("scenario-type") != "agentic-coding"
+    ]
+    final_results["agentic_evals"] = [
+        e for e in single_node_evals
+        if e.get("scenario-type") == "agentic-coding"
+    ]
     final_results["multinode_evals"] = [e for e in all_eval_results if e.get("prefill") is not None]
 
     # Validate final results structure

--- a/utils/recover_failed_ingest.py
+++ b/utils/recover_failed_ingest.py
@@ -492,6 +492,7 @@ def build_config(
         )
         + len(config.get("multi_node", {}).get("agentic", []) or []),
         "eval_jobs": len(config.get("evals", []) or [])
+        + len(config.get("agentic_evals", []) or [])
         + len(config.get("multinode_evals", []) or []),
     }
 

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -599,91 +599,43 @@ def test_eval_rows_split_into_fixed_and_agentic_buckets(
     - Mixed fixed-seq-len and agentic eval selection
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
 """
-
-    fixed_eval_row = {
+    common = {
         "image": "vllm/vllm-openai:v0.11.0",
-        "model": "deepseek-ai/DeepSeek-V4-Pro",
-        "model-prefix": "dsv4",
-        "precision": "fp4",
-        "framework": "vllm",
-        "spec-decoding": "mtp",
-        "runner": "cluster:b300-nv",
-        "isl": 8192,
-        "osl": 1024,
-        "tp": 8,
-        "pp": 1,
-        "dcp-size": 1,
-        "pcp-size": 1,
-        "ep": 8,
-        "dp-attn": True,
-        "conc": 224,
-        "max-model-len": 10240,
-        "exp-name": "dsv4_8k1k_fixed_eval",
-        "disagg": False,
-        "run-eval": True,
-        "eval-only": True,
+        "model": "deepseek-ai/DeepSeek-V4-Pro", "model-prefix": "dsv4",
+        "precision": "fp4", "framework": "vllm", "spec-decoding": "mtp",
+        "runner": "cluster:b300-nv", "tp": 8, "pp": 1, "dcp-size": 1,
+        "pcp-size": 1, "ep": 8, "dp-attn": True, "conc": 224,
+        "run-eval": True, "eval-only": True,
+    }
+    fixed_eval_row = {
+        **common, "isl": 8192, "osl": 1024, "max-model-len": 10240,
+        "disagg": False, "exp-name": "fixed_eval",
     }
     agentic_eval_row = {
-        "image": "vllm/vllm-openai:v0.11.0",
-        "model": "deepseek-ai/DeepSeek-V4-Pro",
-        "model-prefix": "dsv4",
-        "precision": "fp4",
-        "framework": "vllm",
-        "runner": "cluster:b300-nv",
-        "tp": 8,
-        "pp": 1,
-        "dcp-size": 1,
-        "pcp-size": 1,
-        "ep": 8,
-        "dp-attn": True,
-        "spec-decoding": "mtp",
-        "conc": 224,
-        "kv-offloading": "none",
-        "router": {"name": "vllm-router", "version": "0.1.14"},
-        "total-cpu-dram-gb": 0,
-        "duration": 3600,
-        "exp-name": "dsv4_agentic_eval",
-        "scenario-type": "agentic-coding",
-        "run-eval": True,
-        "eval-only": True,
+        **common, "kv-offloading": "none", "total-cpu-dram-gb": 0,
+        "duration": 3600, "scenario-type": "agentic-coding",
+        "exp-name": "agentic_eval",
     }
 
     monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
+        process_changelog, "get_added_lines", lambda *_: added_yaml)
     monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
+        process_changelog, "load_config_files", lambda _: {"test-config": {}})
 
     def fake_run(command, **kwargs):
-        if "--evals-only" in command:
-            stdout = json.dumps([fixed_eval_row, agentic_eval_row])
-        else:
-            stdout = "[]"
-        return SimpleNamespace(stdout=stdout)
+        is_evals = "--evals-only" in command
+        rows = [fixed_eval_row, agentic_eval_row] if is_evals else []
+        return SimpleNamespace(stdout=json.dumps(rows))
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
+        "process_changelog.py", "--base-ref", "base", "--head-ref", "head",
         "--changelog-file", "perf-changelog.yaml",
     ])
 
     process_changelog.main()
 
     output = json.loads(capsys.readouterr().out)
-    assert [row["exp-name"] for row in output["evals"]] == [
-        "dsv4_8k1k_fixed_eval"
-    ]
-    assert [row["exp-name"] for row in output["agentic_evals"]] == [
-        "dsv4_agentic_eval"
-    ]
+    assert [r["exp-name"] for r in output["evals"]] == ["fixed_eval"]
+    assert [r["exp-name"] for r in output["agentic_evals"]] == ["agentic_eval"]
     assert output["multinode_evals"] == []
-    assert output["agentic_evals"][0]["scenario-type"] == "agentic-coding"
-    assert output["agentic_evals"][0]["run-eval"] is True
-    assert output["agentic_evals"][0]["eval-only"] is True

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -583,3 +583,107 @@ def test_agentic_only_all_evals_does_not_suppress_later_fixed_evals(
     assert "--all-evals" not in commands[2]
     assert _scenario_values(commands[2]) == ["fixed-seq-len"]
     json.loads(capsys.readouterr().out)
+
+
+def test_eval_rows_split_into_fixed_and_agentic_buckets(
+    monkeypatch,
+    capsys,
+):
+    """Realistic eval rows must pass final validation and land in the bucket
+    matching their dispatch job: fixed-seq-len rows in `evals`, agentic
+    (SWE-bench) rows in `agentic_evals`."""
+    added_yaml = """
+- config-keys:
+    - test-config
+  description:
+    - Mixed fixed-seq-len and agentic eval selection
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
+"""
+
+    fixed_eval_row = {
+        "image": "vllm/vllm-openai:v0.11.0",
+        "model": "deepseek-ai/DeepSeek-V4-Pro",
+        "model-prefix": "dsv4",
+        "precision": "fp4",
+        "framework": "vllm",
+        "spec-decoding": "mtp",
+        "runner": "cluster:b300-nv",
+        "isl": 8192,
+        "osl": 1024,
+        "tp": 8,
+        "pp": 1,
+        "dcp-size": 1,
+        "pcp-size": 1,
+        "ep": 8,
+        "dp-attn": True,
+        "conc": 224,
+        "max-model-len": 10240,
+        "exp-name": "dsv4_8k1k_fixed_eval",
+        "disagg": False,
+        "run-eval": True,
+        "eval-only": True,
+    }
+    agentic_eval_row = {
+        "image": "vllm/vllm-openai:v0.11.0",
+        "model": "deepseek-ai/DeepSeek-V4-Pro",
+        "model-prefix": "dsv4",
+        "precision": "fp4",
+        "framework": "vllm",
+        "runner": "cluster:b300-nv",
+        "tp": 8,
+        "pp": 1,
+        "dcp-size": 1,
+        "pcp-size": 1,
+        "ep": 8,
+        "dp-attn": True,
+        "spec-decoding": "mtp",
+        "conc": 224,
+        "kv-offloading": "none",
+        "router": {"name": "vllm-router", "version": "0.1.14"},
+        "total-cpu-dram-gb": 0,
+        "duration": 3600,
+        "exp-name": "dsv4_agentic_eval",
+        "scenario-type": "agentic-coding",
+        "run-eval": True,
+        "eval-only": True,
+    }
+
+    monkeypatch.setattr(
+        process_changelog,
+        "get_added_lines",
+        lambda *_: added_yaml,
+    )
+    monkeypatch.setattr(
+        process_changelog,
+        "load_config_files",
+        lambda _: {"test-config": {}},
+    )
+
+    def fake_run(command, **kwargs):
+        if "--evals-only" in command:
+            stdout = json.dumps([fixed_eval_row, agentic_eval_row])
+        else:
+            stdout = "[]"
+        return SimpleNamespace(stdout=stdout)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", [
+        "process_changelog.py",
+        "--base-ref", "base",
+        "--head-ref", "head",
+        "--changelog-file", "perf-changelog.yaml",
+    ])
+
+    process_changelog.main()
+
+    output = json.loads(capsys.readouterr().out)
+    assert [row["exp-name"] for row in output["evals"]] == [
+        "dsv4_8k1k_fixed_eval"
+    ]
+    assert [row["exp-name"] for row in output["agentic_evals"]] == [
+        "dsv4_agentic_eval"
+    ]
+    assert output["multinode_evals"] == []
+    assert output["agentic_evals"][0]["scenario-type"] == "agentic-coding"
+    assert output["agentic_evals"][0]["run-eval"] is True
+    assert output["agentic_evals"][0]["eval-only"] is True


### PR DESCRIPTION
## Problem

Since #1947, `generate_sweep_configs --evals-only` marks the top-concurrency agentic arm of each config as a SWE-bench eval row, but two downstream consumers were never taught about agentic eval rows, so **any PR touching a single-node agentic-coding config fails its sweep** (first seen on #2258):

1. **Schema layer** — `ChangelogMatrixEntry.evals` is typed `list[SingleNodeMatrixEntry]` (fixed-seq-len only), so `process_changelog.py`'s final `model_validate` rejects the agentic eval row with 8 errors (missing `isl`/`osl`/`max-model-len`/`disagg`, forbidden `kv-offloading`/`total-cpu-dram-gb`/`duration`/`scenario-type`). `check-changelog` fails before any GPU work: [example run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29562666926/job/87828303096#step:5:49).
2. **Dispatch layer** — even with the schema widened (attempted on `agentx/dsv4-v300-vllm-mtp`), `sweep-evals` dispatches every eval row with fixed-seq-len inputs: `ISL`/`OSL`/`MAX_MODEL_LEN` come out empty, `scenario-type` defaults to `fixed-seq-len`, and the launcher runs the *fixed_seq_len* benchmark script, which exits at `check_env_vars`: [example run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29626988314/job/88033326577#step:4:133).

## Fix

Route agentic eval rows into their own bucket, mirroring how the repo already separates agentic benchmark rows (`single_node['agentic']` → dedicated `sweep-agentic` job with a static, correct input block):

- `validation.py`: `ChangelogMatrixEntry.agentic_evals: list[SingleNodeAgenticMatrixEntry]`; the agentic model accepts optional `run-eval`/`eval-only` (carried by eval rows; `exclude_none` keeps benchmark-row output byte-identical, preserving artifact-reuse row shapes). `evals` stays fixed-seq-len-only, so an agentic row reaching the fixed-seq-len dispatch is now **structurally impossible** — it fails `check-changelog` instead.
- `process_changelog.py`: split single-node eval rows by `scenario-type` into `evals` / `agentic_evals`.
- `run-sweep.yml`: new `sweep-agentic-evals` job cloned from `sweep-agentic`'s input block (forwards `scenario-type`, `kv-offloading`, `kv-offload-backend(+metadata)`, `total-cpu-dram-gb`, `duration`, stubs `isl`/`osl`/`max-model-len` to `'0'`) plus `run-eval: true` / `eval-only: true`; wired into `collect-evals`. This satisfies the agentic scripts' `check_env_vars` gate and routes the launcher to `benchmarks/single_node/agentic/`, whose `EVAL_ONLY=true` branch runs the SWE-bench `run_eval` path from #1947.
- `recover_failed_ingest.py`: count `agentic_evals` in `eval_jobs` (uses `.get`, so pre-existing reuse artifacts without the key still work; on the workflow side a missing key yields `null`, which the job's `!= 'null'` condition skips).
- Tests: existing `process_changelog` tests mock `subprocess.run` with `stdout="[]"`, so no realistic row ever hit the schema — CI was the first place this could fail. Added an end-to-end split test with realistic fixed + agentic eval rows flowing through the real `ChangelogMatrixEntry.model_validate`, plus `ChangelogMatrixEntry` bucket tests (including a guard that `evals` still rejects agentic rows, and that benchmark-row dumps don't gain eval flags).

`python -m pytest utils/ -q`: 543 passed; the 2 failures in `utils/evals/test_run_eval_dispatch.py` are pre-existing on `main` (environment-dependent, they shell out to mini-swe-agent) and unrelated.

Non-goal: `trigger-ingest` / `trigger-agentic-ingest` gating is unchanged; whether a main-push run with *only* agentic evals (agentic `evals-only` entry) should route to the agentic ingest is left as a follow-up.

After merge, `agentx/dsv4-v300-vllm-mtp` (#2258) should rebase onto main and drop its `validation.py` union commit.

## 中文说明

### 问题

自 #1947 起，`generate_sweep_configs --evals-only` 会将每个配置中并发度最高的 agentic 条目标记为 SWE-bench 评估行，但下游两个消费方并不认识 agentic 评估行，导致任何涉及单节点 agentic-coding 配置的 PR 扫描失败（最早出现在 #2258）：

1. **Schema 层** — `ChangelogMatrixEntry.evals` 的类型是 `list[SingleNodeMatrixEntry]`（仅固定序列长度），`process_changelog.py` 最终的 `model_validate` 会以 8 个校验错误拒绝 agentic 评估行，`check-changelog` 在任何 GPU 任务开始前即失败。
2. **调度层** — 即便放宽 schema（`agentx/dsv4-v300-vllm-mtp` 分支曾尝试），`sweep-evals` 仍按固定序列长度的输入派发所有评估行：`ISL`/`OSL`/`MAX_MODEL_LEN` 为空、`scenario-type` 回落为 `fixed-seq-len`，启动器因此运行 *fixed_seq_len* 目录下的基准测试脚本，并在 `check_env_vars` 处退出。

### 修复

将 agentic 评估行放入独立分桶，与仓库现有的 agentic 基准测试行设计一致（`single_node['agentic']` → 专用 `sweep-agentic` 任务）：

- `validation.py`：新增 `ChangelogMatrixEntry.agentic_evals`；agentic 模型接受可选的 `run-eval`/`eval-only`（`exclude_none` 保证基准测试行输出逐字节不变，不影响产物复用）。`evals` 仍仅接受固定序列长度条目，agentic 行进入固定序列长度调度路径从结构上不再可能。
- `process_changelog.py`：按 `scenario-type` 将单节点评估行拆分到 `evals` / `agentic_evals`。
- `run-sweep.yml`：新增 `sweep-agentic-evals` 任务，输入块复制自 `sweep-agentic`（转发 `scenario-type`、`kv-offloading`、`kv-offload-backend(+metadata)`、`total-cpu-dram-gb`、`duration`，`isl`/`osl`/`max-model-len` 置为 `'0'`），并附加 `run-eval: true` / `eval-only: true`；同时接入 `collect-evals`。
- `recover_failed_ingest.py`：`eval_jobs` 统计计入 `agentic_evals`（使用 `.get`，兼容旧的复用产物）。
- 测试：现有测试用 `stdout="[]"` 模拟子进程，真实行形状从未经过 schema 校验，CI 成了第一道防线。本 PR 新增端到端拆分测试（真实的固定 + agentic 评估行经过真实的 `model_validate`）及 `ChangelogMatrixEntry` 分桶测试（含 `evals` 拒绝 agentic 行的守卫测试）。

`python -m pytest utils/ -q`：543 通过；`utils/evals/test_run_eval_dispatch.py` 的 2 个失败在 `main` 上即存在（依赖本地 mini-swe-agent 环境），与本 PR 无关。

非目标：`trigger-ingest` / `trigger-agentic-ingest` 的触发条件未改动；仅含 agentic 评估的 main 推送应走哪条 ingest 路径留作后续跟进。

合并后，`agentx/dsv4-v300-vllm-mtp`（#2258）应 rebase 到 main 并移除其 `validation.py` 的 union 提交。

## Validation run / 验证运行

This PR carries an eval-only, agentic-scoped changelog entry for the existing `dsv4-fp4-b300-vllm-agentic` config, so the sweep itself proves the fix (the same eval-only dispatch that failed on #2258/#2259): [run 29633097900](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29633097900) — `check-changelog` passes (previously 8 schema errors), the fixed-seq-len `eval /` job is skipped, and the new `agentic eval /` job dispatches the DEP8 conc-224 SWE-bench eval with agentic inputs (previously died in 7s on `check_env_vars: ISL/OSL/MAX_MODEL_LEN`). After merge, the same entry re-runs through the `on: push` main sweep, confirming the push path too.

中文：本 PR 附带一条针对现有 `dsv4-fp4-b300-vllm-agentic` 配置的 evals-only、仅 agentic 场景的 changelog 条目，使扫描本身即可验证修复（与 #2258/#2259 失败的 eval-only 调度路径完全一致）：见 [run 29633097900](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29633097900) —— `check-changelog` 通过（此前报 8 个 schema 校验错误），固定序列长度的 `eval /` 任务被正确跳过，新的 `agentic eval /` 任务以 agentic 输入派发 DEP8 conc-224 的 SWE-bench 评估（此前在 7 秒内因 `check_env_vars: ISL/OSL/MAX_MODEL_LEN` 退出）。合并后，同一条目会经由 main 分支的 `on: push` 扫描再次运行，同时验证 push 路径。
