### PR TITLE
fix(reuse): accept a pinned cancelled sweep run as a reuse source

### DIFF
--- a/utils/find_reusable_sweep_run.py
+++ b/utils/find_reusable_sweep_run.py
@@ -244,9 +244,18 @@ def validate_reusable_run(
         raise RuntimeError(f"Reusable source run {run_id} is not a pull_request run.")
     if run.get("status") != "completed":
         raise RuntimeError(f"Reusable source run {run_id} is not completed.")
-    allowed_conclusions = {"success", "failure"} if allow_failed else {"success"}
+    # A pinned run is an explicit maintainer choice, so incomplete sweeps are
+    # allowed: ingestion skips rows without results, leaving only the completed
+    # points.  ``cancelled`` belongs here alongside ``failure`` because a
+    # fail-fast sweep cancels its remaining jobs, so a run whose benchmark jobs
+    # all passed still concludes ``cancelled`` when a later job is cut short.
+    allowed_conclusions = (
+        {"success", "failure", "cancelled"} if allow_failed else {"success"}
+    )
     if run.get("conclusion") not in allowed_conclusions:
-        expected = "success or failure" if allow_failed else "success"
+        expected = (
+            "success, failure, or cancelled" if allow_failed else "success"
+        )
         raise RuntimeError(
             f"Reusable source run {run_id} has conclusion {run.get('conclusion')!r}; "
             f"expected {expected}."

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -413,6 +413,59 @@ def test_validate_reusable_run_rejects_failed_run_by_default(monkeypatch) -> Non
         raise AssertionError("expected an unpinned failed run to be rejected")
 
 
+def test_validate_reusable_run_accepts_cancelled_run_when_explicitly_allowed(
+    monkeypatch,
+) -> None:
+    """A fail-fast sweep concludes ``cancelled`` once a job is cut short.
+
+    Its completed benchmark jobs still uploaded usable artifacts, so a pinned
+    ``cancelled`` run is reusable on the same terms as a pinned failure.
+    """
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
+
+    reuse.validate_reusable_run(
+        "SemiAnalysisAI/InferenceX",
+        "run-sweep.yml",
+        1321,
+        {
+            "id": 25763404168,
+            "event": "pull_request",
+            "status": "completed",
+            "conclusion": "cancelled",
+            "path": ".github/workflows/run-sweep.yml",
+            "head_sha": "abc123",
+        },
+        "token",
+        allow_failed=True,
+    )
+
+
+def test_validate_reusable_run_rejects_cancelled_run_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(reuse, "artifact_names", lambda *args: {"results_bmk"})
+    monkeypatch.setattr(reuse, "pr_commit_shas", lambda *args: {"abc123"})
+
+    try:
+        reuse.validate_reusable_run(
+            "SemiAnalysisAI/InferenceX",
+            "run-sweep.yml",
+            1321,
+            {
+                "id": 25763404168,
+                "event": "pull_request",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "path": ".github/workflows/run-sweep.yml",
+                "head_sha": "abc123",
+            },
+            "token",
+        )
+    except RuntimeError as error:
+        assert "expected success" in str(error)
+    else:
+        raise AssertionError("expected an unpinned cancelled run to be rejected")
+
+
 def test_validate_reusable_run_accepts_run_for_older_pr_commit(monkeypatch) -> None:
     """Regression: pinned run survives an additional commit landing on the PR.
 


### PR DESCRIPTION
`validate_reusable_run` allows an incomplete source run only when the run was
explicitly pinned with `/reuse-sweep-run <run_id>`, because ingestion skips rows
without results and therefore lands only the completed points. That allowance
covered `success` and `failure` but not `cancelled`.

`cancelled` is the conclusion a fail-fast sweep reaches whenever a job is cut
short: the remaining jobs are cancelled, and the run concludes `cancelled` even
when every benchmark job passed and uploaded artifacts. Those runs could not be
pinned at all, so a maintainer had no way to recover their completed points.

Concrete case: PR #2371's sweep
[run 30326393603](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30326393603)
has all 12 `agentic` jobs `success` with 12 `bmk_agentic_*` artifacts, but one
`eval-only` job was cancelled, cascading to `trigger-ingest` — so the run
concluded `cancelled` and the #2371 ingest could not be recovered
(#2386 is blocked on this).

Unpinned reuse is unchanged and still requires `success`.

Verified: `pytest utils/test_find_reusable_sweep_run.py` → 26 passed, including
the two new cases (pinned `cancelled` accepted, unpinned `cancelled` rejected),
plus a direct `validate_reusable_run` call against the real run 30326393603 and
PR #2386 commit list.