### PR TITLE
[Klaud Cold] docs: refer to InferenceX-e2e in MODELS doc / MODELS 文档改用 InferenceX-e2e 名称

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -2,7 +2,7 @@
 
 English | [中文](MODELS_zh.md)
 
-This document tracks every model benchmarked by InferenceX: when it was added, which benchmark scenarios are currently active for it, and which scenarios are deprecated. Results for active scenarios are published to <https://inferencex.com/>.
+This document tracks every model benchmarked by InferenceX-e2e: when it was added, which benchmark scenarios are currently active for it, and which scenarios are deprecated. Results for active scenarios are published to <https://inferencex.com/>.
 
 ## Scenarios
 

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -2,7 +2,7 @@
 
 [English](MODELS.md) | 中文
 
-本文档记录 InferenceX 基准测试覆盖的所有模型：加入日期、当前启用的基准测试场景，以及已弃用的场景。启用场景的结果发布于 <https://inferencex.com/>。
+本文档记录 InferenceX-e2e 基准测试覆盖的所有模型：加入日期、当前启用的基准测试场景，以及已弃用的场景。启用场景的结果发布于 <https://inferencex.com/>。
 
 ## 场景
 


### PR DESCRIPTION
## Summary

Follow-up to #2343: the intro line of `MODELS.md` / `MODELS_zh.md` now says the doc tracks models benchmarked by **InferenceX-e2e** instead of InferenceX. GitHub PR URLs are untouched.

Docs-only change — head commit carries `[skip-sweep]`.

## 中文说明

作为 #2343 的后续：`MODELS.md` / `MODELS_zh.md` 的引言改为记录 **InferenceX-e2e** 基准测试覆盖的模型（原为 InferenceX）。GitHub PR 链接保持不变。

仅文档变更 — head commit 带有 `[skip-sweep]` 标记。

🤖 Generated with [Claude Code](https://claude.com/claude-code)