### PR TITLE
[AMD] Add dsv4-fp4-mi355x-atom-disagg-mtp config

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1603,6 +1603,75 @@ dsv4-fp4-mi355x-atom-disagg:
           additional-settings:
           - "DECODE_NODES=1"
       # 1P1D TP8
+
+# MTP variant of dsv4-fp4-mi355x-atom-disagg. Identical topology; enables
+# DeepSeek-V4-Pro built-in MTP via spec-decoding=mtp + DECODE_MTP_SIZE>0 on the
+# decode workers. server_atom.sh then appends models_atom.yaml's mtp_flags
+# ("--method mtp --num-speculative-tokens <N>"). Reuses the same launch script
+# (dsv4_fp4_mi355x_atom-disagg.sh) — the multinode launcher adds no _mtp suffix.
+# Results are disambiguated from the base config by the spec-mtp RESULT_FILENAME
+# segment, so no filename collision. Image bumped to nightly_202607201550
+# (2026-07-20): verified on-node it carries the dsv4 mtp path
+# (deepseek_v4 -> deepseek_v4_mtp -> DeepseekV4MTPModel) and the atomesh router.
+# Draft depth (DECODE_MTP_SIZE -> --num-speculative-tokens) is 3 on both arms,
+# matching the single-node dsv4_fp4_mi355x_atom_mtp.sh recipe. The Atom MTP head
+# runs autoregressively N times, so N=3 is valid even though dsv4 ships 1 nextn
+# layer. At high concurrency (>=512) a shallower depth may be worth revisiting
+# once the curve is measured (cf. the concurrency taper in
+# dsr1-fp4-mi355x-sglang-disagg-mtp), but we start with a uniform 3.
+dsv4-fp4-mi355x-atom-disagg-mtp:
+  image: rocm/atom-dev:nightly_202607201550
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: mi355x
+  precision: fp4
+  framework: atom-disagg
+  router: { name: atomesh, version: "087b82d9c1f630e79149ba37e6213257ec9a76f8" }
+  kv-p2p-transfer: mooncake
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      # 2P1D DPA+TP8
+      - spec-decoding: "mtp"
+        conc-list: [ 256, 512, 768, 1024, 2048 ]
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 1
+          dp-attn: true
+          additional-settings:
+          - "PREFILL_NODES=2"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: true
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "DECODE_MTP_SIZE=3"
+      # 1P1D TP8
+      - spec-decoding: "mtp"
+        conc-list: [ 4, 8, 16, 32, 64, 128 ]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "DECODE_MTP_SIZE=3"
+
 minimaxm3-fp8-mi355x-vllm:
   image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
   model: MiniMaxAI/MiniMax-M3-MXFP8

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4982,3 +4982,12 @@
     - "DEP arm runs conc-list [48] only (was [48, 64, 96, 128, 192, 256, 512]): conc 48 is the frontier peak (163 tok/s/gpu out, ttft 2.8s); conc >=64 overflows the HBM+host radix cache (GPU hit 0.93->0.57 at 48->64) and thrashes on re-prefill, so it is strictly dominated"
     - "Low-latency TP8 arm (conc [1, 2, 4, 8, 16, 32], fp8 KV + cutedsl bf16 GEMM) unchanged; DEP mirrors the proven dsv4-fp4-b300-sglang tp8/ep8/dp-attn DEP arm"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2281
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-disagg-mtp
+  description:
+    - "Add DeepSeek-V4-Pro FP4 MI355X ATOM disaggregated MTP benchmark (spec-decoding=mtp, num-speculative-tokens=3 via DECODE_MTP_SIZE)"
+    - "Config-only: mirrors dsv4-fp4-mi355x-atom-disagg topology (2P1D DPA+TP8 conc 256-2048, 1P1D TP8 conc 4-128) and reuses benchmarks/multi_node/dsv4_fp4_mi355x_atom-disagg.sh; MTP is driven by models_atom.yaml mtp_flags + DECODE_MTP_SIZE in the decode additional-settings"
+    - "Draft depth 3 on both arms (matches single-node dsv4_fp4_mi355x_atom_mtp.sh); high-conc depth may be reduced later per the dsr1-fp4-mi355x-sglang-disagg-mtp concurrency taper once results land"
+    - "Image rocm/atom-dev:nightly_202607201550 (bumped from the base config's stale 2026-06-10 nightly): verified on-node it carries the dsv4 mtp path (deepseek_v4 -> deepseek_v4_mtp -> DeepseekV4MTPModel) and the atomesh disagg router"
+  pr-link: XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -4990,4 +4990,4 @@
     - "Config-only: mirrors dsv4-fp4-mi355x-atom-disagg topology (2P1D DPA+TP8 conc 256-2048, 1P1D TP8 conc 4-128) and reuses benchmarks/multi_node/dsv4_fp4_mi355x_atom-disagg.sh; MTP is driven by models_atom.yaml mtp_flags + DECODE_MTP_SIZE in the decode additional-settings"
     - "Draft depth 3 on both arms (matches single-node dsv4_fp4_mi355x_atom_mtp.sh); high-conc depth may be reduced later per the dsr1-fp4-mi355x-sglang-disagg-mtp concurrency taper once results land"
     - "Image rocm/atom-dev:nightly_202607201550 (bumped from the base config's stale 2026-06-10 nightly): verified on-node it carries the dsv4 mtp path (deepseek_v4 -> deepseek_v4_mtp -> DeepseekV4MTPModel) and the atomesh disagg router"
-  pr-link: XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2294


### PR DESCRIPTION
## Summary

Adds a DeepSeek-V4-Pro FP4 MI355X **ATOM disaggregated MTP** benchmark, `dsv4-fp4-mi355x-atom-disagg-mtp` (`spec-decoding=mtp`, `num-speculative-tokens=3` via `DECODE_MTP_SIZE`).

This is **config-only** — no new benchmark script:
- Mirrors the `dsv4-fp4-mi355x-atom-disagg` topology: 2P1D DPA+TP8 (conc 256–2048) and 1P1D TP8 (conc 4–128).
- Reuses `benchmarks/multi_node/dsv4_fp4_mi355x_atom-disagg.sh`; the multinode launcher builds the script name without a `_mtp` suffix, so the same script serves STP and MTP.
- MTP is driven by the DeepSeek-V4-Pro `mtp_flags` already present in `benchmarks/multi_node/amd_utils/models_atom.yaml` (`--method mtp --num-speculative-tokens`) plus `DECODE_MTP_SIZE` in the decode `additional-settings`; `server_atom.sh` composes the spec args.
- Results are disambiguated from the base config by the `spec-mtp` segment in `RESULT_FILENAME` (no collision).

## Image

Bumped to `rocm/atom-dev:nightly_202607201550` (2026-07-20) from the base config's stale 2026-06-10 nightly. Verified on-node that this image carries the dsv4 MTP path (`deepseek_v4 -> deepseek_v4_mtp -> DeepseekV4MTPModel`) and the atomesh disagg router (`/usr/local/bin/atomesh`).

## Draft depth

`DECODE_MTP_SIZE=3` on both arms, matching the single-node `dsv4_fp4_mi355x_atom_mtp.sh` recipe. The Atom MTP head runs autoregressively N times, so N=3 is valid even though dsv4 ships one nextn layer. A shallower high-concurrency depth (per the `dsr1-fp4-mi355x-sglang-disagg-mtp` concurrency taper) may follow once results land.

## Validation

- `generate_sweep_configs.py test-config` — passes Pydantic, generates 2 MTP arms, `max-model-len 9472` auto-injected.
- `pytest utils/matrix_logic/` — 224 passed.
- Not yet run on real GPUs (MI355X cluster was saturated); intended to run through the normal run-sweep path.

> Note: `perf-changelog.yaml` `pr-link` will be updated to this PR's URL in a follow-up commit.