### PR TITLE
[Klaud Cold] docs: add TPUv7x Ironwood Ghostfish as Coming Soon SKU / 文档：新增 TPUv7x Ironwood Ghostfish（即将支持）

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This pace of software advancement creates a challenge: benchmarks conducted at a
 | MI300X | ✅ |
 | H200 | ✅ |
 | H100 | ✅ |
+| TPUv7x Ironwood Ghostfish | Coming Soon 🔜 |
 | MI455 UALoE72 | Coming Soon 🔜 |
 | Vera Rubin NVL72 | Coming Soon 🔜 |
 | Rubin NVL8 | Coming Soon 🔜 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,6 +59,7 @@ SGLang、vLLM、TensorRT-LLM、CUDA、ROCm 等 AI 软件通过核函式優化、
 | MI300X | ✅ |
 | H200 | ✅ |
 | H100 | ✅ |
+| TPUv7x Ironwood Ghostfish | Coming Soon 🔜 |
 | MI455 UALoE72 | Coming Soon 🔜 |
 | Vera Rubin NVL72 | Coming Soon 🔜 |
 | Rubin NVL8 | Coming Soon 🔜 |


### PR DESCRIPTION
## Summary
- Adds **TPUv7x Ironwood Ghostfish** with status **Coming Soon 🔜** to the supported-hardware table in `README.md` and `README_zh.md`, inserted between `H100 ✅` and `MI455 UALoE72 Coming Soon 🔜`.
- Docs-only change; head commit carries `[skip-sweep]` so no benchmark setup runs.

## 中文说明
- 在 `README.md` 与 `README_zh.md` 的硬件支持表中新增 **TPUv7x Ironwood Ghostfish**（Coming Soon 🔜），位于 `H100` 与 `MI455 UALoE72` 之间。
- 仅文档改动；head commit 含 `[skip-sweep]`，不触发基准测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)