### PR TITLE
GLM-5.2 NVFP4 B300 SGLang high-throughput arm to DEP8, cap conc at 64 

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh
@@ -106,11 +106,6 @@ if [ "$DP_ATTENTION" = "true" ]; then
     # while KV usage sat at ~0.01). Use the cookbook's own dp8 lever from
     # the B200 cells (32768 = ~4096/rank).
     CHUNKED_PREFILL_SIZE=32768
-    # At conc 512 the saturation working set outlives the default 1800s
-    # warmup drain grace: the drain converges healthily (~0.45 req/s, zero
-    # errors) but needs ~2500s end to end. 3600 is a maximum wait, not a
-    # fixed sleep — lower-conc DPA points still finish as fast as they drain.
-    export AGENTIC_WARMUP_GRACE_PERIOD=3600
     PARALLEL_ARGS+=(
         --dp "$TP"
         --enable-dp-attention

--- a/benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh
@@ -8,7 +8,8 @@ set -x
 # (https://docs.sglang.io/cookbook/autoregressive/GLM/GLM-5.2), STP only:
 # the cookbook's EAGLE MTP variants are intentionally not wired up yet.
 #   DP_ATTENTION=false -> low-latency arm (TP8, fp8 KV, cutedsl bf16 GEMM)
-#   DP_ATTENTION=true  -> high-throughput arm (TP8 + DP8 attention-DP)
+#   DP_ATTENTION=true  -> high-throughput DEP arm (TP8 + DP8 attention-DP +
+#                         EP_SIZE expert-parallel MoE via --ep-size)
 #
 # Required env vars:
 #   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION,

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7875,5 +7875,8 @@ glm5.2-fp4-b300-sglang-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 2, 4, 8, 16, 32] }
-      # DEP (attention-DP + EP8 expert-parallel MoE) throughput arm, capped at conc 64.
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48, 64], router: { name: sglang-router, version: "0.3.2" } }
+      # DEP (attention-DP + EP8 expert-parallel MoE) throughput arm at conc 48 — the
+      # frontier peak (163 tok/s/gpu out, ttft 2.8s). conc >=64 overflows the HBM+host
+      # radix cache (GPU hit 0.93->0.57 at 48->64) and thrashes on re-prefill, so it is
+      # strictly dominated by conc 48 on both throughput and interactivity.
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48], router: { name: sglang-router, version: "0.3.2" } }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7858,9 +7858,10 @@ qwen3.5-fp8-gb300-dynamo-sglang:
 # single-node recipes (https://docs.sglang.io/cookbook/autoregressive/GLM/GLM-5.2),
 # STP only (the cookbook's EAGLE MTP variants are deferred). The TP8 arm is the
 # cookbook low-latency recipe (fp8 KV, cutedsl bf16 GEMM) and covers the
-# interactivity end; the TP8/DP8 attention-DP arm is the cookbook
-# high-throughput recipe behind sglang-router consistent hashing for session
-# affinity. Conc lists are disjoint between arms so exp-names stay unique.
+# interactivity end; the TP8/DP8/EP8 DEP arm (attention-DP + expert-parallel
+# MoE) is the cookbook high-throughput recipe behind sglang-router consistent
+# hashing for session affinity. Conc lists are disjoint between arms so
+# exp-names stay unique.
 glm5.2-fp4-b300-sglang-agentic:
   image: lmsysorg/sglang:v0.5.15.post1-cu130
   model: nvidia/GLM-5.2-NVFP4
@@ -7874,4 +7875,5 @@ glm5.2-fp4-b300-sglang-agentic:
     - dram-utilization: 0.80
       search-space:
       - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 2, 4, 8, 16, 32] }
-      - { tp: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48, 64, 96, 128, 192, 256, 512], router: { name: sglang-router, version: "0.3.2" } }
+      # DEP (attention-DP + EP8 expert-parallel MoE) throughput arm, capped at conc 64.
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48, 64], router: { name: sglang-router, version: "0.3.2" } }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4973,4 +4973,4 @@
     - "Convert the high-throughput arm to DEP: add ep: 8 to the TP8/DP8 attention-DP arm so the MoE layers run expert-parallel across all 8 ranks (--ep-size 8) instead of TP-sharded (the arm previously left ep unset -> EP_SIZE=1). Attention stays data-parallel behind sglang-router consistent hashing; the recipe already passes --ep-size EP_SIZE unconditionally, so only the master-config search space changes"
     - "Cap the DEP arm concurrency at 64: conc-list [48, 64] (was [48, 64, 96, 128, 192, 256, 512])"
     - "Low-latency TP8 arm (conc [1, 2, 4, 8, 16, 32], fp8 KV + cutedsl bf16 GEMM) unchanged; DEP mirrors the proven dsv4-fp4-b300-sglang tp8/ep8/dp-attn DEP arm"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2281

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4971,6 +4971,6 @@
     - glm5.2-fp4-b300-sglang-agentic
   description:
     - "Convert the high-throughput arm to DEP: add ep: 8 to the TP8/DP8 attention-DP arm so the MoE layers run expert-parallel across all 8 ranks (--ep-size 8) instead of TP-sharded (the arm previously left ep unset -> EP_SIZE=1). Attention stays data-parallel behind sglang-router consistent hashing; the recipe already passes --ep-size EP_SIZE unconditionally, so only the master-config search space changes"
-    - "Cap the DEP arm concurrency at 64: conc-list [48, 64] (was [48, 64, 96, 128, 192, 256, 512])"
+    - "DEP arm runs conc-list [48] only (was [48, 64, 96, 128, 192, 256, 512]): conc 48 is the frontier peak (163 tok/s/gpu out, ttft 2.8s); conc >=64 overflows the HBM+host radix cache (GPU hit 0.93->0.57 at 48->64) and thrashes on re-prefill, so it is strictly dominated"
     - "Low-latency TP8 arm (conc [1, 2, 4, 8, 16, 32], fp8 KV + cutedsl bf16 GEMM) unchanged; DEP mirrors the proven dsv4-fp4-b300-sglang tp8/ep8/dp-attn DEP arm"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2281

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4966,3 +4966,11 @@
     - "Run 29651235293 showed the 1M-context corpus working set outgrowing the HBM KV pool past conc 8 (TP8) / conc 64 (DP8): gpu_kv_cache_usage pinned at 1.0 and the radix hit rate collapsed from a ~0.97 theoretical ceiling to 0.04-0.06, so every post-knee turn re-prefilled its full history and throughput fell together with interactivity"
     - "HiCache spills evicted prefixes to host DRAM and restores them at C2C bandwidth instead of recomputing; sizing follows the qwen3.5-fp8-b300-sglang-agentic-hicache recipe (GLM-5.2 is plain GQA: one host pool per rank, GB-based --hicache-size)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2280
+
+- config-keys:
+    - glm5.2-fp4-b300-sglang-agentic
+  description:
+    - "Convert the high-throughput arm to DEP: add ep: 8 to the TP8/DP8 attention-DP arm so the MoE layers run expert-parallel across all 8 ranks (--ep-size 8) instead of TP-sharded (the arm previously left ep unset -> EP_SIZE=1). Attention stays data-parallel behind sglang-router consistent hashing; the recipe already passes --ep-size EP_SIZE unconditionally, so only the master-config search space changes"
+    - "Cap the DEP arm concurrency at 64: conc-list [48, 64] (was [48, 64, 96, 128, 192, 256, 512])"
+    - "Low-latency TP8 arm (conc [1, 2, 4, 8, 16, 32], fp8 KV + cutedsl bf16 GEMM) unchanged; DEP mirrors the proven dsv4-fp4-b300-sglang tp8/ep8/dp-attn DEP arm"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING


### PR DESCRIPTION
## Summary

Follow-up to #2268 / #2279. The GLM-5.2 NVFP4 B300 SGLang agentic recipe's high-throughput arm ran **TP8 + DP8 attention-DP with the MoE layers TP-sharded** — the arm left `ep` unset, so `EP_SIZE` defaulted to `1`. This converts that arm to **DEP** (data-parallel attention + expert-parallel MoE) and runs it at **conc 48** (the frontier peak).

- **`ep: 8` added** to the `{ tp: 8, dp-attn: true, ... }` throughput arm → the MoE layers now run expert-parallel across all 8 ranks (`--ep-size 8`) while attention stays data-parallel behind sglang-router consistent hashing. Mirrors the already-proven `dsv4-fp4-b300-sglang` `tp8/ep8/dp-attn` DEP arm.
- **DEP arm runs conc 48 only**: `conc-list` is `[48]` (was `[48, 64, 96, 128, 192, 256, 512]`). The validation sweep (run 29717273540) measured DEP conc-48 at **163 tok/s/gpu output / 2.8 s TTFT / 0.93 GPU radix hit** — vs the previously-published dp-attn-`ep1` conc-48 at 124 / 5.3 s / 0.91, i.e. **+31% output throughput** from the EP change. Higher concurrencies are dropped (see the conc-64 note).
- **Low-latency TP8 arm unchanged**: `conc [1, 2, 4, 8, 16, 32]` with its fp8-KV / cutedsl bf16-GEMM levers stays exactly as-is (per the chosen scope — only the throughput arm becomes DEP).
- **Recipe edits are minimal**: `glm5.2_fp4_b300_sglang.sh` already passes `--ep-size "$EP_SIZE"` unconditionally, so the DEP switch is master-config-only. The recipe is touched only to (a) update the header comment to describe the DEP arm and (b) drop the now-stale conc-512-tuned `AGENTIC_WARMUP_GRACE_PERIOD=3600` override — the DEP arm now runs conc 48, which drains within the default 1800 s grace (a ceiling, not a fixed sleep).

The `EP_SIZE` / `DP_ATTENTION` plumbing already reaches the container: `generate_sweep_configs.py` (`ep` defaults to 1) → `benchmark-tmpl.yml` (`EP_SIZE`/`DP_ATTENTION` job env) → `launch_b300-nv.sh` (`srun --export=ALL`).

### Why conc 48 only (the conc-64 investigation)

conc 64 was dropped after investigating why it looked bad — the story had two distinct causes:

1. **The originally-published conc-64 point was a crash, not a cliff.** In the prior HiCache run (29682242847) the sglang scheduler crashed mid-run with `CUDA error: CUBLAS_STATUS_EXECUTION_FAILED` in the MoE router-gate GEMM (`linear_bf16_fp32`, `deepseek_v2.py` `MoEGate.forward`), profiling only 129 records before AIPerf aborted on the error spike. This is the normal cuBLAS router-gate path for batches > `max_router_gemm_tokens` (16); it is **not** selected by `--bf16-gemm-backend`, so cutedsl would not have helped. It hit conc 48 and 64 on two different nodes while conc 96/128 ran the identical path clean — an **intermittent cuBLAS/CUDA execution failure**. The DEP rerun (29717273540) confirmed this was transient: conc 64 ran clean (1357 records, full duration, 0 crashes).
2. **Even clean, conc 64 is strictly dominated.** At conc 64 the concurrent 1M-context working set overflows the fixed HBM + host radix cache: GPU radix hit collapses 0.93 → 0.57 (48 → 64), ~25% of every turn's 100k+-token history is re-prefilled, and throughput/interactivity fall together — **41 tok/s/gpu output, 56 s TTFT** vs conc 48's 164 / 2.8 s. The host DRAM tier (ratio 0.75, ~1 TB) is too small to absorb the overflow and can't be safely enlarged (ratio 2 ≈ 2.7 TB OOM-killed the 3 TB node, per #2279).

So conc 64 is dominated on both axes and unrecoverable within the node's memory envelope → the DEP arm runs conc 48 only. The SWE-bench `agentic_evals` point also moves to conc 48 (the conc-64 eval job hung ~4.5 h).

### Note / possible follow-up

Unlike the DSv4 B300 DEP arm (which adds `--moe-runner-backend flashinfer_mxfp4`), this change does **not** add an explicit MoE-dispatch backend flag — SGLang's default single-node (NVLink) all-to-all dispatch is used.

## Validation

- `generate_sweep_configs.py full-sweep --model-prefix glm5.2` → **7 agentic points**: 6 low-latency (`ep=1`, conc 1–32, unchanged) + 1 DEP (`ep=8, dp-attn=true, router`, conc 48); exp-names unique.
- `process_changelog.py --base-ref origin/main --head-ref HEAD` emits the 7 rows + the SWE-bench `agentic_evals` row on the DEP conc-48 point, `ep: 8` on the DEP arm.
- On-cluster sweep (run 29717273540): DEP conc-48 throughput job green, 163 tok/s/gpu output, no CUBLAS crash.
- `pytest utils/matrix_logic/test_validation.py utils/test_process_changelog.py`: 135 passed.
- `bash -n benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh`.

## 中文说明

延续 #2268 / #2279。GLM-5.2 NVFP4 B300 SGLang agentic recipe 的高吞吐分支此前运行的是 **TP8 + DP8 注意力数据并行(attention-DP)，而 混合专家(MoE) 层按 TP 切分**——该分支未设置 `ep`，因此 `EP_SIZE` 默认为 `1`。本次将该分支改为 **DEP**（注意力数据并行 + 专家并行(EP) MoE），并以 **conc 48**（前沿峰值）运行。

- **新增 `ep: 8`** 到 `{ tp: 8, dp-attn: true, ... }` 高吞吐分支 → MoE 层现按 专家并行 分布在全部 8 个 rank 上（`--ep-size 8`），注意力仍为数据并行并置于 sglang-router 一致性哈希之后。对齐已验证的 `dsv4-fp4-b300-sglang` `tp8/ep8/dp-attn` DEP 分支。
- **DEP 分支仅运行 conc 48**：`conc-list` 现为 `[48]`（原先为 `[48, 64, 96, 128, 192, 256, 512]`）。验证扫描(run 29717273540)测得 DEP conc-48 为 **163 tok/s/gpu 输出 / 2.8s TTFT / 0.93 GPU radix 命中**——对比此前发布的 dp-attn-`ep1` conc-48 的 124 / 5.3s / 0.91，即 EP 带来 **+31% 输出吞吐**。更高并发已移除（见 conc-64 说明）。
- **低延迟 TP8 分支保持不变**：`conc [1, 2, 4, 8, 16, 32]`，其 fp8-KV / cutedsl bf16-GEMM 配置完全保留（按所选范围，仅高吞吐分支改为 DEP）。
- **recipe 改动极小**：`glm5.2_fp4_b300_sglang.sh` 本就无条件传入 `--ep-size "$EP_SIZE"`，故 DEP 切换仅涉及 master 配置。recipe 仅做两处修改：(a) 更新头注释以描述 DEP 分支；(b) 移除已过时、为 conc 512 调优的 `AGENTIC_WARMUP_GRACE_PERIOD=3600` 覆盖值——DEP 分支现运行 conc 48，可在默认 1800s grace 内完成 drain（grace 是上限而非固定等待）。

`EP_SIZE` / `DP_ATTENTION` 的传递链路已就绪：`generate_sweep_configs.py`（`ep` 默认为 1）→ `benchmark-tmpl.yml`（`EP_SIZE`/`DP_ATTENTION` 任务级 env）→ `launch_b300-nv.sh`（`srun --export=ALL`）。

### 为何仅保留 conc 48（conc-64 调查）

在确认 conc 64 表现不佳的原因后将其移除，问题有两个独立成因：

1. **最初发布的 conc-64 数据点是崩溃，而非性能悬崖。** 在此前的 HiCache 运行(29682242847)中，sglang 调度器运行中崩溃：MoE 路由门 GEMM(`linear_bf16_fp32`，`deepseek_v2.py` `MoEGate.forward`)抛出 `CUDA error: CUBLAS_STATUS_EXECUTION_FAILED`，AIPerf 在错误率超阈后中止，仅 profile 了 129 条记录。这是批大小 > `max_router_gemm_tokens`(16) 时走的正常 cuBLAS 路由门路径，**不受 `--bf16-gemm-backend` 控制**，故 cutedsl 无法修复。它在两个不同节点上命中 conc 48 与 64，而 conc 96/128 走同一路径却正常完成——属于**间歇性 cuBLAS/CUDA 执行失败**。DEP 重跑(29717273540)证实其为偶发：conc 64 运行正常(1357 条记录，完整时长，0 崩溃)。
2. **即便正常运行，conc 64 也被严格支配。** 在 conc 64 下，并发的 1M-context 工作集会使固定的 HBM + host radix 缓存溢出：GPU radix 命中率从 0.93 跌至 0.57(48→64)，每轮约 25% 的 10 万+ token 历史被重新预填充，吞吐与交互性一同下降——**输出 41 tok/s/gpu，TTFT 56s**，而 conc 48 为 164 / 2.8s。host DRAM 层(ratio 0.75，约 1TB)太小，无法吸收溢出，且无法安全增大(ratio 2 ≈ 2.7TB 会 OOM 3TB 节点，见 #2279)。

因此 conc 64 在两个维度上均被支配，且在节点内存范围内无法恢复 → DEP 分支仅运行 conc 48。SWE-bench `agentic_evals` 点也随之移到 conc 48（conc-64 评估任务曾卡住约 4.5 小时）。

### 备注 / 可能的后续

与 DSv4 B300 DEP 分支（额外添加 `--moe-runner-backend flashinfer_mxfp4`）不同，本次改动**未**显式添加 MoE 分发后端参数——使用 SGLang 默认的单节点(NVLink)全互联(all-to-all)分发。

## 验证

- `generate_sweep_configs.py full-sweep --model-prefix glm5.2` → **7 个 agentic 点**：6 个低延迟（`ep=1`，conc 1–32，未变）+ 1 个 DEP（`ep=8, dp-attn=true, router`，conc 48）；exp-name 唯一。
- `process_changelog.py --base-ref origin/main --head-ref HEAD` 输出 7 行 + DEP conc-48 点上的 SWE-bench `agentic_evals` 行，DEP 分支带 `ep: 8`。
- 集群扫描(run 29717273540)：DEP conc-48 吞吐任务通过，输出 163 tok/s/gpu，无 CUBLAS 崩溃。
- `pytest utils/matrix_logic/test_validation.py utils/test_process_changelog.py`：135 passed。
- `bash -n benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh`。
