### PR TITLE
[AMD] dsv4-fp4-mi355x-atom: latest atom-dev image + opt recipe

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
@@ -37,9 +37,11 @@ if [ "$DP_ATTENTION" = "true" ]; then
     fi
 fi 
 
-# max_req=conc only for mid/high concurrency (conc>=64). Low conc uses the ATOM
-# default: dev shows default is on-par or ~4% better at very low conc (e.g. c2).
-if [ "$CONC" -ge 64 ]; then
+# max_req=conc for every dp-on cell (mandatory: dp-attention keeps a full KV pool
+# per rank, so the large default max_num_seqs OOMs even at low conc like c16/c32)
+# and for mid/high conc (conc>=64). dp-off low conc uses the ATOM default
+# (dev: default is on-par or ~4% better at very low conc, e.g. c2).
+if [ "$DP_ATTENTION" = "true" ] || [ "$CONC" -ge 64 ]; then
     PARALLEL_ARGS+=(--max-num-seqs "$CONC")
 fi
 

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
@@ -27,11 +27,8 @@ if [ "$DP_ATTENTION" = "true" ]; then
     if [ "$EP_SIZE" -gt 1 ]; then #DP+EP
         PARALLEL_ARGS=(-tp "$TP" --enable-expert-parallel --enable-dp-attention )
     else #DPA+TP
-        #DPA+TP+TBO
-        if [ "$ISL" -eq 1024 ] && [ "$OSL" -eq 1024 ] && [ "$CONC" -ge 1024 ]; then
-            PARALLEL_ARGS=(-tp "$TP" --enable-dp-attention --enable-tbo)
-            export GPU_MAX_HW_QUEUES=5
-        elif [ "$ISL" -eq 8192 ] && [ "$OSL" -eq 1024 ] && [ "$CONC" -ge 256 ]; then
+        #DPA+TP+TBO (opt: TBO on for dp-attn cells at conc>=64, no per-scenario gate)
+        if [ "$CONC" -ge 64 ]; then
             PARALLEL_ARGS=(-tp "$TP" --enable-dp-attention --enable-tbo)
             export GPU_MAX_HW_QUEUES=5
         else
@@ -63,6 +60,7 @@ python3 -m atom.entrypoints.openai_server \
     --trust-remote-code \
     --gpu-memory-utilization $MEM_FRAC_STATIC \
     --no-enable_prefix_caching \
+    --max-num-seqs "$CONC" \
     --cudagraph-capture-sizes "${CUDAGRAPH_SIZES}" \
     > "$SERVER_LOG" 2>&1 &
 

--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom.sh
@@ -37,6 +37,12 @@ if [ "$DP_ATTENTION" = "true" ]; then
     fi
 fi 
 
+# max_req=conc only for mid/high concurrency (conc>=64). Low conc uses the ATOM
+# default: dev shows default is on-par or ~4% better at very low conc (e.g. c2).
+if [ "$CONC" -ge 64 ]; then
+    PARALLEL_ARGS+=(--max-num-seqs "$CONC")
+fi
+
 BENCHMARK_MAX_MODEL_LEN="$MAX_MODEL_LEN"
 
 if [ "${EVAL_ONLY}" = "true" ]; then
@@ -60,7 +66,6 @@ python3 -m atom.entrypoints.openai_server \
     --trust-remote-code \
     --gpu-memory-utilization $MEM_FRAC_STATIC \
     --no-enable_prefix_caching \
-    --max-num-seqs "$CONC" \
     --cudagraph-capture-sizes "${CUDAGRAPH_SIZES}" \
     > "$SERVER_LOG" 2>&1 &
 

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1322,7 +1322,7 @@ dsv4-fp4-mi355x-vllm-mtp:
       - { tp: 8, conc-start: 4, conc-end: 512, spec-decoding: mtp }
 
 dsv4-fp4-mi355x-atom:
-  image: rocm/atom-dev:nightly_202606161823
+  image: rocm/atom-dev:nightly_202607231538
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1331,15 +1331,20 @@ dsv4-fp4-mi355x-atom:
   multinode: false
   scenarios:
     fixed-seq-len:
+    - isl: 1024
+      osl: 1024
+      search-space:
+      - { tp: 8, ep: 1, conc-start: 1,  conc-end: 64 }
+      - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 2048 }
     - isl: 8192
       osl: 1024
       search-space:
-        # conc4-64, TP8
-        # conc128, DPA
-        # conc256-2048, DPA TBO
-      - { tp: 4, ep: 1, conc-list: [8, 16, 32, 64] }
-      - { tp: 8, ep: 1, conc-list: [1, 2, 4, 8, 16, 32, 64] }
-      - { tp: 8, ep: 1, dp-attn: true, conc-start: 128, conc-end: 2048 }
+      # conc<64: tp4 dp-off (best at low conc); conc>=64: dp-on + TBO.
+      # tp8 dp-off low-conc kept as redundancy to recheck the crossover on the new image.
+      - { tp: 4, ep: 1, dp-attn: false, conc-start: 1,  conc-end: 64 }
+      - { tp: 4, ep: 1, dp-attn: true,  conc-start: 16, conc-end: 128 }
+      - { tp: 8, ep: 1, dp-attn: false, conc-start: 1,  conc-end: 64 }
+      - { tp: 8, ep: 1, dp-attn: true,  conc-start: 64, conc-end: 2048 }
 
 dsv4-fp4-mi355x-atom-mtp:
   image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1336,6 +1336,8 @@ dsv4-fp4-mi355x-atom:
       search-space:
       # conc<64: tp4 dp-off (best at low conc); conc>=64: dp-on + TBO.
       # tp8 dp-off low-conc kept as redundancy to recheck the crossover on the new image.
+      # dp-on cells always set max_req=conc (recipe .sh) to avoid OOM from the large
+      # default max_num_seqs (dp-attn keeps a full KV pool per rank); TBO stays conc>=64.
       - { tp: 4, ep: 1, dp-attn: false, conc-start: 1,  conc-end: 64 }
       - { tp: 4, ep: 1, dp-attn: true,  conc-start: 16, conc-end: 128 }
       - { tp: 8, ep: 1, dp-attn: false, conc-start: 1,  conc-end: 64 }

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1331,11 +1331,6 @@ dsv4-fp4-mi355x-atom:
   multinode: false
   scenarios:
     fixed-seq-len:
-    - isl: 1024
-      osl: 1024
-      search-space:
-      - { tp: 8, ep: 1, conc-start: 1,  conc-end: 64 }
-      - { tp: 8, ep: 1, dp-attn: true, conc-start: 64, conc-end: 2048 }
     - isl: 8192
       osl: 1024
       search-space:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -2,7 +2,7 @@
     - dsv4-fp4-mi355x-atom
   description:
     - "Re-sweep dsv4-fp4-mi355x-atom on latest atom-dev nightly (nightly_202607231538, was 202606161823). Recipe: max_num_seqs=conc + TBO on dp-attn cells at conc>=64 (was per-scenario gate 256/1024). Add 1k1k scenario; 8k1k grid adds tp8 dp-off low-conc redundancy to recheck the crossover on the new image."
-  pr-link: PLACEHOLDER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2325
 
 - config-keys:
     - 70b-fp8-*-vllm

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,4 +1,10 @@
 - config-keys:
+    - dsv4-fp4-mi355x-atom
+  description:
+    - "Re-sweep dsv4-fp4-mi355x-atom on latest atom-dev nightly (nightly_202607231538, was 202606161823). Recipe: max_num_seqs=conc + TBO on dp-attn cells at conc>=64 (was per-scenario gate 256/1024). Add 1k1k scenario; 8k1k grid adds tp8 dp-off low-conc redundancy to recheck the crossover on the new image."
+  pr-link: PLACEHOLDER
+
+- config-keys:
     - 70b-fp8-*-vllm
   description:
     - 'Add compilation-config ''{"custom_ops": ["-rms_norm", "-quant_fp8", "-silu_and_mul"]}'' as extra config to all benchmarks/70b_fp8_mi*.sh scripts'

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -1,7 +1,7 @@
 - config-keys:
     - dsv4-fp4-mi355x-atom
   description:
-    - "Re-sweep dsv4-fp4-mi355x-atom on latest atom-dev nightly (nightly_202607231538, was 202606161823). Recipe: max_num_seqs=conc + TBO on dp-attn cells at conc>=64 (was per-scenario gate 256/1024). Add 1k1k scenario; 8k1k grid adds tp8 dp-off low-conc redundancy to recheck the crossover on the new image."
+    - "Re-sweep dsv4-fp4-mi355x-atom on latest atom-dev nightly (nightly_202607231538, was 202606161823). Recipe: max_num_seqs=conc + TBO on dp-attn cells at conc>=64 (was per-scenario gate 256/1024). 8k1k grid adds tp8 dp-off low-conc redundancy to recheck the crossover on the new image."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2325
 
 - config-keys:


### PR DESCRIPTION
## What
Re-sweep `dsv4-fp4-mi355x-atom` (DeepSeek-V4-Pro FP4, MI355X) on the latest atom-dev image with an optimized recipe.

## Changes
- **Image**: `nightly_202606161823` → `nightly_202607231538` (latest atom-dev)
- **Recipe** (`dsv4_fp4_mi355x_atom.sh`):
  - `--max-num-seqs "$CONC"` (was ATOM default) — so high concurrency (1024/2048) isn't capped by max_num_seqs
  - TBO enabled on dp-attn cells at `conc>=64` (was per-scenario gate 256/1024)
- **8k/1k grid**: aligns the AMD dev sweep (run 20260723) + keeps a tp8 dp-off low-conc line as redundancy to recheck the dp crossover on the new image

## Why the recipe change
AMD internal dev benchmarking (atom-dev image b31cc35) shows this recipe beats the prior default:
- `max_num_seqs=conc` removes the high-concurrency throughput cap
- TBO gate lowered to `conc>=64` from measured crossover (no measurable TBO gain below conc 64 on 8k/1k)

## Note for reviewers
Needs the `full-sweep-fail-fast` label to run the sweep on the new image. `RANDOM_RANGE_RATIO` stays at the repo default (0.8), matching the dev runs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
