### PR TITLE
feat(agentx): add 5-minute warmup and 20-minute profiling preset / feat(agentx)：新增 5 分钟预热与 20 分钟性能采集预设

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -154,6 +154,11 @@ on:
         type: string
         required: false
         default: "3600"
+      agentx-fast:
+        description: "Use the AgentX 5-minute warmup and 20-minute profiling preset"
+        type: boolean
+        required: false
+        default: false
       kv-offloading:
         description: "KV offload mode for agentic scenarios (none/dram)"
         required: false
@@ -214,6 +219,7 @@ env:
   IS_AGENTIC: ${{ inputs.scenario-type == 'agentic-coding' && '1' || '0' }}
   CONC: ${{ inputs.conc }}
   DURATION: ${{ inputs.duration }}
+  AIPERF_EXPERIMENTAL_FAST: ${{ inputs.agentx-fast && '1' || '0' }}
   KV_OFFLOADING: ${{ inputs.kv-offloading }}
   KV_OFFLOAD_BACKEND: ${{ inputs.kv-offload-backend }}
   KV_OFFLOAD_BACKEND_METADATA: ${{ inputs.kv-offload-backend-metadata }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -129,6 +129,11 @@ on:
         required: false
         type: string
         default: '3600'
+      agentx-fast:
+        description: "Use the AgentX 5-minute warmup and 20-minute profiling preset"
+        required: false
+        type: boolean
+        default: false
       eval-limit:
         description: "Eval instance count: empty/full = whole split (default); N = first-N smoke slice"
         required: false
@@ -174,6 +179,7 @@ env:
   KV_P2P_TRANSFER: ${{ inputs.kv-p2p-transfer }}
   TOTAL_CPU_DRAM_GB: ${{ inputs.total-cpu-dram-gb }}
   DURATION: ${{ inputs.duration }}
+  AIPERF_EXPERIMENTAL_FAST: ${{ inputs.agentx-fast && '1' || '0' }}
   EVAL_LIMIT: ${{ inputs.eval-limit }}
   SWEBENCH_GEN_MODE: ${{ inputs.swebench-gen-mode }}
   AIPERF_FAILED_REQUEST_THRESHOLD: '0.10'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,11 @@ on:
                 required: false
                 type: string
                 default: ""
+            agentx-fast:
+                description: "AgentX fast feedback: 5-minute cache warmup and 20-minute profile."
+                required: false
+                type: boolean
+                default: false
             eval-limit:
                 description: "Eval instance count: empty/full = whole split (default); N = first-N smoke slice"
                 required: false
@@ -50,6 +55,11 @@ on:
                 required: false
                 type: string
                 default: ""
+            agentx-fast:
+                description: "AgentX fast feedback: 5-minute cache warmup and 20-minute profile."
+                required: false
+                type: boolean
+                default: false
             eval-limit:
                 description: "Eval instance count: empty/full = whole split (default); N = first-N smoke slice"
                 required: false
@@ -264,7 +274,8 @@ jobs:
             kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
             kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
             total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
-            duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
+            duration: ${{ inputs.agentx-fast && '1200' || (inputs.duration-override != '' && inputs.duration-override || matrix.config.duration) }}
+            agentx-fast: ${{ inputs.agentx-fast }}
             isl: '0'
             osl: '0'
             max-model-len: '0'
@@ -301,7 +312,8 @@ jobs:
             kv-offloading: ${{ matrix.config.kv-offloading }}
             kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
             total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
-            duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
+            duration: ${{ inputs.agentx-fast && '1200' || (inputs.duration-override != '' && inputs.duration-override || matrix.config.duration) }}
+            agentx-fast: ${{ inputs.agentx-fast }}
             isl: '0'
             osl: '0'
             max-model-len: '0'
@@ -364,7 +376,8 @@ jobs:
             kv-offloading: ${{ matrix.config.kv-offloading }}
             kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
             kv-offload-backend-metadata: ${{ matrix.config['kv-offload-backend'] && toJson(matrix.config['kv-offload-backend']) || '' }}
-            duration: ${{ inputs.duration-override != '' && inputs.duration-override || matrix.config.duration }}
+            duration: ${{ inputs.agentx-fast && '1200' || (inputs.duration-override != '' && inputs.duration-override || matrix.config.duration) }}
+            agentx-fast: ${{ inputs.agentx-fast }}
             run-eval: false
             scenario-type: agentic-coding
             ref: ${{ inputs.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,8 @@ gh api -X POST \
 
 Inputs: top-level `ref` (required) is the workflow ref to dispatch from, almost always `main`. `inputs[ref]` is the repo ref under test (defaults to the dispatch ref's `github.sha`). `inputs[generate-cli-command]` (required) is passed verbatim to `generate_sweep_configs.py` - test locally first. `inputs[test-name]` is the display name in the Actions UI. `inputs[duration-override]` overrides per-config duration (seconds); empty = use matrix value.
 
+For an AgentX preflight, add `-F 'inputs[agentx-fast]=true'` to the dispatch command. This selects a 5-minute cache warmup and 20-minute profile for every AgentX job in that e2e dispatch and takes precedence over `duration-override`. Use it to get faster signal while debugging, then run the official sweep without `agentx-fast`; canonical AgentX timing remains a 10-minute cache warmup and 1-hour profile.
+
 The POST returns no body and no run ID - find the run with `gh run list` below.
 
 ### Monitoring jobs

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1744,6 +1744,15 @@ build_replay_cmd() {
     # utils/aiperf/docs/tutorials/agentx-mvp.md.
     local result_dir="$1"
     local duration="$DURATION"
+    local cache_warmup_duration="${AIPERF_AGENTIC_CACHE_WARMUP_DURATION:-600}"
+
+    # Fast mode is an e2e-only feedback preset used before canonical one-hour
+    # sweeps. AIPerf already exposes both controls, so no AIPerf patch is
+    # required.
+    if [[ "${AIPERF_EXPERIMENTAL_FAST:-0}" == "1" ]]; then
+        duration=1200
+        cache_warmup_duration=300
+    fi
 
     export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES:-0}"
     # Dataset configuration (load + reconstruct + inputs.json + mmap)
@@ -1776,9 +1785,9 @@ build_replay_cmd() {
     REPLAY_CMD+=" --trajectory-start-min-ratio 0.25"
     REPLAY_CMD+=" --trajectory-start-max-ratio 0.75"
     # After the normal t* snapshot warmup, continue those exact trajectories
-    # with one-token outputs and no idle delays for 10 minutes. Profiling begins
-    # only after those requests drain and resumes from the resulting live state.
-    REPLAY_CMD+=" --agentic-cache-warmup-duration 600"
+    # with one-token outputs and no idle delays. Profiling begins only after
+    # those requests drain and resumes from the resulting live state.
+    REPLAY_CMD+=" --agentic-cache-warmup-duration $cache_warmup_duration"
     # Give long-context warmup requests up to 30 minutes to drain before
     # declaring warmup failed. Recipes whose saturation arms carry a larger
     # in-flight working set may override via AGENTIC_WARMUP_GRACE_PERIOD


### PR DESCRIPTION
## Description

- Add an `agentx-fast` switch to the manual e2e workflow for faster AgentX feedback.
- Use a 5-minute cache warmup and 20-minute profiling window when enabled; keep the canonical 10-minute warmup and 1-hour profile unchanged by default.
- Document the exact AgentX preflight dispatch syntax and require canonical timing for the official sweep.
- Reuse existing AIPerf timing flags. This PR does not change AIPerf or its submodule pointer.

Implements [Oren's suggestion](https://semianalysis.slack.com/archives/C09PULGMVNG/p1785214442791739).

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other

## Validation

- `actionlint` on the three changed workflows (no new errors; existing lint notices remain)
- `shellcheck -x benchmarks/benchmark_lib.sh` (existing notices only)
- 41 targeted workflow and AgentX validation tests passed
- Verified generated AIPerf commands for default, explicit warmup override, and fast-mode timing
- `git diff --check`

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the agent documentation
- [x] No container image, benchmark config, or `perf-changelog.yaml` change
- [ ] Reuse sign-off is not applicable until a final eligible full sweep exists

## 中文说明

- 为手动端到端工作流新增 `agentx-fast` 开关，以便更快获得 AgentX 反馈。
- 启用后采用 5 分钟缓存预热和 20 分钟性能采集；默认仍保持标准的 10 分钟预热和 1 小时性能采集。
- 记录 AgentX 预检的准确触发命令，并要求正式扫描恢复标准时长。
- 直接复用 AIPerf 现有的时长参数；本 PR 不修改 AIPerf，也不更新其子模块指针。

本 PR 实现了 [Oren 的建议](https://semianalysis.slack.com/archives/C09PULGMVNG/p1785214442791739)。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 配置变更
- [x] 文档更新
- [ ] 其他

## 验证

- 对三个变更工作流运行 `actionlint`（无新增错误，仍有既有提示）
- 运行 `shellcheck -x benchmarks/benchmark_lib.sh`（仅有既有提示）
- 41 项工作流与 AgentX 定向验证测试通过
- 已验证默认模式、显式预热覆盖以及快速模式生成的 AIPerf 命令时长
- `git diff --check`
