### PR TITLE
[AMD] kimik2.5-fp4-mi355x-vllm-disagg: split P/D by concurrency (1D low, 2D high) / 优化 kimik2.5-fp4-mi355x-vllm-disagg：按并发拆分 P/D 拓扑（低并发 1D、高并发 2D）

### DIFF
--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -337,7 +337,7 @@ export DOCKER_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_${MODEL_NAME}_${S
 # vLLM external router container.
 # NOTE: vllm/vllm-router only retains ~16 recent nightlies on Docker Hub; older
 # dated tags are garbage-collected (manifest unknown)
-VLLM_ROUTER_IMAGE="${VLLM_ROUTER_IMAGE:-vllm/vllm-router:nightly-20260629-e667ebb}"
+VLLM_ROUTER_IMAGE="${VLLM_ROUTER_IMAGE:-vllm/vllm-router:nightly-20260716-1fbcde7}"
 ROUTER_CONT_NAME="router_vllm_${SANITIZED_USER}_${SLURM_JOB_ID}"
 # Separate agentic benchmark-client container (see CLIENT_IMAGE handling below).
 CLIENT_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_client_${SLURM_JOB_ID}"

--- a/benchmarks/multi_node/amd_utils/models_vllm.yaml
+++ b/benchmarks/multi_node/amd_utils/models_vllm.yaml
@@ -25,9 +25,9 @@ amd-Llama-3.3-70B-Instruct-FP8-KV:
   env: "VLLM_USE_V1=1 VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 AMDGCN_USE_BUFFER_OPS=1 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_RMSNORM=1 VLLM_USE_AITER_TRITON_ROPE=1 TRITON_HIP_ASYNC_COPY_BYPASS_PERMUTE=1 TRITON_HIP_USE_ASYNC_COPY=1 TRITON_HIP_USE_BLOCK_PINGPONG=1 TRITON_HIP_ASYNC_FAST_SWIZZLE=1"
 
 Kimi-K2.5-MXFP4:
-  prefill_flags: "--tensor-parallel-size 8 --compilation-config '{\"cudagraph_mode\":\"PIECEWISE\"}' --no-enable-prefix-caching --block-size 1 --gpu-memory-utilization 0.90 --mm-encoder-tp-mode data"
-  decode_flags: "--tensor-parallel-size 8 --enable-expert-parallel --all2all-backend mori_low_latency --compilation-config '{\"cudagraph_mode\":\"PIECEWISE\"}' --no-enable-prefix-caching --block-size 1 --gpu-memory-utilization 0.90 --mm-encoder-tp-mode data"
-  env: "VLLM_USE_V1=1 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_PAGED_ATTN=0 VLLM_ROCM_USE_AITER_RMSNORM=1 VLLM_USE_AITER_TRITON_SILU_MUL=0 VLLM_ENGINE_READY_TIMEOUT_S=3600"
+  prefill_flags: "--tensor-parallel-size 8 --no-enable-prefix-caching --block-size 1 --gpu-memory-utilization 0.90 --max-model-len 32768 --mm-encoder-tp-mode data --kv-cache-dtype fp8 --max-num-seqs 256 --max-num-batched-tokens 32768"
+  decode_flags: "--tensor-parallel-size 8 --all2all-backend mori_low_latency --no-enable-prefix-caching --block-size 1 --gpu-memory-utilization 0.90 --max-model-len 32768 --mm-encoder-tp-mode data --kv-cache-dtype fp8 --max-num-seqs 256 --max-num-batched-tokens 32768"
+  env: "VLLM_USE_V1=1 VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_RMSNORM=1 VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 HSA_NO_SCRATCH_RECLAIM=1 VLLM_ENGINE_READY_TIMEOUT_S=3600"
   hf_dir: "models--amd--Kimi-K2.5-MXFP4"
 
 MiniMax-M2.5:

--- a/benchmarks/multi_node/amd_utils/submit.sh
+++ b/benchmarks/multi_node/amd_utils/submit.sh
@@ -166,7 +166,7 @@ fi
 # Optional: exclude specific nodes (e.g. nodes with broken Docker sockets).
 # Set SLURM_EXCLUDE_NODES env var to a comma-separated list of hostnames.
 EXCLUDE_OPT=()
-SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g11,mia1-p01-g12,mia1-p01-g15}"
+SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES:-mia1-p01-g09,mia1-p01-g11,mia1-p01-g12,mia1-p01-g14,mia1-p01-g15}"
 if [[ -n "${SLURM_EXCLUDE_NODES:-}" ]]; then
     EXCLUDE_OPT=(--exclude "$SLURM_EXCLUDE_NODES")
 fi

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -798,7 +798,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
           - "DECODE_MTP_SIZE=2"
 
 kimik2.5-fp4-mi355x-vllm-disagg:
-  image: vllm/vllm-openai-rocm:v0.24.0
+  image: vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
   runner: mi355x-disagg
@@ -810,22 +810,43 @@ kimik2.5-fp4-mi355x-vllm-disagg:
   disagg: true
   scenarios:
     fixed-seq-len:
+    # All workers TP4 (real-weight sweep: TP8 decode is no better than TP4).
+    # Split across P/D topologies: 1D is stable at low conc; the high-conc tail
+    # runs on 2D so decode load is spread across two engines.
     - isl: 8192
       osl: 1024
       search-space:
+      # 1P(TP4) 1D(TP4) = 2 nodes. Low concurrency only.
+      - spec-decoding: "none"
+        conc-list: [ 1, 2, 4 ]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+        decode:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=1"
+      # 1P(TP4) 2D(TP4) = 3 nodes. High concurrency (decode KV/load spread over 2D).
       - spec-decoding: "none"
         conc-list: [ 8, 16, 32, 64, 128, 256, 512 ]
         prefill:
           num-worker: 1
-          tp: 8
+          tp: 4
           ep: 1
           dp-attn: false
           additional-settings:
           - "PREFILL_NODES=1"
         decode:
           num-worker: 2
-          tp: 8
-          ep: 8
+          tp: 4
+          ep: 1
           dp-attn: false
           additional-settings:
           - "DECODE_NODES=2"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5038,3 +5038,14 @@
     - "Topologies: 1p4d-dep4-tep8 (conc 4/24), 1p5d-dep4-tep4 (conc 5/30/60/115/195), 1p1d-dep4-dep8 (conc 308), 2p1d-dep4-dep8 (conc 615), 3p1d-dep4-dep8 (conc 1127), 4p1d-dep4-dep8 (conc 2151)"
     - "Runner updated to clone srt-slurm at sa-submission-q2-2026 and copy local recipes into recipes/trtllm/kimi-k25-nvfp4/b200-fp4/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2249
+
+- config-keys:
+    - kimik2.5-fp4-mi355x-vllm-disagg
+  description:
+    - "Bump image to vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9"
+    - "All-TP4 prefill/decode (drop TP8): a real-weight sweep showed TP8 decode is no better than TP4 on tok/s/GPU; expert parallelism off (ep:1, single-node TP8 sweep showed EP -14% to -27% slower than dense)"
+    - "Split the 8k/1k P/D topology by concurrency: low conc (1,2,4) on 1P(TP4)/1D(TP4); high conc (8,16,32,64,128,256,512) on 1P(TP4)/2D(TP4) so decode load/KV is spread across two decode engines (the single-decode engine is unstable in the high-conc tail)"
+    - "Sync per-worker vLLM serve flags/env with the single-node recipe: --kv-cache-dtype fp8, --max-model-len 32768, --max-num-seqs 256, --max-num-batched-tokens 32768; VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4, HSA_NO_SCRATCH_RECLAIM=1, AITER defaults; drop the --compilation-config PIECEWISE pin (use vLLM default FULL_AND_PIECEWISE)"
+    - "Re-pin VLLM_ROUTER_IMAGE to vllm/vllm-router:nightly-20260716-1fbcde7 (previous nightly-20260629-e667ebb was garbage-collected from Docker Hub)"
+    - "Exclude known-bad nodes mia1-p01-g09,g14 from the disagg node pool"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2301


### PR DESCRIPTION
## Description

Retunes the `kimik2.5-fp4-mi355x-vllm-disagg` disaggregated recipe for MI355X on top of current `main`. The recipe deltas mirror the previously-green run (`hy/kk-green-sha`, no barrier or eval-harness changes); the new idea is to **split the 8k/1k P/D topology by concurrency** so each concurrency band runs on the layout that is stable there.

**Recipe (`configs/amd-master.yaml`, `benchmarks/multi_node/amd_utils/models_vllm.yaml`)**
- **Image bump** to `vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9`.
- **All-TP4 prefill/decode** (TP8 dropped — a real-weight sweep showed TP8 decode gives no per-GPU benefit over TP4); **expert parallelism off** (`ep:1`; a single-node TP8 sweep showed EP 14–27% slower than dense).
- **Serve-flag/env sync** with the single-node recipe: `--kv-cache-dtype fp8`, `--max-model-len 32768`, `--max-num-seqs 256`, `--max-num-batched-tokens 32768`; `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, `HSA_NO_SCRATCH_RECLAIM=1`, AITER defaults; drop the `cudagraph_mode: PIECEWISE` pin (use vLLM's default `FULL_AND_PIECEWISE`).
- **Concurrency-split topology (the key change):** conc `1/2/4` on `1P(TP4)/1D(TP4)` (2 nodes); conc `8/16/32/64/128/256/512` on `1P(TP4)/2D(TP4)` (3 nodes). A single decode engine is unstable in the high-concurrency tail for this recipe; running the tail on 2D spreads decode load/KV across two engines.

**Infra (`benchmarks/multi_node/amd_utils/job.slurm`, `submit.sh`)**
- **Re-pin `VLLM_ROUTER_IMAGE`** to `vllm/vllm-router:nightly-20260716-1fbcde7` (the previous `nightly-20260629-e667ebb` was garbage-collected from Docker Hub).
- **Exclude known-bad nodes** `mia1-p01-g09,g14` from the disagg node pool.

**Note on AITER RMSNorm (re: review comment):** `VLLM_ROCM_USE_AITER_RMSNORM=1` is intentionally kept at TP4. The single-node recipe disables it for TP<8 for a historical accuracy issue (v0.16→0.18 era), but a local TP4 GSM8K A/B on this pinned image showed identical accuracy with RMSNorm on vs off (0.9697 vs 0.9697), so the perf path is kept — same rationale as the green run. Happy to add the `TP<8 → RMSNorm off` guard if reviewers prefer strict parity with single-node.

## Results

Full sweep is green: https://inferencex.semianalysis.com/inference?unofficialRun=29948517533

## Test plan

- `full-sweep-fail-fast` green for `kimik2.5-fp4-mi355x-vllm-disagg` (run 29948517533).
- vLLM recipe: vllm-project/recipes#650.

---

## 中文说明

在当前 `main` 基础上，为 MI355X 重新调优分离式(disagg)配置 `kimik2.5-fp4-mi355x-vllm-disagg`。配方改动与此前已通过(green)的运行(`hy/kk-green-sha`，不含 barrier 与 eval 相关改动)保持一致；本 PR 的新思路是**按并发(concurrency)拆分 8k/1k 的 P/D 拓扑**，让每个并发区间跑在其稳定的布局上。

**配方改动(`configs/amd-master.yaml`、`benchmarks/multi_node/amd_utils/models_vllm.yaml`)**
- **镜像升级**至 `vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9`。
- **全部改为 TP4 的 prefill/decode**（移除 TP8：真权重实测显示 TP8 解码相比 TP4 无每 GPU 收益）；**关闭专家并行(EP)**（`ep:1`；单节点 TP8 实测显示 EP 相比 dense 慢 14%~27%）。
- **serve 参数/环境变量对齐单节点配方**：`--kv-cache-dtype fp8`、`--max-model-len 32768`、`--max-num-seqs 256`、`--max-num-batched-tokens 32768`；`VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`、`HSA_NO_SCRATCH_RECLAIM=1`、AITER 默认值；移除 `cudagraph_mode: PIECEWISE` 固定值（改用 vLLM 默认的 `FULL_AND_PIECEWISE`）。
- **按并发拆分拓扑（核心改动）：** 并发 `1/2/4` 跑 `1P(TP4)/1D(TP4)`（2 节点）；并发 `8/16/32/64/128/256/512` 跑 `1P(TP4)/2D(TP4)`（3 节点）。该配方下单个 decode 引擎在高并发尾部不稳定，将尾部放到 2D 可将 decode 负载/KV 分摊到两个引擎上。

**基础设施(`benchmarks/multi_node/amd_utils/job.slurm`、`submit.sh`)**
- **重新固定 `VLLM_ROUTER_IMAGE`** 至 `vllm/vllm-router:nightly-20260716-1fbcde7`（此前的 `nightly-20260629-e667ebb` 已被 Docker Hub 回收）。
- **排除已知故障节点** `mia1-p01-g09,g14`。

**关于 AITER RMSNorm（回应评审意见）：** 在 TP4 下有意保留 `VLLM_ROCM_USE_AITER_RMSNORM=1`。单节点配方在 TP<8 时会关闭它（针对 v0.16→0.18 时期的历史精度问题），但在本固定镜像上的本地 TP4 GSM8K A/B 显示开/关精度一致（0.9697 vs 0.9697），因此保留该性能路径——与 green 运行的判断一致。如评审倾向与单节点严格对齐，可加上 `TP<8 → 关闭 RMSNorm` 的判断。

## 结果

完整 sweep 已通过(green)：https://inferencex.semianalysis.com/inference?unofficialRun=29948517533

## 测试计划

- `kimik2.5-fp4-mi355x-vllm-disagg` 的 `full-sweep-fail-fast` 通过（run 29948517533）。
- vLLM recipe：vllm-project/recipes#650。
