### PR TITLE
Refresh MiniMax-M3 NVFP4 B300 8k1k disaggregated EAGLE Dynamo-vLLM / 刷新 MiniMax-M3 NVFP4 B300 8k1k 分离式 EAGLE Dynamo-vLLM 配置

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p1d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p1d-dep2-tp4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p1d-dep2-tp4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p2d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p2d-dep2-tp4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p2d-dep2-tp4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p4d-dep2-tp4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p6d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p6d-dep2-tp4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-1p6d-dep2-tp4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p1d-dep2-dep4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p1d-dep2-dep4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p1d-dep2-dep4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p1d-dep2-dep4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p1d-dep2-dep4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p1d-dep2-dep4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
+  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
   precision: fp4
 
 resources:
@@ -31,10 +31,12 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p3d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p3d-dep2-tp4-eagle3-8k1k.yaml
@@ -2,7 +2,7 @@ name: "minimax-m3-vllm-disagg-b300-2p3d-dep2-tp4-fp4-8k1k-eagle3"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2"
+  container: "vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
   precision: fp4
 
 resources:
@@ -31,12 +31,10 @@ backend:
 
   prefill_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   decode_environment:
     VLLM_FLOAT32_MATMUL_PRECISION: high
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: trtllm
     UCX_TLS: cuda_copy,cuda_ipc,rc
 
   vllm_config:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7004,6 +7004,23 @@ minimaxm3-fp4-b300-dynamo-vllm-mtp:
           tp: 4
           ep: 1
           dp-attn: false
+
+minimaxm3-fp4-b300-dynamo-vllm-mtp-legacy-dep4:
+  image: vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2
+  model: nvidia/MiniMax-M3-NVFP4
+  model-prefix: minimaxm3
+  runner: b300
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260710" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
       - spec-decoding: "mtp"
         conc-list: [256, 512]
         prefill:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6918,7 +6918,7 @@ minimaxm3-fp4-b300-dynamo-vllm-8k1k-legacy-max-tput:
           dp-attn: false
 
 minimaxm3-fp4-b300-dynamo-vllm-mtp:
-  image: vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2
+  image: vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5060,3 +5060,11 @@
     - "Re-pin VLLM_ROUTER_IMAGE to vllm/vllm-router:nightly-20260716-1fbcde7 (previous nightly-20260629-e667ebb was garbage-collected from Docker Hub)"
     - "Exclude known-bad nodes mia1-p01-g09,g14 from the disagg node pool"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2301
+
+- config-keys:
+    - minimaxm3-fp4-b300-dynamo-vllm-mtp
+  description:
+    - "Refresh the six existing MiniMax-M3 NVFP4 B300 8k1k disaggregated Dynamo-vLLM EAGLE3 recipes from vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2 to vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
+    - "Remove the deprecated VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm override from prefill and decode environments, matching the image compatibility adjustment established by PR #2120"
+    - "Preserve the six existing 8k1k EAGLE3 topologies, speculative-token settings, chat template, random range ratio, and 12 total concurrency points"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2314

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5063,8 +5063,10 @@
 
 - config-keys:
     - minimaxm3-fp4-b300-dynamo-vllm-mtp
+    - minimaxm3-fp4-b300-dynamo-vllm-mtp-legacy-dep4
   description:
-    - "Refresh the six existing MiniMax-M3 NVFP4 B300 8k1k disaggregated Dynamo-vLLM EAGLE3 recipes from vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2 to vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
-    - "Remove the deprecated VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm override from prefill and decode environments, matching the image compatibility adjustment established by PR #2120"
-    - "Preserve the six existing 8k1k EAGLE3 topologies, speculative-token settings, chat template, random range ratio, and 12 total concurrency points"
+    - "Refresh five MiniMax-M3 NVFP4 B300 8k1k disaggregated Dynamo-vLLM EAGLE3 recipes from vllm/vllm-openai:nightly-8e981630c9336233ca9de91452f68918bddbc4e2 to vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9"
+    - "Remove the deprecated VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm override from the five refreshed prefill and decode environments, matching the image compatibility adjustment established by PR #2120"
+    - "Retain the 2P1D DEP4 recipe on its legacy image and all-reduce settings under a separate matrix key"
+    - "Preserve all six existing 8k1k EAGLE3 topologies, speculative-token settings, chat template, random range ratio, and 12 total concurrency points"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2314


### PR DESCRIPTION
## Summary

- Refresh five MiniMax-M3 NVFP4 B300 8k1k disaggregated Dynamo-vLLM EAGLE3 recipes to `vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9`.
- Remove the deprecated `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` override from those five refreshed recipes, matching the image-compatibility change established in #2120.
- Retain the 2P1D DEP4 recipe on its legacy image and all-reduce settings under a separate matrix key after the refreshed image showed a correctness regression.
- Preserve all six EAGLE3 topologies, speculative-token settings, chat template, random range ratio, and 12 total concurrency points.
- This PR contains no B200 or non-EAGLE recipe changes.

## Validation

- `python -m pytest utils/matrix_logic/ utils/changelog_gate_tests/ -q`: 300 passed.
- Generated scope: five refreshed jobs with 10 concurrency points plus one legacy DEP4 job with two points.

## 中文说明

- 将五个 MiniMax-M3 NVFP4 B300 8k1k 分离式 Dynamo-vLLM EAGLE3 配方更新到 `vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9`。
- 从这五个更新后的配方中移除已弃用的 `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` 覆盖配置，与 #2120 的镜像兼容性调整保持一致。
- 由于新镜像出现正确性回退，将 2P1D DEP4 配方保留在旧镜像和原有 all-reduce 设置下，并拆分为独立 matrix key。
- 保留全部六种 EAGLE3 拓扑、推测 token 设置、chat template、随机范围比例和共 12 个并发点。
- 本 PR 不包含 B200 或非 EAGLE 配方变更。

## 验证

- `python -m pytest utils/matrix_logic/ utils/changelog_gate_tests/ -q`：300 项测试通过。
- 生成范围：五个更新任务共 10 个并发点，另加一个旧版 DEP4 任务的两个并发点。