### PR TITLE
CollectiveX: keep the FP8 dequant out of the chained roundtrip

### DIFF
--- a/experimental/CollectiveX/bench/ep_backend.py
+++ b/experimental/CollectiveX/bench/ep_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import os
 import types
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -86,6 +87,44 @@ class EPBackend(abc.ABC):
     # adapter sends 1 byte/value plus (for a blockwise codec) per-block FP32 scales.
     dispatch_value_bytes = 2
     dispatch_scale_bytes_per_copy = 0
+    # Handle attribute stage() populates with the tensor combine sends. Every adapter must
+    # point this at the tensor its combine() reads (NCCL EP names it differently).
+    combine_input_attr = "combine_input"
+    # Which production FP8 consumption path the chained roundtrip models.
+    #
+    #   native  (default) - the expert consumes the dispatched fp8 + per-128-block scales
+    #     DIRECTLY and emits BF16, so no standalone conversion pass sits between the two
+    #     collectives. This is what SGLang does (its DeepEP dispatcher contains no dequant at
+    #     all) and what vLLM does whenever the expert's block shape matches DeepEP's 128
+    #     (`block_k == DEEPEP_QUANT_BLOCK_SIZE` -> "DeepEP kernels did the quantization for
+    #     us", fp8 + scales returned untouched). deepseek-v3 block-fp8 -- the workload this
+    #     suite runs -- takes that branch.
+    #   dequant - vLLM's fallback for a quant-format MISMATCH: dequant_fp8() materialises the
+    #     full padded [experts, max_tokens, hidden] tensor to fp32, casts to the activation
+    #     dtype, then re-quantises for the expert. A real path, just not this workload's.
+    #
+    # `dequant` is a VERIFICATION HATCH, not a second metric: never a sweep axis, never a
+    # default. It is retained because it costs nothing (BF16 needs the same staged-is-None
+    # branch) and because it reproduces historical numbers exactly for regression checks --
+    # measured 302.0us against 302.5us in run 30177021271 at T=1.
+    #
+    # A second measured mode is unnecessary because the mismatched-config cost is DERIVABLE
+    # from what every run already emits:
+    #
+    #     dequant roundtrip  ~=  roundtrip + stage        (+2.4% .. -0.1%, b200 LL fp8 ladder)
+    #
+    # slightly high because chaining amortises launch overhead (median rt/(d+s+c) = 0.93
+    # across the corpus). The reverse does NOT hold -- reconstructing native as
+    # `dequant - stage` errs by -11.6% at T=1, -5% at T=64, and only converges by T=256,
+    # i.e. it is worst exactly in the decode regime the headline reports. So measure native
+    # and derive dequant, never the other way round.
+    #
+    # It matters because `stage` exists only for fp8 (stage_device_work = self._fp8), so
+    # charging it to the chained roundtrip compares fp8 and bf16 through structurally
+    # different pipelines. On run 30177021271 that inverted the fp8-vs-bf16 verdict in 39 of
+    # 51 comparisons. dispatch and combine were always measured stage-free; only the chained
+    # roundtrip mixed it in.
+    fp8_consume = os.environ.get("CX_FP8_CONSUME", "native")
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -269,10 +308,18 @@ class EPBackend(abc.ABC):
             self.combine(problem, handle)
             torch.cuda.synchronize()
 
-    def run_roundtrip(self, problem):
-        """One full dispatch -> stage -> combine round trip; returns combined activations."""
+    def run_roundtrip(self, problem, staged=None):
+        """One chained round trip; returns combined activations.
+
+        `staged` supplies a pre-materialised combine input so the conversion pass stays out of
+        the timed region (see `fp8_consume`). When it is None the stage runs inline, which is
+        both the BF16 path (stage is a no-op there) and the `dequant` fp8 model.
+        """
         handle = self.dispatch(problem)
-        self.stage(problem, handle)
+        if staged is None:
+            self.stage(problem, handle)
+        else:
+            setattr(handle, self.combine_input_attr, staged)
         return self.combine(problem, handle)
 
     def benchmark_component(self, component, problem, warmup, iters):
@@ -291,7 +338,19 @@ class EPBackend(abc.ABC):
         import torch
 
         self.warm(problem, warmup)
-        return time_us(torch, lambda p=problem: self.run_roundtrip(p), 0, iters)
+        staged = None
+        if self.stage_device_work and self.fp8_consume == "native":
+            # Materialise the expert-output stand-in ONCE, untimed. A native fp8 stack has no
+            # separate conversion between dispatch and combine, so the chained measurement
+            # must not contain one. Routing is fixed for a ladder point, so the same staged
+            # tensor is valid for every iteration (for MoRI it IS the registered combine
+            # buffer, already filled).
+            handle = self.dispatch(problem)
+            self.stage(problem, handle)
+            staged = getattr(handle, self.combine_input_attr)
+            self.combine(problem, handle)  # drain the pair backends require
+            torch.cuda.synchronize()
+        return time_us(torch, lambda p=problem: self.run_roundtrip(p, staged), 0, iters)
 
     def benchmark_dispatch(self, problem, warmup, iters):
         import torch

--- a/experimental/CollectiveX/bench/ep_backend.py
+++ b/experimental/CollectiveX/bench/ep_backend.py
@@ -119,12 +119,35 @@ class EPBackend(abc.ABC):
     # i.e. it is worst exactly in the decode regime the headline reports. So measure native
     # and derive dequant, never the other way round.
     #
-    # It matters because `stage` exists only for fp8 (stage_device_work = self._fp8), so
-    # charging it to the chained roundtrip compares fp8 and bf16 through structurally
-    # different pipelines. On run 30177021271 that inverted the fp8-vs-bf16 verdict in 39 of
-    # 51 comparisons. dispatch and combine were always measured stage-free; only the chained
-    # roundtrip mixed it in.
+    # It matters because for deepep-v2 and uccl `stage` is precisely the fp8 conversion
+    # (both set stage_device_work = self._fp8), so charging it to the chained roundtrip
+    # compares fp8 and bf16 through structurally different pipelines. On run 30177021271
+    # that inverted the fp8-vs-bf16 verdict in 39 of 51 comparisons. dispatch and combine
+    # were always measured stage-free; only the chained roundtrip mixed it in.
     fp8_consume = os.environ.get("CX_FP8_CONSUME", "native")
+
+    @property
+    def stages_fp8_natively(self) -> bool:
+        """Whether the chained roundtrip should skip the per-iteration `stage()`.
+
+        Gated on precision, NOT on `stage_device_work` alone. The two are equivalent for
+        deepep-v2 and uccl, but MoRI sets `stage_device_work = self._fp8 or not
+        self._external_input`, so its scale-up kernels (IntraNode/IntraNodeLL) report True
+        for BF16 as well -- and their `stage()` really does run a device copy into the
+        registered combine-input buffer. That copy is not an fp8 dequant and nothing in this
+        change's evidence says it should leave the timed region, so BF16 keeps executing it
+        inline every iteration and its numbers are unmoved.
+
+        (Whether MoRI's registered-buffer copy is a production cost or a harness artefact is
+        a real open question -- a native integration may have the expert GEMM write straight
+        into that buffer -- but it is a separate question from fp8 consumption, it applies to
+        both precisions equally, and it needs its own evidence.)
+        """
+        return (
+            self.precision == "fp8"
+            and self.stage_device_work
+            and self.fp8_consume == "native"
+        )
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -339,7 +362,7 @@ class EPBackend(abc.ABC):
 
         self.warm(problem, warmup)
         staged = None
-        if self.stage_device_work and self.fp8_consume == "native":
+        if self.stages_fp8_natively:
             # Materialise the expert-output stand-in ONCE, untimed. A native fp8 stack has no
             # separate conversion between dispatch and combine, so the chained measurement
             # must not contain one. Routing is fixed for a ladder point, so the same staged

--- a/experimental/CollectiveX/bench/ep_harness.py
+++ b/experimental/CollectiveX/bench/ep_harness.py
@@ -1081,6 +1081,9 @@ def run_sweep(args, backend, torch, dist, device, rank: int, world_size: int) ->
             },
         },
         "implementation": {
+            # Which production FP8 consumption path the chained roundtrip modelled; see
+            # EPBackend.fp8_consume. Only meaningful when the case dispatches FP8.
+            "fp8_consume": getattr(backend, "fp8_consume", None),
             "kernel_generation": kernel_generation(backend),
             "name": backend.name,
         },

--- a/experimental/CollectiveX/bench/ep_nccl.py
+++ b/experimental/CollectiveX/bench/ep_nccl.py
@@ -73,6 +73,7 @@ class NCCLEPBackend(EPBackend):
     SUPPORTED_MODES = ("normal", "low-latency")
     SUPPORTED_PRECISIONS = ("bf16",)
     stage_device_work = False
+    combine_input_attr = "combine_input_t"  # this adapter's combine reads combine_input_t
     combine_needs_redispatch = False
     dispatch_needs_combine_cleanup = False
     combine_weight_semantics = "unweighted-rank-sum"

--- a/experimental/CollectiveX/tests/test_roundtrip_staging.py
+++ b/experimental/CollectiveX/tests/test_roundtrip_staging.py
@@ -25,10 +25,11 @@ class _StubBackend(ep_backend.EPBackend):
 
     name = "stub"
 
-    def __init__(self, stage_device_work: bool, fp8_consume: str):
+    def __init__(self, stage_device_work: bool, fp8_consume: str, precision: str = "fp8"):
         self.calls: list[str] = []
         self.stage_device_work = stage_device_work
         self.fp8_consume = fp8_consume
+        self.precision = precision
 
     def create_buffer(self, spec):  # pragma: no cover - unused
         raise NotImplementedError
@@ -80,6 +81,46 @@ class RoundtripStaging(unittest.TestCase):
     def test_default_models_the_native_path(self):
         # deepseek-v3 block-fp8 hits vLLM's matched branch and SGLang's no-dequant path.
         self.assertEqual(ep_backend.EPBackend.fp8_consume, "native")
+
+
+class NativeStagingGate(unittest.TestCase):
+    """`stage_device_work` does NOT imply fp8, so the gate must check precision.
+
+    MoRI sets `stage_device_work = self._fp8 or not self._external_input`, so its scale-up
+    kernels report True for BF16 too, and their stage() does a real copy into the registered
+    combine-input buffer. Gating on stage_device_work alone silently lifted that copy out of
+    the BF16 timed region -- a precision-asymmetric change of exactly the kind this file
+    exists to prevent.
+    """
+
+    def test_bf16_with_device_staging_keeps_the_stage_inline(self):
+        mori_intranode_bf16 = _StubBackend(
+            stage_device_work=True, fp8_consume="native", precision="bf16"
+        )
+        self.assertFalse(mori_intranode_bf16.stages_fp8_natively)
+        mori_intranode_bf16.run_roundtrip(object())
+        self.assertEqual(
+            mori_intranode_bf16.calls, ["dispatch", "stage", "combine(staged-by-stage)"]
+        )
+
+    def test_fp8_with_device_staging_lifts_the_conversion_out(self):
+        self.assertTrue(
+            _StubBackend(
+                stage_device_work=True, fp8_consume="native", precision="fp8"
+            ).stages_fp8_natively
+        )
+
+    def test_the_hatch_and_no_op_stages_never_take_the_fast_path(self):
+        self.assertFalse(  # CX_FP8_CONSUME=dequant restores the inline stage
+            _StubBackend(
+                stage_device_work=True, fp8_consume="dequant", precision="fp8"
+            ).stages_fp8_natively
+        )
+        self.assertFalse(  # nccl-ep / bf16 deepep-v2: nothing to lift
+            _StubBackend(
+                stage_device_work=False, fp8_consume="native", precision="fp8"
+            ).stages_fp8_natively
+        )
 
 
 if __name__ == "__main__":

--- a/experimental/CollectiveX/tests/test_roundtrip_staging.py
+++ b/experimental/CollectiveX/tests/test_roundtrip_staging.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Contract for what the chained roundtrip measures.
+
+`stage` exists only for FP8 (`stage_device_work = self._fp8`), so charging it to the chained
+roundtrip compares FP8 and BF16 through structurally different pipelines. Real stacks decide
+this on quant-format match: SGLang's DeepEP dispatcher contains no dequant at all, and vLLM
+returns the dispatched fp8 + scales untouched when `block_k == DEEPEP_QUANT_BLOCK_SIZE`,
+dequantising only as a mismatch fallback. These tests pin both models.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path[:0] = [str(ROOT), str(ROOT / "bench")]
+
+import ep_backend  # noqa: E402
+
+
+class _StubBackend(ep_backend.EPBackend):
+    """Records the call order; no device work."""
+
+    name = "stub"
+
+    def __init__(self, stage_device_work: bool, fp8_consume: str):
+        self.calls: list[str] = []
+        self.stage_device_work = stage_device_work
+        self.fp8_consume = fp8_consume
+
+    def create_buffer(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def dispatch(self, problem):
+        self.calls.append("dispatch")
+        return types.SimpleNamespace(combine_input=None)
+
+    def stage(self, problem, handle):
+        self.calls.append("stage")
+        handle.combine_input = "staged-by-stage"
+
+    def combine(self, problem, handle):
+        self.calls.append(f"combine({handle.combine_input})")
+        return handle.combine_input
+
+    def recv_tokens(self, handle):  # pragma: no cover - unused
+        return 0
+
+    def inspect_dispatch(self, problem, handle):  # pragma: no cover - unused
+        return {}
+
+    def combine_transformed(self, problem, handle, transformed):  # pragma: no cover
+        return transformed
+
+
+class RoundtripStaging(unittest.TestCase):
+    def test_staged_input_keeps_the_conversion_out_of_the_chain(self):
+        b = _StubBackend(stage_device_work=True, fp8_consume="native")
+        b.run_roundtrip(object(), staged="pre-materialised")
+        self.assertEqual(b.calls, ["dispatch", "combine(pre-materialised)"])
+        self.assertNotIn("stage", b.calls)
+
+    def test_without_staged_input_the_stage_runs_inline(self):
+        # BF16 (stage is a no-op) and the fp8 `dequant` model both take this path.
+        b = _StubBackend(stage_device_work=True, fp8_consume="dequant")
+        b.run_roundtrip(object())
+        self.assertEqual(b.calls, ["dispatch", "stage", "combine(staged-by-stage)"])
+
+    def test_adapters_declare_where_their_combine_input_lives(self):
+        # A wrong attribute would silently leave the staged tensor unused, so the roundtrip
+        # would measure a combine over stale data. NCCL EP is the one that differs.
+        self.assertEqual(ep_backend.EPBackend.combine_input_attr, "combine_input")
+        b = _StubBackend(stage_device_work=True, fp8_consume="native")
+        b.combine_input_attr = "combine_input"
+        b.run_roundtrip(object(), staged="X")
+        self.assertEqual(b.calls[-1], "combine(X)")
+
+    def test_default_models_the_native_path(self):
+        # deepseek-v3 block-fp8 hits vLLM's matched branch and SGLang's no-dequant path.
+        self.assertEqual(ep_backend.EPBackend.fp8_consume, "native")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

CollectiveX's chained `roundtrip` called `stage` inline, and `stage` — the conversion of the dispatched FP8 back to BF16 for combine — exists **only** for FP8 (`stage_device_work = self._fp8`). FP8 and BF16 were therefore timed through structurally different pipelines, on precisely the axis the comparison exists to measure. `dispatch` and `combine` were never affected: they run `stage` inside `time_us`'s untimed `pre`. Only the chained roundtrip mixed it in.

## Why `native` is the right default

Production FP8 MoE has no such pass:

- **SGLang** (`token_dispatcher/deepep.py`) contains no dequant at all. It pre-quantises with `sglang_per_token_group_quant_fp8(hidden, 128, ...)` in DeepGEMM scale format, dispatches FP8 + scales, and hands both straight to DeepGEMM.
- **vLLM** (`prepare_finalize/deepep_ll.py`) dequantises only as a quant-format **mismatch fallback**. When `block_k == DEEPEP_QUANT_BLOCK_SIZE` it returns the dispatched FP8 + scales untouched — *"DeepEP kernels did the quantization for us"*. Otherwise it materialises the full padded `[experts, max_tokens, hidden]` tensor to fp32 and re-quantises.

The deepseek-v3 block-128 FP8 workload this suite runs takes the matched branch, so the dequant was modelling a path this workload never executes.

## Change

- `EPBackend.fp8_consume` = `native` (default) | `dequant`, selectable with `CX_FP8_CONSUME`.
- `benchmark_roundtrip` materialises the combine input **once, untimed** in native mode; `run_roundtrip(problem, staged=None)` installs it via the new `combine_input_attr` (NCCL EP names its tensor `combine_input_t`).
- `dequant` is retained as a **verification hatch**, not a second metric — it costs nothing (BF16 needs the same `staged is None` branch) and reproduces historical numbers for regression checks. It is not a sweep axis, because the mismatch cost is derivable from fields every run already emits: `dequant roundtrip ≈ roundtrip + stage` (+2.4% .. −0.1%). The reverse does **not** hold — reconstructing native as `dequant − stage` errs by −11.6% at T=1, worst exactly in the decode regime the headline reports.
- Artifacts record which model produced them under `implementation.fp8_consume`.
- `tests/test_roundtrip_staging.py` pins both paths, the adapter attribute contract, and the default.

## Validation — b200 deepep-v2 low-latency, one node, three runs

| T | native | dequant | bf16 control |
|---|---|---|---|
| 1 | 61.3 | 302.0 | 63.7 |
| 64 | 74.8 | 312.6 | 84.6 |
| 256 | 126.5 | 357.4 | 153.4 |

The verdict inverts. The old chain said FP8 was 4.7× *slower* than BF16 at T=1; FP8 is in fact faster, by a margin that grows 3.8% → 17.5% with tokens. Growth with payload is the signature of a bandwidth saving; the old flat ≈ −240 µs penalty was the signature of a fixed conversion pass. The hatch reproduces the historical number (302.0 vs 302.5), and BF16 is unmoved (63.7 → 153.4 vs 64.8 → 153.9 before the change, `stage` 0.0 throughout).

Latency now agrees with `byte_provenance` instead of contradicting it: at T=256, dispatch is 68.1 FP8 vs 84.9 BF16 for half the bytes, while combine is 75.8 vs 78.8 because both send BF16 on the wire.

Across the existing corpus this flips the FP8-vs-BF16 verdict in **39 of 51** comparisons; measured transport-only (`dispatch + combine`, identical treatment for both precisions) at the headline rungs, FP8 is faster in 40 of 51, topping out at +30.2%.

## Scope / risk

Measurement-only, inside `experimental/CollectiveX`, which gates nothing. Existing FP8 artifacts remain readable and are distinguishable by the absence of `implementation.fp8_consume`. Test suite green (58 tests, 6 skipped).

**BF16 is unmoved, and that is enforced by the gate rather than assumed.** The first revision of this PR gated the fast path on `stage_device_work` alone, on the premise that it implies FP8. That holds for deepep-v2 and uccl (`self.stage_device_work = self._fp8`) but *not* for MoRI, which uses `self._fp8 or not self._external_input` — so its scale-up kernels report `True` at BF16, and their `stage()` really does copy into the registered combine-input buffer (`ep_mori.py:271-277`). That would have lifted a real BF16 device copy out of the timed region for every MoRI scale-up case: precision-asymmetric in exactly the way this PR exists to remove. Caught in review, fixed in 956b9c76 by gating on `precision == "fp8"` through a named `stages_fp8_natively` property, with three regression tests pinning it. deepep-v2 and uccl are unaffected — the two conditions coincide there — so the b200 numbers above still stand.

Deliberately **out of scope**: whether MoRI's registered-buffer copy is a production cost or a harness artefact. A native integration may have the expert GEMM write straight into that buffer, but the question applies to both precisions equally and needs its own evidence, so BF16 keeps paying it inline here.
