### PR TITLE
docs: add /ci-queue-times command for per-cluster CI queue latency / 新增 /ci-queue-times 命令：按集群查看 CI 排队延迟

### DIFF
--- a/.claude/commands/ci-queue-times.md
+++ b/.claude/commands/ci-queue-times.md
@@ -1,72 +1,70 @@
 ---
-description: Check CI queue times across all GPU clusters — live queued jobs with wait so far, historical per-cluster queue latency, and per-pool runner availability
-argument-hint: [history-run-limit]   # optional, default 150 recent runs
+description: Show CI cluster pressure right now — active jobs per GPU pool, the live queue with wait-so-far, and a per-pool active/queued summary
+argument-hint: [pool-filter-regex]   # optional, e.g. "h200" or "b200|mi355x" to restrict output
 ---
 
-GitHub has no queue-metrics API for self-hosted runners, so queue time is derived
-from the Actions API: **queue time per job = `started_at − created_at`** (time spent
-waiting for a free runner), and the cluster is the job's runner label. The pool →
-runner-name mapping lives in `configs/runners.yaml`.
+GitHub has no queue-metrics API for self-hosted runners, so this derives cluster
+pressure from the Actions API: a job's **wait so far = now − `created_at`** (queued
+jobs) and **runtime so far = now − `started_at`** (active jobs). The cluster is the
+job's runner label; the pool → runner-name mapping lives in `configs/runners.yaml`.
 
-Run all three sections and report them as compact tables. `$ARGUMENTS` (optional)
-overrides the history window in Step 2 (default 150 recent runs).
+`$ARGUMENTS` (optional) is a regex restricting which pools are shown in Steps 2–4
+(e.g. `h200`). Run all steps and report the tables as-is.
 
-## Step 1 — Live queue: who is waiting right now, and for how long
+## Step 1 — Take one snapshot of all GPU jobs (active + queued)
 
 A run can be `in_progress` while its matrix jobs are still `queued` waiting for
-runners (the sweep fan-out), so scan both statuses:
+runners (the sweep fan-out), so scan both statuses in a single pass:
 
 ```bash
-{ gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=50" --jq '.workflow_runs[].id'
-  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=50" --jq '.workflow_runs[].id'
+SNAP=$(mktemp /tmp/ci_snapshot.XXXXXX.ndjson)
+{ gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'
+  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id'
 } | sort -u | while read -r RUN; do
   gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN/jobs?per_page=100" --paginate \
-    --jq '.jobs[] | select(.status=="queued") | {labels: [.labels[] | sub("^cluster:";"") | select(test("^(self-hosted|Linux|X64|ARM64|slurm)$|_\\d+$") | not)], name, created_at, run_id}'
-done | jq -s -r 'sort_by(.created_at) | .[]
-  | [((now - (.created_at|fromdateiso8601))/60 | floor | tostring) + " min",
-     (.labels | join(",")), (.name[0:60]), (.run_id|tostring)] | @tsv' | column -t -s$'\t'
+    --jq '.jobs[] | select(.status=="in_progress" or .status=="queued")
+      | {c: ([.labels[] | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | first // "other"),
+         status, name, created_at, started_at, run_id}
+      | select(.c != "other")'
+done > "$SNAP"
 ```
 
-## Step 2 — Historical queue latency per cluster
+Sanity-check coverage: compare against
+`gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=1" --jq .total_count`
+(and the same for `queued`) — if either exceeds 100, paginate the runs list too.
 
-Uses the last N runs (default 150; `$ARGUMENTS` overrides). **Filter `.q >= 0` is
-mandatory** — re-run jobs keep `started_at` from the first attempt and produce
-negative values. For a wider window raise the limit or add
-`--created ">YYYY-MM-DD"` to `gh run list`.
+## Step 2 — Per-pool summary (active vs queued)
 
 ```bash
-LIMIT="${ARGUMENTS:-150}"
-gh run list --repo SemiAnalysisAI/InferenceX --limit "$LIMIT" --json databaseId --jq '.[].databaseId' | while read -r RUN; do
-  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN/jobs?per_page=100" --paginate \
-    --jq '.jobs[] | select(.started_at != null)
-      | {c: ([.labels[] | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | first // empty),
-         q: (((.started_at|fromdateiso8601) - (.created_at|fromdateiso8601))/60)}
-      | select(.c != "" and .q >= 0)'
-done | jq -s -r 'group_by(.c)
-  | map({cluster: .[0].c, n: length, avg: (map(.q)|add/length),
-         p50: (map(.q)|sort|.[(length*0.5|floor)]), max: (map(.q)|max)})
-  | sort_by(-.p50) | .[]
-  | [.cluster, (.n|tostring), ((.avg*10|round)/10|tostring), ((.p50*10|round)/10|tostring), ((.max|round)|tostring)] | @tsv' \
-  | (printf "cluster\tjobs\tavg_min\tp50_min\tmax_min\n"; cat) | column -t -s$'\t'
+jq -s -r 'group_by(.c) | map({c: .[0].c,
+    active: ([.[] | select(.status=="in_progress")] | length),
+    queued: ([.[] | select(.status=="queued")] | length)})
+  | sort_by(-.queued, -.active) | .[] | [.c, (.active|tostring), (.queued|tostring)] | @tsv' "$SNAP" \
+  | (printf "pool\tactive\tqueued\n"; cat) | column -t -s$'\t'
 ```
 
-Note: the sample only covers clusters that actually ran within the window — a
-missing cluster means no recent jobs, not zero queue.
+A pool with **0 active but a growing queue** means its runners are offline, stuck
+"busy" (cancelled-job artifact), or busy with another repo's jobs (runners may be
+org-scoped) — investigate the fleet, not the workflow.
 
-## Step 3 — Runner availability per pool (the "why" behind queue times)
+## Step 3 — Active jobs (what is running, and for how long)
 
 ```bash
-gh api "repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100" --paginate \
-  --jq '.runners[] | . as $r | [.labels[].name | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | unique | .[] | {c: ., status: $r.status, busy: $r.busy}' \
-| jq -s -r 'group_by(.c) | map({c: .[0].c, total: length,
-    online: ([.[]|select(.status=="online")]|length),
-    busy: ([.[]|select(.busy==true)]|length)}) | sort_by(.c) | .[]
-  | [.c, (.total|tostring), (.online|tostring), (.busy|tostring)] | @tsv' \
-| (printf "pool\ttotal_runners\tonline\tbusy\n"; cat) | column -t -s$'\t'
+jq -s -r '[.[] | select(.status=="in_progress")] | sort_by(.c, .started_at) | .[]
+  | [.c, (((now - (.started_at|fromdateiso8601))/60 | floor | tostring) + " min"), (.name[0:58]), (.run_id|tostring)] | @tsv' "$SNAP" \
+  | column -t -s$'\t'
 ```
 
-A pool with `online == busy` (or many runners `offline`) fully explains long queues
-for jobs targeting it.
+## Step 4 — Queued jobs (what is waiting, and for how long)
+
+```bash
+jq -s -r '[.[] | select(.status=="queued")] | sort_by(.c, .created_at) | .[]
+  | [.c, (((now - (.created_at|fromdateiso8601))/60 | floor | tostring) + " min"), (.name[0:58]), (.run_id|tostring)] | @tsv' "$SNAP" \
+  | column -t -s$'\t'
+```
+
+To apply `$ARGUMENTS`, pipe Steps 2–4 through `grep -E "<pattern>"` (keep the
+header line of Step 2).
 
 ## Caveats
 
@@ -75,7 +73,9 @@ for jobs targeting it.
   unique per-runner labels (`h100-dgxc-slurm_00`). The `sub()` calls normalize all
   of these — do not drop the `cluster:` prefix handling or multi-node jobs silently
   vanish from the results.
-- **Re-run artifacts:** always keep the `.q >= 0` filter (see Step 2).
+- **Re-run artifacts:** re-run jobs can report `started_at` from an earlier
+  attempt, inflating runtime in Step 3. Cross-check an outlier against the job's
+  page before believing it.
 - **SLURM second queue:** for SLURM-backed pools (`*-dgxc`, `*-nv`), once the
   GitHub job starts there is a second queue inside SLURM that GitHub-side numbers
   do not capture. Check it on the cluster with `squeue -u <runner-user>` (see
@@ -83,3 +83,6 @@ for jobs targeting it.
 - Queue time measured this way excludes time spent behind the sweep canary gate:
   matrix jobs are only *created* after the gate passes, so their `created_at` marks
   genuine runner-wait start.
+- Runner capacity per pool (online/busy/offline) is a separate question — use
+  `gh api repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100 --paginate`
+  and bucket labels the same way as Step 1 if needed.

--- a/.claude/commands/ci-queue-times.md
+++ b/.claude/commands/ci-queue-times.md
@@ -5,29 +5,43 @@ argument-hint: [pool-filter-regex]   # optional, e.g. "h200" or "b200|mi355x" to
 
 GitHub has no queue-metrics API for self-hosted runners, so this derives cluster
 pressure from the Actions API: a job's **wait so far = now − `created_at`** (queued
-jobs) and **runtime so far = now − `started_at`** (active jobs). The cluster is the
-job's runner label; the pool → runner-name mapping lives in `configs/runners.yaml`.
+jobs) and **runtime so far = now − `started_at`** (active jobs). Pool membership
+comes from the repo's own `configs/runners.yaml` (the authoritative pool →
+runner-name mapping), so run this **from the repo root**.
 
 `$ARGUMENTS` (optional) is a regex restricting which pools are shown in Steps 2–4
 (e.g. `h200`). Run all steps and report the tables as-is.
 
-**Key fact for interpreting the numbers:** a self-hosted runner agent executes
-**exactly one job at a time**, so per pool `jobs_active` should always be ≤
-`runners_busy`. Parallelism comes from multiple registered agents per pool
-(`h100-dgxc-slurm_00` … `_19`). A multi-node SLURM job still occupies exactly one
-agent (the orchestrator) — the nodes it allocates inside SLURM are invisible here.
+**Key facts for interpreting the numbers:**
+
+- A self-hosted runner agent executes **exactly one job at a time**, so per pool
+  `jobs_active` should always be ≤ `runners_busy`. Parallelism comes from multiple
+  registered agents per pool (`h100-dgxc-slurm_00` … `_19`).
+- Pools overlap **by design** in `configs/runners.yaml` (e.g. `h100-multinode` ⊂
+  `h100`, and the same `b200-dgxc_*` machines serve `b200`, `b200-dsv4`, and
+  `b200-dgxc` jobs), so one physical runner can count toward several pool rows.
+- A multi-node SLURM job still occupies exactly one agent (the orchestrator) — the
+  nodes it allocates inside SLURM are invisible here.
 
 ## Step 1 — Take one snapshot of jobs (active + queued) and runners
 
 A run can be `in_progress` while its matrix jobs are still `queued` waiting for
-runners (the sweep fan-out), so scan both statuses in a single pass:
+runners (the sweep fan-out), so scan both statuses. Every list call uses
+`--paginate` — without it the runs lists are silently capped at the first page.
 
 ```bash
 SNAP=$(mktemp /tmp/ci_snapshot.XXXXXX.ndjson)
 RUNNERS=$(mktemp /tmp/ci_runners.XXXXXX.ndjson)
+POOLS=$(mktemp /tmp/ci_pools.XXXXXX.tsv)
 
-{ gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'
-  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id'
+# Pool → runner-name membership, from the repo's own config (bare pool keys and
+# cluster:* keys are normalized to the same bucket: cluster:b200-dgxc → b200-dgxc).
+awk '/^  [A-Za-z0-9:-]+:$/ { k=$1; sub(":$","",k); sub("^cluster:","",k); pool=k; next }
+     /^    - / { print pool "\t" $2 }' configs/runners.yaml > "$POOLS"
+
+# Jobs, bucketed by the pool label they requested (demand side).
+{ gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=100" --paginate --jq '.workflow_runs[].id'
+  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=100" --paginate --jq '.workflow_runs[].id'
 } | sort -u | while read -r RUN; do
   gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN/jobs?per_page=100" --paginate \
     --jq '.jobs[] | select(.status=="in_progress" or .status=="queued")
@@ -36,25 +50,26 @@ RUNNERS=$(mktemp /tmp/ci_runners.XXXXXX.ndjson)
       | select(.c != "other")'
 done > "$SNAP"
 
+# Runners by name (capacity side) — names match configs/runners.yaml entries.
 gh api "repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100" --paginate \
-  --jq '.runners[] | . as $r | [.labels[].name | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | unique | .[] | {c: ., status: $r.status, busy: $r.busy}' \
-  > "$RUNNERS"
+  --jq '.runners[] | {name, status, busy}' > "$RUNNERS"
 ```
-
-Sanity-check coverage: compare against
-`gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=1" --jq .total_count`
-(and the same for `queued`) — if either exceeds 100, paginate the runs list too.
 
 ## Step 2 — Per-pool summary: runners online/busy vs jobs active/queued
 
+Joins demand (job labels) against capacity (`configs/runners.yaml` membership):
+
 ```bash
-jq -n -r --slurpfile jobs "$SNAP" --slurpfile runners "$RUNNERS" '
-  ($jobs | group_by(.c) | map({key: .[0].c, value: {
+jq -n -r --slurpfile jobs "$SNAP" --slurpfile runners "$RUNNERS" --rawfile pools "$POOLS" '
+  ($pools | split("\n") | map(select(contains("\t")) | split("\t"))
+    | group_by(.[1]) | map({key: .[0][1], value: [.[].[0]]}) | from_entries) as $name2pools
+  | ($jobs | group_by(.c) | map({key: .[0].c, value: {
       active: ([.[] | select(.status=="in_progress")] | length),
       queued: ([.[] | select(.status=="queued")] | length)}}) | from_entries) as $j
-  | ($runners | group_by(.c) | map({key: .[0].c, value: {
-      online: ([.[] | select(.status=="online")] | length),
-      busy:   ([.[] | select(.busy == true)] | length)}}) | from_entries) as $r
+  | ([ $runners[] as $r | ($name2pools[$r.name] // [])[] as $p | {c: $p, status: $r.status, busy: $r.busy} ]
+     | group_by(.c) | map({key: .[0].c, value: {
+         online: ([.[] | select(.status=="online")] | length),
+         busy:   ([.[] | select(.busy==true)] | length)}}) | from_entries) as $r
   | [([$j, $r] | map(keys) | add | unique | .[]) as $c
       | {c: $c, on: ($r[$c].online // 0), busy: ($r[$c].busy // 0),
          active: ($j[$c].active // 0), queued: ($j[$c].queued // 0)}]
@@ -71,12 +86,9 @@ How to read it (one job per runner agent, so these patterns are diagnostic):
 | `busy == active`, `queued == 0` | healthy, pool has spare capacity if `busy < online` |
 | `busy == online`, `queued > 0` | pool saturated — jobs waiting for a free runner (normal queue) |
 | `online == 0`, `queued > 0` | **pool is down** — no live runners; investigate the fleet, not the workflow |
-| `busy > active` | runners stuck "busy" (cancelled-job artifact) or busy with another repo's jobs (runners may be org-scoped) |
-| `active > busy` | impossible in steady state — treat as snapshot skew between the two API calls |
-
-Note a physical runner counts toward **every** pool label it carries (e.g. the
-same machine appears in `h200`, `h200-dgxc`, and `h200-dgxc-slurm`), so summing
-rows over-counts physical machines.
+| `busy > active` | the pool's runners are busy serving **another pool's** jobs (shared membership in `configs/runners.yaml`, e.g. `b200` vs `b200-dgxc`), stuck "busy" after a cancellation, or busy with another repo's jobs (runners may be org-scoped) |
+| `active > busy` | impossible in steady state — treat as snapshot skew between the API calls |
+| pool absent entirely | no online runners and no jobs — either idle-and-offline, or (if jobs *do* target it) the pool is not defined in `configs/runners.yaml` |
 
 ## Step 3 — Active jobs (what is running, and for how long)
 
@@ -99,11 +111,13 @@ header line of Step 2).
 
 ## Caveats
 
-- **Label shapes:** single-node jobs carry pool labels (`b200`, `mi355x`);
-  multi-node jobs carry `cluster:*` labels (`cluster:gb200-nv`); runners also carry
-  unique per-runner labels (`h100-dgxc-slurm_00`). The `sub()` calls normalize all
-  of these — do not drop the `cluster:` prefix handling or multi-node jobs silently
-  vanish from the results.
+- **Demand vs capacity bucketing:** jobs are bucketed by the label they *request*
+  (single-node jobs use pool labels like `b200`, multi-node jobs use `cluster:*`
+  labels — the `sub()` normalization merges them). Runners are bucketed strictly by
+  `configs/runners.yaml` membership, so bogus rows from per-runner name labels
+  (e.g. `h100-dgxc-slurm`) cannot appear.
+- **`gh api --jq` does not accept jq `--arg`** — extra arguments are parsed as API
+  parameters. Interpolate values into the `--jq` string via the shell instead.
 - **Re-run artifacts:** re-run jobs can report `started_at` from an earlier
   attempt, inflating runtime in Step 3. Cross-check an outlier against the job's
   page before believing it.

--- a/.claude/commands/ci-queue-times.md
+++ b/.claude/commands/ci-queue-times.md
@@ -1,5 +1,5 @@
 ---
-description: Show CI cluster pressure right now — active jobs per GPU pool, the live queue with wait-so-far, and a per-pool active/queued summary
+description: Show CI cluster pressure right now — per-pool runners online/busy vs jobs active/queued, plus the live queue with wait-so-far
 argument-hint: [pool-filter-regex]   # optional, e.g. "h200" or "b200|mi355x" to restrict output
 ---
 
@@ -11,13 +11,21 @@ job's runner label; the pool → runner-name mapping lives in `configs/runners.y
 `$ARGUMENTS` (optional) is a regex restricting which pools are shown in Steps 2–4
 (e.g. `h200`). Run all steps and report the tables as-is.
 
-## Step 1 — Take one snapshot of all GPU jobs (active + queued)
+**Key fact for interpreting the numbers:** a self-hosted runner agent executes
+**exactly one job at a time**, so per pool `jobs_active` should always be ≤
+`runners_busy`. Parallelism comes from multiple registered agents per pool
+(`h100-dgxc-slurm_00` … `_19`). A multi-node SLURM job still occupies exactly one
+agent (the orchestrator) — the nodes it allocates inside SLURM are invisible here.
+
+## Step 1 — Take one snapshot of jobs (active + queued) and runners
 
 A run can be `in_progress` while its matrix jobs are still `queued` waiting for
 runners (the sweep fan-out), so scan both statuses in a single pass:
 
 ```bash
 SNAP=$(mktemp /tmp/ci_snapshot.XXXXXX.ndjson)
+RUNNERS=$(mktemp /tmp/ci_runners.XXXXXX.ndjson)
+
 { gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=100" --jq '.workflow_runs[].id'
   gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=100" --jq '.workflow_runs[].id'
 } | sort -u | while read -r RUN; do
@@ -27,25 +35,48 @@ SNAP=$(mktemp /tmp/ci_snapshot.XXXXXX.ndjson)
          status, name, created_at, started_at, run_id}
       | select(.c != "other")'
 done > "$SNAP"
+
+gh api "repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100" --paginate \
+  --jq '.runners[] | . as $r | [.labels[].name | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | unique | .[] | {c: ., status: $r.status, busy: $r.busy}' \
+  > "$RUNNERS"
 ```
 
 Sanity-check coverage: compare against
 `gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=1" --jq .total_count`
 (and the same for `queued`) — if either exceeds 100, paginate the runs list too.
 
-## Step 2 — Per-pool summary (active vs queued)
+## Step 2 — Per-pool summary: runners online/busy vs jobs active/queued
 
 ```bash
-jq -s -r 'group_by(.c) | map({c: .[0].c,
-    active: ([.[] | select(.status=="in_progress")] | length),
-    queued: ([.[] | select(.status=="queued")] | length)})
-  | sort_by(-.queued, -.active) | .[] | [.c, (.active|tostring), (.queued|tostring)] | @tsv' "$SNAP" \
-  | (printf "pool\tactive\tqueued\n"; cat) | column -t -s$'\t'
+jq -n -r --slurpfile jobs "$SNAP" --slurpfile runners "$RUNNERS" '
+  ($jobs | group_by(.c) | map({key: .[0].c, value: {
+      active: ([.[] | select(.status=="in_progress")] | length),
+      queued: ([.[] | select(.status=="queued")] | length)}}) | from_entries) as $j
+  | ($runners | group_by(.c) | map({key: .[0].c, value: {
+      online: ([.[] | select(.status=="online")] | length),
+      busy:   ([.[] | select(.busy == true)] | length)}}) | from_entries) as $r
+  | [([$j, $r] | map(keys) | add | unique | .[]) as $c
+      | {c: $c, on: ($r[$c].online // 0), busy: ($r[$c].busy // 0),
+         active: ($j[$c].active // 0), queued: ($j[$c].queued // 0)}]
+  | map(select(.on + .busy + .active + .queued > 0))
+  | sort_by(-.queued, -.active)
+  | .[] | [.c, (.on|tostring), (.busy|tostring), (.active|tostring), (.queued|tostring)] | @tsv' \
+  | (printf "pool\trunners_online\trunners_busy\tjobs_active\tjobs_queued\n"; cat) | column -t -s$'\t'
 ```
 
-A pool with **0 active but a growing queue** means its runners are offline, stuck
-"busy" (cancelled-job artifact), or busy with another repo's jobs (runners may be
-org-scoped) — investigate the fleet, not the workflow.
+How to read it (one job per runner agent, so these patterns are diagnostic):
+
+| pattern | meaning |
+|---|---|
+| `busy == active`, `queued == 0` | healthy, pool has spare capacity if `busy < online` |
+| `busy == online`, `queued > 0` | pool saturated — jobs waiting for a free runner (normal queue) |
+| `online == 0`, `queued > 0` | **pool is down** — no live runners; investigate the fleet, not the workflow |
+| `busy > active` | runners stuck "busy" (cancelled-job artifact) or busy with another repo's jobs (runners may be org-scoped) |
+| `active > busy` | impossible in steady state — treat as snapshot skew between the two API calls |
+
+Note a physical runner counts toward **every** pool label it carries (e.g. the
+same machine appears in `h200`, `h200-dgxc`, and `h200-dgxc-slurm`), so summing
+rows over-counts physical machines.
 
 ## Step 3 — Active jobs (what is running, and for how long)
 
@@ -83,6 +114,5 @@ header line of Step 2).
 - Queue time measured this way excludes time spent behind the sweep canary gate:
   matrix jobs are only *created* after the gate passes, so their `created_at` marks
   genuine runner-wait start.
-- Runner capacity per pool (online/busy/offline) is a separate question — use
-  `gh api repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100 --paginate`
-  and bucket labels the same way as Step 1 if needed.
+- Snapshot skew: jobs and runners are fetched a few seconds apart; a job that
+  starts/ends in between can briefly violate `active <= busy`.

--- a/.claude/commands/ci-queue-times.md
+++ b/.claude/commands/ci-queue-times.md
@@ -1,0 +1,85 @@
+---
+description: Check CI queue times across all GPU clusters — live queued jobs with wait so far, historical per-cluster queue latency, and per-pool runner availability
+argument-hint: [history-run-limit]   # optional, default 150 recent runs
+---
+
+GitHub has no queue-metrics API for self-hosted runners, so queue time is derived
+from the Actions API: **queue time per job = `started_at − created_at`** (time spent
+waiting for a free runner), and the cluster is the job's runner label. The pool →
+runner-name mapping lives in `configs/runners.yaml`.
+
+Run all three sections and report them as compact tables. `$ARGUMENTS` (optional)
+overrides the history window in Step 2 (default 150 recent runs).
+
+## Step 1 — Live queue: who is waiting right now, and for how long
+
+A run can be `in_progress` while its matrix jobs are still `queued` waiting for
+runners (the sweep fan-out), so scan both statuses:
+
+```bash
+{ gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=queued&per_page=50" --jq '.workflow_runs[].id'
+  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs?status=in_progress&per_page=50" --jq '.workflow_runs[].id'
+} | sort -u | while read -r RUN; do
+  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN/jobs?per_page=100" --paginate \
+    --jq '.jobs[] | select(.status=="queued") | {labels: [.labels[] | sub("^cluster:";"") | select(test("^(self-hosted|Linux|X64|ARM64|slurm)$|_\\d+$") | not)], name, created_at, run_id}'
+done | jq -s -r 'sort_by(.created_at) | .[]
+  | [((now - (.created_at|fromdateiso8601))/60 | floor | tostring) + " min",
+     (.labels | join(",")), (.name[0:60]), (.run_id|tostring)] | @tsv' | column -t -s$'\t'
+```
+
+## Step 2 — Historical queue latency per cluster
+
+Uses the last N runs (default 150; `$ARGUMENTS` overrides). **Filter `.q >= 0` is
+mandatory** — re-run jobs keep `started_at` from the first attempt and produce
+negative values. For a wider window raise the limit or add
+`--created ">YYYY-MM-DD"` to `gh run list`.
+
+```bash
+LIMIT="${ARGUMENTS:-150}"
+gh run list --repo SemiAnalysisAI/InferenceX --limit "$LIMIT" --json databaseId --jq '.[].databaseId' | while read -r RUN; do
+  gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN/jobs?per_page=100" --paginate \
+    --jq '.jobs[] | select(.started_at != null)
+      | {c: ([.labels[] | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | first // empty),
+         q: (((.started_at|fromdateiso8601) - (.created_at|fromdateiso8601))/60)}
+      | select(.c != "" and .q >= 0)'
+done | jq -s -r 'group_by(.c)
+  | map({cluster: .[0].c, n: length, avg: (map(.q)|add/length),
+         p50: (map(.q)|sort|.[(length*0.5|floor)]), max: (map(.q)|max)})
+  | sort_by(-.p50) | .[]
+  | [.cluster, (.n|tostring), ((.avg*10|round)/10|tostring), ((.p50*10|round)/10|tostring), ((.max|round)|tostring)] | @tsv' \
+  | (printf "cluster\tjobs\tavg_min\tp50_min\tmax_min\n"; cat) | column -t -s$'\t'
+```
+
+Note: the sample only covers clusters that actually ran within the window — a
+missing cluster means no recent jobs, not zero queue.
+
+## Step 3 — Runner availability per pool (the "why" behind queue times)
+
+```bash
+gh api "repos/SemiAnalysisAI/InferenceX/actions/runners?per_page=100" --paginate \
+  --jq '.runners[] | . as $r | [.labels[].name | select(test("^(cluster:)?(b200|b300|h100|h200|gb200|gb300|mi300x|mi325x|mi355x)")) | sub("^cluster:";"") | sub("_\\d+$";"")] | unique | .[] | {c: ., status: $r.status, busy: $r.busy}' \
+| jq -s -r 'group_by(.c) | map({c: .[0].c, total: length,
+    online: ([.[]|select(.status=="online")]|length),
+    busy: ([.[]|select(.busy==true)]|length)}) | sort_by(.c) | .[]
+  | [.c, (.total|tostring), (.online|tostring), (.busy|tostring)] | @tsv' \
+| (printf "pool\ttotal_runners\tonline\tbusy\n"; cat) | column -t -s$'\t'
+```
+
+A pool with `online == busy` (or many runners `offline`) fully explains long queues
+for jobs targeting it.
+
+## Caveats
+
+- **Label shapes:** single-node jobs carry pool labels (`b200`, `mi355x`);
+  multi-node jobs carry `cluster:*` labels (`cluster:gb200-nv`); runners also carry
+  unique per-runner labels (`h100-dgxc-slurm_00`). The `sub()` calls normalize all
+  of these — do not drop the `cluster:` prefix handling or multi-node jobs silently
+  vanish from the results.
+- **Re-run artifacts:** always keep the `.q >= 0` filter (see Step 2).
+- **SLURM second queue:** for SLURM-backed pools (`*-dgxc`, `*-nv`), once the
+  GitHub job starts there is a second queue inside SLURM that GitHub-side numbers
+  do not capture. Check it on the cluster with `squeue -u <runner-user>` (see
+  `.claude/skills/debug-runs/SKILL.md`).
+- Queue time measured this way excludes time spent behind the sweep canary gate:
+  matrix jobs are only *created* after the gate passes, so their `created_at` marks
+  genuine runner-wait start.


### PR DESCRIPTION
## Description

Adds a new `.claude/commands/ci-queue-times.md` slash command — `/ci-queue-times [history-run-limit]` — for checking CI queue times across all GPU clusters.

GitHub has no queue-metrics API for self-hosted runners, so the command derives queue time from the Actions API (**queue time = job `started_at` − `created_at`**, cluster = job runner label; pool mapping from `configs/runners.yaml`). It bundles three verified queries:

1. **Live queue** — currently queued jobs (including queued matrix jobs inside in-progress sweep runs) with wait-so-far, cluster label, and run ID.
2. **Historical per-cluster latency** — jobs / avg / p50 / max queue minutes over the last N runs (default 150), with re-run artifacts filtered (`q >= 0`) and `cluster:*` label normalization.
3. **Runner availability per pool** — total / online / busy runners per pool, i.e. the "why" behind queue times.

Caveats are documented in the file: the SLURM second queue on `*-dgxc` / `*-nv` pools (check via `squeue -u <runner-user>`), canary-gate exclusion, and label-shape handling.

None of the existing `.claude/commands/` covers this — the PR-status commands only see GitHub check *states*, and `klaud-pr-status-html`'s queue-aware ETA is a pessimistic pool-pressure estimate scoped to claude/* PRs, not measured per-cluster queue latency.

All three queries were executed against live Actions data during development. This is an agent-instruction file → English-only per the bilingual-docs exception in `AGENTS.md`.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally (all three embedded queries run against the live Actions API)
- [x] I have updated documentation if necessary (the command file *is* the doc; agent-instruction files are English-only per `AGENTS.md`)
- [ ] **If I changed a container image or config, I have already updated `perf-changelog.yaml`** — N/A, no image/config change
- [ ] **Before merging via reuse ... `/reuse-sweep-run` ...** — N/A, no benchmark sweep needed (no sweep label applied; nothing here affects benchmark results)

## 中文说明

新增 `.claude/commands/ci-queue-times.md` 斜杠命令 —— `/ci-queue-times [历史窗口]` —— 用于查看所有 GPU 集群的 CI 排队时间。

GitHub 没有针对自托管 runner 的排队指标 API，因此该命令通过 Actions API 推导排队时间（**排队时间 = 任务 `started_at` − `created_at`**，集群 = 任务的 runner 标签；池与 runner 的映射见 `configs/runners.yaml`）。包含三个已验证的查询：

1. **当前队列** —— 正在排队的任务（包括进行中的扫描工作流里尚未调度到 runner 的矩阵任务），显示已等待时长、集群标签和 run ID。
2. **按集群统计的历史排队延迟** —— 最近 N 个运行（默认 150）内的任务数 / 平均 / P50 / 最大排队分钟数；已过滤重跑导致的异常负值（`q >= 0`），并对 `cluster:*` 标签做归一化。
3. **按 runner 池统计的可用性** —— 每个池的总数 / 在线 / 忙碌 runner 数，用于解释排队背后的原因。

文件中已注明注意事项：`*-dgxc` / `*-nv` 池存在 SLURM 二级队列（需在集群上用 `squeue -u <runner-user>` 查看）、金丝雀门禁（canary gate）不计入排队时间、以及标签格式的处理方式。

现有 `.claude/commands/` 均不覆盖此场景 —— PR 状态类命令只能看到 GitHub check 的*状态*，而 `klaud-pr-status-html` 的排队 ETA 只是面向 claude/* PR 的悲观池压力估算，并非实测的按集群排队延迟。

三个查询在开发过程中均已对仓库的 Actions 数据实际执行验证。本文件属于 agent 指令文件，按 `AGENTS.md` 的双语文档例外规则仅提供英文版本。

其他：无镜像或配置变更，无需更新 `perf-changelog.yaml`；未添加扫描（sweep）标签，本变更不应触发任何 GPU 基准测试。
