### PR TITLE
[VERIFY / DO NOT MERGE] atom-mtp TBO+MTP probe @ c128

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp4_mi355x_atom_mtp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")/../benchmark_lib.sh"
+source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
     MODEL \
@@ -26,20 +26,42 @@ PARALLEL_ARGS=(-tp "$TP") #TP
 if [ "$DP_ATTENTION" = "true" ]; then
     if [ "$EP_SIZE" -gt 1 ]; then #DP+EP
         PARALLEL_ARGS=(-tp "$TP" --enable-expert-parallel --enable-dp-attention )
-    else #DP+TP
+    else #DPA+TP
         PARALLEL_ARGS=(-tp "$TP" --enable-dp-attention )
     fi
-fi 
+fi
 
-SPEC_ARGS=(--method mtp --num-speculative-tokens 3 )
+SPEC_ARGS=(--method mtp --num-speculative-tokens 3)
 
-# Start GPU monitoring (power, temperature, clocks every second)
+# VERIFY (throwaway branch): TBO + MTP at conc>=128. ATOM owner says TBO now works
+# with MTP at high concurrency. dp-on cells at conc>=128 add --enable-tbo +
+# GPU_MAX_HW_QUEUES=5. MUST CONFIRM MTP is not silently dropped (ubatch_wrapper
+# sets spec_decode_metadata=None) — check server log for spec/MTP init + eval
+# accept-rate. If MTP is dropped, this image doesn't support the combo.
+if [ "$DP_ATTENTION" = "true" ] && [ "$CONC" -ge 128 ]; then
+    PARALLEL_ARGS+=(--enable-tbo)
+    export GPU_MAX_HW_QUEUES=5
+fi
+
+# max_num_seqs=conc for dp-on cells and conc>=64 (avoid OOM; MTP reserves q=mtp_k+1)
+if [ "$DP_ATTENTION" = "true" ] || [ "$CONC" -ge 64 ]; then
+    PARALLEL_ARGS+=(--max-num-seqs "$CONC")
+fi
+
+BENCHMARK_MAX_MODEL_LEN="$MAX_MODEL_LEN"
+
+if [ "${EVAL_ONLY}" = "true" ]; then
+    EVAL_MAX_MODEL_LEN=$(compute_eval_context_length "$MODEL" "$BENCHMARK_MAX_MODEL_LEN")
+    export EVAL_MAX_MODEL_LEN
+fi
+
 start_gpu_monitor
 
 set -x
 export ATOM_DISABLE_MMAP=true
 export AITER_BF16_FP8_MOE_BOUND=0
 export ATOM_MOE_GU_ITLV=1
+
 python3 -m atom.entrypoints.openai_server \
     --model $MODEL \
     --server-port $PORT \
@@ -47,19 +69,15 @@ python3 -m atom.entrypoints.openai_server \
     "${SPEC_ARGS[@]}" \
     --kv_cache_dtype fp8 \
     --trust-remote-code \
-    > $SERVER_LOG 2>&1 &
+    --no-enable_prefix_caching \
+    > "$SERVER_LOG" 2>&1 &
 
 SERVER_PID=$!
 
-# Wait for server to be ready
 wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
-# --dsv4 routes prompts through encoding_dsv4.py (PR #1153), which emits the
-# <bos><User>...<Assistant><think> framing DeepSeek-V4-Pro expects. The DSv4-Pro
-# tokenizer ships without a jinja chat_template, so plain --use-chat-template
-# would crash; --dsv4 sidesteps that and satisfies the AGENTS.md rule that all
-# MTP scripts must benchmark against chat-formatted inputs (EAGLE acceptance
-# silently regresses on raw random tokens).
+# --dsv4: InferenceX bench (utils/bench_serving) uses encoding_dsv4.py; DSv4-Pro has
+# no jinja chat_template so plain --use-chat-template yields no result.
 run_benchmark_serving \
     --model "$MODEL" \
     --port "$PORT" \
@@ -74,12 +92,10 @@ run_benchmark_serving \
     --trust-remote-code \
     --dsv4
 
-# After throughput, run evaluation only if RUN_EVAL is true
 if [ "${RUN_EVAL}" = "true" ]; then
     run_eval --framework lm-eval --port "$PORT"
     append_lm_eval_summary
 fi
 
-# Stop GPU monitoring
 stop_gpu_monitor
 set +x

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1425,7 +1425,7 @@ dsv4-fp4-mi355x-atom:
       - { tp: 8, ep: 1, dp-attn: true, conc-start: 128, conc-end: 2048 }
 
 dsv4-fp4-mi355x-atom-mtp:
-  image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.3
+  image: rocm/atom-dev:nightly_202607231538
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1437,7 +1437,9 @@ dsv4-fp4-mi355x-atom-mtp:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 1, conc-end: 1024, spec-decoding: mtp }
+      # TBO+MTP verify (throwaway branch): single c128 dp-on point; recipe adds
+      # --enable-tbo at conc>=128. Compare tput vs non-TBO c128 from run 30238071409.
+      - { tp: 8, ep: 1, dp-attn: true, conc-start: 128, conc-end: 128, spec-decoding: mtp }
 
 qwen3.5-bf16-mi325x-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-rocm720-mi30x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5094,3 +5094,9 @@
     - "Recipe fix (model): adds mtp_flags (--speculative-algorithm EAGLE --speculative-eagle-topk 1) to the DeepSeek-V4-Pro-DI models.yaml entry; without it DECODE_MTP_SIZE>0 emitted --speculative-num-steps/--speculative-num-draft-tokens with no --speculative-algorithm, so sglang never engaged spec decoding. EAGLE with in-checkpoint draft (no draft-model-path); NEXTN (the V3/R1 keyword) crashes the dsv4 decode server at init"
     - "Recipe fix (launcher): build_server_config appended the speculative flags to the decode server only, so prefill never allocated the nextn (MTP draft) KV layer -- prefill registered 3 PD state components, decode 4. SGLang PD-disaggregation requires matching speculative config on both roles (the draft/MTP layers participate in both prefill KV computation and decode verification): v0.5.15 hard-fails the mismatch (mori 'state component count mismatch'), while v0.5.14 tolerated it silently but decode's nextn state was never seeded from prefill, corrupting greedy EAGLE verification (gsm8k 0.96 -> 0.88, worse at depth 2). Fix: apply the speculative flags to both prefill and decode"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2305/changes
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-mtp
+  description:
+    - "[VERIFY-ONLY, throwaway branch, do NOT merge] TBO+MTP probe at c128: single dp-on c128 point adds --enable-tbo (+ GPU_MAX_HW_QUEUES=5) on top of --method mtp, to verify whether TBO works with MTP on nightly_202607231538 (ATOM owner reports it does). Checks tput + eval accept-rate vs the non-TBO c128 from run 30238071409; if MTP is silently dropped the image lacks support."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5099,4 +5099,4 @@
     - dsv4-fp4-mi355x-atom-mtp
   description:
     - "[VERIFY-ONLY, throwaway branch, do NOT merge] TBO+MTP probe at c128: single dp-on c128 point adds --enable-tbo (+ GPU_MAX_HW_QUEUES=5) on top of --method mtp, to verify whether TBO works with MTP on nightly_202607231538 (ATOM owner reports it does). Checks tput + eval accept-rate vs the non-TBO c128 from run 30238071409; if MTP is silently dropped the image lacks support."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2350


### PR DESCRIPTION
**Throwaway verification branch — DO NOT MERGE / DO NOT REVIEW.** Will be closed after the probe.

## Purpose
Verify whether **TBO works together with MTP** at high concurrency on `nightly_202607231538` (ATOM owner reports it does; but ATOM main `ubatch_wrapper.py:562` still hardcodes `spec_decode_metadata=None  # not supported with TBO`).

## Setup
Single **c128 dp-on** point: `--enable-tbo` + `--method mtp --num-speculative-tokens 3` together (+ GPU_MAX_HW_QUEUES=5).

## What to check
- server log: MTP/spec init present (MTP **not** silently dropped by TBO)
- eval accept-rate normal (MTP actually engaged)
- throughput vs non-TBO c128 (from run 30238071409) → is TBO a win?