### PR TITLE
[AMD] minimaxm3-fp4-mi355x-vllm: enable QuickReduce INT4 for all-reduce / [AMD] minimaxm3-fp4-mi355x-vllm：为 all-reduce 启用 QuickReduce INT4

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
@@ -37,11 +37,7 @@ export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
 # QuickReduce INT4, matching AITER_QUICK_REDUCE_QUANTIZATION=INT4 in the ATOM
 # recipe. Defaults to NONE, so QuickReduce was previously off entirely here.
-# The 1 MB gate overrides the built-in table (2 MB for FP16/TP4/INT4 once BF16
-# inputs are cast to FP16, which is the default) so prefill-sized all-reduces
-# qualify.
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
-export VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh
@@ -35,6 +35,13 @@ export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+# QuickReduce INT4, matching AITER_QUICK_REDUCE_QUANTIZATION=INT4 in the ATOM
+# recipe. Defaults to NONE, so QuickReduce was previously off entirely here.
+# The 1 MB gate overrides the built-in table (2 MB for FP16/TP4/INT4 once BF16
+# inputs are cast to FP16, which is the default) so prefill-sized all-reduces
+# qualify.
+export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+export VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1
 
 if [ "${EVAL_ONLY}" = "true" ]; then
     setup_eval_context

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1749,10 +1749,7 @@ minimaxm3-fp4-mi355x-vllm:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, conc-start: 1, conc-end: 64 }
-      - { tp: 8, ep: 8, conc-start: 1, conc-end: 512 }
-      - { tp: 4, conc-start: 1, conc-end: 128 }
-      - { tp: 8, ep: 8, dp-attn: true, conc-start: 128, conc-end: 512 }
+      - { tp: 4, conc-start: 1, conc-end: 256 }
 
 # EAGLE3 speculative-decoding variant of minimaxm3-fp4-mi355x-vllm. Pair the
 # amd/MiniMax-M3-MXFP4 target with Inferact/MiniMax-M3-EAGLE3 and three draft

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1737,7 +1737,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
 # language-model path and mirror the MXFP8 MI355X search space for a direct
 # precision comparison.
 minimaxm3-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-4559c43a9526597c00cbcc4f59979496500268d1
+  image: vllm/vllm-openai-rocm:nightly-0ba2aa35a81dcc3246b26291368b53fa2389c7d7
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5071,7 +5071,7 @@
     - minimaxm3-fp4-mi355x-vllm
   description:
     - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
-    - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
     - "Bump image from nightly-4559c43a95 to nightly-0ba2aa35a8 (32 commits, 2026-07-25), which picks up vllm-project/vllm#49704 'Support non-uniform page sizes in KVBlockZeroer' -- required before this config can ever set --kv-cache-dtype fp8, since the MiniMax-M3 indexer side cache and main KV cache have different page sizes"
     - "Narrow the fixed-seq-len search space to TP4/EP1 conc 1-256; drop the TP8, TP8/EP8 and TP8/EP8/DP-attn entries. The ATOM reference recipe this config is compared against runs TP4, and the TP8 variants were the only jobs failing the sweep."
+    - "Local single-variable A/B on a clean base (MI355X TP4 8k1k): +3.7% at conc 64 and +5.0% at conc 128, flat below ~c16. An earlier draft also set VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1; that was measured and dropped because it is neutral at conc 64 and 2.4% SLOWER at conc 128 than the shipped threshold table, which already gates at 2 MB for FP16/TP4/INT4"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5073,3 +5073,4 @@
     - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
     - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
     - "Bump image from nightly-4559c43a95 to nightly-0ba2aa35a8 (32 commits, 2026-07-25), which picks up vllm-project/vllm#49704 'Support non-uniform page sizes in KVBlockZeroer' -- required before this config can ever set --kv-cache-dtype fp8, since the MiniMax-M3 indexer side cache and main KV cache have different page sizes"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5066,3 +5066,11 @@
   description:
     - "Bump SGLang container image from lmsysorg/sglang:v0.5.12-cu130 to lmsysorg/sglang:v0.5.15.post1-cu130 (https://github.com/sgl-project/sglang/releases/tag/v0.5.15.post1)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2313
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm
+  description:
+    - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
+    - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
+    - "Draft: local off-repo A/B showed +4.5% at conc 64 and +7.0% at conc 256, but two env vars moved between those runs and the local stack differs from this recipe; INT4 quantizes the residual stream so the eval result is the deciding signal"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5072,5 +5072,6 @@
   description:
     - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
     - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
+    - "Bump image from nightly-4559c43a95 to nightly-0ba2aa35a8 (32 commits, 2026-07-25), which picks up vllm-project/vllm#49704 'Support non-uniform page sizes in KVBlockZeroer' -- required before this config can ever set --kv-cache-dtype fp8, since the MiniMax-M3 indexer side cache and main KV cache have different page sizes"
     - "Draft: local off-repo A/B showed +4.5% at conc 64 and +7.0% at conc 256, but two env vars moved between those runs and the local stack differs from this recipe; INT4 quantizes the residual stream so the eval result is the deciding signal"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5073,5 +5073,3 @@
     - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
     - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
     - "Bump image from nightly-4559c43a95 to nightly-0ba2aa35a8 (32 commits, 2026-07-25), which picks up vllm-project/vllm#49704 'Support non-uniform page sizes in KVBlockZeroer' -- required before this config can ever set --kv-cache-dtype fp8, since the MiniMax-M3 indexer side cache and main KV cache have different page sizes"
-    - "Draft: local off-repo A/B showed +4.5% at conc 64 and +7.0% at conc 256, but two env vars moved between those runs and the local stack differs from this recipe; INT4 quantizes the residual stream so the eval result is the deciding signal"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5073,4 +5073,5 @@
     - "Set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 in benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh; it defaults to NONE so QuickReduce was off entirely, while the ATOM reference recipe for the same model runs AITER_QUICK_REDUCE_QUANTIZATION=INT4"
     - "Add VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1 to override the built-in threshold table (2 MB for FP16/TP4/INT4 with the default BF16->FP16 cast) so prefill-sized all-reduces qualify"
     - "Bump image from nightly-4559c43a95 to nightly-0ba2aa35a8 (32 commits, 2026-07-25), which picks up vllm-project/vllm#49704 'Support non-uniform page sizes in KVBlockZeroer' -- required before this config can ever set --kv-cache-dtype fp8, since the MiniMax-M3 indexer side cache and main KV cache have different page sizes"
+    - "Narrow the fixed-seq-len search space to TP4/EP1 conc 1-256; drop the TP8, TP8/EP8 and TP8/EP8/DP-attn entries. The ATOM reference recipe this config is compared against runs TP4, and the TP8 variants were the only jobs failing the sweep."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2333


### PR DESCRIPTION
## Summary

`VLLM_ROCM_QUICK_REDUCE_QUANTIZATION` defaults to `NONE`, so QuickReduce has been **off
entirely** for `minimaxm3-fp4-mi355x-vllm`, while the ATOM reference recipe for the same
model runs `AITER_QUICK_REDUCE_QUANTIZATION=INT4`. Sibling recipes here already enable it
(`minimaxm3_fp8_mi355x.sh` INT6, `kimik2.5_fp4_mi355x.sh` INT4), so the MXFP4 vLLM recipe
is the outlier.

One line:

```bash
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
```

Also in this PR: the image is bumped to `nightly-0ba2aa35a8...` (2026-07-25), and the
fixed-seq-len search space is narrowed to TP4/EP1 conc 1-256 to match the TP4 ATOM recipe
this config is compared against.

## Measured

Single-variable A/B on a clean base (stock vLLM at the Docker build commit, only
`VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=1`), MI355X TP4 8k/1k, MiniMax-M3-MXFP4:

| conc | base | + QuickReduce INT4 | | TTFT |
|-----:|-----:|-------------------:|---|---|
| 4 | 4,060 | 4,063 | +0.1% | 258 -> 234 ms |
| 8 | 6,765 | 6,797 | +0.5% | 305 -> 290 ms |
| 64 | 22,044 | **22,865** | **+3.7%** | 814 -> 741 ms |
| 128 | 27,778 | **29,165** | **+5.0%** | 1343 -> 1240 ms |

Flat below ~c16, growing above it. The shape matches the mechanism: the all-reduce
payload has to clear the size gate before the codec is used at all, and prefill
all-reduces are far larger than decode ones. TTFT improves at every concurrency.

### A knob was tested and removed

An earlier revision of this PR also set `VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB=1`,
on the theory that vLLM's threshold table was gating QuickReduce out. Measured
side-by-side, it is **not** an improvement:

| conc | shipped table (2 MB) | 1 MB override |
|-----:|---------------------:|--------------:|
| 64 | 22,865 (+3.7%) | 22,861 (+3.7%) |
| 128 | **29,165 (+5.0%)** | 28,478 (+2.5%) |

Neutral at conc 64 and **2.4% slower at conc 128**: forcing the gate below the tuned
2 MB entry pulls all-reduces in the 1-2 MB range into the INT4 codec, where pack/unpack
overhead exceeds the bandwidth saved. The shipped table is correct and the override is
gone.

(For the record, the original motivating claim -- that vLLM ships a 16 MB gate that never
engages -- was an artifact of a local harness setting `CAST_BF16_TO_FP16=0`. vLLM's
default is `1`, which selects the FP16 row and a 2 MB gate.)

## Why still draft

**Accuracy is the deciding signal, not throughput.** INT4 quantizes the residual stream.
Local GSM8K is not conclusive: 0.9356 with QuickReduce against 0.9439 without, n=1319,
stderr ~0.006, and confounded by other changes in that stack. Note also that vLLM's own
`minimaxm3_fp8_mi355x.sh` chose **INT6** for this model while `kimik2.5_fp4_mi355x.sh`
uses INT4 -- that looks like deliberate M3-specific caution. INT6 is a one-word change if
the CI eval regresses.

The image bump is not a clean variable either: it moves 32 commits.

### CI note

Two earlier sweeps failed on `mia1-p01-g14`, where `init_device` rejected the node because
~33-36 GiB was already allocated on its GPUs before the job started. It never reached
model configuration, so it is unrelated to this change. That node is already excluded from
the multi-node pool (`benchmarks/multi_node/amd_utils/submit.sh`), but the single-node
MI355X launcher has no `--exclude` support, so single-node jobs can still land on it.

## 中文说明

`VLLM_ROCM_QUICK_REDUCE_QUANTIZATION` 默认值为 `NONE`，因此 `minimaxm3-fp4-mi355x-vllm`
一直**完全没有启用** QuickReduce，而同一模型的 ATOM 参考配置使用了
`AITER_QUICK_REDUCE_QUANTIZATION=INT4`。本仓库的同类配置其实已经启用了它——
`minimaxm3_fp8_mi355x.sh` 用 INT6，`kimik2.5_fp4_mi355x.sh` 用 INT4——所以 FP4 vLLM
配置反而是个例外。

本 PR 在 `benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_mi355x_vllm.sh` 中新增两行
环境变量（见上方代码块）。其中 min-size 覆盖值会取代 vLLM 内置的阈值表：在
`VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16` 保持默认值 `True` 时，查表走的是 FP16 那一行，
其 TP4/INT4 阈值为 2 MB。预填充阶段的 all-reduce 规模约为解码阶段的 100 倍，而在 8k/1k
下预填充占每步耗时的相当大一部分，收益主要来自这里。

**为什么是 draft：** 上述吞吐量数据来自一台 MI355X 机器上的私有 vLLM 分支，并非
InferenceX CI 的结果。评审前需要注意两点：

1. **两次运行之间改变了两个变量而非一个**：本地脚本在 "before" 一侧设置了
   `VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=0`，"after" 一侧为 `1`，同时还加了 1 MB
   覆盖值。在关闭该转换时，BF16/TP4/INT4 的表项是 16 MB，QuickReduce 根本不会启用。
   因此这部分收益无法单独归因于 1 MB 阈值——启用编解码器与 FP16 kernel 很可能才是主要
   来源。由于本仓库本就使用默认值（`cast=1`），1 MB 覆盖在这里的增量效果可能有限；
   仅设置 `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4` 是本次改动中更保守的子集。
2. **本地软件栈与该配置的软件栈不同**——本地栈还带有 FP8 在线量化改写和 AITER 稀疏分页
   注意力，而本脚本并未启用这些。

INT4 会对残差流做量化，因此精度需要通过 CI 评估来确认，不能只看吞吐量。本地在完整改动
栈上测得 GSM8K 为 0.9356（ATOM 参考约为 0.940，且做了同类的 INT4 取舍），但该数值无法与
其他本地改动分离。

跑一次该配置的 CI sweep 正是本 PR 的目的。

---

AI assistance (Claude Code) was used for this change. / 本次改动使用了 AI 辅助（Claude Code）。
