### PR TITLE
[AMD][MI35X] Bump qwen3.5-fp8 MI355X SGLang single-node image to v0.5.16

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -246,7 +246,7 @@ qwen3.5-fp8-mi325x-sglang:
       - { tp: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-mi355x-sglang:
-  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x
@@ -261,7 +261,7 @@ qwen3.5-fp8-mi355x-sglang:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp8-mi355x-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
+  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi355x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5094,3 +5094,10 @@
     - "Recipe fix (model): adds mtp_flags (--speculative-algorithm EAGLE --speculative-eagle-topk 1) to the DeepSeek-V4-Pro-DI models.yaml entry; without it DECODE_MTP_SIZE>0 emitted --speculative-num-steps/--speculative-num-draft-tokens with no --speculative-algorithm, so sglang never engaged spec decoding. EAGLE with in-checkpoint draft (no draft-model-path); NEXTN (the V3/R1 keyword) crashes the dsv4 decode server at init"
     - "Recipe fix (launcher): build_server_config appended the speculative flags to the decode server only, so prefill never allocated the nextn (MTP draft) KV layer -- prefill registered 3 PD state components, decode 4. SGLang PD-disaggregation requires matching speculative config on both roles (the draft/MTP layers participate in both prefill KV computation and decode verification): v0.5.15 hard-fails the mismatch (mori 'state component count mismatch'), while v0.5.14 tolerated it silently but decode's nextn state was never seeded from prefill, corrupting greedy EAGLE verification (gsm8k 0.96 -> 0.88, worse at depth 2). Fix: apply the speculative flags to both prefill and decode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2305/changes
+
+- config-keys:
+    - qwen3.5-fp8-mi355x-sglang
+    - qwen3.5-fp8-mi355x-sglang-mtp
+  description:
+    - "Bump image from lmsysorg/sglang:v0.5.14-rocm720-mi35x to lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2201

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5100,4 +5100,4 @@
     - qwen3.5-fp8-mi355x-sglang-mtp
   description:
     - "Bump image from lmsysorg/sglang:v0.5.14-rocm720-mi35x to lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2201
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2349


### PR DESCRIPTION
see unofficial run visualizer at https://inferencex.semianalysis.com/inference?unofficialRun=30248106614
see unofficial run visualizer at https://inferencex.semianalysis.com/evaluation?unofficialRun=30248106614

## Motivation

Update the single-node MI355X SGLang benchmark configs for Qwen3.5-397B-A17B-FP8 to the latest ROCm SGLang image. Follows the same image-bump pattern as #2201 (which bumped the MXFP4 variant).

## Modifications

- `configs/amd-master.yaml`: bump the image for `qwen3.5-fp8-mi355x-sglang` and `qwen3.5-fp8-mi355x-sglang-mtp` from `lmsysorg/sglang:v0.5.14-rocm720-mi35x` to `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726`.
- `perf-changelog.yaml`: append a changelog entry triggering a re-benchmark for the two config-keys.

No benchmark-script changes (env vars unchanged).

## Accuracy Tests / Benchmarking

Re-benchmark via the sweep. `python -m pytest utils/matrix_logic/` passes (122 relevant tests); `generate_sweep_configs.py` emits the new image for both non-MTP and MTP arms.