### PR TITLE
Experiment with MiniMax-M2.7 EAGLE on B200 / 在 B200 上实验 MiniMax-M2.7 EAGLE

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export SCENARIO_TYPE=agentic-coding
+source "$(dirname "${BASH_SOURCE[0]}")/../fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh"

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# MiniMax-M2.7 NVFP4 on B200 with the public full-vocabulary EAGLE3 draft.
+# This entrypoint serves both fixed-sequence and AgentX wrappers so the target,
+# draft, speculative settings, and chat behavior cannot drift between them.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFERENCEX_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$INFERENCEX_ROOT/benchmarks/benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    EP_SIZE \
+    CONC \
+    PORT \
+    PRECISION \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ "$PRECISION" != "fp4" || "$EP_SIZE" != "1" ]]; then
+    echo "MiniMax-M2.7 EAGLE3 expects NVFP4 with pure tensor parallelism, got precision=$PRECISION EP=$EP_SIZE" >&2
+    exit 1
+fi
+if [[ "$TP" != "4" && "$TP" != "8" ]]; then
+    echo "MiniMax-M2.7 EAGLE3 supports the configured TP4/TP8 search space, got TP=$TP" >&2
+    exit 1
+fi
+
+readonly TARGET_MODEL="nvidia/MiniMax-M2.7-NVFP4"
+readonly TARGET_REVISION="e79701cb1f9dce8fe5395b9ed2b20170beebecde"
+readonly DRAFT_MODEL="asherszhang/MiniMax-M2.7-EAGLE3-draft-vocab200k"
+readonly DRAFT_REVISION="252b54f7d05a5d0db7734563ae10e2e6a81d6a7d"
+
+if [[ "$MODEL" != "$TARGET_MODEL" && "$MODEL" != /* ]]; then
+    echo "Unexpected target model: $MODEL (expected $TARGET_MODEL)" >&2
+    exit 1
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    TARGET_MODEL_PATH="$MODEL_PATH"
+elif [[ "$MODEL" == /* ]]; then
+    TARGET_MODEL_PATH="$MODEL"
+else
+    TARGET_MODEL_PATH="$TARGET_MODEL"
+fi
+
+if [[ "$TARGET_MODEL_PATH" == /* ]]; then
+    MODEL_ROOT=$(dirname "$TARGET_MODEL_PATH")
+    DRAFT_MODEL_PATH="${DRAFT_MODEL_PATH:-$MODEL_ROOT/MiniMax-M2.7-EAGLE3-draft-vocab200k}"
+    mkdir -p "$TARGET_MODEL_PATH" "$DRAFT_MODEL_PATH"
+    exec 8>"$MODEL_ROOT/.minimax-m2.7-eagle3-stage.lock"
+    flock -w 7200 8
+    if [[ ! -f "$TARGET_MODEL_PATH/config.json" || \
+          ! -f "$TARGET_MODEL_PATH/model.safetensors.index.json" || \
+          $(find "$TARGET_MODEL_PATH" -maxdepth 1 -name 'model-*-of-00015.safetensors' | wc -l) -ne 15 ]]; then
+        hf download "$TARGET_MODEL" --revision "$TARGET_REVISION" --local-dir "$TARGET_MODEL_PATH"
+    fi
+    if [[ ! -f "$DRAFT_MODEL_PATH/config.json" || ! -f "$DRAFT_MODEL_PATH/model.safetensors" ]]; then
+        hf download "$DRAFT_MODEL" --revision "$DRAFT_REVISION" --local-dir "$DRAFT_MODEL_PATH"
+    fi
+    flock -u 8
+else
+    hf download "$TARGET_MODEL" --revision "$TARGET_REVISION"
+    hf download "$DRAFT_MODEL" --revision "$DRAFT_REVISION"
+    DRAFT_MODEL_PATH="$DRAFT_MODEL"
+fi
+
+python3 - "$TARGET_MODEL_PATH" "$DRAFT_MODEL_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+target_path, draft_path = map(Path, sys.argv[1:])
+target = json.loads((target_path / "config.json").read_text())
+draft = json.loads((draft_path / "config.json").read_text())
+quant = target.get("quantization_config", {})
+if quant.get("quant_algo") != "NVFP4" or quant.get("quant_method") != "modelopt":
+    raise SystemExit(f"Unexpected NVFP4 target configuration: {quant}")
+if target.get("vocab_size") != 200064:
+    raise SystemExit(f"Unexpected target vocabulary: {target.get('vocab_size')}")
+if draft.get("architectures") != ["LlamaForCausalLMEagle3"]:
+    raise SystemExit(f"Unexpected EAGLE3 architecture: {draft.get('architectures')}")
+if draft.get("vocab_size") != 200064 or draft.get("num_hidden_layers") != 1:
+    raise SystemExit(
+        f"Unexpected EAGLE3 draft contract: vocab={draft.get('vocab_size')} "
+        f"layers={draft.get('num_hidden_layers')}"
+    )
+print(f"Validated target={target_path} draft={draft_path}")
+PY
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+nvidia-smi
+
+IS_AGENTIC=false
+if [[ "${SCENARIO_TYPE:-fixed-seq-len}" == "agentic-coding" ]]; then
+    IS_AGENTIC=true
+    check_env_vars DURATION RESULT_DIR KV_OFFLOADING TOTAL_CPU_DRAM_GB
+    if [[ "$KV_OFFLOADING" != "none" ]]; then
+        echo "This low-concurrency EAGLE3 experiment requires GPU-resident KV cache" >&2
+        exit 1
+    fi
+    export INFMAX_CONTAINER_WORKSPACE="${INFMAX_CONTAINER_WORKSPACE:-/workspace}"
+    resolve_trace_source
+    install_agentic_deps
+    OUTPUT_DIR="$RESULT_DIR"
+    CONTEXT_LENGTH=196608
+    MAX_RUNNING_REQUESTS=$((CONC * 2))
+    (( MAX_RUNNING_REQUESTS < 8 )) && MAX_RUNNING_REQUESTS=8
+else
+    check_env_vars ISL OSL MAX_MODEL_LEN
+    OUTPUT_DIR="$PWD"
+    CONTEXT_LENGTH="$MAX_MODEL_LEN"
+    MAX_RUNNING_REQUESTS=$((CONC * 2))
+fi
+mkdir -p "$OUTPUT_DIR"
+
+SERVER_LOG="$OUTPUT_DIR/server.log"
+SERVER_PID=""
+GPU_MONITOR_STARTED=false
+
+cleanup() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    if [[ "$GPU_MONITOR_STARTED" == "true" ]]; then
+        stop_gpu_monitor
+    fi
+    stop_background_process_tree "$SERVER_PID" "MiniMax-M2.7 EAGLE3 server" 60
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+start_gpu_monitor --output "$OUTPUT_DIR/gpu_metrics.csv"
+GPU_MONITOR_STARTED=true
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$TARGET_MODEL_PATH"
+    --served-model-name "$TARGET_MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    --tp "$TP"
+    --ep-size "$EP_SIZE"
+    --quantization modelopt_fp4
+    --dtype bfloat16
+    --attention-backend triton
+    --moe-runner-backend flashinfer_cutlass
+    --speculative-algorithm EAGLE3
+    --speculative-draft-model-path "$DRAFT_MODEL_PATH"
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --speculative-draft-model-quantization unquant
+    --speculative-draft-attention-backend triton
+    --reasoning-parser minimax
+    --tool-call-parser minimax-m2
+    --context-length "$CONTEXT_LENGTH"
+    --chunked-prefill-size 16384
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --mem-fraction-static 0.90
+    --enable-metrics
+    --watchdog-timeout 1800
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$OUTPUT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$OUTPUT_DIR/sglang_command.txt"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+mtp_metrics=$(curl -fsS "http://127.0.0.1:$PORT/metrics")
+if ! grep -m1 '^sglang:spec_accept_length' <<< "$mtp_metrics"; then
+    echo "EAGLE3 acceptance metrics are absent; refusing to publish a non-speculative result" >&2
+    exit 1
+fi
+
+if [[ "$IS_AGENTIC" == "true" ]]; then
+    # AgentX sends structured chat messages to /v1/chat/completions, so the
+    # target checkpoint's native chat template is applied by the server.
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+else
+    # EAGLE3 was trained on chat-formatted prompts; keep the benchmark client
+    # on the target checkpoint's native chat template.
+    run_benchmark_serving \
+        --model "$TARGET_MODEL_PATH" \
+        --port "$PORT" \
+        --backend vllm \
+        --input-len "$ISL" \
+        --output-len "$OSL" \
+        --random-range-ratio "$RANDOM_RANGE_RATIO" \
+        --num-prompts "$((CONC * 10))" \
+        --max-concurrency "$CONC" \
+        --result-filename "$RESULT_FILENAME" \
+        --result-dir "$PWD" \
+        --trust-remote-code \
+        --use-chat-template
+
+    if [[ "${RUN_EVAL:-false}" == "true" ]]; then
+        run_eval --framework lm-eval --port "$PORT"
+        append_lm_eval_summary
+    fi
+fi

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -108,6 +108,7 @@ if [[ "${SCENARIO_TYPE:-fixed-seq-len}" == "agentic-coding" ]]; then
     install_agentic_deps
     OUTPUT_DIR="$RESULT_DIR"
     CONTEXT_LENGTH=196608
+    export MAX_MODEL_LEN="$CONTEXT_LENGTH"
     MAX_RUNNING_REQUESTS=$((CONC * 2))
     (( MAX_RUNNING_REQUESTS < 8 )) && MAX_RUNNING_REQUESTS=8
 else

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -186,6 +186,12 @@ if [[ "$IS_AGENTIC" == "true" ]]; then
     # AgentX sends structured chat messages to /v1/chat/completions, so the
     # target checkpoint's native chat template is applied by the server.
     build_replay_cmd "$RESULT_DIR"
+    # TP4 can take several minutes to finish a long response that was already
+    # admitted near the end of the measurement window. The AIPerf default is
+    # only 30 seconds, which cancelled the sole profiling request in the TP4
+    # smoke while the healthy server was still decoding it. Bound the drain at
+    # 30 minutes without extending the measured request-admission window.
+    REPLAY_CMD+=" --benchmark-grace-period 1800"
     REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 else

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -161,6 +161,7 @@ SGLANG_CMD=(
     --tool-call-parser minimax-m2
     --context-length "$CONTEXT_LENGTH"
     --chunked-prefill-size 16384
+    --weight-loader-prefetch-checkpoints
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --mem-fraction-static 0.90
     --enable-metrics

--- a/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm2.7_fp4_b200_sglang_mtp.sh
@@ -163,7 +163,7 @@ SGLANG_CMD=(
     --chunked-prefill-size 16384
     --weight-loader-prefetch-checkpoints
     --max-running-requests "$MAX_RUNNING_REQUESTS"
-    --mem-fraction-static 0.90
+    --mem-fraction-static 0.85
     --enable-metrics
     --watchdog-timeout 1800
 )

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7875,3 +7875,28 @@ glm5.2-fp4-b300-sglang-agentic:
       search-space:
       - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48, 64, 96, 128, 192, 256, 512], router: { name: sglang-router, version: "0.3.2" } }
+
+# Experimental public-weight MiniMax-M2.7 NVFP4 + EAGLE3 B200 baseline. The
+# target and full-vocabulary draft revisions are pinned in the benchmark
+# entrypoint; both scenarios use the same upstream SGLang runtime and 3/1/4
+# speculative chain.
+minimaxm2.7-fp4-b200-sglang-eagle:
+  image: lmsysorg/sglang:v0.5.15.post1-cu130
+  model: nvidia/MiniMax-M2.7-NVFP4
+  model-prefix: minimaxm2.7
+  runner: cluster:b200-dgxc
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 1, conc-list: [1, 2, 4, 8], spec-decoding: mtp }
+      - { tp: 8, ep: 1, conc-list: [1, 2, 4, 8], spec-decoding: mtp }
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4], spec-decoding: mtp }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4], spec-decoding: mtp }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4974,3 +4974,11 @@
     - "Run 29651235293 showed the 1M-context corpus working set outgrowing the HBM KV pool past conc 8 (TP8) / conc 64 (DP8): gpu_kv_cache_usage pinned at 1.0 and the radix hit rate collapsed from a ~0.97 theoretical ceiling to 0.04-0.06, so every post-knee turn re-prefilled its full history and throughput fell together with interactivity"
     - "HiCache spills evicted prefixes to host DRAM and restores them at C2C bandwidth instead of recomputing; sizing follows the qwen3.5-fp8-b300-sglang-agentic-hicache recipe (GLM-5.2 is plain GQA: one host pool per rank, GB-based --hicache-size)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2280
+
+- config-keys:
+    - minimaxm2.7-fp4-b200-sglang-eagle
+  description:
+    - "Experiment with MiniMax-M2.7 NVFP4 and a public full-vocabulary EAGLE3 draft on B200 using upstream SGLang v0.5.15.post1."
+    - "Run 8K/1K and AgentX at pure TP4/TP8 with chat templates and a 3-step, top-k-1, 4-draft-token speculative chain."
+    - "Pin nvidia/MiniMax-M2.7-NVFP4 and asherszhang/MiniMax-M2.7-EAGLE3-draft-vocab200k revisions in the benchmark preflight."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4981,4 +4981,4 @@
     - "Experiment with MiniMax-M2.7 NVFP4 and a public full-vocabulary EAGLE3 draft on B200 using upstream SGLang v0.5.15.post1."
     - "Run 8K/1K and AgentX at pure TP4/TP8 with chat templates and a 3-step, top-k-1, 4-draft-token speculative chain."
     - "Pin nvidia/MiniMax-M2.7-NVFP4 and asherszhang/MiniMax-M2.7-EAGLE3-draft-vocab200k revisions in the benchmark preflight."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2289

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -60,6 +60,11 @@ elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp8" ]]; then
 elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/lustre/fsw/models/MiniMax-M2.5-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.5-nvfp4"
+elif [[ $MODEL_PREFIX == "minimaxm2.7" && $PRECISION == "fp4" ]]; then
+    # Public NVFP4 target and EAGLE3 draft are staged in the runner-writable
+    # shared model tree by the benchmark's revision-pinned preflight.
+    export MODEL_PATH="/lustre/fsw/gharunners/models/MiniMax-M2.7-NVFP4"
+    export SRT_SLURM_MODEL_PREFIX="minimax-m2.7-nvfp4"
 elif [[ $MODEL_PREFIX == "gptoss" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/lustre/fsw/models/gpt-oss-120b"
     export SRT_SLURM_MODEL_PREFIX="gptoss"
@@ -397,6 +402,12 @@ else
     # pulling from the HF hub cache. Bench scripts skip `hf download` when
     # MODEL is a local path.
     export MODEL="$MODEL_PATH"
+    MODEL_MOUNT_SPEC="$MODEL_PATH:$MODEL_PATH"
+    if [[ "$MODEL_PREFIX" == "minimaxm2.7" ]]; then
+        MODEL_ROOT=$(dirname "$MODEL_PATH")
+        mkdir -p "$MODEL_PATH" "$MODEL_ROOT/MiniMax-M2.7-EAGLE3-draft-vocab200k"
+        MODEL_MOUNT_SPEC="$MODEL_ROOT:$MODEL_ROOT"
+    fi
     FRAMEWORK_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
     SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
     # Prefer a framework-tagged script (e.g. dsv4_fp4_b200_vllm.sh) so models
@@ -447,7 +458,7 @@ else
 
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$MODEL_PATH:$MODEL_PATH,$AIPERF_MMAP_CACHE_HOST_PATH:/aiperf_mmap_cache \
+        --container-mounts=$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR,$MODEL_MOUNT_SPEC,$AIPERF_MMAP_CACHE_HOST_PATH:/aiperf_mmap_cache \
         --no-container-mount-home \
         --container-workdir=$CONTAINER_MOUNT_DIR \
         --no-container-entrypoint --export=ALL,PORT=8888,AIPERF_DATASET_MMAP_CACHE_DIR=/aiperf_mmap_cache \

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -65,6 +65,9 @@ elif [[ $MODEL_PREFIX == "minimaxm2.7" && $PRECISION == "fp4" ]]; then
     # shared model tree by the benchmark's revision-pinned preflight.
     export MODEL_PATH="/lustre/fsw/gharunners/models/MiniMax-M2.7-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.7-nvfp4"
+    # Keep this experiment off the saturated gpu-2 partition. All ten gpu-1
+    # B200 nodes are currently healthy and idle.
+    SLURM_PARTITION="gpu-1"
 elif [[ $MODEL_PREFIX == "gptoss" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/lustre/fsw/models/gpt-oss-120b"
     export SRT_SLURM_MODEL_PREFIX="gptoss"
@@ -431,10 +434,9 @@ else
         CONTAINER_MOUNT_DIR=/workspace
     fi
 
-    # b200-dgxc cluster was re-partitioned to gpu-1 / gpu-2; the prior gpu-10
-    # and gpu-15 names no longer exist. gpu-2 currently has 10 fully-idle GPU
-    # nodes (all of gpu-2-[0-9]); gpu-1 has 2 drained (gpu-1-4, gpu-1-8). We
-    # land on gpu-2 to avoid drained nodes and skip the per-node excludes.
+    # b200-dgxc is partitioned into gpu-1 / gpu-2; the prior gpu-10 and gpu-15
+    # names no longer exist. Model-specific mappings above may select the
+    # currently idle partition without affecting other benchmark families.
     export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"
 
     SALLOC_TIME_LIMIT="${SALLOC_TIME_LIMIT:-480}"

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -65,6 +65,9 @@ elif [[ $MODEL_PREFIX == "minimaxm2.7" && $PRECISION == "fp4" ]]; then
     # shared model tree by the benchmark's revision-pinned preflight.
     export MODEL_PATH="/lustre/fsw/gharunners/models/MiniMax-M2.7-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.7-nvfp4"
+    # Covers the one-hour AgentX measurement plus setup and warmup while still
+    # allowing Slurm to backfill this experiment ahead of large reservations.
+    SALLOC_TIME_LIMIT="${SALLOC_TIME_LIMIT:-150}"
 elif [[ $MODEL_PREFIX == "gptoss" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/lustre/fsw/models/gpt-oss-120b"
     export SRT_SLURM_MODEL_PREFIX="gptoss"

--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -65,9 +65,6 @@ elif [[ $MODEL_PREFIX == "minimaxm2.7" && $PRECISION == "fp4" ]]; then
     # shared model tree by the benchmark's revision-pinned preflight.
     export MODEL_PATH="/lustre/fsw/gharunners/models/MiniMax-M2.7-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.7-nvfp4"
-    # Keep this experiment off the saturated gpu-2 partition. All ten gpu-1
-    # B200 nodes are currently healthy and idle.
-    SLURM_PARTITION="gpu-1"
 elif [[ $MODEL_PREFIX == "gptoss" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/lustre/fsw/models/gpt-oss-120b"
     export SRT_SLURM_MODEL_PREFIX="gptoss"
@@ -435,8 +432,8 @@ else
     fi
 
     # b200-dgxc is partitioned into gpu-1 / gpu-2; the prior gpu-10 and gpu-15
-    # names no longer exist. Model-specific mappings above may select the
-    # currently idle partition without affecting other benchmark families.
+    # names no longer exist. sa-shared's benchmark association currently has
+    # only gpu-2_qos, so idle gpu-1 nodes cannot accept these jobs.
     export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"
 
     SALLOC_TIME_LIMIT="${SALLOC_TIME_LIMIT:-480}"


### PR DESCRIPTION
## Summary

- benchmark the public MiniMax-M2.7 NVFP4 checkpoint with a public full-vocabulary EAGLE3 draft on B200
- cover TP4 and TP8 for 8K/1K and AgentX with chat templates enabled
- pin both model revisions and use the latest stable upstream SGLang image

## Validation

- `bash -n` on the launcher and both benchmark entrypoints
- `python -m pytest utils/matrix_logic/ -v` (224 passed)
- generated the focused 8K/1K and AgentX matrices locally

## 中文说明

- 在 B200 上使用公开的 MiniMax-M2.7 NVFP4 检查点和公开的全词表 EAGLE3 草稿模型进行基准测试
- 覆盖 TP4、TP8 的 8K/1K 与 AgentX 场景，并启用聊天模板
- 固定两个模型的版本，并使用最新稳定版上游 SGLang 镜像

## 验证

- 对启动器和两个基准测试入口执行 `bash -n`
- 执行 `python -m pytest utils/matrix_logic/ -v`（224 项通过）
- 在本地生成并核对聚焦的 8K/1K 与 AgentX 扫描矩阵