### PR TITLE
Proposal (Unofficial, not merge-ready): DeepSeek-V4-Flash 4xH200 SGLang MTP recipe / 提案（非官方，尚不可合并）：DeepSeek-V4-Flash 4×H200 SGLang MTP 配方

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4flash_fp8_h200_sglang_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4flash_fp8_h200_sglang_mtp.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Unofficial DeepSeek-V4-Flash 4xH200 recipe. The topology and checkpoint are
+# adapted from the public SGLang Hopper cookbook recipe to the smaller Flash
+# checkpoint: TP4, Marlin W4A16 MoE runner, EAGLE (3 steps, top-k 1, 4 draft
+# tokens). Server flags follow the sibling dsv4_fp8_h200_sglang_mtp.sh recipe.
+# Proposal status: Unofficial pending maintainer scope confirmation, a full green
+# upstream H200 sweep/evals, NVIDIA CODEOWNER sign-off, and /reuse-sweep-run.
+#
+# The checkpoint revision is pinned so an Unofficial proposal stays reproducible
+# while DeepSeek-V4-Flash is still being revised on the Hub.
+MODEL_REVISION="60d8d70770c6776ff598c94bb586a859a38244f1"
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    ISL \
+    OSL \
+    RANDOM_RANGE_RATIO \
+    RESULT_FILENAME
+
+if [[ -n "$SLURM_JOB_ID" ]]; then
+  echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+if [[ "$MODEL" != /* ]]; then hf download "$MODEL" --revision "$MODEL_REVISION" --exclude "*.md"; fi
+
+nvidia-smi
+
+SERVER_LOG="$PWD/server.log"
+
+echo "TP: $TP, CONC: $CONC, ISL: $ISL, OSL: $OSL"
+
+EVAL_CONTEXT_ARGS=""
+if [ "${EVAL_ONLY}" = "true" ]; then
+    setup_eval_context
+    EVAL_CONTEXT_ARGS="--context-length $EVAL_MAX_MODEL_LEN"
+fi
+
+start_gpu_monitor --output "$PWD/gpu_metrics.csv"
+
+set -x
+PYTHONNOUSERSITE=1 sglang serve \
+    --model-path $MODEL \
+    --revision "$MODEL_REVISION" \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --trust-remote-code \
+    --tp $TP \
+    --moe-runner-backend marlin \
+    --chunked-prefill-size 4096 \
+    --disable-flashinfer-autotune \
+    --disable-radix-cache \
+    --mem-fraction-static 0.88 \
+    --max-running-requests "$(( CONC * 3 / 2 > 8 ? CONC * 3 / 2 : 8 ))" \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    $EVAL_CONTEXT_ARGS >> $SERVER_LOG 2>&1 &
+
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+pip install -q datasets pandas
+
+# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
+# <bos><User>...<Assistant><think> framing the DeepSeek-V4 family expects. The
+# DeepSeek-V4-Flash tokenizer ships without a jinja chat_template, so plain
+# --use-chat-template would crash; --dsv4 sidesteps that and satisfies the
+# AGENTS.md rule that all MTP scripts must benchmark against chat-formatted
+# inputs (EAGLE acceptance silently regresses on raw random tokens). This
+# mirrors the existing dsv4_fp8_h200_sglang_mtp.sh recipe.
+run_benchmark_serving \
+    --model "$MODEL" \
+    --port "$PORT" \
+    --backend vllm \
+    --input-len "$ISL" \
+    --output-len "$OSL" \
+    --random-range-ratio "$RANDOM_RANGE_RATIO" \
+    --num-prompts $((CONC * 10)) \
+    --max-concurrency "$CONC" \
+    --result-filename "$RESULT_FILENAME" \
+    --result-dir "$PWD/" \
+    --dsv4
+
+if [ "${RUN_EVAL}" = "true" ]; then
+    run_eval --framework lm-eval --port "$PORT"
+    append_lm_eval_summary
+fi
+
+stop_gpu_monitor
+set +x

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1641,6 +1641,29 @@ dsr1-fp8-h200-sglang-mtp:
       search-space:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
+# Unofficial DeepSeek-V4-Flash 4xH200 recipe on the stock checkpoint, adapted
+# from the public SGLang Hopper TP4 + Marlin + EAGLE (3/1/4) recommendation.
+# Precision is labelled fp8 to match the sibling dsv4-fp8-h200-sglang-mtp entry:
+# every H200 DeepSeek-V4 config in this file serves the stock checkpoint (which
+# declares quant_method fp8) through the Marlin W4A16 MoE runner. The SGLang
+# cookbook calls this same Hopper path "original FP4"; happy to rename the key
+# to dsv4flash-fp4-h200-sglang-mtp if maintainers prefer the cookbook taxonomy.
+# Proposal remains Unofficial pending maintainer scope confirmation and required gates.
+dsv4flash-fp8-h200-sglang-mtp:
+  image: lmsysorg/sglang:v0.5.15.post1@sha256:289cf51da1e5fd6f8eb3231f0202d46800c2e241ecf28f68a5a51507ed928e31
+  model: deepseek-ai/DeepSeek-V4-Flash
+  model-prefix: dsv4flash
+  runner: h200-dgxc
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128, spec-decoding: mtp }
+
 # DeepSeek-V4-Pro H200 recipe from https://vllm.ai/blog/deepseek-v4
 # Uses the cu129 image. H200 has no FP4 path, so the FP4 indexer cache
 # flag is omitted. Max-model-len is pinned at 800k per the recipe.

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5122,4 +5122,4 @@
   description:
     - "Proposal only (Unofficial): add DeepSeek-V4-Flash on 4xH200 with SGLang TP4, Marlin W4A16 MoE runner, and EAGLE 3 steps / top-k 1 / 4 draft tokens; stock checkpoint revision 60d8d70770c6776ff598c94bb586a859a38244f1 and image digest sha256:289cf51da1e5fd6f8eb3231f0202d46800c2e241ecf28f68a5a51507ed928e31 are pinned"
     - "Preserve InferenceX 8k1k semantics and the intended full concurrency sweep [1, 2, 4, 8, 16, 32, 64, 128]; upstream H200 sweep/evals, NVIDIA CODEOWNER sign-off, and authorized /reuse-sweep-run remain required"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PR_NUMBER
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2329

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5116,3 +5116,10 @@
   description:
     - "Bump image from lmsysorg/sglang:v0.5.14-rocm720-mi35x to lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2349
+
+- config-keys:
+    - dsv4flash-fp8-h200-sglang-mtp
+  description:
+    - "Proposal only (Unofficial): add DeepSeek-V4-Flash on 4xH200 with SGLang TP4, Marlin W4A16 MoE runner, and EAGLE 3 steps / top-k 1 / 4 draft tokens; stock checkpoint revision 60d8d70770c6776ff598c94bb586a859a38244f1 and image digest sha256:289cf51da1e5fd6f8eb3231f0202d46800c2e241ecf28f68a5a51507ed928e31 are pinned"
+    - "Preserve InferenceX 8k1k semantics and the intended full concurrency sweep [1, 2, 4, 8, 16, 32, 64, 128]; upstream H200 sweep/evals, NVIDIA CODEOWNER sign-off, and authorized /reuse-sweep-run remain required"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PR_NUMBER

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -2,6 +2,7 @@
 import pytest
 import argparse
 import copy
+from pathlib import Path
 from generate_sweep_configs import (
     MIN_EVAL_CONC,
     seq_len_stoi,
@@ -172,6 +173,72 @@ def full_sweep_args_multi_node():
     args.single_node = False
     args.multi_node = True
     return args
+
+
+@pytest.fixture
+def dsv4flash_h200_config():
+    """Unofficial DeepSeek-V4-Flash H200 proposal config."""
+    return {
+        "dsv4flash-fp8-h200-sglang-mtp": {
+            "image": "lmsysorg/sglang:v0.5.15.post1@sha256:289cf51da1e5fd6f8eb3231f0202d46800c2e241ecf28f68a5a51507ed928e31",
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "model-prefix": "dsv4flash",
+            "runner": "h200-dgxc",
+            "precision": "fp8",
+            "framework": "sglang",
+            "multinode": False,
+            "scenarios": {
+                "fixed-seq-len": [{
+                    "isl": 8192,
+                    "osl": 1024,
+                    "search-space": [{
+                        "tp": 4, "ep": 1, "conc-start": 1, "conc-end": 128,
+                        "spec-decoding": "mtp",
+                    }],
+                }],
+            },
+        },
+    }
+
+
+def test_dsv4flash_h200_proposal_generates_full_8k1k_sweep(
+    dsv4flash_h200_config, sample_runner_config, full_sweep_args_single_node
+):
+    """Proposal keeps exact model identity, topology, and c1..128 matrix."""
+    result = generate_full_sweep(
+        full_sweep_args_single_node, dsv4flash_h200_config, sample_runner_config
+    )
+
+    assert [entry["conc"] for entry in result] == [1, 2, 4, 8, 16, 32, 64, 128]
+    assert {entry["model"] for entry in result} == {"deepseek-ai/DeepSeek-V4-Flash"}
+    assert {entry["model-prefix"] for entry in result} == {"dsv4flash"}
+    assert {entry["precision"] for entry in result} == {"fp8"}
+    assert {entry["framework"] for entry in result} == {"sglang"}
+    assert {entry["isl"] for entry in result} == {8192}
+    assert {entry["osl"] for entry in result} == {1024}
+    assert {entry["tp"] for entry in result} == {4}
+    assert {entry["ep"] for entry in result} == {1}
+    assert {entry["spec-decoding"] for entry in result} == {"mtp"}
+    # The image must stay digest-pinned so an Unofficial proposal is reproducible.
+    assert all("@sha256:" in entry["image"] for entry in result)
+
+
+def test_dsv4flash_h200_proposal_benchmark_script_exists(dsv4flash_h200_config):
+    """The H200 launchers derive the script path from the generated fields.
+
+    launch_h200-dgxc-slurm.sh builds
+    benchmarks/single_node/fixed_seq_len/<model-prefix>_<precision>_h200_<framework>_mtp.sh,
+    so renaming the config key or precision without renaming the script silently
+    breaks the sweep at launch time rather than at validation time.
+    """
+    config = dsv4flash_h200_config["dsv4flash-fp8-h200-sglang-mtp"]
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "benchmarks/single_node/fixed_seq_len"
+        / f"{config['model-prefix']}_{config['precision']}_h200_{config['framework']}_mtp.sh"
+    )
+
+    assert script.is_file(), f"missing benchmark script: {script}"
 
 
 # =============================================================================


### PR DESCRIPTION
> **Not merge-ready.** This is an external community proposal opened for scope confirmation and maintainer sponsorship. It claims **no benchmark numbers**. Please do not merge until the gates in "Outstanding gates" below are satisfied.

## Description

Adds an **Unofficial**, proposal-only single-node recipe for **DeepSeek-V4-Flash** on **4xH200** with SGLang:

- **TP4**, `--moe-runner-backend marlin` (W4A16), **EAGLE** speculative decoding: 3 steps / top-k 1 / 4 draft tokens
- Image **digest-pinned**: `lmsysorg/sglang:v0.5.15.post1@sha256:289cf51da1e5fd6f8eb3231f0202d46800c2e241ecf28f68a5a51507ed928e31` (upstream `lmsysorg` Docker Hub, unmodified — no engine patching)
- Checkpoint **revision-pinned**: `deepseek-ai/DeepSeek-V4-Flash` @ `60d8d70770c6776ff598c94bb586a859a38244f1`
- Topology adapted from the public SGLang Hopper cookbook recommendation; server flags mirror the existing `dsv4_fp8_h200_sglang_mtp.sh` sibling

Benchmark semantics are stock InferenceX, unchanged: **8192 ISL / 1024 OSL**, deterministic random tokens, ignore-EOS, `10 x concurrency` measured requests, and the full **c1..128** sweep (`1, 2, 4, 8, 16, 32, 64, 128`), with evals marked at c64/c128 by the existing `mark_eval_entries()` logic.

### Files changed

| File | Change |
|---|---|
| `benchmarks/single_node/fixed_seq_len/dsv4flash_fp8_h200_sglang_mtp.sh` | new benchmark script |
| `configs/nvidia-master.yaml` | new `dsv4flash-fp8-h200-sglang-mtp` entry |
| `perf-changelog.yaml` | one entry appended at EOF |
| `utils/matrix_logic/test_generate_sweep_configs.py` | 2 new tests |

## Related Issue

Proposal issue: #2315

## Type of Change

- [x] New feature
- [x] Configuration change

## Two decisions I would like maintainers to confirm

**1. Is DeepSeek-V4-Flash in scope at all?** PR #1135 was previously closed in favour of DeepSeek-V4-Pro. If Flash is still out of scope, say so and I will close this and the issue — I do not want to consume review time on an unwanted model. Everything below only matters if Flash is in scope.

**2. `fp8` vs `fp4` in the config key.** I labelled this `dsv4flash-fp8-h200-sglang-mtp` (`precision: fp8`) to match the existing `dsv4-fp8-h200-sglang-mtp` sibling: every H200 DeepSeek-V4 entry in `nvidia-master.yaml` serves the stock checkpoint (which declares `quant_method: fp8`) through the Marlin runner, and the neighbouring comment already notes "H200 has no FP4 path". The SGLang cookbook calls this same Hopper path "original FP4", so the two taxonomies disagree. Happy to rename to `dsv4flash-fp4-h200-sglang-mtp` if you prefer the cookbook naming — note the key, `precision`, and the script filename must move together, because the H200 launchers derive the script path as `<model-prefix>_<precision>_h200_<framework>_mtp.sh`.

Related: I set `runner: h200-dgxc` rather than the broader `h200` pool, because `launch_h200-cw.sh` / `launch_h200-nb.sh` build the script name without the `_<framework>` tag and would look for a nonexistent `dsv4flash_fp8_h200_mtp.sh`. Retarget as you see fit.

## Outstanding gates (none of these are met)

Per `CONTRIBUTING.md` and `docs/PR_REVIEW_CHECKLIST.md`, this PR is **not** eligible for merge until:

- [ ] A **green full upstream H200 sweep including evals** on a commit in this PR. I have no access to the H200 runner pool, so this needs maintainer sponsorship.
- [ ] **NVIDIA CODEOWNER sign-off** (`configs/nvidia-master.yaml` → @ankur-singh / @kedarpotdar-nv / @InferenceX/core) using the current checklist template.
- [ ] A **merged SGLang cookbook recipe PR** for this exact single-node recipe. The Hopper guidance this is adapted from is published, but there is no merged cookbook PR specific to Flash on 4xH200 that I can link, and the checklist requires MERGED.
- [ ] An authorized maintainer comment of **`/reuse-sweep-run`**.
- [x] ~~`perf-changelog.yaml` `pr-link` placeholder~~ — resolved, now points at this PR.

I have deliberately **not** applied a sweep label, since I am not a maintainer and a full H200 fan-out is expensive shared GPU time. Please apply `full-sweep-fail-fast` if and when you want it to run.

## About our local numbers — diagnostic only, not part of this PR

We ran bounded 4xH200 attempts on Modal at concurrency 1, 4, and 8. Those numbers are **diagnostic and Unofficial**: hand-run on non-InferenceX infrastructure, outside the authorized runner pool, and not produced by this repository's workflow. **They are deliberately not committed** — `results/` is not a tracked directory anywhere in this repository, so committing result JSONs would be a non-workflow artifact. They are not evidence of performance and nothing in this PR depends on them; I can attach them to #2315 on request.

## Checklist

- [x] I have tested my changes locally (see below)
- [x] I have updated documentation if necessary (config + script comments; no bilingual `_zh` doc pair is affected)
- [x] **If I changed a container image or config, I have already updated `perf-changelog.yaml`**
  - [x] New `perf-changelog.yaml` entries are **appended to the end** of the file
- [ ] **Before merging via reuse, an authorized maintainer has commented `/reuse-sweep-run`** — not done, and premature: there is no green sweep yet

### Local validation

| Check | Result |
|---|---|
| `bash -n dsv4flash_fp8_h200_sglang_mtp.sh` | pass |
| `pytest utils/matrix_logic/` | 226 passed (224 existing + 2 new) |
| `pytest utils/changelog_gate_tests/ utils/test_process_changelog.py` | 89 passed |
| `utils/validate_perf_changelog.py --base-ref main` | pass, final newline present, matrix generated |
| `generate_sweep_configs.py full-sweep --model-prefix dsv4flash` | 8 entries, conc `[1,2,4,8,16,32,64,128]`, evals at c64/c128 |
| `git diff --check` | clean |
| Secret / token / ephemeral-URL scan of the diff | clean |

`perf-changelog.yaml` is append-only in this PR (7 lines added, 0 removed, no whitespace touched).

---

## 中文说明

> **尚未达到可合并状态。** 这是一个外部社区提案，目的是确认该模型是否在收录范围内并寻求维护者支持。本 PR **不声明任何基准测试数值**，在下方"仍未满足的门槛"全部完成之前请勿合并。

### 变更内容

新增 **DeepSeek-V4-Flash** 在 **4xH200** 上的**非官方（Unofficial）**单节点 SGLang 配方（仅为提案）：

- **TP4**、`--moe-runner-backend marlin`（W4A16）、**EAGLE** 投机解码：3 步 / top-k 1 / 4 个草稿 token
- 镜像按 digest 固定：`lmsysorg/sglang:v0.5.15.post1@sha256:289cf51d...`（来自上游 `lmsysorg` 官方仓库，未做任何修改，不存在对推理引擎打补丁的情况）
- 检查点按 revision 固定：`deepseek-ai/DeepSeek-V4-Flash` @ `60d8d707...`
- 拓扑参考公开的 SGLang Hopper 配方；服务端参数与现有的 `dsv4_fp8_h200_sglang_mtp.sh` 保持一致

基准测试语义完全沿用 InferenceX 现有实现，未做改动：**8192 ISL / 1024 OSL**、随机 token、ignore-EOS、`10 × 并发数` 的测量请求，以及完整的 **c1..128** 并发扫描（`1, 2, 4, 8, 16, 32, 64, 128`），评估由现有的 `mark_eval_entries()` 逻辑标记在 c64/c128。

### 希望维护者确认的两个问题

**1. DeepSeek-V4-Flash 是否在收录范围内？** 此前 PR #1135 已被关闭，转而采用 DeepSeek-V4-Pro。如果 Flash 仍不在范围内，请直接告知，我会关闭本 PR 和对应 issue，不占用额外的评审资源。

**2. 配置键使用 `fp8` 还是 `fp4`？** 我采用 `dsv4flash-fp8-h200-sglang-mtp`（`precision: fp8`），以与现有的 `dsv4-fp8-h200-sglang-mtp` 保持一致：`nvidia-master.yaml` 中所有 H200 的 DeepSeek-V4 配置都通过 Marlin 运行后端加载原始检查点（其 `quant_method` 声明为 `fp8`），且相邻注释已说明 "H200 has no FP4 path"。而 SGLang cookbook 将同一条 Hopper 路径称为 "original FP4"，两套命名口径不一致。如果维护者更倾向 cookbook 的命名，我可以改名为 `dsv4flash-fp4-h200-sglang-mtp` —— 需要注意配置键、`precision` 与脚本文件名必须同步修改，因为 H200 启动器按 `<model-prefix>_<precision>_h200_<framework>_mtp.sh` 推导脚本路径。

此外，我将 `runner` 设为 `h200-dgxc` 而非更宽泛的 `h200` 资源池：`launch_h200-cw.sh` / `launch_h200-nb.sh` 在拼接脚本名时不带 `_<framework>` 后缀，会去寻找并不存在的 `dsv4flash_fp8_h200_mtp.sh`。维护者可按需调整。

### 仍未满足的门槛（以下均未完成）

依据 `CONTRIBUTING.md` 与 `docs/PR_REVIEW_CHECKLIST.md`，本 PR 在满足以下条件前**不具备**合并资格：

- [ ] 在本 PR 的某个提交上取得**包含评估在内的、完整且全绿的上游 H200 扫描**。我无法访问 H200 运行器资源池，因此需要维护者提供运行支持。
- [ ] **NVIDIA CODEOWNER 签署**（`configs/nvidia-master.yaml` → @ankur-singh / @kedarpotdar-nv / @InferenceX/core），并使用当前版本的检查清单模板。
- [ ] 针对该单节点配方的**已合并的 SGLang cookbook 配方 PR**。本配方所参考的 Hopper 指引虽已公开，但我无法提供一个专门针对 Flash 4xH200 且已合并的 cookbook PR，而检查清单要求必须为 MERGED 状态。
- [ ] 由授权维护者评论 **`/reuse-sweep-run`**。
- [x] ~~`perf-changelog.yaml` 的 `pr-link` 占位符~~ —— 已解决，现已指向本 PR。

我特意**没有**添加任何 sweep 标签：我并非维护者，而完整的 H200 扫描会占用大量共享 GPU 资源。如需运行，请由维护者添加 `full-sweep-fail-fast`。

### 关于我们本地的测试数据——仅供诊断，不属于本 PR

我们在 Modal 上以并发 1、4、8 进行了有界的 4xH200 尝试。这些数据**仅供诊断，且为非官方（Unofficial）**：由人工在非 InferenceX 基础设施上运行，不在授权运行器资源池内，也并非由本仓库的工作流产生。**这些结果文件已刻意不提交**——`results/` 在本仓库中并非受版本控制的目录，提交结果 JSON 属于非工作流产物。它们不构成任何性能证据，本 PR 也不依赖它们；如有需要，我可以将其附在 #2315 中。

### 本地验证

`bash -n` 通过；`pytest utils/matrix_logic/` 226 项通过（224 项原有 + 2 项新增）；`pytest utils/changelog_gate_tests/` 等 89 项通过；`validate_perf_changelog.py` 通过；配置生成得到 8 条目、并发 `[1,2,4,8,16,32,64,128]`、评估位于 c64/c128；`git diff --check` 无异常；针对 diff 的密钥/令牌/临时 URL 扫描无异常。`perf-changelog.yaml` 在本 PR 中为纯追加（新增 7 行，删除 0 行，未改动任何空白字符）。
