### PR TITLE
fix(ci): report persistent staged runs / 修复预发布运行持久化状态提示

### DIFF
--- a/.github/workflows/stage-results-callback.yml
+++ b/.github/workflows/stage-results-callback.yml
@@ -66,9 +66,17 @@ jobs:
               ? [
                   `@${requestedBy} staged run ${runId}: ${chartUrl}`,
                   '',
-                  `This shared staging slot remains available until the next \`/stage-results\` request. [Staging workflow](${appRunUrl})`,
+                  `This run remains available across future \`/stage-results\` requests. Staging the same run ID again updates its staged data. [Staging workflow](${appRunUrl})`,
+                  '',
+                  `@${requestedBy} 已将运行 ${runId} 发布到预发布环境：${chartUrl}`,
+                  '',
+                  `后续的 \`/stage-results\` 请求不会移除此运行；再次发布相同的运行 ID 会更新其预发布数据。[预发布工作流](${appRunUrl})`,
                 ].join('\n')
-              : `@${requestedBy} staging run ${runId} failed. [Inspect the staging workflow](${appRunUrl}).`;
+              : [
+                  `@${requestedBy} staging run ${runId} failed. [Inspect the staging workflow](${appRunUrl}).`,
+                  '',
+                  `@${requestedBy} 预发布运行 ${runId} 失败。[查看预发布工作流](${appRunUrl})。`,
+                ].join('\n');
 
             if (commentId) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -256,7 +256,11 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const body = `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). The shared staging slot is serialized; a completion link will be posted here.`;
+            const body = [
+              `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). Existing staged runs will be preserved; a completion link will be posted here.`,
+              '',
+              `@${process.env.REQUESTED_BY} 正在将[运行 ${process.env.RUN_ID}](${process.env.RUN_URL})发布到预发布环境。已有的预发布运行会继续保留；完成后将在此处提供链接。`,
+            ].join('\n');
             const comment = await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- Update `/stage-results` acknowledgments to state that existing staged runs are preserved.
- Update completion callbacks to explain that future staging requests retain the run and re-staging the same run ID updates its data.
- Provide English and Simplified Chinese versions of the generated PR comments.

## Companion PR

This messaging change accompanies [InferenceX-app PR #643](https://github.com/SemiAnalysisAI/InferenceX-app/pull/643), which removes the default destructive Neon restore and implements persistent multi-run staging. The app PR provides the functional behavior; this PR keeps the InferenceX command contract and user-facing status accurate.

## Validation

- `actionlint .github/workflows/stage-results.yml .github/workflows/stage-results-callback.yml`
- `git diff --check`

## 中文说明

### 变更概述

- 更新 `/stage-results` 请求确认提示，明确已有的预发布运行会继续保留。
- 更新完成回调，说明后续预发布请求不会移除当前运行，重复发布相同运行 ID 时会更新其数据。
- 为工作流生成的 PR 评论同时提供英文和简体中文版本。

### 配套 PR

本提示变更与 [InferenceX-app PR #643](https://github.com/SemiAnalysisAI/InferenceX-app/pull/643) 配套。app PR 会移除默认执行的破坏性 Neon 恢复操作，实现多运行持久化预发布；本 PR 则同步更新 InferenceX 的命令语义和用户提示。实际功能由 app PR 提供。

### 验证

- `actionlint .github/workflows/stage-results.yml .github/workflows/stage-results-callback.yml`
- `git diff --check`
