### PR TITLE
[AMD] exclude mia1-p01-g09 from AMD multi-node Slurm jobs

### DIFF
--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -166,7 +166,7 @@ fi
 # Optional: exclude specific nodes (e.g. nodes with broken Docker sockets).
 # Set SLURM_EXCLUDE_NODES env var to a comma-separated list of hostnames.
 EXCLUDE_OPT=()
-SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15,mia1-p01-g09,mia1-p01-g14}"
+SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15,mia1-p01-g09}"
 if [[ -n "${SLURM_EXCLUDE_NODES:-}" ]]; then
     EXCLUDE_OPT=(--exclude "$SLURM_EXCLUDE_NODES")
 fi

--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -166,7 +166,7 @@ fi
 # Optional: exclude specific nodes (e.g. nodes with broken Docker sockets).
 # Set SLURM_EXCLUDE_NODES env var to a comma-separated list of hostnames.
 EXCLUDE_OPT=()
-SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15}"
+SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15,mia1-p01-g09,mia1-p01-g14}"
 if [[ -n "${SLURM_EXCLUDE_NODES:-}" ]]; then
     EXCLUDE_OPT=(--exclude "$SLURM_EXCLUDE_NODES")
 fi


### PR DESCRIPTION
Evidence of failing PD on these nodes
https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29683845216/job/88211152187?pr=2247

## Summary
- Add `mia1-p01-g09` and `mia1-p01-g14` to the default `SLURM_EXCLUDE_NODES` list in the AMD multi-node submit script

## Test plan
- [ ] Verify multi-node AMD Slurm jobs no longer schedule on the excluded nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)