### PR TITLE
CollectiveX: one nccl-ep handle per group, and restore the low-latency rows

### DIFF
--- a/experimental/CollectiveX/bench/ep_nccl.py
+++ b/experimental/CollectiveX/bench/ep_nccl.py
@@ -114,6 +114,9 @@ class NCCLEPBackend(EPBackend):
         self._combine_cfg = CombineConfig(send_only=0)
         self._comm = None
         self._ep_group = None
+        # Exactly ONE handle per group, rebound per problem shape — see _ensure_handle.
+        self._handle = None
+        self._bound = None
 
     def buffer_cap(self, args):
         if self._ll:
@@ -238,15 +241,34 @@ class NCCLEPBackend(EPBackend):
             self._ht_disp_counts_t = self._t(self._ht_disp_counts)
 
     def _ensure_handle(self, p):
-        """Create (once, cached on the problem) the reusable per-step handle for p's routing.
+        """Bind the group's single handle to p's routing, creating it on first use.
 
-        create_handle is collective and, in HT, performs the metadata exchange that fixes the
-        received-token count — so it must run in the same order on every rank. It first runs
-        inside Pass 1's untimed warm (ladder order, identical across ranks); the timed passes
-        then reuse the cached handle and never enter a collective here.
+        ONE handle per group, rebound per shape — never one handle per shape. `buffer_idx`, the
+        LL double-buffer parity selector, is per-HANDLE state, but the buffers it selects are
+        offsets into the per-GROUP rdma_buffer: two handles built from the same group config
+        resolve to the SAME parity-0/parity-1 count+flag slots and advance their parity
+        independently, so one handle's "next buffer, safe to clean" is the other's "current
+        buffer, in flight". Interleaving handles therefore corrupts the signalling even when it
+        does not hang outright, which makes every latency drawn from such a run suspect. Filed
+        upstream as NVIDIA/nccl#2303; reproduced on a stock wheel by ladder [1] (one handle,
+        clean) vs ladder [1, 2] (two handles, 64 dispatch + 6 combine receive timeouts -> 719).
+
+        `ncclEpInitHandle` takes no token count and `ncclEpUpdateHandle` is documented as a
+        "per-step collective: prepare the handle for the given top-k routing decisions", so
+        rebinding IS the intended lifecycle. This also matches the other three backends, which
+        each allocate one object sized to the ladder maximum and vary the token count per call.
+
+        Both create_handle and update are collective, and HT additionally performs the metadata
+        exchange that fixes the received-token count, so they must run in the same order on
+        every rank. They only ever run on a shape CHANGE, and every timed component is preceded
+        by an untimed warm() on its own problem — so the collective always lands in warm (or in
+        the oracle passes), never inside a timed window. Re-entering with the already-bound
+        problem returns immediately without a collective or a sync.
         """
         cached = getattr(p, "_nccl", None)
         if cached is not None:
+            if self._bound is not cached:
+                self._rebind(cached)
             return cached
         stream = self._stream()
         topk_idx_t = self._t(p.topk_idx)
@@ -271,18 +293,45 @@ class NCCLEPBackend(EPBackend):
                 expert_counters=self._t(h.recv_experts),
                 recv_total_counter=self._t(h.recv_total),
             )
-        h.handle = self._ep_group.create_handle(
-            self._layout,
-            topk_idx_t,
-            layout_info=ht_layout_info,
-            config=HandleConfig(),
-            stream=stream,
+        # LL takes layout_info only on dispatch (the API forbids it on create/update); HT needs
+        # it here so this problem's counters receive its own metadata-exchange results.
+        h.layout_info = ht_layout_info
+        if self._handle is None:
+            self._handle = self._ep_group.create_handle(
+                self._layout,
+                topk_idx_t,
+                layout_info=ht_layout_info,
+                config=HandleConfig(),
+                stream=stream,
+            )
+            h.handle = self._handle
+            torch.cuda.synchronize()
+            if not self._ll:
+                h.count = int(h.recv_total.item())
+            self._bound = h
+        else:
+            h.handle = self._handle
+            self._rebind(h)
+        p._nccl = h
+        return h
+
+    def _rebind(self, h):
+        """Point the single handle at h's routing (collective; untimed callers only).
+
+        Rebinding does not reallocate: `Handle.update` only swaps in the new top-k indices.
+        HT re-reads its received-token count because the metadata exchange recomputes it for
+        this routing; the value is deterministic per problem, so a later rebind to the same
+        problem reproduces it.
+        """
+        self._handle.update(
+            h.topk_idx_t,
+            layout_info=None if self._ll else h.layout_info,
+            stream=self._stream(),
         )
         torch.cuda.synchronize()
         if not self._ll:
             h.count = int(h.recv_total.item())
-        p._nccl = h
-        return h
+        self._bound = h
 
     # ---- transport contract ------------------------------------------------------------------
 
@@ -464,8 +513,11 @@ class NCCLEPBackend(EPBackend):
         return rc
 
     def _destroy_handles(self):
-        # Per-problem handles are cached on the problem namespaces; the group keeps no registry,
-        # so there is nothing to walk here. Handles are released when their problems are GC'd
-        # (Handle.destroy runs in the binding's __del__); the group/comm destroy below reclaims
-        # the device buffers. Kept as a seam in case bring-up needs explicit handle teardown.
-        return
+        # One handle for the whole group, so teardown is a single explicit destroy rather than
+        # waiting on per-problem GC. The problem namespaces still hold a reference to it for
+        # their dispatch/combine calls; dropping _bound first keeps a late rebind from touching
+        # a destroyed handle. The group/comm destroy below reclaims the device buffers.
+        self._bound = None
+        if self._handle is not None:
+            self._handle.destroy()
+            self._handle = None

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -10,7 +10,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 2x200GbE", "switch": "Arista 7060DX5-64S (Tomahawk4, 25.6T)"},
       "operator": {
         "partition": "hpc-gpu-1",
@@ -34,7 +34,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 400G", "switch": "NVIDIA Quantum-2 QM9790 (25.6T, InfiniBand)"},
       "operator": {
         "partition": "main",
@@ -54,7 +54,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 400GbE", "switch": "Whitebox Tomahawk3 leaf + Tomahawk4 (RoCE)"},
       "operator": {
         "partition": "gpu-2",
@@ -77,6 +77,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "nccl-ep": [8]},
+      "ll_backends": {"nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-8 2x400GbE", "switch": "NVIDIA Spectrum-X SN5600 (51.2T)"},
       "operator": {
         "partition": "batch_1",
@@ -101,6 +102,7 @@
       "scale_up_transport": "mnnvl",
       "launcher": "gb-nv",
       "backends": {"deepep-v2": [8, 16], "nccl-ep": [8, 16]},
+      "ll_backends": {"nccl-ep": [8]},
       "fabric": {"nic": "MNNVL (scale-out not used)", "switch": "NVLink NVL72"},
       "operator": {
         "partition": "batch",
@@ -120,6 +122,7 @@
       "scale_up_transport": "mnnvl",
       "launcher": "gb-nv",
       "backends": {"deepep-v2": [8, 16], "nccl-ep": [8, 16]},
+      "ll_backends": {"nccl-ep": [8]},
       "fabric": {"nic": "MNNVL (scale-out not used)", "switch": "NVLink NVL72"},
       "operator": {
         "partition": "batch_1",

--- a/experimental/CollectiveX/tests/test_ep_nccl_handle.py
+++ b/experimental/CollectiveX/tests/test_ep_nccl_handle.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Torch-free tests for the nccl-ep single-handle contract.
+
+The invariant under test: ONE handle per group, rebound per problem shape. Two handles built
+from the same group config resolve to the same LL parity signal slots while advancing their
+parity independently, which corrupts signalling (NVIDIA/nccl#2303) -- so a regression that
+reintroduces per-shape handles must fail loudly here rather than on a cluster.
+
+torch and nccl are stubbed so this runs without the benchmark image.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _stub_modules():
+    """Fake torch / nccl modules so `import ep_nccl` succeeds without the benchmark image."""
+    torch = types.ModuleType("torch")
+    torch.bfloat16 = "bfloat16"
+    torch.int32 = "int32"
+    torch.empty = lambda *a, **k: types.SimpleNamespace(shape=a[0] if a else ())
+    torch.zeros = lambda *a, **k: types.SimpleNamespace(item=lambda: 7)
+    torch.cuda = types.SimpleNamespace(synchronize=lambda: None)
+    dist = types.ModuleType("torch.distributed")
+    torch.distributed = dist
+
+    ep = types.ModuleType("nccl.ep")
+    for name in (
+        "Algorithm", "CombineConfig", "CombineInputs", "CombineOutputs", "DispatchConfig",
+        "DispatchInputs", "DispatchOutputs", "GroupConfig", "HandleConfig", "Layout",
+        "LayoutInfo", "Tensor",
+    ):
+        setattr(ep, name, type(name, (), {"__init__": lambda self, *a, **k: None}))
+    ep.Algorithm = types.SimpleNamespace(LOW_LATENCY="LL", HIGH_THROUGHPUT="HT")
+    ep.Layout = types.SimpleNamespace(EXPERT_MAJOR="EM", FLAT="FLAT")
+    core = types.ModuleType("nccl.core")
+    pkg = types.ModuleType("nccl")
+    pkg.ep, pkg.core = ep, core
+    return {
+        "torch": torch, "torch.distributed": dist,
+        "nccl": pkg, "nccl.ep": ep, "nccl.core": core,
+    }
+
+
+sys.path[:0] = [str(ROOT), str(ROOT / "bench")]
+
+# Import ep_nccl against the stubs, then withdraw them: leaving a fake torch in sys.modules
+# makes the genuinely torch-dependent modules in this process (test_runtime, test_ll_oracle)
+# error instead of skipping. Dropping ep_nccl too keeps the stub-built module private to us.
+with mock.patch.dict(sys.modules, _stub_modules()):
+    import ep_nccl  # noqa: E402
+
+    sys.modules.pop("ep_nccl", None)
+
+
+class FakeHandle:
+    """Records every rebind so the tests can assert on the collective call pattern."""
+
+    def __init__(self):
+        self.updates = []
+        self.destroyed = False
+
+    def update(self, topk_idx, *, layout_info=None, stream=None):
+        self.updates.append((topk_idx, layout_info))
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class FakeGroup:
+    def __init__(self):
+        self.created = 0
+        self.handle = FakeHandle()
+
+    def create_handle(self, layout, topk_idx, *, layout_info=None, config=None, stream=None):
+        self.created += 1
+        return self.handle
+
+
+def backend(ll=True):
+    """An NCCLEPBackend with just the fields _ensure_handle touches (no __init__, no GPU)."""
+    b = object.__new__(ep_nccl.NCCLEPBackend)
+    b._ll = ll
+    b._layout = "EM" if ll else "FLAT"
+    b._handle = None
+    b._bound = None
+    b._ep_group = FakeGroup()
+    b.device = "cuda:0"
+    b.num_local_experts = 4
+    b.args = types.SimpleNamespace(hidden=16)
+    b._t = lambda x: x
+    b._stream = lambda: 0
+    return b
+
+
+def problem(T):
+    return types.SimpleNamespace(
+        T=T, dispatch_x=f"x{T}", topk_idx=f"idx{T}", topk_weights=f"w{T}"
+    )
+
+
+class TestSingleHandle(unittest.TestCase):
+    def test_one_handle_across_many_shapes(self):
+        """Nine ladder rungs must still produce exactly one create_handle."""
+        b = backend()
+        for T in (1, 2, 4, 8, 16, 32, 64, 128, 256):
+            b._ensure_handle(problem(T))
+        self.assertEqual(b._ep_group.created, 1)
+
+    def test_shape_change_rebinds_and_repeat_does_not(self):
+        """update() on a shape switch; no collective when the bound shape is re-entered."""
+        b = backend()
+        pa, pb = problem(1), problem(2)
+        b._ensure_handle(pa)
+        self.assertEqual(len(b._ep_group.handle.updates), 0)  # first bind is the create
+
+        b._ensure_handle(pb)
+        self.assertEqual(len(b._ep_group.handle.updates), 1)
+
+        # Re-entering the bound problem repeatedly -- the timed loop's steady state -- must not
+        # enter a collective, otherwise every iteration gains a rank-synchronising step.
+        for _ in range(8):
+            b._ensure_handle(pb)
+        self.assertEqual(len(b._ep_group.handle.updates), 1)
+
+        # Returning to an earlier shape rebinds again (its cached namespace is reused).
+        b._ensure_handle(pa)
+        self.assertEqual(len(b._ep_group.handle.updates), 2)
+
+    def test_every_problem_shares_the_one_handle(self):
+        b = backend()
+        handles = {id(b._ensure_handle(problem(T)).handle) for T in (1, 2, 4)}
+        self.assertEqual(len(handles), 1)
+        self.assertIs(b._ensure_handle(problem(1)).handle, b._handle)
+
+    def test_ll_never_passes_layout_info_on_rebind(self):
+        """The API forbids layout_info on create/update in LL mode."""
+        b = backend(ll=True)
+        b._ensure_handle(problem(1))
+        b._ensure_handle(problem(2))
+        self.assertEqual([info for _, info in b._ep_group.handle.updates], [None])
+
+    def test_ht_rebind_carries_that_problems_counters(self):
+        """HT re-runs the metadata exchange into the rebound problem's own counter tensors."""
+        b = backend(ll=False)
+        ha = b._ensure_handle(problem(1))
+        hb = b._ensure_handle(problem(2))
+        self.assertEqual(len(b._ep_group.handle.updates), 1)
+        self.assertIs(b._ep_group.handle.updates[0][1], hb.layout_info)
+        self.assertIsNot(ha.layout_info, hb.layout_info)
+        self.assertEqual(hb.count, 7)  # re-read after the exchange
+
+    def test_destroy_releases_the_handle_once(self):
+        b = backend()
+        b._ensure_handle(problem(1))
+        handle = b._handle
+        b._destroy_handles()
+        self.assertTrue(handle.destroyed)
+        self.assertIsNone(b._handle)
+        self.assertIsNone(b._bound)
+        b._destroy_handles()  # idempotent
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experimental/CollectiveX/tests/test_matrix.py
+++ b/experimental/CollectiveX/tests/test_matrix.py
@@ -213,14 +213,15 @@ class MatrixTests(unittest.TestCase):
         #     both stay inside the 72-GPU scale-up domain (world <= scale_up_domain => LSA, no GIN),
         #     so EP16 works over MNNVL where the RDMA-GIN path walls.
         #   * AMD SKUs: no rows (NCCL EP is NVIDIA-only; AMD runs mori).
-        #   * LOW-LATENCY: no rows on ANY SKU. The wheel's LL count/flag protocol consumes stale
-        #     double-buffer signals (values carry no generation, so a signal from two calls earlier is
-        #     bit-identical at a repeating workload); a rank that slips one parity cycle gets lapped and
-        #     the pipeline wedges on dispatch/combine receive timeouts, ending in cudaErrorLaunchFailure.
-        #     Reported as NVIDIA/nccl#2303, fixed by NVIDIA/nccl#2306, unfixable here (we install the
-        #     published wheel). Observed first on GB, then reproduced on every x86 SKU — 5/5 over SSH and
-        #     4/4 in sweep 30155842613 — so ll_backends carries no nccl-ep row anywhere until a fixed
-        #     wheel ships. Restore per-SKU rows only alongside a spec bump that contains the fix.
+        #   * LOW-LATENCY: EP8 on all six NVIDIA SKUs. These rows were dropped while every LL leg
+        #     wedged, on the reading that only a fixed wheel could restore them. That reading was
+        #     wrong about the cause: the wedge needed TWO LL handles live on one group. `buffer_idx`
+        #     is per-handle but its buffers are offsets into the per-group rdma_buffer, so same-config
+        #     handles alias one another's parity count/flag slots. The adapter now binds a single
+        #     handle and rebinds it per shape, which removes the aliasing without a wheel bump —
+        #     proven on a stock wheel by ladder [1] (one handle, clean) vs [1, 2] (two handles,
+        #     64 dispatch + 6 combine receive timeouts). LL is decode-only and EP8-only: GB stays at
+        #     EP8 here even though normal mode runs EP16, because LL adds no EP16 row on any SKU.
         # BF16 only — no FP8 case (NCCL EP FP8 unsupported this release).
         document = matrix(backend="all")
         runnable = {
@@ -255,14 +256,16 @@ class MatrixTests(unittest.TestCase):
             },
             {"bf16"},
         )
-        # Low-latency: no nccl-ep case on any SKU while the wheel carries the stale-signal wedge.
+        # Low-latency: EP8 on every NVIDIA SKU, and EP8 only — a stray EP16 LL row would dispatch a
+        # shape the mode does not define.
         ll = {
             (item["sku"], item["case"]["ep"])
             for item in document["requested_cases"]
             if item["case"]["backend"] == "nccl-ep"
             and item["case"]["mode"] == "low-latency"
+            and item["disposition"] == "runnable"
         }
-        self.assertEqual(ll, set())
+        self.assertEqual(ll, {(sku, 8) for sku in rdma_skus | gb_skus})
 
     def test_invalid_filters_fail_closed(self):
         for options in (


### PR DESCRIPTION
## Why

The nccl-ep adapter created one handle per problem shape and cached it on the problem, so walking a token ladder left up to nine handles live on a single EP group, interleaved by the randomised trial order.

That is unsafe. `buffer_idx` — the LL double-buffer parity selector — is per-**handle** state, but the buffers it selects are offsets into the per-**group** `rdma_buffer`. Two handles built from the same group config resolve to the *same* parity-0/parity-1 count and flag slots (which themselves share one offset) and advance their parity independently, so one handle's "next buffer, safe to clean" is the other's "current buffer, in flight". Cleans land on live signals and polls observe a sibling handle's leftovers.

This is the real cause of the low-latency wedge we had attributed to the wheel. Isolated on a **stock** `nccl4py[cu13]==0.3.1` wheel, GB200, 4 ranks on one tray, with the handle count as the only variable:

| decode ladder | handles | result |
|---|---|---|
| `[1]` | 1 | completes, **zero** receive timeouts, correctness passing |
| `[1, 2]` | 2 | **64 dispatch + 6 combine** receive timeouts → `cudaErrorLaunchFailure` |

NVIDIA's own `ep_bench` never reproduces it across eight configurations (per-iteration `MPI_Barrier` removed, an injected 500 ms rank stall, dispatch-only and combine-only loops, up to 20 000 iterations) purely because it uses a single handle. The upstream report has been corrected accordingly — NVIDIA/nccl#2303.

It also corrupts signalling *without* hanging, so latencies from any multi-handle run were suspect, not only the runs that wedged.

## What changed

Rebinding is the intended lifecycle, not a workaround: `ncclEpInitHandle` takes no token count, and `ncclEpUpdateHandle` is documented as a "per-step collective: prepare the handle for the given top-k routing decisions". The wheel exposes it as `Handle.update`, which rebinds top-k indices without reallocating buffers. This also brings nccl-ep in line with the other three backends, each of which allocates one object sized to the ladder maximum and varies the token count per call.

1. **One handle per group** (`bench/ep_nccl.py`). The per-problem namespace stays — it holds only host-side tensor descriptors and, for HT, that problem's counters — while the handle moves to the group and is rebound when the bound shape changes. Both create and update are collective, so they must run in the same order on every rank; they only run on a shape change, and since every timed component is preceded by an untimed `warm()` on its own problem, the collective always lands in `warm` or the oracle passes, never inside a timed window. Re-entering the already-bound problem returns with no collective and no sync, so a timed loop's steady state is unchanged. HT re-reads its received-token count on rebind because the metadata exchange recomputes it for that routing; the value is deterministic per problem. Teardown is a single explicit `Handle.destroy`.

2. **Low-latency rows restored on all six NVIDIA SKUs** (`configs/platform_config.json`). These were dropped in d58d56566 while every LL leg wedged, on the reading that only a fixed wheel could restore them — that reading was wrong about the cause, and the single-handle adapter removes the aliasing on the stock wheel. `COLLX_NCCL4PY_SPEC` is untouched. LL is decode-only and EP8-only, so the GB SKUs carry an EP8 row even though normal mode runs EP16 there, and b300/gb200/gb300 gain their first `ll_backends` entry. `test_nccl_ep_rollout_shape` previously pinned the *absence* of these rows and now pins their presence, plus the absence of any EP16 LL row.

## CI validation

**High throughput** (h100 EP8, decode + prefill) against a `main` baseline on the same pool — [PR run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30436725064) / [baseline](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30438014051). Both `success`, every rung correct, 2048 samples per point, max relative error unchanged. Round-trip p50 within ±1.3% and decode p99 within ±2.1% — so the per-shape `update` collective does not perturb the steady state. Prefill p99 came in 5.7–9.9% *lower* on all four rungs with p50 flat, which is the signature of removed tail interference; suggestive only, two runs cannot separate it from pool variance.

**Low latency** — [run 30440418355](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30440418355), all six SKUs green, 9 rungs each (decode T=1…256), every rung `correct=True`, max relative error 0.00389 throughout:

| SKU | transport | nodes | RT p50 T=1 → T=256 |
|---|---|---|---|
| h100-dgxc | nvlink | 1 | 55.1 → 239.8 µs |
| h200-dgxc | nvlink | 1 | 53.4 → 226.2 µs |
| b200-dgxc | nvlink | 1 | 70.0 → 142.2 µs |
| b300 | nvlink | 1 | 60.1 → 133.9 µs |
| gb200 | mnnvl | 2 | 74.5 → 148.4 µs |
| gb300 | mnnvl | 2 | 67.1 → 141.5 µs |

The two GB rows are EP8 across two trays over MNNVL — the configuration from NVIDIA/nccl#2303, which had never completed on any wheel — and the four x86 SKUs previously wedged 5/5 over SSH and 4/4 in sweep 30155842613.

Unit tests: `python3 -m unittest discover -s tests` — 64 passed, 6 skipped (torch-dependent).

## Notes

`tests/test_ep_nccl_handle.py` stubs torch and nccl so it runs without the benchmark image, and locks the contract: one `create_handle` across nine rungs, `update` on a shape switch, **no** collective when the bound shape is re-entered, no `layout_info` on an LL rebind, HT rebinds carrying that problem's own counters, and idempotent teardown. The stubs are withdrawn after the import so the genuinely torch-dependent modules still skip rather than error.

The upstream patch (NVIDIA/nccl#2306) is now a defence-in-depth measure rather than the thing that unblocks us: it makes a foreign or stale signal inert, which is worth having, but this tree no longer depends on it.
