### PR TITLE
Add GLM-5.1 FP8 B300 SGLang MTP configuration / 新增 GLM-5.1 FP8 B300 SGLang MTP 配置

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/glm5_fp8_b300_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/glm5_fp8_b300_mtp.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
+# does not have a B300-specific recipe, so this script reuses the GLM5 FP8
+# B200 SGLang recipe until B300-specific guidance is available.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+# `hf download` creates the target directory if needed and is idempotent.
+# When MODEL_PATH is unset for a stand-alone run, fall back to the HF cache.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+    echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+nvidia-smi
+
+export SGLANG_ENABLE_JIT_DEEPGEMM=1
+export SGLANG_ENABLE_SPEC_V2=1
+
+SERVER_LOG=/workspace/server.log
+
+echo "CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [[ "${EVAL_ONLY}" == "true" ]]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor
+
+set -x
+PYTHONNOUSERSITE=1 python3 -m sglang.launch_server \
+    --model-path "$MODEL_PATH" \
+    --served-model-name "$MODEL" \
+    --host 0.0.0.0 \
+    --port "$PORT" \
+    --trust-remote-code \
+    --tensor-parallel-size "$TP" \
+    --data-parallel-size 1 \
+    --expert-parallel-size 1 \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --kv-cache-dtype fp8_e4m3 \
+    --quantization fp8 \
+    --attention-backend nsa \
+    --nsa-decode-backend trtllm \
+    --nsa-prefill-backend trtllm \
+    --moe-runner-backend flashinfer_trtllm \
+    --cuda-graph-max-bs "$CONC" \
+    --max-running-requests "$CONC" \
+    --mem-fraction-static 0.85 \
+    --chunked-prefill-size 32768 \
+    --max-prefill-tokens 32768 \
+    --enable-flashinfer-allreduce-fusion \
+    --disable-radix-cache \
+    --stream-interval 30 \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --model-loader-extra-config '{"enable_multithread_load": true}' \
+    $EVAL_CONTEXT_ARGS > "$SERVER_LOG" 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts "$((CONC * 10))" \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir /workspace/ \
+    --use-chat-template
+
+if [[ "${RUN_EVAL}" == "true" ]]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1281,6 +1281,25 @@ qwen3.5-fp4-b200-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 4, spec-decoding: mtp }
       - { tp: 2, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
+  # NOTE: At the time of submission, https://cookbook.sglang.io/autoregressive/GLM/GLM-5.1
+  # does not have a B300-specific recipe, so this config reuses the GLM5 FP8
+  # B200 SGLang recipe until B300-specific guidance is available.
+
+glm5-fp8-b300-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.15.post1-cu130
+  model: zai-org/GLM-5.1-FP8
+  model-prefix: glm5
+  runner: b300
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
+
 qwen3.5-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.14-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5070,4 +5070,4 @@
     - "启用 EAGLE 投机解码，并为基准测试请求使用聊天模板"
     - "Use the writable /data/models/GLM-5.1-FP8 cache when the model is not pre-staged"
     - "模型未预置时，使用可写的 /data/models/GLM-5.1-FP8 缓存"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2321

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5060,3 +5060,14 @@
     - "Re-pin VLLM_ROUTER_IMAGE to vllm/vllm-router:nightly-20260716-1fbcde7 (previous nightly-20260629-e667ebb was garbage-collected from Docker Hub)"
     - "Exclude known-bad nodes mia1-p01-g09,g14 from the disagg node pool"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2301
+
+- config-keys:
+    - glm5-fp8-b300-sglang-mtp
+  description:
+    - "Add the GLM-5.1 FP8 B300 SGLang MTP configuration with the lmsysorg/sglang:v0.5.15.post1-cu130 image"
+    - "新增 GLM-5.1 FP8 B300 SGLang MTP 配置，并使用 lmsysorg/sglang:v0.5.15.post1-cu130 镜像"
+    - "Enable EAGLE speculative decoding and use the chat template for benchmark requests"
+    - "启用 EAGLE 投机解码，并为基准测试请求使用聊天模板"
+    - "Use the writable /data/models/GLM-5.1-FP8 cache when the model is not pre-staged"
+    - "模型未预置时，使用可写的 /data/models/GLM-5.1-FP8 缓存"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Summary

- Add a GLM-5.1 FP8 B300 SGLang MTP benchmark configuration using `lmsysorg/sglang:v0.5.15.post1-cu130`.
- Add the matching single-node script with EAGLE speculative decoding and chat-template requests, using the writable model cache when weights are not pre-staged.

## 中文说明

- 新增 GLM-5.1 FP8 B300 SGLang MTP 基准测试配置，使用 `lmsysorg/sglang:v0.5.15.post1-cu130` 镜像。
- 新增对应的单节点脚本，启用 EAGLE 投机解码并为请求使用聊天模板；权重未预置时使用可写模型缓存。