### PR TITLE
Restore DeepSeek-V4 tool calling for AgentX evals

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm.sh
@@ -335,6 +335,8 @@ VLLM_CMD=(
     --no-enable-flashinfer-autotune
     --tokenizer-mode deepseek_v4
     --reasoning-parser deepseek_v4
+    --tool-call-parser deepseek_v4
+    --enable-auto-tool-choice
     --attention-config '{"backend":"FLASHINFER_MLA_SPARSE_DSV4","use_prefill_query_quantization":true,"use_fp4_indexer_cache":true}'
     --no-disable-hybrid-kv-cache-manager
     --disable-uvicorn-access-log

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5003,3 +5003,13 @@
     - "LMCache MP server (lmcache_driven transfer mode) + LMCacheMPConnector per PR #2153; L1 pool derated to 75% of TOTAL_CPU_DRAM_GB; --enable-cumem-allocator dropped on the lmcache arm only (cuMem/VMM allocations cannot be CUDA-IPC-exported to the LMCache server)"
     - "LMCache TP8 points mirror the vllm-simple ladder (conc [8, 12, 16]); LMCache DEP8 points mirror the Mooncake ladder (conc [12, 20, 28, 36, 44, 52, 60, 68, 76]) for a like-for-like backend comparison; the PR #2231 bring-up sweep validated the recipe across DEP8 conc 8-80 (peak ~25.7k total tok/s/GPU at conc 72, 96-98% cache hit)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2231
+
+- config-keys:
+    - dsv4-fp4-b200-vllm-agentic
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Eval-only follow-up to PR #2231: restore the official DeepSeek-V4 vLLM tool-calling frontend flags --tool-call-parser deepseek_v4 and --enable-auto-tool-choice"
+    - "Re-run the dedicated AgentX SWE-bench eval to verify tool definitions are accepted instead of failing with 'tool parsing is disabled by frontend configuration'"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2231
+  evals-only: true


### PR DESCRIPTION
## What changed

- Restore `--tool-call-parser deepseek_v4` and `--enable-auto-tool-choice` in the DeepSeek-V4 B200 vLLM AgentX server command.
- Append an eval-only, AgentX-scoped perf changelog entry referencing #2231.

## Why

The #2231 SWE-bench eval received backend 500 responses because vLLM rejected requests containing tool definitions with `tool parsing is disabled by frontend configuration`. These are the official DeepSeek-V4 vLLM frontend flags required to accept and parse tool calls.

## Validation

- `bash -n benchmarks/single_node/agentic/dsv4_fp4_b200_vllm.sh`
- `python3 utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD --changelog-file perf-changelog.yaml`
- Generated matrix: exactly one `agentic_evals` row and no throughput rows
- `python3 -m pytest -q utils/test_process_changelog.py utils/matrix_logic/test_generate_sweep_configs.py` (115 passed)

Follow-up to #2231.
