### PR TITLE
fix(evals): raise SWE-bench agentic defaults to 250 steps / 6h

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1191,7 +1191,7 @@ import os, sys, yaml
 default_path, out_path = sys.argv[1], sys.argv[2]
 d = yaml.safe_load(open(default_path)) or {}
 d.setdefault("agent", {})
-step_limit = int(os.environ.get("SWEBENCH_AGENT_STEP_LIMIT", "75"))
+step_limit = int(os.environ.get("SWEBENCH_AGENT_STEP_LIMIT", "250"))
 guidance = f"""
 
 <additional_critical_guidance>
@@ -1246,7 +1246,7 @@ PYGEN
 
     export MSWEA_COST_TRACKING=ignore_errors
     local expected="${EVAL_LIMIT:-${SWEBENCH_EXPECTED_INSTANCES:-300}}"
-    echo "[swebench-agentic] mini-swe-agent: workers=${SWEBENCH_AGENT_WORKERS:-${CONC:-64}} step_limit=${SWEBENCH_AGENT_STEP_LIMIT:-75} slice=${EVAL_LIMIT:-full} expected=$expected"
+    echo "[swebench-agentic] mini-swe-agent: workers=${SWEBENCH_AGENT_WORKERS:-${CONC:-64}} step_limit=${SWEBENCH_AGENT_STEP_LIMIT:-250} slice=${EVAL_LIMIT:-full} expected=$expected"
     local agen_rc=0
     mini-extra swebench \
         -c "$cfg" \
@@ -1258,12 +1258,12 @@ PYGEN
     local mini_pid=$!
     # preds.json detects completion despite teardown hangs.
     local preds_file="$gen_dir/agent_out/preds.json"
-    local deadline=$(( $(date +%s) + ${SWEBENCH_AGENT_TIMEOUT:-14400} ))
+    local deadline=$(( $(date +%s) + ${SWEBENCH_AGENT_TIMEOUT:-21600} ))
     local grace_until=0
     local killed_after_complete=0
     while kill -0 "$mini_pid" 2>/dev/null; do
         if [ "$(date +%s)" -ge "$deadline" ]; then
-            echo "ERROR: generation exceeded SWEBENCH_AGENT_TIMEOUT (${SWEBENCH_AGENT_TIMEOUT:-14400}s); killing mini-extra" >&2
+            echo "ERROR: generation exceeded SWEBENCH_AGENT_TIMEOUT (${SWEBENCH_AGENT_TIMEOUT:-21600}s); killing mini-extra" >&2
             kill "$mini_pid" 2>/dev/null; sleep 5; kill -9 "$mini_pid" 2>/dev/null
             agen_rc=124
             break

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -200,8 +200,8 @@ append_lm_eval_summary
   local endpoint, each instance's shell running in a Modal sandbox via swe-rex — the real
   SWE-bench setting) or `single-shot` (lm-eval, one prompt per instance — a ~10% floor baseline,
   kept only as an explicit debugging escape hatch). Agentic knobs: `SWEBENCH_AGENT_WORKERS`
-  (default: the config's `CONC`, else 64), `SWEBENCH_AGENT_STEP_LIMIT` (75),
-  `SWEBENCH_AGENT_CMD_TIMEOUT` (per command, 300s), `SWEBENCH_AGENT_TIMEOUT` (4h),
+  (default: the config's `CONC`, else 64), `SWEBENCH_AGENT_STEP_LIMIT` (250),
+  `SWEBENCH_AGENT_CMD_TIMEOUT` (per command, 300s), `SWEBENCH_AGENT_TIMEOUT` (6h),
   `SWEBENCH_AGENT_SANDBOX_CPU` (unset = Modal default), and `SWEBENCH_MODAL_APP_NAME`
   (`infx-evals-swe`).
 - Run size: `EVAL_LIMIT` empty runs the full ~300-instance split; a positive integer runs the


### PR DESCRIPTION
The agentic SWE-bench harness gated each instance at 75 commands and the
whole batch at a 4h wall-clock. On the MiniMax-M3 full split this produced
88 incompletes (the 4h global watchdog killed the batch before those
instances wrote predictions) and 71 empty patches (instances exhausted the
75-command budget), scoring 0.3679 < the 0.50 gate.

Our 75-step cap was tighter than upstream mini-swe-agent 2.4.5's own default
of 250, and the 4h wall-clock is an InferenceX-only global batch watchdog
(upstream gates per-instance on steps + a $3 cost budget, which we disable
since we serve locally). Raise the per-instance command budget to the
upstream 250 and the batch wall-clock to 6h. Change is in the harness only;
recipe-level env exports (e.g. glm5.2 step_limit=150) still take precedence.

中文：智能体 SWE-bench 评估之前对每个实例限制 75 条命令、对整个批次限制 4 小时
墙钟时间。在 MiniMax-M3 全量测试集上，这导致 88 个实例未完成（4 小时全局看门狗
在这些实例写出预测前就终止了批次）以及 71 个空补丁（实例耗尽了 75 条命令预算），
最终得分 0.3679，低于 0.50 门槛。我们的 75 步上限比上游 mini-swe-agent 2.4.5 自
身的默认值 250 更严格，而 4 小时墙钟是 InferenceX 特有的全局批次看门狗（上游按每个
实例的步数 + 3 美元成本预算来限制，由于我们使用本地推理，该成本预算已被禁用）。此改
动将每实例命令预算恢复为上游的 250，并将批次墙钟提高到 6 小时。仅修改评估框架
(harness)；配方级别的环境变量覆盖（如 glm5.2 的 step_limit=150）仍然优先生效。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TvKhrwVskLVWtGFYRFLLPg