### PR TITLE
[Klaud Cold] glm5.2-fp4-rtx6000pro-sglang-agentic: add GLM-5.2 SGLang AgentX recipe for RTX PRO 6000 / 新增 GLM-5.2 RTX PRO 6000 SGLang AgentX 基准配置

### DIFF
--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -235,6 +235,13 @@ jobs:
             done
           fi
 
+          # The direct-host RTX runner mounts this checkout into a rootful
+          # container. Repair files left by an interrupted job before
+          # actions/checkout attempts its clean reset.
+          if [ "${{ runner.name }}" = "rtx6000pro-lat_00" ]; then
+            sudo -n chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
+          fi
+
           # Cleanup SLURM resources
           if command -v squeue >/dev/null 2>&1; then
             echo "[Slurm] Cleaning up jobs with name: ${{ runner.name }} ..."

--- a/benchmarks/single_node/agentic/glm5.2_fp4_rtx6000pro_sglang.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_rtx6000pro_sglang.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# AgentX trace replay for GLM-5.2 NVFP4 on the 8x RTX PRO 6000 Blackwell
+# (SM120) node using SGLang.
+#
+# Flags start from the merged B300 NVFP4 cookbook recipe
+# (benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh, STP only) and
+# then apply the SM120 deltas this GPU family needs:
+#
+#   * TP8 only. The checkpoint is 433 GB, so pure TP across all eight 96 GB
+#     GPUs is the only layout that leaves room for the KV pool; TP4 does not
+#     fit the weights at all.
+#   * Shared-experts fusion is force-disabled. SGLang enables it for this
+#     config (n_routed_experts=256, n_shared_experts=1, EP off), but
+#     nvidia/GLM-5.2-NVFP4 stores the shared expert loose and unquantized
+#     (BF16 [2048, 6144]) while the routed experts are packed NVFP4
+#     ([2048, 3072]), so the fused loader aborts during weight load with
+#     "The size of tensor a (3072) must match the size of tensor b (6144)".
+#     This is the same trap the in-tree comment records for the
+#     compressed-tensors Kimi-K2.5 checkpoint.
+#   * Attention falls back to Triton MLA. SGLang would default this DSA model
+#     to --attention-backend dsa, whose indexer metadata comes only from
+#     DeepGEMM, and DeepGEMM has no SM120 kernel. Sparse attention is
+#     therefore not exercised on this GPU family, and prefill cost grows
+#     superlinearly with context.
+#   * MoE runner backend is left at SGLang's own SM120 choice for
+#     modelopt_fp4 (flashinfer_cutlass; trtllm-gen MoE is SM100-only) and is
+#     overridable through MOE_RUNNER_BACKEND.
+#   * HiCache is not supported on RTX PRO 6000, so this recipe is
+#     GPU-resident KV only.
+#
+# Required env vars:
+#   MODEL, TP, CONC, KV_OFFLOADING, TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION,
+#   EP_SIZE, DP_ATTENTION
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL \
+    TP \
+    CONC \
+    KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB \
+    RESULT_DIR \
+    DURATION \
+    EP_SIZE \
+    DP_ATTENTION
+
+if [[ "$TP" != "8" ]]; then
+    echo "GLM-5.2 SGLang on RTX PRO 6000 requires TP8: the 433 GB NVFP4 checkpoint does not fit in fewer than eight 96 GB GPUs" >&2
+    exit 1
+fi
+if [[ "$KV_OFFLOADING" != "none" ]]; then
+    echo "GLM-5.2 SGLang on RTX PRO 6000 supports GPU-resident KV cache only (HiCache is unsupported on this GPU family)" >&2
+    exit 1
+fi
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    echo "GLM-5.2 SGLang on RTX PRO 6000 does not support DP attention: attention-DP replicates the KV pool per rank, which the 96 GB GPUs cannot hold alongside 54 GB of weights" >&2
+    exit 1
+fi
+if [[ "$EP_SIZE" != "1" ]]; then
+    echo "GLM-5.2 SGLang on RTX PRO 6000 supports EP1 only" >&2
+    exit 1
+fi
+
+# `hf download` creates the target dir if missing and is itself idempotent.
+# When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE.
+# Either way, MODEL_PATH is what the server is launched with.
+MODEL_REVISION="${GLM52_MODEL_REVISION:-aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa}"
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --revision "$MODEL_REVISION" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL" --revision "$MODEL_REVISION"
+    export MODEL_PATH="$MODEL"
+fi
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+nvidia-smi
+nvidia-smi topo -m || true
+
+# The FP8 KV pool holds 464,768 tokens per rank (~51 KB/token across 78
+# layers) at mem-fraction-static 0.85, so the model's 1M context does not fit
+# and the server is capped at 256k. Replay the matching 256k-capped corpus
+# instead of the 1M default this model prefix would otherwise select.
+export WEKA_LOADER_OVERRIDE="${WEKA_LOADER_OVERRIDE:-semianalysis_cc_traces_weka_062126_256k}"
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+export PYTHONNOUSERSITE=1
+export TORCH_CUDA_ARCH_LIST=12.0a
+# All eight GPUs are SYS-connected (PCIe only, no NVLink) on this node, and
+# NCCL 2.28.9 segfaults probing its bnxt_re devices; the runner already sets
+# NCCL_IB_DISABLE=1. Keep collectives on the local PCIe/SHM transports.
+export NCCL_P2P_LEVEL="${NCCL_P2P_LEVEL:-SYS}"
+export NCCL_PROTO="${NCCL_PROTO:-LL,LL128,Simple}"
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo}"
+export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-16}"
+
+# NOTE for whoever revisits the DSA path: SGLang carries a set of SM120
+# kernel fixups (SGLANG_OPT_FP8_WO_A_GEMM / SGLANG_OPT_USE_TOPK_V2 /
+# SGLANG_OPT_USE_TILELANG_MHC_PRE / SGLANG_OPT_DEEPGEMM_HC_PRENORM off,
+# SGLANG_FP8_PAGED_MQA_LOGITS_TORCH on) that it applies only inside its
+# DeepseekV4ForCausalLM branch, and GLM-5.2 (GlmMoeDsaForCausalLM) misses
+# them. They were tested on-node and are NOT needed on this Triton MLA
+# fallback path — boot and generation are identical with and without them —
+# so they are deliberately not exported here. They become relevant again if
+# the sparse DSA backend ever works on SM120.
+#
+# Do not simply switch --attention-backend back to dsa: enabling the sparse
+# path on SM120 was attempted on-node (2026-07-26) and needs kernel work, not
+# a flag. Patching SGLang to route the indexer's paged-MQA logits through its
+# TileLang/torch implementations (both already used by the dsv4 indexer) and
+# to stop building the DeepGEMM schedule plan does clear the "Unsupported
+# architecture" abort, and the server then boots and serves — but four more
+# walls follow:
+#   1. TileLang's CUDA sparse-MLA kernel takes bf16 KV only (its fp8 variants
+#      are ROCm-only), which halves the KV pool to 256,256 tokens/rank.
+#   2. That kernel asks for 170,048 B of dynamic shared memory; SM120 allows
+#      ~100 KB. Its tile size is not a knob — the barrier arrive_counts
+#      (384/256/128) encode the BI=64 thread mapping, so block_I=32 compiles
+#      and then reads out of bounds.
+#   3. The plain (v1) kernel does fit at block_I=32 / num_stages=1 / 128
+#      threads, but CUDA-graph capture fails because TileLang JIT-compiles
+#      inside the capture (cudaErrorStreamCaptureUnsupported).
+#   4. With graphs disabled it runs and is still numerically wrong: degenerate
+#      repetition on a 26-token prompt and an empty answer on the 45k-token
+#      needle, identically with the TileLang and the torch reference logits
+#      kernels — so the fault is the sparse-MLA kernel itself, not the indexer.
+# Fixing this means an SM120-shaped sparse-MLA kernel (split the d_v=512
+# accumulation so KV tiles stay under ~32 KB, re-derive the barrier counts,
+# validate against the dense path), not a config change. Full logs from the
+# attempt: rtx6000pro-lat:/home/ubuntu/glm52-sglang-patch/out/server.dsa*.log.
+
+# Agentic warmup dispatches hundreds of large prompts at once; allow up to
+# 15 minutes of TCP progress before AIPerf declares a connection dead.
+export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
+# AIPerf pins one pooled keep-alive connection per session (client-side
+# keep-alive 300s) while uvicorn's default SGLANG_TIMEOUT_KEEP_ALIVE is 5s;
+# inter-turn idle gaps can reuse a socket exactly as the server closes it ->
+# ECONNRESET -> terminal warmup failure. Outlast the client pool.
+export SGLANG_TIMEOUT_KEEP_ALIVE=900
+# Dense-attention prefill on this node measured 872 tok/s at 4.4k context
+# falling to 418 tok/s at 244k (single stream), so a warmup snapshot of
+# 100k-token histories needs several minutes per trajectory. Double the
+# shared 1800s warmup grace so warmup drains instead of being declared
+# failed; grace is a maximum wait, not a fixed sleep.
+export AGENTIC_WARMUP_GRACE_PERIOD="${AGENTIC_WARMUP_GRACE_PERIOD:-3600}"
+
+# AgentX concurrency counts live session trees, not individual requests.
+# Allow subagent fan-out to exceed CONC without clipping request bursts.
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+CUDA_GRAPH_MAX_BS=$MAX_RUNNING_REQUESTS
+[ "$CUDA_GRAPH_MAX_BS" -gt 64 ] && CUDA_GRAPH_MAX_BS=64
+
+MEM_FRACTION_STATIC="${MEM_FRACTION_STATIC:-0.85}"
+CONTEXT_LENGTH="${CONTEXT_LENGTH:-262144}"
+ATTENTION_BACKEND="${ATTENTION_BACKEND:-triton}"
+
+MOE_ARGS=()
+if [[ -n "${MOE_RUNNER_BACKEND:-}" ]]; then
+    MOE_ARGS=(--moe-runner-backend "$MOE_RUNNER_BACKEND")
+fi
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    --tp "$TP"
+    --ep-size "$EP_SIZE"
+    --quantization modelopt_fp4
+    # nvidia/GLM-5.2-NVFP4 keeps the shared expert loose and in BF16, so the
+    # fused-shared-expert loader cannot consume it (see the header note).
+    --disable-shared-experts-fusion
+    # SGLang would default this DSA model to --attention-backend dsa, whose
+    # indexer metadata is built by deep_gemm.get_paged_mqa_logits_metadata
+    # (the only CUDA option; 'cutedsl' is gated to SM100). DeepGEMM aborts
+    # with "Assertion error (attention.hpp:227): Unsupported architecture" on
+    # SM120 during warmup, so fall back to Triton MLA. Sparse attention is
+    # consequently not exercised on this GPU family.
+    --attention-backend "$ATTENTION_BACKEND"
+    "${MOE_ARGS[@]}"
+    # GLM-5.2 emits the GLM-4.7-style <tool_call>/<arg_key>/<arg_value>
+    # format; glm47 is required for structured message.tool_calls, and the
+    # reasoning parser keeps hybrid-thinking output in reasoning_content.
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --context-length "$CONTEXT_LENGTH"
+    --chunked-prefill-size 8192
+    --mem-fraction-static "$MEM_FRACTION_STATIC"
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --watchdog-timeout 1800
+    --enable-metrics
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
+
+echo "Starting SGLang server for RTX PRO 6000..."
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+cleanup_agentic_server() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "SGLang server" 60
+    exit "$exit_code"
+}
+trap cleanup_agentic_server EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8097,3 +8097,35 @@ glm5.2-fp4-b300-sglang-agentic:
       # radix cache (GPU hit 0.93->0.57 at 48->64) and thrashes on re-prefill, so it is
       # strictly dominated by conc 48 on both throughput and interactivity.
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48], router: { name: sglang-router, version: "0.3.2" } }
+
+# GLM-5.2 NVFP4 AgentX on the 8x RTX PRO 6000 Blackwell (SM120) Latitude node
+# with SGLang. Three SM120 facts shape this entry:
+#
+#   * TP8 only. The checkpoint is 433 GB (56 GB/GPU loaded), so pure TP across
+#     all eight 96 GB GPUs is the only layout that leaves room for a KV pool;
+#     TP4 cannot hold the weights, and attention-DP would replicate the pool
+#     per rank.
+#   * Sparse DSA attention is unavailable. SGLang's DSA backend builds its
+#     indexer paged-MQA-logits metadata through DeepGEMM (the only CUDA
+#     option; 'cutedsl' is gated to SM100), and DeepGEMM asserts "Unsupported
+#     architecture" on SM120, so the recipe runs the Triton MLA fallback with
+#     the sparse indexer bypassed. Prefill therefore scales superlinearly with
+#     context (measured on-node: 17.6k tokens 5.2 s -> 70.5k tokens 38.9 s).
+#   * Context is capped at 256k, not the model's 1M. The FP8 KV pool is
+#     464,768 tokens per rank at mem-fraction-static 0.85 (~51 KB/token across
+#     78 layers), so the recipe replays the 256k-capped trace corpus and stops
+#     at conc 4, where four full-length sessions already exceed the pool and
+#     start re-prefilling.
+glm5.2-fp4-rtx6000pro-sglang-agentic:
+  image: lmsysorg/sglang:v0.5.15.post1-cu130
+  model: nvidia/GLM-5.2-NVFP4
+  model-prefix: glm5.2
+  runner: cluster:rtx6000pro-lat
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 2, 4] }

--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -164,6 +164,10 @@ labels:
     - gb300-nv_0
     - gb300-nv_1
     - gb300-nv_2
+  rtx6000pro:
+    - rtx6000pro-lat_00
+  rtx6000pro-lat:
+    - rtx6000pro-lat_00
   cluster:h100-cw:
     - h100-cw_00
     - h100-cw_01
@@ -251,6 +255,8 @@ labels:
     - gb300-nv_0
     - gb300-nv_1
     - gb300-nv_2
+  cluster:rtx6000pro-lat:
+    - rtx6000pro-lat_00
   cluster:mi300x-amds:
     - mi300x-amds_00
     - mi300x-amds_01

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5066,3 +5066,19 @@
   description:
     - "Bump SGLang container image from lmsysorg/sglang:v0.5.12-cu130 to lmsysorg/sglang:v0.5.15.post1-cu130 (https://github.com/sgl-project/sglang/releases/tag/v0.5.15.post1)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2313
+
+- config-keys:
+    - glm5.2-fp4-rtx6000pro-sglang-agentic
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add a GLM-5.2 NVFP4 SGLang AgentX sweep on the 8x RTX PRO 6000 Blackwell (SM120) Latitude runner, TP8/EP1 with GPU-resident FP8 KV cache at concurrency 1, 2, and 4"
+    - "Pin lmsysorg/sglang:v0.5.15.post1-cu130, the same image as the merged B300 GLM-5.2 SGLang recipe and the first release whose GlmMoeDsaForCausalLM support is present"
+    - "Force --disable-shared-experts-fusion: SGLang enables fusion for this config, but nvidia/GLM-5.2-NVFP4 stores the shared expert loose in BF16 while the routed experts are packed NVFP4, so the fused loader aborts weight load with a 3072-vs-6144 shape mismatch"
+    - "Run the Triton MLA attention fallback instead of the sparse DSA backend: SGLang builds DSA indexer paged-MQA-logits metadata through DeepGEMM only ('cutedsl' is gated to SM100), and DeepGEMM asserts 'Unsupported architecture' on SM120, so GLM-5.2's sparse-attention advantage is not realized on this GPU family"
+    - "Do not carry SGLang's DeepseekV4-only SM120 kernel fixups (FP8 weight-only GEMM, topk_v2, tilelang/DeepGEMM hidden-compression prenorm, torch paged-MQA logits): tested on-node, boot and generation are identical with and without them on this Triton fallback path"
+    - "Cap context at 256k and replay the 256k-capped trace corpus: the FP8 KV pool holds 464,768 tokens per rank at mem-fraction-static 0.85 (~51 KB/token across 78 layers), so the model's 1M context does not fit and conc >4 re-prefills continuously"
+    - "Raise the agentic warmup grace period to 3600s: dense-attention prefill measured 872 tok/s at 4.4k context falling to 418 tok/s at 244k, so long-history warmup snapshots need more than the shared 1800s default"
+    - "Validated over SSH: TP8 boot on the node (56.04 GB weights/GPU, 464,768-token KV pool/rank, CUDA graphs captured, /health 200), short-prompt correctness through the glm45/glm47 parsers, and exact needle retrieval at 45,394 / 155,552 / 220,029-token prompts with no NaN from the SM120 flashinfer_cutlass NVFP4 MoE path"
+    - "Record in the recipe why the sparse DSA path cannot be re-enabled by flag: patching SGLang to use its TileLang/torch paged-MQA-logits kernels clears the DeepGEMM abort and boots, but the TileLang sparse-MLA kernel needs bf16 KV, asks for 170,048 B of shared memory against SM120's ~100 KB, cannot be CUDA-graph captured, and is numerically wrong at the only tile size that fits"
+  pr-link: XXX

--- a/runners/launch_rtx6000pro-lat.sh
+++ b/runners/launch_rtx6000pro-lat.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+# This runner executes directly on the single RTX PRO 6000 GPU node. Docker
+# therefore owns a separate image cache from the node's RKE2/containerd cache.
+HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-/var/lib/inferencex/hf-hub-cache}"
+export HF_HUB_CACHE="${HF_HUB_CACHE:-/mnt/hf_hub_cache/}"
+PORT="${PORT:-8888}"
+
+# NCCL 2.28.9 segfaults while probing this node's bnxt_re RDMA devices.
+# Disable that RDMA path by default while preserving local CUDA P2P/SHM and
+# allowing an explicit caller override.
+export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
+: "${IMAGE:?IMAGE must be set}"
+: "${EXP_NAME:?EXP_NAME must be set}"
+: "${PRECISION:?PRECISION must be set}"
+
+mkdir -p "$HF_HUB_CACHE_MOUNT"
+
+export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"
+if [[ ! "$GPU_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+    echo "GPU_COUNT must be a positive integer, got: $GPU_COUNT" >&2
+    exit 1
+fi
+
+export CUDA_VISIBLE_DEVICES
+CUDA_VISIBLE_DEVICES="$(seq -s, 0 "$((GPU_COUNT - 1))")"
+
+# Some Slurm/enroot configs spell registry paths as nvcr.io#namespace/image.
+# Docker requires the normal slash form.
+DOCKER_IMAGE="${IMAGE//#//}"
+
+SPEC_SUFFIX=""
+if [[ "${SPEC_DECODING:-}" == "mtp" ]]; then
+    SPEC_SUFFIX="_mtp"
+fi
+
+export SCENARIO_SUBDIR="${SCENARIO_SUBDIR:-fixed_seq_len/}"
+SCENARIO_SUBDIR="${SCENARIO_SUBDIR#/}"
+SCENARIO_SUBDIR="${SCENARIO_SUBDIR%/}/"
+BENCH_BASE="benchmarks/single_node/${SCENARIO_SUBDIR}${EXP_NAME%%_*}_${PRECISION}_rtx6000pro"
+
+# Prefer the framework-tagged name so several engines can serve the same model
+# on this runner, and fall back to the untagged name that predates it.
+BENCH_SCRIPT="${BENCH_BASE}_${FRAMEWORK:-vllm}${SPEC_SUFFIX}.sh"
+if [[ ! -f "$GITHUB_WORKSPACE/$BENCH_SCRIPT" ]]; then
+    BENCH_SCRIPT="${BENCH_BASE}${SPEC_SUFFIX}.sh"
+fi
+
+if [[ ! -f "$GITHUB_WORKSPACE/$BENCH_SCRIPT" ]]; then
+    echo "Benchmark script not found: $GITHUB_WORKSPACE/$BENCH_SCRIPT" >&2
+    exit 1
+fi
+
+server_name="bmk-server-${RUNNER_NAME:-rtx6000pro-lat}"
+server_name="${server_name//[^a-zA-Z0-9_.-]/-}"
+
+cleanup() {
+    docker rm -f "$server_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Clear a container left behind by a cancelled or interrupted workflow.
+cleanup
+
+docker run \
+    --rm \
+    --pull=missing \
+    --name="$server_name" \
+    --runtime=nvidia \
+    --gpus="$GPU_COUNT" \
+    --network=host \
+    --ipc=host \
+    --privileged \
+    --shm-size=32g \
+    --ulimit memlock=-1 \
+    --ulimit stack=67108864 \
+    --security-opt seccomp=unconfined \
+    --cap-add=SYS_PTRACE \
+    --volume "$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE" \
+    --volume "$GITHUB_WORKSPACE:/workspace/" \
+    --workdir=/workspace/ \
+    --env HF_TOKEN \
+    --env HF_HUB_CACHE \
+    --env MODEL \
+    --env MODEL_PREFIX \
+    --env MODEL_PATH \
+    --env TP \
+    --env PP_SIZE \
+    --env DCP_SIZE \
+    --env PCP_SIZE \
+    --env EP_SIZE \
+    --env DP_SIZE \
+    --env DP_ATTENTION \
+    --env GPU_COUNT \
+    --env CONC \
+    --env MAX_MODEL_LEN \
+    --env ISL \
+    --env OSL \
+    --env FRAMEWORK \
+    --env PRECISION \
+    --env DISAGG \
+    --env SPEC_DECODING \
+    --env NUM_SPEC_TOKENS \
+    --env RUN_EVAL \
+    --env EVAL_ONLY \
+    --env EVAL_LIMIT \
+    --env EVAL_MAX_MODEL_LEN \
+    --env RUNNER_TYPE \
+    --env RUNNER_NAME \
+    --env RESULT_FILENAME \
+    --env RESULT_DIR \
+    --env RANDOM_RANGE_RATIO \
+    --env GPU_MEM_UTIL \
+    --env AIPERF_FAILED_REQUEST_THRESHOLD \
+    --env KV_OFFLOADING \
+    --env KV_OFFLOAD_BACKEND \
+    --env KV_OFFLOAD_BACKEND_METADATA \
+    --env ROUTER_METADATA \
+    --env KV_P2P_TRANSFER \
+    --env TOTAL_CPU_DRAM_GB \
+    --env DURATION \
+    --env SCENARIO_TYPE \
+    --env SCENARIO_SUBDIR \
+    --env IS_AGENTIC \
+    --env SWEBENCH_GEN_MODE \
+    --env SWEBENCH_USE_MODAL \
+    --env MODAL_TOKEN_ID \
+    --env MODAL_TOKEN_SECRET \
+    --env PROFILE \
+    --env SGLANG_TORCH_PROFILER_DIR \
+    --env VLLM_TORCH_PROFILER_DIR \
+    --env VLLM_RPC_TIMEOUT \
+    --env PYTHONDONTWRITEBYTECODE \
+    --env PYTHONPYCACHEPREFIX=/tmp/pycache/ \
+    --env PORT="$PORT" \
+    --env CUDA_DEVICE_ORDER=PCI_BUS_ID \
+    --env CUDA_VISIBLE_DEVICES \
+    --env NCCL_IB_DISABLE \
+    --entrypoint=/bin/bash \
+    "$DOCKER_IMAGE" \
+    "$BENCH_SCRIPT"


### PR DESCRIPTION
## Summary

Adds the SGLang counterpart to the RTX PRO 6000 vLLM recipes (#2312 Qwen3.5, #2332 GLM-5.2): a GLM-5.2 NVFP4 AgentX trace-replay sweep on the 8× RTX PRO 6000 Blackwell (SM120) Latitude node, TP8/EP1 with GPU-resident FP8 KV cache at concurrency 1, 2 and 4.

New config key: `glm5.2-fp4-rtx6000pro-sglang-agentic`, image `lmsysorg/sglang:v0.5.15.post1-cu130` (the same image as the merged `glm5.2-fp4-b300-sglang-agentic` recipe).

### What SM120 forces this recipe to do differently

Every item below was established on the node, not inferred:

1. **TP8 only.** The checkpoint loads to 56 GB/GPU (433 GB total), so pure TP over all eight 96 GB GPUs is the only layout with room for a KV pool. TP4 cannot hold the weights and attention-DP would replicate the pool per rank; both are rejected by the script.
2. **`--disable-shared-experts-fusion` is mandatory.** SGLang enables shared-experts fusion for this config (`n_routed_experts=256`, `n_shared_experts=1`, EP off), but `nvidia/GLM-5.2-NVFP4` stores the shared expert loose and unquantized (BF16 `[2048, 6144]`) while the routed experts are packed NVFP4 (`[2048, 3072]`). Weight load aborts with `RuntimeError: The size of tensor a (3072) must match the size of tensor b (6144) at non-singleton dimension 1` — the same trap the in-tree comment records for the compressed-tensors Kimi-K2.5 checkpoint. Disabling fusion loads cleanly.
3. **The sparse DSA attention backend cannot run on SM120, so this recipe uses the Triton MLA fallback.** SGLang builds the DSA indexer's paged-MQA-logits metadata exclusively through DeepGEMM (`dsa_paged_mqa_logits_backend` accepts only `deepgemm` on CUDA; `cutedsl` is gated to SM100), and DeepGEMM aborts during warmup with `tvm.error.InternalError: Assertion error (attention.hpp:227): Unsupported architecture`. Verified still unfixed in `v0.5.16-cu130`. Consequence: GLM-5.2's sparse-attention advantage is **not** realized on this GPU family — prefill throughput decays with context as dense attention would (measured on-node, single stream: 872 tok/s at 4.4k → 580 tok/s at 100k → 418 tok/s at 244k).
4. **SGLang's DeepseekV4-only SM120 kernel fixups are deliberately *not* carried.** SGLang switches off FP8 weight-only GEMM, `topk_v2`, tilelang MHC prenorm and DeepGEMM HC prenorm (and forces torch paged-MQA logits) inside its `DeepseekV4ForCausalLM` branch only, which `GlmMoeDsaForCausalLM` misses. Both variants were booted on the node: startup and generation are identical, so the recipe stays minimal and the script header records where to look if the DSA path is ever revisited.
5. **Context is capped at 256k, not the model's 1M**, and the recipe replays the 256k-capped trace corpus. The FP8 KV pool is 464,768 tokens per rank at `mem-fraction-static 0.85` (~51 KB/token across 78 layers), so 1M-token sessions cannot be resident and concurrency above 4 re-prefills continuously.

### On-node validation

* TP8 boot on `lmsysorg/sglang:v0.5.15.post1-cu130`: weights loaded (56.04 GB/GPU), KV pool 464,768 tokens/rank (23.91 GB), CUDA graphs captured, `/health` 200.
* Short-prompt correctness: `17 * 24` → `408` with clean `reasoning_content`/`content` split through the `glm45`/`glm47` parsers — no NaN or garbage from the SM120 `flashinfer_cutlass` NVFP4 MoE path (the failure mode of sgl-project/sglang#18954).
* Long-context retrieval: a needle placed in engineering-log filler was returned exactly at **45,394 tokens** (depth 0.5, answer also cited the correct log line), **155,552 tokens** (depth 0.75) and **220,029 tokens** (depth 0.9) with the server at 256k context length.
* Decode ran under CUDA graphs at ~28 tok/s per request with two ~110k-token sessions resident (56 tok/s aggregate), and the KV pool reached 0.79 occupancy with the radix cache holding prior turns — the basis for stopping the sweep at concurrency 4.

### Can the sparse path be enabled instead? Attempted on-node — no

Because the caveat above decides how these numbers should be read, the sparse path was actually tried on the node rather than assumed dead. Patching SGLang so the indexer's paged-MQA logits go through its **TileLang** or **torch** implementations (both already used by the `dsv4` indexer) and so the DeepGEMM schedule plan is no longer built unconditionally does clear the abort, and the server boots and serves. Four further walls follow:

1. TileLang's CUDA sparse-MLA kernel accepts **bf16 KV only** — its fp8 variants are ROCm-only — which halves the pool to 256,256 tokens/rank.
2. That kernel requests **170,048 B of dynamic shared memory** against SM120's ~100 KB. Its tile size is not a knob: the barrier `arrive_count`s (384/256/128) encode the `block_I=64` thread mapping, so `block_I=32` compiles and then reads out of bounds.
3. The plain (v1) kernel does fit at `block_I=32` / `num_stages=1` / 128 threads, but **CUDA-graph capture fails** — TileLang JIT-compiles inside the capture (`cudaErrorStreamCaptureUnsupported`).
4. With graphs disabled it runs and is **numerically wrong**: degenerate repetition on a 26-token prompt, empty answer on the 45k-token needle — identically with the TileLang *and* the torch reference logits kernels, which localises the fault to the sparse-MLA kernel rather than the indexer.

Closing this needs an SM120-shaped sparse-MLA kernel (split the `d_v=512` accumulation so KV tiles stay under ~32 KB, re-derive the barrier counts, validate against the dense path) — kernel work, not configuration. The recipe header records this so the next reader does not re-burn a sweep on the flag.

**Reading these numbers against vLLM:** PR #2332 serves the same checkpoint on the same node with `--attention-backend B12X_MLA_SPARSE`, i.e. vLLM *does* get sparse MLA on SM120 through B12X. A lower SGLang result here is engine kernel coverage, not a hardware or recipe regression.

### Also included (shared with #2312 / #2332)

`runners/launch_rtx6000pro-lat.sh`, the `rtx6000pro*` / `cluster:rtx6000pro-lat` runner labels and hardware metadata, and the `benchmark-tmpl.yml` workspace-ownership repair for this direct-host runner are duplicated from those PRs because neither has merged yet. The launcher here additionally resolves **framework-tagged** script names (`<model>_<precision>_rtx6000pro_<framework>[_mtp].sh`, falling back to the untagged name) so SGLang and vLLM recipes can coexist on this runner. Whichever of the three PRs merges first, the others should drop the duplicated files on rebase.

## 中文说明

本 PR 为 RTX PRO 6000 增加 SGLang 侧的配方，与 #2312（Qwen3.5, vLLM）、#2332（GLM-5.2, vLLM）互补：在 8× RTX PRO 6000 Blackwell（SM120）Latitude 节点上运行 GLM-5.2 NVFP4 的智能体（AgentX）轨迹回放扫描，TP8/EP1，KV 缓存全部驻留 GPU（FP8），并发 1、2、4。

新增配置项 `glm5.2-fp4-rtx6000pro-sglang-agentic`，镜像 `lmsysorg/sglang:v0.5.15.post1-cu130`（与已合并的 `glm5.2-fp4-b300-sglang-agentic` 相同）。

### SM120 带来的差异（均在节点上实测得出）

1. **仅支持 TP8。** 权重加载后每卡占用 56 GB（共 433 GB），只有跨全部八张 96 GB GPU 的纯 TP 才留得下 KV 池；TP4 装不下权重，注意力 DP 会在每个 rank 复制 KV 池——脚本对两者都会直接报错退出。
2. **必须加 `--disable-shared-experts-fusion`。** SGLang 在该配置下（`n_routed_experts=256`、`n_shared_experts=1`、EP 关闭）会启用共享专家融合，但 `nvidia/GLM-5.2-NVFP4` 的共享专家是松散存放且未量化的 BF16 `[2048, 6144]`，而路由专家是打包后的 NVFP4 `[2048, 3072]`，加载权重时会报 3072 与 6144 的形状不匹配。这与代码注释中记录的 compressed-tensors 版 Kimi-K2.5 是同一个坑。关闭融合后加载正常。
3. **稀疏 DSA 注意力后端在 SM120 上跑不起来，本配方改用 Triton MLA 回退路径。** SGLang 的 DSA indexer 只能通过 DeepGEMM 构建 paged-MQA-logits 元数据（CUDA 上 `dsa_paged_mqa_logits_backend` 仅接受 `deepgemm`，`cutedsl` 限定 SM100），而 DeepGEMM 在预热阶段直接断言 `Unsupported architecture`；已确认最新的 `v0.5.16-cu130` 仍未修复。因此 GLM-5.2 的稀疏注意力优势在该 GPU 系列上**无法体现**：单流预填充吞吐随上下文增长而下降（实测 4.4k 时 872 tok/s，100k 时 580 tok/s，244k 时 418 tok/s），与稠密注意力的表现一致。
4. **有意不沿用 SGLang 中仅针对 DeepseekV4 的 SM120 内核修正开关。** SGLang 只在 `DeepseekV4ForCausalLM` 分支内关闭 FP8 weight-only GEMM、`topk_v2`、tilelang MHC prenorm、DeepGEMM HC prenorm 并强制走 torch paged-MQA logits，而 `GlmMoeDsaForCausalLM` 拿不到这些设置。两种配置都在节点上实际启动过：启动与生成结果完全一致，因此配方保持精简，并在脚本头部记录了后续若重新尝试 DSA 路径时该查看哪些开关。
5. **上下文上限设为 256k（而非模型的 1M）**，并改用 256k 截断版轨迹语料。在 `mem-fraction-static 0.85` 下 FP8 KV 池为每 rank 464,768 个 token（78 层合计约 51 KB/token），1M token 的会话无法常驻，并发超过 4 就会持续重新预填充。

### 节点验证

* 在 `lmsysorg/sglang:v0.5.15.post1-cu130` 上完成 TP8 启动：权重每卡 56.04 GB，KV 池每 rank 464,768 token（23.91 GB），CUDA graph 捕获完成，`/health` 返回 200。
* 短提示正确性：`17 * 24` → `408`，`glm45`/`glm47` 解析器正确区分 `reasoning_content` 与 `content`，SM120 上的 `flashinfer_cutlass` NVFP4 MoE 路径未出现 NaN 或乱码（即 sgl-project/sglang#18954 的故障模式）。
* 长上下文检索：在工程日志式填充文本中埋入 needle，在 **45,394 token**（深度 0.5，回答还准确引用了对应日志行号）、**155,552 token**（深度 0.75）与 **220,029 token**（深度 0.9）下均被准确取回，服务端上下文上限为 256k。
* 两个约 110k token 的会话常驻时，解码在 CUDA graph 下约 28 tok/s/请求（合计 56 tok/s）；radix 缓存保留历史轮次后 KV 池占用达到 0.79——这也是扫描并发止步于 4 的依据。

### 能否改用稀疏路径？已在节点上尝试——不行

由于上述限制直接决定了这些数据该如何解读，我们并没有想当然地认为稀疏路径不可用，而是实际在节点上做了尝试。给 SGLang 打补丁，让 indexer 的 paged-MQA logits 走它自带的 **TileLang** 或 **torch** 实现（这两者 `dsv4` 的 indexer 已在使用），并且不再无条件构建 DeepGEMM 调度计划，确实可以消除那个断言，服务也能正常启动并对外提供推理。但后面还有四道坎：

1. TileLang 的 CUDA 稀疏 MLA 内核**只接受 bf16 KV**（fp8 变体仅 ROCm 有），这会把 KV 池减半到每 rank 256,256 个 token。
2. 该内核申请 **170,048 B 动态共享内存**，而 SM120 上限约 100 KB。其分块大小并不是一个可自由调节的参数：屏障的 `arrive_count`（384/256/128）已经把 `block_I=64` 的线程映射写死，所以改成 `block_I=32` 虽然能编译，但会越界访问。
3. 朴素版（v1）内核在 `block_I=32` / `num_stages=1` / 128 线程下确实能放下，但 **CUDA graph 捕获失败**——TileLang 会在捕获过程中做 JIT 编译（`cudaErrorStreamCaptureUnsupported`）。
4. 关闭 CUDA graph 后可以跑起来，但**数值结果是错的**：26 token 的短提示出现退化重复，45k token 的 needle 测试返回空答案；使用 TileLang 与 torch 参考 logits 内核的表现完全一致，说明问题出在稀疏 MLA 内核本身，而不是 indexer。

要彻底解决，需要一个适配 SM120 的稀疏 MLA 内核（把 `d_v=512` 的累加拆分，使 KV 分块保持在约 32 KB 以内，重新推导屏障计数，并与稠密路径做数值对齐验证）——这属于内核开发工作，而非配置调整。脚本头部已记录这一结论，避免后续读者再为这个开关浪费一次扫描。

**与 vLLM 结果的对比方式：** PR #2332 在同一节点、同一权重上使用 `--attention-backend B12X_MLA_SPARSE`，即 vLLM 通过 B12X 在 SM120 上**确实**跑的是稀疏 MLA。因此这里 SGLang 数据偏低反映的是推理引擎的内核覆盖差异，而不是硬件问题或配置退化。

### 与 #2312 / #2332 重复的文件

`runners/launch_rtx6000pro-lat.sh`、`rtx6000pro*` 与 `cluster:rtx6000pro-lat` 运行器标签及硬件元数据、以及针对该直连主机运行器的 `benchmark-tmpl.yml` 工作区属主修复，都因为那两个 PR 尚未合并而在此重复提交。本 PR 的启动器额外支持**带框架后缀**的脚本名（`<model>_<precision>_rtx6000pro_<framework>[_mtp].sh`，找不到时回退到不带后缀的名字），以便 SGLang 与 vLLM 配方在同一运行器上共存。三个 PR 中任一先合并后，其余应在 rebase 时删除重复文件。
