### PR TITLE
fix(runners): scope b200-dgxc qwen3.5 fp4 model path to the V2 checkpoint / 修复：将 b200-dgxc 的 qwen3.5 fp4 模型路径限定到 V2 检查点

### DIFF
--- a/runners/launch_b200-dgxc.sh
+++ b/runners/launch_b200-dgxc.sh
@@ -39,8 +39,18 @@ elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "bf16" ]]; then
 elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp8" ]]; then
     export MODEL_PATH="/lustre/fsw/models/Qwen3.5-397B-A17B-FP8"
     export SRT_SLURM_MODEL_PREFIX="qwen3.5-fp8"
-elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp4" ]]; then
+# qwen3.5 fp4 spans two checkpoints, so this must branch on the checkpoint and
+# not on MODEL_PREFIX+PRECISION alone: the sglang keys moved to NVFP4-V2 while
+# qwen3.5-fp4-b200-trt / -trt-mtp still declare plain NVFP4. Both share
+# model-prefix qwen3.5 + precision fp4 + runner b200, and further down this
+# script does `export MODEL="$MODEL_PATH"`, so a single shared branch would
+# serve V2 weights to the TRT configs while publishing them under the old
+# checkpoint name.
+elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp4" && $MODEL == *NVFP4-V2 ]]; then
     export MODEL_PATH="/scratch/fsw/models/Qwen3.5-397B-A17B-NVFP4-V2"
+    export SRT_SLURM_MODEL_PREFIX="qwen3.5-fp4"
+elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp4" ]]; then
+    export MODEL_PATH="/lustre/fsw/models/Qwen3.5-397B-A17B-NVFP4"
     export SRT_SLURM_MODEL_PREFIX="qwen3.5-fp4"
 elif [[ $MODEL_PREFIX == "glm5" && $PRECISION == "fp8" ]]; then
     export MODEL_PATH="/lustre/fsw/models/GLM-5-FP8"


### PR DESCRIPTION
Targets `qwen3.5-fp4-nvfp4-v2` (the branch behind #2205), not `main`.

## Problem

In `runners/launch_b200-dgxc.sh` at #2205's head, the model-path branch keys only on `MODEL_PREFIX` + `PRECISION`:

```bash
elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp4" ]]; then
    export MODEL_PATH="/scratch/fsw/models/Qwen3.5-397B-A17B-NVFP4-V2"
```

But two checkpoints now share that pair:

| Config key | `model:` at head |
|---|---|
| `qwen3.5-fp4-b200-sglang`, `-sglang-mtp` | `nvidia/Qwen3.5-397B-A17B-NVFP4-V2` |
| `qwen3.5-fp4-b200-trt`, `-trt-mtp` | `nvidia/Qwen3.5-397B-A17B-NVFP4` |

Because the script later does `export MODEL="$MODEL_PATH"`, the two **TRT** configs would serve **V2 weights while publishing results under the old checkpoint name**.

It is also runner-dependent: the `b200` pool spans `b200-cw_*`, `b200-nb_*` and `b200-dgxc_*`, and only `launch_b200-dgxc.sh` pins a path. So the same config key served old weights on cw/nb and V2 on dgxc, depending on scheduling.

**Origin:** 25ef4a15 ("remove trt configs") reverted the TRT keys to `NVFP4` but left the launcher on the V2 path — a partial revert.

## Fix

Branch on the checkpoint so each key resolves to its own weights. The old-checkpoint arm restores the exact `/lustre` path used on `main`.

## Verification

Extracted the real resolution chain from the file and ran the configs through it:

| Config (model) | main | before (bug) | after (fix) |
|---|---|---|---|
| `…NVFP4-V2` (sglang) | `/lustre/…NVFP4` | `/scratch/…NVFP4-V2` | `/scratch/…NVFP4-V2` ✅ |
| `…NVFP4` (trt) | `/lustre/…NVFP4` | `/scratch/…NVFP4-V2` ❌ | `/lustre/…NVFP4` ✅ |

`bash -n` clean; `fp8` and `bf16` qwen3.5 arms unaffected.

Because the TRT arm now resolves identically to `main`, TRT behaviour is unchanged and **no re-sweep is needed**; #2205's existing sweep covers the sglang keys it actually changes.

Draft because #2205 itself still has open items (a `CHANGES_REQUESTED` review, and the SGLang cookbook still documenting the pre-V2 checkpoint). Merging this into that branch changes its head SHA, so its sweep evidence will need a `/reuse-sweep-run` authorization afterwards.

中文：`launch_b200-dgxc.sh` 的 qwen3.5+fp4 分支仅依据 model-prefix 与 precision 判断，而这两个字段现对应两个检查点，导致 TRT 配置在 b200-dgxc 运行器上加载 V2 权重却以旧检查点名称发布结果。改为按检查点分支；旧检查点恢复 main 上的 /lustre 路径，故 TRT 行为不变、无需重跑 sweep。