### PR TITLE
[AMD][AgentX] MINIMAX-M3 FP4 MI355X agentX vLLM disagg

### DIFF
--- a/benchmarks/multi_node/agentic/minimaxm3_fp4_mi355x_vllm-disagg.sh
+++ b/benchmarks/multi_node/agentic/minimaxm3_fp4_mi355x_vllm-disagg.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Agentic trace-replay recipe for a disaggregated vLLM server on MI355X
+# (MiniMax-M3 MXFP4, 1P1D TP8). CI-style sibling of
+# minimaxm3_fp4_mi355x_vllm-disagg.sh: driven by workflow env vars and
+# submits a SLURM job via submit.sh.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../benchmark_lib.sh"
+
+check_env_vars \
+    CONC_LIST \
+    ISL \
+    OSL \
+    IMAGE \
+    SPEC_DECODING \
+    MODEL_PATH \
+    PREFILL_NUM_WORKERS \
+    PREFILL_TP \
+    PREFILL_EP \
+    PREFILL_DP_ATTN \
+    DECODE_NUM_WORKERS \
+    DECODE_TP \
+    DECODE_EP \
+    DECODE_DP_ATTN \
+    PREFILL_NODES \
+    DECODE_NODES \
+    RANDOM_RANGE_RATIO \
+    DURATION \
+    KV_OFFLOADING \
+    IS_AGENTIC \
+    FRAMEWORK
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+set -x
+
+cd "$GITHUB_WORKSPACE/benchmarks/multi_node/amd_utils" || exit 1
+
+export TIME_LIMIT="${TIME_LIMIT:-08:00:00}"
+export MODEL_PATH=$MODEL_PATH
+export MODEL_NAME=$MODEL_NAME
+export CONTAINER_IMAGE=$IMAGE
+
+export MODEL_PREFIX="${MODEL_PREFIX:-minimaxm3}"
+export PRECISION="${PRECISION:-fp4}"
+export RESULT_FILENAME="${RESULT_FILENAME:-${RUNNER_NAME:-minimaxm3-fp4-agentic}}"
+
+export IS_AGENTIC="${IS_AGENTIC:-1}"
+export DURATION="${DURATION:-1800}"
+export MAX_MODEL_LEN="${MAX_MODEL_LEN:-1000000}"
+export GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.9}"
+
+# KV cache offload: dram via MooncakeStoreConnector (MultiConnector + MoRIIO P/D).
+export KV_OFFLOADING="${KV_OFFLOADING:-none}"
+if [[ "$KV_OFFLOADING" != "none" ]]; then
+    export KV_OFFLOAD_BACKEND="${KV_OFFLOAD_BACKEND:-mooncake}"
+fi
+
+export ENABLE_METRICS="${ENABLE_METRICS:-1}"
+
+if [[ "${PREFILL_EP:-1}" -eq 1 ]]; then
+    export PREFILL_ENABLE_EP=false
+else
+    export PREFILL_ENABLE_EP=true
+fi
+
+if [[ "$PREFILL_DP_ATTN" == "true" ]]; then
+    export PREFILL_ENABLE_DP=true
+else
+    export PREFILL_ENABLE_DP=false
+fi
+
+if [[ "${DECODE_EP:-1}" -eq 1 ]]; then
+    export DECODE_ENABLE_EP=false
+else
+    export DECODE_ENABLE_EP=true
+fi
+
+if [[ "$DECODE_DP_ATTN" == "true" ]]; then
+    export DECODE_ENABLE_DP=true
+else
+    export DECODE_ENABLE_DP=false
+fi
+
+JOB_ID=$(bash ./submit.sh $PREFILL_NODES \
+    $PREFILL_NUM_WORKERS \
+    $DECODE_NODES \
+    $DECODE_NUM_WORKERS \
+    $ISL $OSL "${CONC_LIST// /x}" inf \
+    ${PREFILL_ENABLE_EP} ${PREFILL_ENABLE_DP} \
+    ${DECODE_ENABLE_EP} ${DECODE_ENABLE_DP} \
+    ${PREFILL_TP} ${DECODE_TP} \
+    ${RANDOM_RANGE_RATIO})
+
+if [[ $? -ne 0 ]]; then
+    echo "Failed to submit job" >&2
+    exit 1
+fi
+
+echo "$JOB_ID"

--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -330,6 +330,8 @@ export RUNNER_TYPE="${RUNNER_TYPE:-}"
 export RESULT_FILENAME="${RESULT_FILENAME:-}"
 export SPEC_DECODING="${SPEC_DECODING:-}"
 export IS_MULTINODE="${IS_MULTINODE:-false}"
+export INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS="${INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS:-}"
+export MC_WORKERS_PER_CTX="${MC_WORKERS_PER_CTX:-}"
 
 SANITIZED_USER=$(echo "$USER_NAME" | tr -c 'a-zA-Z0-9_.-' '_')
 export DOCKER_CONT_NAME="container_${ENGINE}_${SANITIZED_USER}_${MODEL_NAME}_${SLURM_JOB_ID}"
@@ -427,12 +429,18 @@ DOCKER_ENV_COMMON=(
     -e SGLANG_AITER_MLA_PERSIST=\${SGLANG_AITER_MLA_PERSIST:-0}
     -e DISABLE_CUSTOM_ALL_REDUCE=\${DISABLE_CUSTOM_ALL_REDUCE:-0}
     -e MAX_MODEL_LEN=\${MAX_MODEL_LEN:-}
+    -e GPU_MEMORY_UTILIZATION=\${GPU_MEMORY_UTILIZATION:-}
+    -e ENABLE_PREFIX_CACHING=\${ENABLE_PREFIX_CACHING:-0}
     -e DURATION=\${DURATION:-1800}
     -e IS_AGENTIC=\${IS_AGENTIC:-0}
     -e KV_OFFLOADING=\${KV_OFFLOADING:-none}
     -e KV_OFFLOAD_BACKEND=\${KV_OFFLOAD_BACKEND:-}
     -e KV_OFFLOAD_BACKEND_METADATA=\"\${KV_OFFLOAD_BACKEND_METADATA:-}\"
     -e TOTAL_CPU_DRAM_GB=\${TOTAL_CPU_DRAM_GB:-}
+    -e HF_HUB_CACHE=\${HF_HUB_CACHE:-/tmp/mooncake-hf-cache}
+    -e INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=\${INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS:-}
+    -e MC_WORKERS_PER_CTX=\${MC_WORKERS_PER_CTX:-}
+    -e VLLM_PATCH_46240=\${VLLM_PATCH_46240:-}
     -e ENABLE_METRICS=\${ENABLE_METRICS:-0}
     -e PREFILL_ROUTER_POLICY=\${PREFILL_ROUTER_POLICY:-random}
     -e DECODE_ROUTER_POLICY=\${DECODE_ROUTER_POLICY:-random}
@@ -445,6 +453,8 @@ DOCKER_ENV_COMMON=(
     -e DECODE_ENABLE_DP=\$DECODE_ENABLE_DP
     -e DECODE_MTP_SIZE=\$DECODE_MTP_SIZE
     -e IS_MULTINODE=\$IS_MULTINODE
+    -e IBDEVICES=\${IBDEVICES:-}
+    -e MORI_RDMA_TC=\${MORI_RDMA_TC:-}
     -e DRY_RUN=\${DRY_RUN:-0}
 )
 
@@ -553,9 +563,11 @@ echo \"Rank \$SLURM_PROCID on \$(hostname)\"
 eval \"\$DOCKER_CMD_DETECT\"
 echo \"[docker-detect] rank \$SLURM_PROCID: DOCKER_CMD=\$DOCKER_CMD\"
 
-# Enable out-of-tree RDMA library mounts for atom-disagg (mooncake requires host RDMA stack)
+# Enable out-of-tree RDMA library mounts on MI355X ionic/bnxt nodes. Required for
+# atom-disagg (mooncake) and vllm-disagg (MoRIIO MultiConnector); container bundled
+# libibverbs/libionic may be ABI-incompatible with the host kernel drivers.
 RDMA_MOUNTS=()
-if [[ "$ENGINE" == "atom-disagg" ]]; then
+if [[ "$ENGINE" == "atom-disagg" || "$ENGINE" == "vllm-disagg" ]]; then
 
 # When the container base OS differs from the host (e.g. Ubuntu 24.04 image
 # on a 22.04 host), the container's bundled libibverbs/libionic may be
@@ -629,7 +641,7 @@ if [[ \${#RDMA_MOUNTS[@]} -gt 0 ]]; then
 else
     echo \"[rdma] no out-of-tree RDMA mounts needed\"
 fi
-fi  # end: if ENGINE == atom-disagg
+fi  # end: if ENGINE needs host RDMA bind-mounts
 
 # Pre-clean (idempotent)
 \$DOCKER_CMD ps -aq --filter \"$CONT_FILTER\" | xargs -r \$DOCKER_CMD rm -f || true

--- a/benchmarks/multi_node/amd_utils/patches/apply_vllm_46240_scheduler_patch.py
+++ b/benchmarks/multi_node/amd_utils/patches/apply_vllm_46240_scheduler_patch.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Apply vLLM issue #46240 workaround to Scheduler._update_from_kv_xfer_finished.
+
+https://github.com/vllm-project/vllm/issues/46240
+
+When async KV connectors (MultiConnector + MooncakeStore) report finished_recving
+and finished_sending for the same request in one step, or report completion after
+the scheduler already freed the request, the hard assert kills EngineCore.
+
+Replace ``assert req_id in self.requests`` with a skip for untracked ids.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PATCH_MARKER = "INFERENCEX_PATCH_46240"
+
+RECV_OLD = """        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            assert req_id in self.requests"""
+
+RECV_NEW = f"""        for req_id in kv_connector_output.finished_recving or ():
+            logger.debug("Finished recving KV transfer for request %s", req_id)
+            if req_id not in self.requests:
+                continue  # {PATCH_MARKER}: stale async KV recv completion"""
+
+SEND_OLD = """        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            assert req_id in self.requests"""
+
+SEND_NEW = f"""        for req_id in kv_connector_output.finished_sending or ():
+            logger.debug("Finished sending KV transfer for request %s", req_id)
+            if req_id not in self.requests:
+                continue  # {PATCH_MARKER}: stale async KV send completion"""
+
+
+def find_scheduler_py() -> Path:
+    import vllm
+
+    return Path(vllm.__file__).resolve().parent / "v1" / "core" / "sched" / "scheduler.py"
+
+
+def apply_patch(path: Path) -> None:
+    text = path.read_text()
+    if PATCH_MARKER in text:
+        print(f"[patch-46240] Already applied: {path}")
+        return
+
+    if RECV_OLD not in text:
+        raise SystemExit(f"[patch-46240] recv pattern not found in {path}")
+    if SEND_OLD not in text:
+        raise SystemExit(f"[patch-46240] send pattern not found in {path}")
+
+    text = text.replace(RECV_OLD, RECV_NEW, 1).replace(SEND_OLD, SEND_NEW, 1)
+    if PATCH_MARKER not in text:
+        raise SystemExit(f"[patch-46240] patch application failed for {path}")
+
+    path.write_text(text)
+    print(f"[patch-46240] Patched {path}")
+
+
+def main() -> None:
+    path = find_scheduler_py()
+    if not path.is_file():
+        raise SystemExit(f"[patch-46240] scheduler.py not found: {path}")
+    apply_patch(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multi_node/amd_utils/patches/apply_vllm_mooncake_transfer_batches.py
+++ b/benchmarks/multi_node/amd_utils/patches/apply_vllm_mooncake_transfer_batches.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Cap MooncakeStoreConnector BatchGet/BatchPut key counts per RPC.
+
+Reads INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS (e.g. 32) to split large
+transfer bursts that exhaust TCP ephemeral ports under high concurrency.
+
+Upstream vLLM only splits GET batches for disk-offload staging budgets; memory
+tier loads use a single sub-batch with all keys (~1000+ at agentic conc=32).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+PATCH_MARKER = "INFERENCEX_MOONCAKE_TRANSFER_BATCH"
+
+HELPER_CODE = f'''
+def _inferencex_max_transfer_batch_keys() -> int | None:  # {PATCH_MARKER}
+    raw = os.environ.get("INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS", "").strip()
+    if not raw:
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _split_transfer_load_batches_by_key_count(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+    block_ids: list[int],
+    max_keys: int,
+) -> list[tuple[list[str], list[list[int]], list[list[int]], list[int]]]:
+    if max_keys <= 0 or len(keys) <= max_keys:
+        return [(keys, addrs, sizes, block_ids)]
+    batches: list[
+        tuple[list[str], list[list[int]], list[list[int]], list[int]]
+    ] = []
+    for start in range(0, len(keys), max_keys):
+        end = start + max_keys
+        batches.append(
+            (keys[start:end], addrs[start:end], sizes[start:end], block_ids[start:end])
+        )
+    return batches
+
+
+def _split_transfer_put_batches_by_key_count(
+    keys: list[str],
+    addrs: list[list[int]],
+    sizes: list[list[int]],
+    max_keys: int,
+) -> list[tuple[list[str], list[list[int]], list[list[int]]]]:
+    if max_keys <= 0 or len(keys) <= max_keys:
+        return [(keys, addrs, sizes)]
+    batches: list[tuple[list[str], list[list[int]], list[list[int]]]] = []
+    for start in range(0, len(keys), max_keys):
+        end = start + max_keys
+        batches.append((keys[start:end], addrs[start:end], sizes[start:end]))
+    return batches
+
+'''
+
+RECV_ANCHOR = (
+    "load_batches = [(key_list_c, addr_list_c, size_list_c, block_id_list_c)]"
+)
+RECV_INSERT = f"""
+        _ix_max_keys = _inferencex_max_transfer_batch_keys()  # {PATCH_MARKER}
+        if (
+            _ix_max_keys is not None
+            and self.usable_disk_offload_buffer_budget_bytes is None
+            and len(key_list_c) > _ix_max_keys
+        ):
+            load_batches = _split_transfer_load_batches_by_key_count(
+                key_list_c,
+                addr_list_c,
+                size_list_c,
+                block_id_list_c,
+                _ix_max_keys,
+            )"""
+
+PUT_OLD_V0231 = """            batch_bytes = _sum_batch_bytes(sizes)
+            put_start = time.perf_counter()
+            try:
+                res = self.store.batch_put_from_multi_buffers(
+                    keys,
+                    addrs,
+                    sizes,
+                    self.replicate_config,
+                )
+                failed = [i for i, v in enumerate(res) if v < 0]
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(keys),
+                    num_bytes=batch_bytes,
+                    status="partial_failure" if failed else "ok",
+                    num_failed_keys=len(failed),
+                )
+                if failed:
+                    failed_codes = set(res[i] for i in failed)
+                    logger.warning(
+                        "batch_put failed: %d/%d keys failed "
+                        "(codes=%s, batch_bytes=%d, num_keys=%d), "
+                        "first_key=%s",
+                        len(failed),
+                        len(keys),
+                        failed_codes,
+                        batch_bytes,
+                        len(keys),
+                        keys[0] if keys else "N/A",
+                    )
+                    if (
+                        MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                        and not self._mark_request_skipped_for_pressure(req_id)
+                    ):
+                        logger.warning(
+                            "Detected Mooncake CPU/disk offloading pressure "
+                            "(NO_AVAILABLE_HANDLE); skipping future store "
+                            "batches for request %s until a later store "
+                            "batch succeeds",
+                            req_id,
+                        )
+                else:
+                    self._record_saved(req_id, token_len)
+                    if self._clear_store_pressure():
+                        logger.info(
+                            "Mooncake CPU/disk offloading pressure cleared "
+                            "after a successful store batch"
+                        )
+            except Exception as e:
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(keys),
+                    num_bytes=batch_bytes,
+                    status="error",
+                    num_failed_keys=len(keys),
+                )
+                logger.error("Failed to put key %s, error: %s", keys, e)"""
+
+PUT_OLD_LEGACY = """            batch_bytes = _sum_batch_bytes(sizes)
+            put_start = time.perf_counter()
+            try:
+                res = self.store.batch_put_from_multi_buffers(
+                    keys,
+                    addrs,
+                    sizes,
+                    self.replicate_config,
+                )
+                failed = [i for i, v in enumerate(res) if v < 0]
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(keys),
+                    num_bytes=batch_bytes,
+                    status="partial_failure" if failed else "ok",
+                    num_failed_keys=len(failed),
+                )
+                if failed:
+                    failed_codes = set(res[i] for i in failed)
+                    logger.warning(
+                        "batch_put failed: %d/%d keys failed "
+                        "(codes=%s, batch_bytes=%d, num_keys=%d), "
+                        "first_key=%s",
+                        len(failed),
+                        len(keys),
+                        failed_codes,
+                        batch_bytes,
+                        len(keys),
+                        keys[0] if keys else "N/A",
+                    )
+                    if (
+                        MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                        and not self._mark_request_skipped_for_pressure(req_id)
+                    ):
+                        logger.warning(
+                            "Detected Mooncake CPU/disk offloading pressure "
+                            "(NO_AVAILABLE_HANDLE); skipping future store "
+                            "batches for request %s until a later store "
+                            "batch succeeds",
+                            req_id,
+                        )
+                elif self._clear_store_pressure():
+                    logger.info(
+                        "Mooncake CPU/disk offloading pressure cleared after a "
+                        "successful store batch"
+                    )
+            except Exception as e:
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(keys),
+                    num_bytes=batch_bytes,
+                    status="error",
+                    num_failed_keys=len(keys),
+                )
+                logger.error("Failed to put key %s, error: %s", keys, e)"""
+
+PUT_LOOP_BODY = f"""                batch_bytes = _sum_batch_bytes(sizes)
+                put_start = time.perf_counter()
+                try:
+                    res = self.store.batch_put_from_multi_buffers(
+                        keys,
+                        addrs,
+                        sizes,
+                        self.replicate_config,
+                    )
+                    failed = [i for i, v in enumerate(res) if v < 0]
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(keys),
+                        num_bytes=batch_bytes,
+                        status="partial_failure" if failed else "ok",
+                        num_failed_keys=len(failed),
+                    )
+                    if failed:
+                        failed_codes = set(res[i] for i in failed)
+                        logger.warning(
+                            "batch_put failed: %d/%d keys failed "
+                            "(codes=%s, batch_bytes=%d, num_keys=%d), "
+                            "first_key=%s",
+                            len(failed),
+                            len(keys),
+                            failed_codes,
+                            batch_bytes,
+                            len(keys),
+                            keys[0] if keys else "N/A",
+                        )
+                        if (
+                            MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                            and not self._mark_request_skipped_for_pressure(req_id)
+                        ):
+                            logger.warning(
+                                "Detected Mooncake CPU/disk offloading pressure "
+                                "(NO_AVAILABLE_HANDLE); skipping future store "
+                                "batches for request %s until a later store "
+                                "batch succeeds",
+                                req_id,
+                            )
+                        _ix_put_failed = True
+                        break
+                except Exception as e:
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(keys),
+                        num_bytes=batch_bytes,
+                        status="error",
+                        num_failed_keys=len(keys),
+                    )
+                    logger.error("Failed to put key %s, error: %s", keys, e)
+                    _ix_put_failed = True
+                    break"""
+
+PUT_NEW_V0231 = f"""            _ix_put_max_keys = _inferencex_max_transfer_batch_keys()  # {PATCH_MARKER}
+            if _ix_put_max_keys is not None:
+                put_batches = _split_transfer_put_batches_by_key_count(
+                    keys, addrs, sizes, _ix_put_max_keys
+                )
+            else:
+                put_batches = [(keys, addrs, sizes)]
+
+            _ix_put_failed = False
+            for keys, addrs, sizes in put_batches:
+{PUT_LOOP_BODY}
+            if not _ix_put_failed:
+                self._record_saved(req_id, token_len)
+                if self._clear_store_pressure():
+                    logger.info(
+                        "Mooncake CPU/disk offloading pressure cleared "
+                        "after a successful store batch"
+                    )"""
+
+PUT_NEW_LEGACY = f"""            _ix_put_max_keys = _inferencex_max_transfer_batch_keys()  # {PATCH_MARKER}
+            if _ix_put_max_keys is not None:
+                put_batches = _split_transfer_put_batches_by_key_count(
+                    keys, addrs, sizes, _ix_put_max_keys
+                )
+            else:
+                put_batches = [(keys, addrs, sizes)]
+
+            _ix_put_failed = False
+            for keys, addrs, sizes in put_batches:
+{PUT_LOOP_BODY}
+            if not _ix_put_failed and self._clear_store_pressure():
+                logger.info(
+                    "Mooncake CPU/disk offloading pressure cleared after a "
+                    "successful store batch"
+                )"""
+
+PUT_PATCH_VARIANTS: list[tuple[str, str, str]] = [
+    ("v0.23.1", PUT_OLD_V0231, PUT_NEW_V0231),
+    ("legacy", PUT_OLD_LEGACY, PUT_NEW_LEGACY),
+]
+
+HELPER_ANCHOR = "def _sum_batch_bytes(sizes: list[list[int]]) -> int:"
+
+
+def find_worker_py() -> Path:
+    import vllm
+
+    return (
+        Path(vllm.__file__).resolve().parent
+        / "distributed"
+        / "kv_transfer"
+        / "kv_connector"
+        / "v1"
+        / "mooncake"
+        / "store"
+        / "worker.py"
+    )
+
+
+def _select_put_patch(text: str) -> tuple[str, str, str] | None:
+    for label, put_old, put_new in PUT_PATCH_VARIANTS:
+        if put_old in text:
+            return label, put_old, put_new
+    return None
+
+
+def apply_patch(path: Path) -> None:
+    text = path.read_text()
+    if PATCH_MARKER in text:
+        print(f"[patch-mooncake-batch] Already applied: {path}")
+        return
+
+    if HELPER_ANCHOR not in text:
+        raise SystemExit(f"[patch-mooncake-batch] helper anchor not found in {path}")
+    if RECV_ANCHOR not in text:
+        raise SystemExit(f"[patch-mooncake-batch] recv anchor not found in {path}")
+
+    put_patch = _select_put_patch(text)
+    if put_patch is None:
+        raise SystemExit(f"[patch-mooncake-batch] put block not found in {path}")
+
+    put_label, put_old, put_new = put_patch
+
+    max_keys = os.environ.get("INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS", "").strip()
+    if not max_keys:
+        raise SystemExit(
+            "[patch-mooncake-batch] set INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS"
+        )
+
+    text = text.replace(HELPER_ANCHOR, HELPER_CODE + HELPER_ANCHOR, 1)
+    text = text.replace(RECV_ANCHOR, RECV_ANCHOR + RECV_INSERT, 1)
+    text = text.replace(put_old, put_new, 1)
+    if PATCH_MARKER not in text:
+        raise SystemExit(f"[patch-mooncake-batch] patch application failed for {path}")
+
+    path.write_text(text)
+    print(
+        f"[patch-mooncake-batch] Patched {path} "
+        f"(variant={put_label}, "
+        f"INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS={max_keys})"
+    )
+
+
+def main() -> None:
+    path = find_worker_py()
+    if not path.is_file():
+        raise SystemExit(f"[patch-mooncake-batch] worker.py not found: {path}")
+    apply_patch(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multi_node/amd_utils/server_vllm.sh
+++ b/benchmarks/multi_node/amd_utils/server_vllm.sh
@@ -171,18 +171,285 @@ fi
 if [[ "${PREFILL_ENABLE_EP:-false}" == "true" ]] && ! echo "$PREFILL_SERVER_CONFIG" | grep -q -- '--enable-expert-parallel'; then
     PREFILL_SERVER_CONFIG+=" --enable-expert-parallel"
 fi
-if [[ "${PREFILL_ENABLE_DP:-false}" == "true" ]] && ! echo "$PREFILL_SERVER_CONFIG" | grep -q -- '--enable-dp-attention'; then
-    PREFILL_SERVER_CONFIG+=" --enable-dp-attention"
-fi
 if [[ "${DECODE_ENABLE_EP:-false}" == "true" ]] && ! echo "$DECODE_SERVER_CONFIG" | grep -q -- '--enable-expert-parallel'; then
     DECODE_SERVER_CONFIG+=" --enable-expert-parallel"
 fi
-if [[ "${DECODE_ENABLE_DP:-false}" == "true" ]] && ! echo "$DECODE_SERVER_CONFIG" | grep -q -- '--enable-dp-attention'; then
-    DECODE_SERVER_CONFIG+=" --enable-dp-attention"
+
+# DEP8 on ROCm vLLM (mori-0625): TP1 + data-parallel-size + EP, not --enable-dp-attention
+# (same as benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh).
+apply_vllm_dp_config() {
+    local cfg="$1"
+    local tp_size="$2"
+    local enable_dp="${3:-false}"
+
+    cfg=$(echo "$cfg" | sed -E 's/[[:space:]]*--enable-dp-attention//g')
+    cfg=$(echo "$cfg" | sed -E 's/[[:space:]]*--data-parallel-size[[:space:]]+[0-9]+//g')
+
+    if [[ "$enable_dp" != "true" ]]; then
+        echo "$cfg"
+        return
+    fi
+
+    if echo "$cfg" | grep -q -- '--tensor-parallel-size'; then
+        echo "$cfg" | sed -E "s/--tensor-parallel-size[[:space:]]+[0-9]+/--tensor-parallel-size 1 --data-parallel-size ${tp_size}/"
+    else
+        echo "$cfg --tensor-parallel-size 1 --data-parallel-size ${tp_size}"
+    fi
+}
+
+PREFILL_SERVER_CONFIG="$(apply_vllm_dp_config "$PREFILL_SERVER_CONFIG" "${PREFILL_TP_SIZE:-8}" "${PREFILL_ENABLE_DP:-false}")"
+DECODE_SERVER_CONFIG="$(apply_vllm_dp_config "$DECODE_SERVER_CONFIG" "${DECODE_TP_SIZE:-8}" "${DECODE_ENABLE_DP:-false}")"
+
+apply_gpu_memory_utilization() {
+    local cfg="$1"
+    local gmu="${GPU_MEMORY_UTILIZATION:-}"
+    if [[ -z "$gmu" ]]; then
+        echo "$cfg"
+        return
+    fi
+    if echo "$cfg" | grep -q -- '--gpu-memory-utilization'; then
+        echo "$cfg" | sed -E "s/--gpu-memory-utilization[[:space:]]+[0-9.]+/--gpu-memory-utilization ${gmu}/g"
+    else
+        echo "$cfg --gpu-memory-utilization ${gmu}"
+    fi
+}
+
+if [[ -n "${GPU_MEMORY_UTILIZATION:-}" ]]; then
+    PREFILL_SERVER_CONFIG="$(apply_gpu_memory_utilization "$PREFILL_SERVER_CONFIG")"
+    DECODE_SERVER_CONFIG="$(apply_gpu_memory_utilization "$DECODE_SERVER_CONFIG")"
+    echo "Applied GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION}"
 fi
 
 echo "PREFILL_SERVER_CONFIG (after TP/EP/DP): $PREFILL_SERVER_CONFIG"
 echo "DECODE_SERVER_CONFIG (after TP/EP/DP): $DECODE_SERVER_CONFIG"
+
+apply_max_model_len() {
+    local cfg="$1"
+    if [[ -n "${MAX_MODEL_LEN:-}" && "${MAX_MODEL_LEN}" != "0" ]]; then
+        if echo "$cfg" | grep -q -- '--max-model-len'; then
+            echo "$cfg" | sed -E "s/--max-model-len[[:space:]]+[0-9]+/--max-model-len ${MAX_MODEL_LEN}/g"
+        else
+            echo "$cfg --max-model-len ${MAX_MODEL_LEN}"
+        fi
+    else
+        echo "$cfg"
+    fi
+}
+
+enable_prefix_caching=false
+if [[ "${IS_AGENTIC:-0}" == "1" || "${IS_AGENTIC:-}" == "true" ]]; then
+    enable_prefix_caching=true
+fi
+if [[ "${ENABLE_PREFIX_CACHING:-0}" == "1" || "${ENABLE_PREFIX_CACHING:-}" == "true" ]]; then
+    enable_prefix_caching=true
+fi
+if [[ "$enable_prefix_caching" == "true" ]]; then
+    PREFILL_SERVER_CONFIG="${PREFILL_SERVER_CONFIG//--no-enable-prefix-caching/--enable-prefix-caching}"
+    DECODE_SERVER_CONFIG="${DECODE_SERVER_CONFIG//--no-enable-prefix-caching/--enable-prefix-caching}"
+fi
+if [[ -n "${MAX_MODEL_LEN:-}" && "${MAX_MODEL_LEN}" != "0" ]]; then
+    PREFILL_SERVER_CONFIG="$(apply_max_model_len "$PREFILL_SERVER_CONFIG")"
+    DECODE_SERVER_CONFIG="$(apply_max_model_len "$DECODE_SERVER_CONFIG")"
+    echo "Applied MAX_MODEL_LEN=${MAX_MODEL_LEN}"
+fi
+if [[ "$enable_prefix_caching" == "true" || -n "${MAX_MODEL_LEN:-}" ]]; then
+    echo "PREFILL_SERVER_CONFIG (overrides): $PREFILL_SERVER_CONFIG"
+    echo "DECODE_SERVER_CONFIG (overrides): $DECODE_SERVER_CONFIG"
+fi
+
+install_mooncake_rocm() {
+    local mooncake_tag="v0.3.11.post1"
+    local mooncake_src="/tmp/Mooncake-$mooncake_tag"
+    local mooncake_stage="/tmp/mooncake-stage-$mooncake_tag"
+    local build_jobs cache_root cache_key cache_archive cache_tmp engine_path
+    local os_version python_abi rocm_version
+
+    build_jobs=$(nproc)
+    if ((build_jobs > 32)); then
+        build_jobs=32
+    fi
+
+    os_version=$(. /etc/os-release && printf '%s-%s' "$ID" "$VERSION_ID")
+    python_abi=$(python3 -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')
+    rocm_version=$(sed -n '1p' /opt/rocm/.info/version 2>/dev/null || true)
+    if [[ -z "$rocm_version" ]]; then
+        rocm_version=$(hipconfig --version)
+    fi
+    rocm_version=${rocm_version//[^[:alnum:]._-]/_}
+    local hf_hub_cache="${HF_HUB_CACHE:-${MODEL_DIR}/.cache/huggingface/hub}"
+    cache_root="${hf_hub_cache}/inferencex/mooncake"
+    cache_key="${mooncake_tag}-${os_version}-${python_abi}-${rocm_version}-$(uname -m)-hip"
+    cache_archive="$cache_root/$cache_key.tar.gz"
+    mkdir -p "$cache_root"
+
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential cmake git libasio-dev libboost-dev libcurl4-openssl-dev \
+        libgflags-dev libgoogle-glog-dev libibverbs-dev libjsoncpp-dev \
+        libnuma-dev libpython3-dev libssl-dev libunwind-dev liburing-dev \
+        libxxhash-dev libyaml-cpp-dev libzstd-dev ninja-build pybind11-dev
+
+    exec 9>"$cache_archive.lock"
+    flock -w 1800 9
+    if [[ -f "$cache_archive" ]] && ! tar -tzf "$cache_archive" >/dev/null 2>&1; then
+        rm -f "$cache_archive"
+    fi
+    if [[ ! -f "$cache_archive" ]]; then
+        echo "[Mooncake] Building HIP cache artifact: $cache_archive"
+        rm -rf "$mooncake_src" "$mooncake_stage"
+        git clone --depth 1 --branch "$mooncake_tag" --recurse-submodules \
+            --shallow-submodules https://github.com/kvcache-ai/Mooncake.git "$mooncake_src"
+        cmake -S "$mooncake_src/extern/yalantinglibs" \
+            -B "$mooncake_src/extern/yalantinglibs/build" \
+            -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=OFF
+        cmake --build "$mooncake_src/extern/yalantinglibs/build" -j "$build_jobs"
+        cmake --install "$mooncake_src/extern/yalantinglibs/build"
+        cmake -S "$mooncake_src" -B "$mooncake_src/build" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=OFF -DUSE_HIP=ON \
+            -DWITH_EP=OFF -DWITH_STORE=ON -DWITH_STORE_RUST=OFF \
+            -DWITH_RUST_EXAMPLE=OFF -DBUILD_EXAMPLES=OFF -DBUILD_UNIT_TESTS=OFF
+        cmake --build "$mooncake_src/build" -j "$build_jobs"
+        mkdir -p "$mooncake_stage"
+        DESTDIR="$mooncake_stage" cmake --install "$mooncake_src/build"
+        cache_tmp=$(mktemp "$cache_root/$cache_key.tmp.XXXXXX")
+        tar -C "$mooncake_stage" -czf "$cache_tmp" .
+        mv -f "$cache_tmp" "$cache_archive"
+    else
+        echo "[Mooncake] Using HIP cache artifact: $cache_archive"
+    fi
+    tar -C / -xzf "$cache_archive"
+    engine_path=$(python3 -c 'import mooncake.engine; print(mooncake.engine.__file__)')
+    ldd "$engine_path" | grep -q 'libamdhip64.so'
+    exec 9>&-
+}
+
+# MiniMax-M3 agentic DRAM offload: per-node mooncake_master + MooncakeStoreConnector.
+# MoRIIOConnector still handles P/D transfer via vLLM MultiConnector.
+ensure_mooncake_kv_offload() {
+    local tp_size="$1"
+    if [[ "${KV_OFFLOADING:-none}" != "dram" || "${KV_OFFLOAD_BACKEND:-}" != "mooncake" ]]; then
+        return 0
+    fi
+    if [[ -n "${MOONCAKE_SETUP_DONE:-}" ]]; then
+        return 0
+    fi
+    if [[ ! "${TOTAL_CPU_DRAM_GB:-}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: KV_OFFLOADING=dram with KV_OFFLOAD_BACKEND=mooncake requires positive TOTAL_CPU_DRAM_GB" >&2
+        exit 1
+    fi
+    if ! python3 -c "from mooncake.store import MooncakeDistributedStore" >/dev/null 2>&1; then
+        install_mooncake_rocm
+    fi
+    python3 -c "from mooncake.store import MooncakeDistributedStore" >/dev/null
+
+    local per_rank_gb=$((TOTAL_CPU_DRAM_GB / tp_size))
+    MOONCAKE_MASTER_PORT=$((SERVER_PORT + 12000))
+    MOONCAKE_CONFIG_PATH="/run_logs/slurm_job-${SLURM_JOB_ID}/mooncake_config_${host_name}.json"
+    mkdir -p "$(dirname "$MOONCAKE_CONFIG_PATH")"
+    cat > "$MOONCAKE_CONFIG_PATH" <<EOF
+{
+  "mode": "embedded",
+  "metadata_server": "P2PHANDSHAKE",
+  "master_server_address": "127.0.0.1:${MOONCAKE_MASTER_PORT}",
+  "global_segment_size": "${per_rank_gb}GB",
+  "local_buffer_size": "4GB",
+  "protocol": "tcp",
+  "device_name": "",
+  "enable_offload": false
+}
+EOF
+    export MOONCAKE_CONFIG_PATH PYTHONHASHSEED=0 MC_SLICE_SIZE=1048576
+    export MC_TCP_ENABLE_CONNECTION_POOL=1
+
+    local transfer_batch_keys_log="off"
+    local mc_workers_log="default"
+    if [[ -n "${INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS:-}" ]]; then
+        export MC_WORKERS_PER_CTX="${MC_WORKERS_PER_CTX:-4}"
+        transfer_batch_keys_log="${INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS}"
+        mc_workers_log="${MC_WORKERS_PER_CTX}"
+
+        MOONCAKE_BATCH_PATCH_SCRIPT="$(dirname "${BASH_SOURCE[0]}")/patches/apply_vllm_mooncake_transfer_batches.py"
+        if [[ ! -f "$MOONCAKE_BATCH_PATCH_SCRIPT" ]]; then
+            echo "ERROR: Mooncake transfer batch patch missing: $MOONCAKE_BATCH_PATCH_SCRIPT" >&2
+            exit 1
+        fi
+        python3 "$MOONCAKE_BATCH_PATCH_SCRIPT"
+    fi
+
+    local mooncake_master_cmd="mooncake_master --port ${MOONCAKE_MASTER_PORT} --default_kv_lease_ttl=120s --eviction_high_watermark_ratio=0.80 --eviction_ratio=0.10"
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "DRY RUN: $mooncake_master_cmd"
+    else
+        MOONCAKE_MASTER_LOG="/run_logs/slurm_job-${SLURM_JOB_ID}/mooncake_master_${host_name}.log"
+        $mooncake_master_cmd > "$MOONCAKE_MASTER_LOG" 2>&1 &
+        MOONCAKE_MASTER_PID=$!
+        sleep 2
+        kill -0 "$MOONCAKE_MASTER_PID"
+    fi
+
+    echo "Applied Mooncake DRAM KV offload on ${host_name}: TOTAL_CPU_DRAM_GB=${TOTAL_CPU_DRAM_GB} tp=${tp_size} per_rank=${per_rank_gb}GB master_port=${MOONCAKE_MASTER_PORT} transfer_batch_keys=${transfer_batch_keys_log} mc_workers_per_ctx=${mc_workers_log}"
+    MOONCAKE_SETUP_DONE=1
+}
+
+build_kv_transfer_config_json() {
+    local mori_role="$1"
+    if [[ "${KV_OFFLOADING:-none}" == "dram" && "${KV_OFFLOAD_BACKEND:-}" == "mooncake" ]]; then
+        NODE0_ADDR="$NODE0_ADDR" PROXY_PING_PORT="$PROXY_PING_PORT" SERVER_PORT="$SERVER_PORT" \
+            MORI_KV_ROLE="$mori_role" python3 -c '
+import json, os
+
+mori_extra = {
+    "proxy_ip": os.environ["NODE0_ADDR"],
+    "proxy_ping_port": os.environ["PROXY_PING_PORT"],
+    "http_port": os.environ["SERVER_PORT"],
+    "read_mode": True,
+}
+print(json.dumps({
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+        "connectors": [
+            {
+                "kv_connector": "MoRIIOConnector",
+                "kv_role": os.environ["MORI_KV_ROLE"],
+                "kv_load_failure_policy": "fail",
+                "kv_connector_extra_config": mori_extra,
+            },
+            {
+                "kv_connector": "MooncakeStoreConnector",
+                "kv_role": "kv_both",
+                "kv_connector_extra_config": {
+                    "load_async": True,
+                    "lookup_async": True,
+                },
+            },
+        ],
+    },
+}))
+'
+        return
+    fi
+
+    cat <<EOF
+{"kv_connector": "MoRIIOConnector", "kv_role": "${mori_role}", "kv_connector_extra_config": {"proxy_ip": "${NODE0_ADDR}", "proxy_ping_port": "${PROXY_PING_PORT}", "http_port": "${SERVER_PORT}", "read_mode": true}}
+EOF
+}
+
+if [[ "${KV_OFFLOADING:-none}" == "dram" && "${KV_OFFLOAD_BACKEND:-}" == "native" ]]; then
+    echo "ERROR: KV_OFFLOAD_BACKEND=native is not supported for vLLM disagg (use mooncake for MiniMax-M3 agentic DRAM offload)" >&2
+    exit 1
+fi
+
+# vLLM #46240: skip stale KV xfer completions instead of assert-killing EngineCore.
+# https://github.com/vllm-project/vllm/issues/46240
+if [[ "${VLLM_PATCH_46240:-${KV_OFFLOADING:-none}}" == "dram" || "${VLLM_PATCH_46240:-}" == "1" ]]; then
+    PATCH_SCRIPT="$(dirname "${BASH_SOURCE[0]}")/patches/apply_vllm_46240_scheduler_patch.py"
+    if [[ ! -f "$PATCH_SCRIPT" ]]; then
+        echo "ERROR: VLLM_PATCH_46240 enabled but missing $PATCH_SCRIPT" >&2
+        exit 1
+    fi
+    python3 "$PATCH_SCRIPT"
+fi
 
 # =============================================================================
 # Container Synchronization
@@ -217,6 +484,23 @@ done
 echo "Prefill node IPs: ${PREFILL_ARGS}"
 echo "Decode  node IPs: ${DECODE_ARGS}"
 
+# Per-worker Prometheus /metrics and cache-flush base URLs for agentic replay.
+# vLLM workers listen on SERVER_PORT; the vllm-router on ROUTER_PORT does not
+# expose Prometheus or fan out cache resets.
+SERVER_METRICS_URLS=()
+SERVER_FLUSH_URLS=()
+for ((i=0; i<xP && i<${#IP_ARRAY[@]}; i++)); do
+    SERVER_METRICS_URLS+=("http://${IP_ARRAY[$i]}:${SERVER_PORT}/metrics")
+    SERVER_FLUSH_URLS+=("http://${IP_ARRAY[$i]}:${SERVER_PORT}")
+done
+for ((i=0; i<yD; i++)); do
+    idx=$((xP + i))
+    if (( idx < ${#IP_ARRAY[@]} )); then
+        SERVER_METRICS_URLS+=("http://${IP_ARRAY[$idx]}:${SERVER_PORT}/metrics")
+        SERVER_FLUSH_URLS+=("http://${IP_ARRAY[$idx]}:${SERVER_PORT}")
+    fi
+done
+
 # MoRI-IO proxy ZMQ registration port (must match vllm-router --vllm-discovery-address)
 PROXY_PING_PORT="${PROXY_PING_PORT:-36367}"
 
@@ -250,6 +534,8 @@ if [ "$NODE_RANK" -eq 0 ]; then
     echo "================================================"
 
     setup_vllm_env
+    ensure_mooncake_kv_offload "$PREFILL_TP_SIZE"
+    KV_TRANSFER_JSON=$(build_kv_transfer_config_json kv_producer)
 
     # Router is started as an external container by job.slurm (VLLM_ROUTER_IMAGE)
     echo "Using external vllm-router container (started by job.slurm on this node)"
@@ -259,7 +545,7 @@ if [ "$NODE_RANK" -eq 0 ]; then
         --served-model-name ${SERVED_MODEL} \
         --port $SERVER_PORT \
         --trust-remote-code \
-        --kv-transfer-config '{\"kv_connector\": \"MoRIIOConnector\", \"kv_role\": \"kv_producer\", \"kv_connector_extra_config\": {\"proxy_ip\": \"${NODE0_ADDR}\", \"proxy_ping_port\": \"${PROXY_PING_PORT}\", \"http_port\": \"${SERVER_PORT}\", \"read_mode\": true}}' \
+        --kv-transfer-config '${KV_TRANSFER_JSON}' \
         ${PREFILL_SERVER_CONFIG}"
 
     if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -305,10 +591,31 @@ if [ "$NODE_RANK" -eq 0 ]; then
     cd $WS_PATH
 
     export ROUTER_PORT=$ROUTER_PORT
-    BENCH_CMD="bash $WS_PATH/bench.sh ${xP} ${yD} $((PREFILL_TP_SIZE*xP)) $((DECODE_TP_SIZE*yD)) \
-        $MODEL_DIR $MODEL_NAME /run_logs/slurm_job-${SLURM_JOB_ID} ${BENCH_INPUT_LEN} \
-        ${BENCH_OUTPUT_LEN} \"${BENCH_MAX_CONCURRENCY}\" ${BENCH_REQUEST_RATE} \
-        ${BENCH_RANDOM_RANGE_RATIO} ${BENCH_NUM_PROMPTS_MULTIPLIER}"
+
+    # IS_AGENTIC=1/true  → agentic trace replay (trace_replay.sh)
+    # IS_AGENTIC unset/0 → fixed-seq-len throughput benchmark (bench.sh)
+    if [[ "${IS_AGENTIC:-0}" == "1" || "${IS_AGENTIC:-}" == "true" ]]; then
+        if [[ "${ENABLE_METRICS:-0}" == "1" && "${#SERVER_METRICS_URLS[@]}" -gt 0 ]]; then
+            AIPERF_SERVER_METRICS_URLS=$(IFS=,; echo "${SERVER_METRICS_URLS[*]}")
+            export AIPERF_SERVER_METRICS_URLS
+            echo "AIPERF_SERVER_METRICS_URLS=${AIPERF_SERVER_METRICS_URLS}"
+        fi
+        if [[ "${#SERVER_FLUSH_URLS[@]}" -gt 0 ]]; then
+            SERVER_FLUSH_URLS_CSV=$(IFS=,; echo "${SERVER_FLUSH_URLS[*]}")
+            export SERVER_FLUSH_URLS_CSV
+            echo "SERVER_FLUSH_URLS_CSV=${SERVER_FLUSH_URLS_CSV}"
+        fi
+        export ENGINE="${FRAMEWORK:-vllm-disagg}"
+        BENCH_CMD="bash $WS_PATH/trace_replay.sh \
+            $MODEL_DIR $MODEL_NAME $BENCH_MAX_CONCURRENCY /run_logs/slurm_job-${SLURM_JOB_ID}"
+        echo "Benchmark runner: trace_replay.sh (agentic, KV_OFFLOADING=${KV_OFFLOADING:-none}, CONC=${BENCH_MAX_CONCURRENCY})"
+    else
+        BENCH_CMD="bash $WS_PATH/bench.sh ${xP} ${yD} $((PREFILL_TP_SIZE*xP)) $((DECODE_TP_SIZE*yD)) \
+            $MODEL_DIR $MODEL_NAME /run_logs/slurm_job-${SLURM_JOB_ID} ${BENCH_INPUT_LEN} \
+            ${BENCH_OUTPUT_LEN} \"${BENCH_MAX_CONCURRENCY}\" ${BENCH_REQUEST_RATE} \
+            ${BENCH_RANDOM_RANGE_RATIO} ${BENCH_NUM_PROMPTS_MULTIPLIER}"
+        echo "Benchmark runner: bench.sh (fixed-seq-len)"
+    fi
 
     if [[ "${EVAL_ONLY:-false}" == "true" ]]; then
         echo "EVAL_ONLY mode: skipping throughput benchmark"
@@ -419,13 +726,15 @@ elif [ "$NODE_RANK" -gt 0 ] && [ "$NODE_RANK" -lt "$xP" ]; then
     echo "Using prefill config: $PREFILL_SERVER_CONFIG"
 
     setup_vllm_env
+    ensure_mooncake_kv_offload "$PREFILL_TP_SIZE"
+    KV_TRANSFER_JSON=$(build_kv_transfer_config_json kv_producer)
 
     SERVED_MODEL="${MODEL_NAME}"
     PREFILL_CMD="vllm serve ${MODEL_PATH} \
         --served-model-name ${SERVED_MODEL} \
         --port $SERVER_PORT \
         --trust-remote-code \
-        --kv-transfer-config '{\"kv_connector\": \"MoRIIOConnector\", \"kv_role\": \"kv_producer\", \"kv_connector_extra_config\": {\"proxy_ip\": \"${NODE0_ADDR}\", \"proxy_ping_port\": \"${PROXY_PING_PORT}\", \"http_port\": \"${SERVER_PORT}\", \"read_mode\": true}}' \
+        --kv-transfer-config '${KV_TRANSFER_JSON}' \
         ${PREFILL_SERVER_CONFIG}"
 
     if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -470,6 +779,8 @@ else
     echo "Using decode config: $DECODE_SERVER_CONFIG"
 
     setup_vllm_env
+    ensure_mooncake_kv_offload "$DECODE_TP_SIZE"
+    KV_TRANSFER_JSON=$(build_kv_transfer_config_json kv_consumer)
 
     for env_pair in ${DECODE_MODEL_ENVS}; do
         export "$env_pair"
@@ -481,7 +792,7 @@ else
         --served-model-name ${SERVED_MODEL} \
         --port $SERVER_PORT \
         --trust-remote-code \
-        --kv-transfer-config '{\"kv_connector\": \"MoRIIOConnector\", \"kv_role\": \"kv_consumer\", \"kv_connector_extra_config\": {\"proxy_ip\": \"${NODE0_ADDR}\", \"proxy_ping_port\": \"${PROXY_PING_PORT}\", \"http_port\": \"${SERVER_PORT}\", \"read_mode\": true}}' \
+        --kv-transfer-config '${KV_TRANSFER_JSON}' \
         ${DECODE_SERVER_CONFIG}"
 
     if [[ "$DRY_RUN" -eq 1 ]]; then

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1694,6 +1694,52 @@ minimaxm3-fp4-mi355x-vllm-disagg:
           dp-attn: false
           additional-settings:
           - "DECODE_NODES=1"
+
+# MiniMax-M3 MXFP4 MI355X vLLM disaggregated agentic (1P1D TP8, Mooncake DRAM KV offload).
+# Mooncake v0.3.11.post1 is installed at job runtime by server_vllm.sh (not baked into image).
+minimaxm3-fp4-mi355x-vllm-disagg-agentic:
+  image: rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625
+  model: amd/MiniMax-M3-MXFP4
+  model-prefix: minimaxm3
+  runner: cluster:mi355x-amds
+  precision: fp4
+  framework: vllm-disagg
+  router: { name: vllm-router, version: "0.1.14" }
+  kv-p2p-transfer: moriio
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - spec-decoding: "none"
+        conc-list: [ 2, 4, 8, 16, 32 ]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "GPU_MEMORY_UTILIZATION=0.9"
+          - "VLLM_PATCH_46240=1"
+          - "HF_HUB_CACHE=/models/.cache/huggingface/hub"
+          - "INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=32"
+          - "MC_WORKERS_PER_CTX=4"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "VLLM_PATCH_46240=1"
+          - "HF_HUB_CACHE=/models/.cache/huggingface/hub"
+          - "INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=32"
+          - "MC_WORKERS_PER_CTX=4"
+
 # MiniMax-M3 MXFP4 MI355X vLLM recipe. The pinned nightly includes upstream
 # MiniMax-M3 Quark MXFP4 support (vllm-project/vllm#45794). Use the text-only
 # language-model path and mirror the MXFP8 MI355X search space for a direct

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1736,7 +1736,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
 # MiniMax-M3 MXFP4 MI355X vLLM disaggregated agentic (1P1D TP8, Mooncake DRAM KV offload).
 # Mooncake v0.3.11.post1 is installed at job runtime by server_vllm.sh (not baked into image).
 minimaxm3-fp4-mi355x-vllm-disagg-agentic:
-  image: rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625
+  image: vllm/vllm-openai-rocm:nightly-dd72658e7db0c6a674f473f6f9f0f5c2ebe7e523
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5028,3 +5028,10 @@
     - "Topologies: 1p4d-dep4-tep8 (conc 4/24), 1p5d-dep4-tep4 (conc 5/30/60/115/195), 1p1d-dep4-dep8 (conc 308), 2p1d-dep4-dep8 (conc 615), 3p1d-dep4-dep8 (conc 1127), 4p1d-dep4-dep8 (conc 2151)"
     - "Runner updated to clone srt-slurm at sa-submission-q2-2026 and copy local recipes into recipes/trtllm/kimi-k25-nvfp4/b200-fp4/"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2249
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm-disagg-agentic
+  description:
+    - "Add MiniMax-M3 MXFP4 MI355X vLLM disaggregated agentic recipe (1P1D TP8, Mooncake DRAM KV offload, batch32 transfer patch)"
+    - "Image: rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625; Mooncake v0.3.11.post1 at runtime (server_vllm.sh); conc-list [2, 4, 8, 16, 32]; VLLM_PATCH_46240 + INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=32"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5034,4 +5034,4 @@
   description:
     - "Add MiniMax-M3 MXFP4 MI355X vLLM disaggregated agentic recipe (1P1D TP8, Mooncake DRAM KV offload, batch32 transfer patch)"
     - "Image: rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625; Mooncake v0.3.11.post1 at runtime (server_vllm.sh); conc-list [2, 4, 8, 16, 32]; VLLM_PATCH_46240 + INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS=32"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2326


### PR DESCRIPTION
## Summary

- Add `minimaxm3-fp4-mi355x-vllm-disagg-agentic` to `amd-master.yaml`: MiniMax-M3 MXFP4 on MI355X, 1P1D TP8 disaggregated vLLM with Mooncake DRAM KV offload, agentic-coding scenario, `conc-list` [2, 4, 8, 16, 32].
- Add launcher `benchmarks/multi_node/agentic/minimaxm3_fp4_mi355x_vllm-disagg.sh` (CI-style sibling of the fixed-seq disagg recipe).
- Extend `server_vllm.sh` for Mooncake runtime install (v0.3.11.post1), MultiConnector + MoRIIO P/D KV transfer, and MiniMax-M3 MXFP4 bring-up on ROCm.
- Add runtime patches:
  - `apply_vllm_46240_scheduler_patch.py` — skip stale async KV recv/send completions (vllm-project/vllm#46240).
  - `apply_vllm_mooncake_transfer_batches.py` — raise Mooncake max transfer batch keys (default 32 via `INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS`).
- Wire `job.slurm` for the new agentic vLLM-disagg path; append `perf-changelog.yaml` entry.

**Image:** `rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625`  
**Model:** `amd/MiniMax-M3-MXFP4`  
**KV offload:** MooncakeStoreConnector (DRAM, `kv-offload-backend: mooncake v0.3.11.post1`)

## 中文说明

- 在 `amd-master.yaml` 新增 `minimaxm3-fp4-mi355x-vllm-disagg-agentic`：MI355X 上 MiniMax-M3 MXFP4 的 1P1D TP8 分离式 vLLM，配合 Mooncake DRAM KV 卸载，agentic-coding 场景，`conc-list` 为 [2, 4, 8, 16, 32]。
- 新增启动脚本 `benchmarks/multi_node/agentic/minimaxm3_fp4_mi355x_vllm-disagg.sh`（与 fixed-seq 分离式 recipe 对应的 CI 入口）。
- 扩展 `server_vllm.sh`：运行时安装 Mooncake（v0.3.11.post1）、MultiConnector + MoRIIO P/D KV 传输，以及 ROCm 上 MiniMax-M3 MXFP4 的 bring-up。
- 新增运行时 patch：
  - `apply_vllm_46240_scheduler_patch.py` — 跳过过期的 async KV recv/send 完成事件（vllm-project/vllm#46240）。
  - `apply_vllm_mooncake_transfer_batches.py` — 提高 Mooncake max transfer batch keys（默认 32，`INFERENCEX_MOONCAKE_MAX_TRANSFER_BATCH_KEYS`）。
- 更新 `job.slurm` 以支持 agentic vLLM-disagg 路径；在 `perf-changelog.yaml` 末尾追加 changelog 条目。

**镜像：** `rocm/vllm-dev:vllm-0.23.1-rocm723-mi35x-mori-0625`  
**模型：** `amd/MiniMax-M3-MXFP4`  
**KV 卸载：** MooncakeStoreConnector（DRAM，`kv-offload-backend: mooncake v0.3.11.post1`）