### PR TITLE
fix(ci): allow staging failed sweep artifacts / 修复 CI：允许暂存失败扫描的产物

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -153,14 +153,20 @@ jobs:
                 name === 'eval_results_all' ||
                 name.startsWith('bmk_agentic_'),
             );
-            const validateRun = async (candidate) => {
+            const validateRun = async (candidate, allowHistoricalAssociation = false) => {
               if (
                 candidate.path !== '.github/workflows/run-sweep.yml' ||
                 candidate.event !== 'pull_request'
               ) {
                 return { valid: false, reason: 'not a pull-request run of run-sweep.yml' };
               }
-              if (!pullCommitShas.has(candidate.head_sha)) {
+              const isAssociatedWithPull = candidate.pull_requests?.some(
+                (candidatePull) => candidatePull.number === context.issue.number,
+              );
+              if (
+                !pullCommitShas.has(candidate.head_sha) &&
+                !(allowHistoricalAssociation && isAssociatedWithPull)
+              ) {
                 return { valid: false, reason: 'its head commit is not in the PR commit list' };
               }
               if (fullSweepLabelsAt(candidate.created_at).length === 0) {
@@ -169,7 +175,7 @@ jobs:
                   reason: 'it was not created while a full-sweep label was applied',
                 };
               }
-              const stageableConclusions = new Set(['success', 'cancelled']);
+              const stageableConclusions = new Set(['success', 'cancelled', 'failure']);
               if (
                 candidate.status !== 'completed' ||
                 !stageableConclusions.has(candidate.conclusion)
@@ -180,7 +186,7 @@ jobs:
                 };
               }
 
-              // Cancelled sweeps may still contain useful partial results. The
+              // Cancelled or failed sweeps may still contain useful partial results. The
               // artifact checks below keep empty or metadata-only runs ineligible.
               const artifactNames = await usableArtifactNames(candidate.id);
               if (!artifactNames.includes('changelog-metadata')) {
@@ -201,7 +207,7 @@ jobs:
                 run_id: Number(requestedRunId),
               });
               run = response.data;
-              const validation = await validateRun(run);
+              const validation = await validateRun(run, true);
               if (!validation.valid) {
                 core.setFailed(`Run ${requestedRunId} cannot be staged because ${validation.reason}`);
                 return;


### PR DESCRIPTION
## Summary

- Allow completed failed full-sweep runs to stage when required metadata and benchmark artifacts are present.
- Keep an explicitly selected run eligible after a PR rebase when GitHub still associates it with that PR. Automatic run selection remains restricted to current PR commits.

## Validation

- actionlint .github/workflows/stage-results.yml
- git diff --check

## 中文说明

- 当必需的元数据和基准测试产物齐全时，允许已完成但失败的完整扫描运行进入预发布。
- 对于显式指定的运行，只要 GitHub 仍将其关联到该 PR，PR 变基后仍可暂存。自动选择仍仅限当前 PR 提交。

## 验证

- actionlint .github/workflows/stage-results.yml
- git diff --check