### PR TITLE
Fix inherited stdin hangs in SWE-bench sandboxes / 修复 SWE-bench 沙箱继承标准输入导致的阻塞

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1113,7 +1113,7 @@ _install_swebench_agent_deps() {
     python3 -m pip install -q --no-cache-dir --break-system-packages \
         'mini-swe-agent==2.4.5' 'swe-rex[modal]==1.4.0' || true
     _patch_swebench_agent || \
-        echo "WARN: mini-swe-agent/swe-rex patches failed; sandboxes will leak until runtime_timeout and budget-exhausted instances will submit nothing" >&2
+        echo "WARN: mini-swe-agent/swe-rex patches failed; sandbox cleanup, submission fallback, or non-interactive stdin handling may be degraded" >&2
 }
 
 _patch_swebench_agent() {

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -174,7 +174,8 @@ Source rewrites are anchor-checked, idempotent, and atomic.
   compatibility (no `{"type": "text"}` injection for non-HF tokenizers).
   Copied into a temp dir as `sitecustomize.py` on `PYTHONPATH`.
 - `patch_swebench_agent.py` (`_patch_swebench_agent`): mini-swe-agent/swe-rex
-  sandbox lifecycle cleanup + budget-exhaustion submission fallback.
+  sandbox lifecycle cleanup, budget-exhaustion submission fallback, and the
+  [SWE-ReX #281](https://github.com/SWE-agent/SWE-ReX/pull/281) closed-stdin fix.
 - `patch_swebench_scoring.py` (`_patch_swebench_scoring`): swebench Modal
   scorer reserved-CPU reduction + sandbox termination on instance completion.
 
@@ -199,8 +200,9 @@ append_lm_eval_summary
   local endpoint, each instance's shell running in a Modal sandbox via swe-rex — the real
   SWE-bench setting) or `single-shot` (lm-eval, one prompt per instance — a ~10% floor baseline,
   kept only as an explicit debugging escape hatch). Agentic knobs: `SWEBENCH_AGENT_WORKERS`
-  (default: the config's `CONC`, else 64), `SWEBENCH_AGENT_STEP_LIMIT` (75), `SWEBENCH_AGENT_TIMEOUT`
-  (4h), `SWEBENCH_AGENT_SANDBOX_CPU` (unset = Modal default), `SWEBENCH_MODAL_APP_NAME`
+  (default: the config's `CONC`, else 64), `SWEBENCH_AGENT_STEP_LIMIT` (75),
+  `SWEBENCH_AGENT_CMD_TIMEOUT` (per command, 300s), `SWEBENCH_AGENT_TIMEOUT` (4h),
+  `SWEBENCH_AGENT_SANDBOX_CPU` (unset = Modal default), and `SWEBENCH_MODAL_APP_NAME`
   (`infx-evals-swe`).
 - Run size: `EVAL_LIMIT` empty runs the full ~300-instance split; a positive integer runs the
   first N as an explicit smoke-test slice. `EVAL_LIMIT=full` (or `0`) also selects the full split.

--- a/utils/evals/patches/patch_swebench_agent.py
+++ b/utils/evals/patches/patch_swebench_agent.py
@@ -40,9 +40,27 @@ def _patch(path: str, replacements: list[tuple[str, str, str]], label: str) -> b
     return True
 
 
+
+def _patch_swerex_environment(path: str) -> bool:
+    return _patch(
+        path,
+        [
+            (
+                '        command = action.get("command", "") if isinstance(action, dict) else action\n'
+                "        try:",
+                '        command = action.get("command", "") if isinstance(action, dict) else action\n'
+                '        command = f"exec </dev/null\\n{command}"  # close inherited server stdin (SWE-ReX #281)\n'
+                "        try:",
+                "# close inherited server stdin (SWE-ReX #281)",
+            ),
+        ],
+        "swebench-agentic",
+    )
+
 def main() -> int:
     import minisweagent.run.benchmarks.swebench as mini_swebench
     import swerex.deployment.modal as rex_modal
+    import minisweagent.environments.extra.swerex_modal as mini_rex_modal
 
     mini_ok = _patch(
         mini_swebench.__file__,
@@ -100,6 +118,8 @@ def main() -> int:
         ],
         "swebench-agentic",
     )
+    mini_env_ok = _patch_swerex_environment(mini_rex_modal.__file__)
+
 
     app_name = os.environ.get("SWEBENCH_MODAL_APP_NAME", "infx-evals-swe")
     rex_ok = _patch(
@@ -137,7 +157,7 @@ def main() -> int:
         ],
         "swebench-agentic",
     )
-    return 0 if mini_ok and rex_ok else 1
+    return 0 if mini_ok and mini_env_ok and rex_ok else 1
 
 
 if __name__ == "__main__":

--- a/utils/evals/test_eval_patches.py
+++ b/utils/evals/test_eval_patches.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import runpy
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -40,6 +41,67 @@ def test_agent_patch_is_atomic_and_idempotent(tmp_path):
     assert patched == "patched-alpha\npatched-beta\n"
     assert agent_patch._patch(str(target), replacements, "test")
     assert target.read_text() == patched
+
+
+def test_agent_patch_closes_inherited_stdin(tmp_path):
+    target = tmp_path / "swerex_modal.py"
+    target.write_text(
+        """import json
+import subprocess
+
+class Environment:
+    def execute(self, action):
+        command = action.get("command", "") if isinstance(action, dict) else action
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                timeout=0.2,
+                stdout=subprocess.PIPE,
+                text=True,
+            )
+        except subprocess.TimeoutExpired:
+            return {"returncode": -1, "output": "timed out"}
+        return {"returncode": result.returncode, "output": result.stdout}
+
+environment = Environment()
+commands = ["cat", "printf 'pipe-ok\\\\n' | cat"]
+print(json.dumps([environment.execute({"command": command}) for command in commands]))
+"""
+    )
+
+    assert agent_patch._patch_swerex_environment(str(target))
+    patched = target.read_text()
+    assert agent_patch._patch_swerex_environment(str(target))
+    assert target.read_text() == patched
+
+    process = subprocess.Popen(
+        [sys.executable, str(target)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.wait(timeout=2) == 0
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        assert process.stdin is not None
+        process.stdin.close()
+
+    assert process.stdout is not None
+    assert process.stderr is not None
+    output = process.stdout.read()
+    errors = process.stderr.read()
+    process.stdout.close()
+    process.stderr.close()
+    assert not errors
+    assert json.loads(output) == [
+        {"returncode": 0, "output": ""},
+        {"returncode": 0, "output": "pipe-ok\n"},
+    ]
 
 
 def test_scoring_patch_is_atomic_and_idempotent(tmp_path):


### PR DESCRIPTION
## Description

Backport the closed-stdin behavior from upstream [SWE-ReX #281](https://github.com/SWE-agent/SWE-ReX/pull/281) for agentic SWE-bench generation.

SWE-ReX 1.4.0 inherits the runtime server's stdin when executing commands in Modal. Because that stdin is an open pipe, model-generated commands such as bare `cat`, `grep`, or `sed` can block until the 300-second command timeout. The upstream fix is merged but has not been released.

This PR applies equivalent behavior at the mini-swe-agent Modal adapter boundary by prepending `exec </dev/null` to each remote command. Explicit pipes, heredocs, and redirections continue to work. The existing 300-second timeout remains unchanged for genuinely long-running commands.

Changes:
- backport closed-stdin semantics to the pinned mini-swe-agent/SWE-ReX integration;
- add a behavioral regression test covering bare stdin readers and preserved pipelines;
- document `SWEBENCH_AGENT_CMD_TIMEOUT` and the temporary upstream backport;
- clarify the runtime-patch failure warning.

## Related Issue

Upstream fix: https://github.com/SWE-agent/SWE-ReX/pull/281

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other

## Verification

- `python -m pytest utils/evals/test_eval_patches.py utils/evals/test_run_eval_dispatch.py -q` — 42 passed
- focused closed-stdin regression — passed
- `ruff check utils/evals/patches/patch_swebench_agent.py utils/evals/test_eval_patches.py` — passed
- `bash -n benchmarks/benchmark_lib.sh` — passed
- applied twice against mini-swe-agent 2.4.5 and SWE-ReX 1.4.0 — idempotent

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] No container image or benchmark configuration changed; `perf-changelog.yaml` is not required
- [ ] Before merging via reuse, an authorized maintainer has commented `/reuse-sweep-run` after a final green full sweep with evals

## 中文说明

本 PR 为 agentic SWE-bench 生成流程回移上游 [SWE-ReX #281](https://github.com/SWE-agent/SWE-ReX/pull/281) 的标准输入关闭逻辑。

SWE-ReX 1.4.0 在 Modal 中执行命令时会继承运行时服务进程的标准输入。该标准输入是一个不会主动结束的管道，因此模型生成的裸 `cat`、`grep` 或 `sed` 等命令可能持续阻塞，直到触发 300 秒命令超时。上游修复已经合并，但尚未发布新版本。

本 PR 在 mini-swe-agent 的 Modal 适配层为每条远程命令添加 `exec </dev/null`，实现与上游一致的行为。显式管道、heredoc 和重定向仍可正常使用；对于真正长时间运行的命令，现有 300 秒超时保持不变。

主要改动：
- 在当前固定版本的 mini-swe-agent/SWE-ReX 集成中回移关闭标准输入的语义；
- 增加行为回归测试，覆盖无输入读取命令以及管道输入不受影响的场景；
- 补充 `SWEBENCH_AGENT_CMD_TIMEOUT` 和临时上游回移的文档；
- 更新运行时补丁失败时的告警说明。

验证结果：相关 SWE-bench 评估测试共 42 项全部通过，定向回归测试、Ruff 检查和 Bash 语法检查均通过；补丁在 mini-swe-agent 2.4.5 与 SWE-ReX 1.4.0 上重复应用时保持幂等。