### PR TITLE
fix(ci): allow staging cancelled sweep artifacts / 允许暂存已取消扫描的产物

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -169,13 +169,19 @@ jobs:
                   reason: 'it was not created while a full-sweep label was applied',
                 };
               }
-              if (candidate.status !== 'completed' || candidate.conclusion !== 'success') {
+              const stageableConclusions = new Set(['success', 'cancelled']);
+              if (
+                candidate.status !== 'completed' ||
+                !stageableConclusions.has(candidate.conclusion)
+              ) {
                 return {
                   valid: false,
                   reason: `it is ${candidate.status}/${candidate.conclusion}`,
                 };
               }
 
+              // Cancelled sweeps may still contain useful partial results. The
+              // artifact checks below keep empty or metadata-only runs ineligible.
               const artifactNames = await usableArtifactNames(candidate.id);
               if (!artifactNames.includes('changelog-metadata')) {
                 return { valid: false, reason: 'it has no unexpired changelog-metadata artifact' };
@@ -222,7 +228,7 @@ jobs:
               }
               if (!run) {
                 core.setFailed(
-                  `No successful completed run-sweep.yml run with unexpired staging artifacts was found for PR #${context.issue.number}`,
+                  `No stageable completed run-sweep.yml run with unexpired staging artifacts was found for PR #${context.issue.number}`,
                 );
                 return;
               }


### PR DESCRIPTION
## Summary

Allow `/stage-results` to use completed cancelled sweep runs when they still contain unexpired changelog metadata and benchmark artifacts. Empty and metadata-only cancellations remain ineligible.

## Validation

- `actionlint .github/workflows/stage-results.yml`
- `git diff --check`
- Confirmed run `30405836523` has `changelog-metadata` and 13 benchmark artifacts

## 中文说明

允许 `/stage-results` 使用已完成但被取消的扫描运行，前提是仍包含未过期的 changelog 元数据和基准测试产物。空运行或仅含元数据的取消运行仍不可暂存。

## 验证

- `actionlint .github/workflows/stage-results.yml`
- `git diff --check`
- 已确认运行 `30405836523` 包含 `changelog-metadata` 和 13 个基准测试产物