### PR TITLE
Add Qwen3.5 FP4 B300 AgentX MTP

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1745,9 +1745,9 @@ build_replay_cmd() {
     local warmup_requests_per_lane="${AIPERF_WARMUP_REQUESTS_PER_LANE:-10}"
 
     # Fast mode retains the canonical 10-request-per-lane warmup while
-    # shortening profiling to 20 minutes.
+    # shortening profiling to 10 minutes.
     if [[ "${AIPERF_EXPERIMENTAL_FAST:-0}" == "1" ]]; then
-        duration=1200
+        duration=600
         warmup_requests_per_lane=10
     fi
 

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1744,11 +1744,11 @@ build_replay_cmd() {
     local duration="$DURATION"
     local warmup_requests_per_lane="${AIPERF_WARMUP_REQUESTS_PER_LANE:-10}"
 
-    # Fast mode retains the canonical 10-request-per-lane warmup while
-    # shortening profiling to 10 minutes.
+    # Fast mode minimizes setup by advancing each trajectory lane only once
+    # and shortens profiling to 20 minutes.
     if [[ "${AIPERF_EXPERIMENTAL_FAST:-0}" == "1" ]]; then
-        duration=600
-        warmup_requests_per_lane=10
+        duration=1200
+        warmup_requests_per_lane=1
     fi
 
     export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES:-0}"

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1744,11 +1744,11 @@ build_replay_cmd() {
     local duration="$DURATION"
     local warmup_requests_per_lane="${AIPERF_WARMUP_REQUESTS_PER_LANE:-10}"
 
-    # Fast mode retains the canonical 10-request-per-lane warmup while
-    # shortening profiling to 20 minutes.
+    # Fast mode minimizes setup by advancing each trajectory lane only once
+    # and shortens profiling to 20 minutes.
     if [[ "${AIPERF_EXPERIMENTAL_FAST:-0}" == "1" ]]; then
         duration=1200
-        warmup_requests_per_lane=10
+        warmup_requests_per_lane=1
     fi
 
     export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES:-0}"

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1744,11 +1744,11 @@ build_replay_cmd() {
     local duration="$DURATION"
     local warmup_requests_per_lane="${AIPERF_WARMUP_REQUESTS_PER_LANE:-10}"
 
-    # Fast mode minimizes setup by advancing each trajectory lane only once
-    # and shortens profiling to 20 minutes.
+    # Fast mode retains the canonical 10-request-per-lane warmup while
+    # shortening profiling to 20 minutes.
     if [[ "${AIPERF_EXPERIMENTAL_FAST:-0}" == "1" ]]; then
         duration=1200
-        warmup_requests_per_lane=1
+        warmup_requests_per_lane=10
     fi
 
     export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES="${AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES:-0}"

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -8,6 +8,9 @@ set -x
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
+# Use the lightweight GSM8K eval instead of the AgentX SWE-bench default.
+export EVAL_FRAMEWORK="lm-eval"
+
 check_env_vars \
     MODEL TP CONC EP_SIZE KV_OFFLOADING \
     TOTAL_CPU_DRAM_GB RESULT_DIR DURATION

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -168,6 +168,7 @@ if [ "${EVAL_ONLY:-false}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --trace-idle-gap-cap-seconds 300"
     REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 fi

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -9,7 +9,7 @@ set -x
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
-    MODEL TP CONC EP_SIZE DP_ATTENTION KV_OFFLOADING \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
     TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 
 SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-10}
@@ -75,17 +75,6 @@ if require_agentic_kv_offload_backend hicache; then
     )
 fi
 
-USE_SGLANG_ROUTER=false
-SGLANG_BACKEND_PORT="$PORT"
-ROUTER_LOG="$RESULT_DIR/router.log"
-if [ "$DP_ATTENTION" = "true" ]; then
-    USE_SGLANG_ROUTER=true
-    export AIPERF_HTTP_X_SMG_ROUTING_KEY_FROM_CORRELATION_ID=true
-    SGLANG_BACKEND_PORT=$((PORT + 1))
-    SGLANG_ROUTER_METRICS_PORT=$((PORT + 10000))
-    SGLANG_ROUTER_CMD=(python3 -m sglang_router.launch_router)
-fi
-
 PARALLEL_ARGS=(
     --tp "$TP"
     --dp 1
@@ -93,20 +82,6 @@ PARALLEL_ARGS=(
 )
 TOKENIZER_WORKERS=6
 STREAM_INTERVAL=50
-if [ "$DP_ATTENTION" = "true" ]; then
-    PARALLEL_ARGS=(
-        --tp "$TP"
-        --dp "$TP"
-        --ep-size "$EP_SIZE"
-        --enable-dp-attention
-        --enable-dp-attention-local-control-broadcast
-        --enable-dp-lm-head
-        --dist-init-addr "127.0.0.1:$((PORT + 2000))"
-        --incremental-streaming-output
-    )
-    TOKENIZER_WORKERS="$TP"
-    STREAM_INTERVAL=20
-fi
 
 # AgentX concurrency counts live session trees rather than individual HTTP
 # requests. Leave room for subagent fan-out and avoid spending HBM on graphs
@@ -132,7 +107,7 @@ SGLANG_CMD=(
     --model-path "$MODEL_PATH"
     --served-model-name "$MODEL"
     --host 0.0.0.0
-    --port "$SGLANG_BACKEND_PORT"
+    --port "$PORT"
     --trust-remote-code
     "${PARALLEL_ARGS[@]}"
     --enable-symm-mem
@@ -170,32 +145,14 @@ SERVER_PID=$!
 capture_cache_metrics() {
     {
         echo "=== SGLang cache metrics snapshot $(date --iso-8601=seconds) ==="
-        curl -fsS "http://localhost:$SGLANG_BACKEND_PORT/metrics" 2>/dev/null \
+        curl -fsS "http://localhost:$PORT/metrics" 2>/dev/null \
             | grep -E '^(sglang:(cache_hit_rate|cached_tokens_total|prompt_tokens_total|hicache_host_used_tokens|hicache_host_total_tokens|token_usage|num_requests_running|num_requests_waiting))' \
             || true
         echo "============================================================"
     } >> "$SERVER_LOG"
 }
 
-wait_for_server_ready --port "$SGLANG_BACKEND_PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
-
-if [ "$USE_SGLANG_ROUTER" = "true" ]; then
-    "${SGLANG_ROUTER_CMD[@]}" \
-        --worker-urls "http://localhost:$SGLANG_BACKEND_PORT" \
-        --policy consistent_hashing \
-        --request-id-headers x-correlation-id \
-        --dp-aware \
-        --host 0.0.0.0 \
-        --port "$PORT" \
-        --prometheus-host 127.0.0.1 \
-        --prometheus-port "$SGLANG_ROUTER_METRICS_PORT" \
-        --connect-timeout-secs 900 \
-        --request-timeout-secs 14400 \
-        --disable-health-check \
-        --disable-retries > "$ROUTER_LOG" 2>&1 &
-    ROUTER_PID=$!
-    wait_for_server_ready --port "$PORT" --server-log "$ROUTER_LOG" --server-pid "$ROUTER_PID"
-fi
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
 
 capture_cache_metrics
 trap capture_cache_metrics EXIT
@@ -204,6 +161,6 @@ if [ "${EVAL_ONLY:-false}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"
-    REPLAY_CMD+=" --server-metrics http://localhost:$SGLANG_BACKEND_PORT/metrics"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 fi

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -82,6 +82,14 @@ PARALLEL_ARGS=(
 )
 STREAM_INTERVAL=50
 
+# TP4 needs parallel tokenization to keep 256k AgentX warmups below the client
+# request timeout. Keep TP2 on SGLang's single-worker default: multi-tokenizer
+# startup races with the TP2 HiCache shared-memory initialization path.
+TOKENIZER_ARGS=()
+if [ "$TP" -ge 4 ]; then
+    TOKENIZER_ARGS=(--tokenizer-worker-num 6)
+fi
+
 # AgentX concurrency counts live session trees rather than individual HTTP
 # requests. Leave room for subagent fan-out and avoid spending HBM on graphs
 # above the batch sizes that remain useful for this long-context workload.
@@ -123,6 +131,7 @@ SGLANG_CMD=(
     --mem-fraction-static 0.80
     --stream-interval "$STREAM_INTERVAL"
     --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    "${TOKENIZER_ARGS[@]}"
     --tokenizer-path "$MODEL"
     --reasoning-parser qwen3
     --tool-call-parser qwen3_coder

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -9,7 +9,8 @@ set -x
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
 check_env_vars \
-    MODEL TP CONC EP_SIZE KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+    MODEL TP CONC EP_SIZE DP_ATTENTION KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 
 SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-10}
 
@@ -36,6 +37,12 @@ mkdir -p "$RESULT_DIR"
 
 CACHE_ARGS=()
 if require_agentic_kv_offload_backend hicache; then
+    REQUESTED_HICACHE_TOTAL_GB="${HICACHE_TOTAL_CPU_DRAM_GB:-$TOTAL_CPU_DRAM_GB}"
+    if [ "$REQUESTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: requested HiCache pool ${REQUESTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    TOTAL_CPU_DRAM_GB="$REQUESTED_HICACHE_TOTAL_GB"
     HICACHE_HOST_POOL_COUNT="${HICACHE_HOST_POOL_COUNT:-2}"
     MAX_HICACHE_SIZE_GB=$((TOTAL_CPU_DRAM_GB / TP / HICACHE_HOST_POOL_COUNT))
     HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
@@ -43,6 +50,7 @@ if require_agentic_kv_offload_backend hicache; then
         echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB" >&2
         exit 1
     fi
+    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB per rank per pool across TP=${TP}, pools=${HICACHE_HOST_POOL_COUNT}; node total <= ${TOTAL_CPU_DRAM_GB} GB"
     CACHE_ARGS=(
         --page-size 64
         --enable-hierarchical-cache
@@ -53,12 +61,51 @@ if require_agentic_kv_offload_backend hicache; then
     )
 fi
 
+USE_SGLANG_ROUTER=false
+SGLANG_BACKEND_PORT="$PORT"
+ROUTER_LOG="$RESULT_DIR/router.log"
+if [ "$DP_ATTENTION" = "true" ]; then
+    USE_SGLANG_ROUTER=true
+    export AIPERF_HTTP_X_SMG_ROUTING_KEY_FROM_CORRELATION_ID=true
+    SGLANG_BACKEND_PORT=$((PORT + 1))
+    SGLANG_ROUTER_METRICS_PORT=$((PORT + 10000))
+    SGLANG_ROUTER_CMD=(python3 -m sglang_router.launch_router)
+fi
+
+PARALLEL_ARGS=(
+    --tp "$TP"
+    --dp 1
+    --ep-size "$EP_SIZE"
+)
+TOKENIZER_WORKERS=6
+STREAM_INTERVAL=50
+if [ "$DP_ATTENTION" = "true" ]; then
+    PARALLEL_ARGS=(
+        --tp "$TP"
+        --dp "$TP"
+        --ep-size "$EP_SIZE"
+        --enable-dp-attention
+        --enable-dp-attention-local-control-broadcast
+        --enable-dp-lm-head
+        --dist-init-addr "127.0.0.1:$((PORT + 2000))"
+        --incremental-streaming-output
+    )
+    TOKENIZER_WORKERS="$TP"
+    STREAM_INTERVAL=20
+fi
+
+# AgentX concurrency counts live session trees rather than individual HTTP
+# requests. Leave room for subagent fan-out and avoid spending HBM on graphs
+# above the batch sizes that remain useful for this long-context workload.
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+CUDA_GRAPH_MAX_BS="$CONC"
+[ "$CUDA_GRAPH_MAX_BS" -gt 64 ] && CUDA_GRAPH_MAX_BS=64
+
 export TORCH_CUDA_ARCH_LIST="10.0"
 export PYTHONNOUSERSITE=1
 export NCCL_NVLS_ENABLE=1
 export SGL_ENABLE_JIT_DEEPGEMM=false
 export SGLANG_ENABLE_FLASHINFER_GEMM=true
-export SGLANG_ENABLE_SPEC_V2=1
 
 if [ "${EVAL_ONLY:-false}" != "true" ]; then
     export SGLANG_SIMULATE_ACC_LEN=3.39
@@ -71,11 +118,9 @@ SGLANG_CMD=(
     --model-path "$MODEL_PATH"
     --served-model-name "$MODEL"
     --host 0.0.0.0
-    --port "$PORT"
+    --port "$SGLANG_BACKEND_PORT"
     --trust-remote-code
-    --tensor-parallel-size "$TP"
-    --data-parallel-size 1
-    --expert-parallel-size "$EP_SIZE"
+    "${PARALLEL_ARGS[@]}"
     --enable-symm-mem
     --quantization modelopt_fp4
     --fp4-gemm-backend flashinfer_cutlass
@@ -83,14 +128,14 @@ SGLANG_CMD=(
     --mamba-ssm-dtype bfloat16
     --attention-backend trtllm_mha
     --moe-runner-backend flashinfer_trtllm
-    --cuda-graph-max-bs "$CONC"
-    --max-running-requests "$CONC"
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
     --max-prefill-tokens 16384
     --chunked-prefill-size 16384
     --mem-fraction-static 0.80
-    --stream-interval 50
+    --stream-interval "$STREAM_INTERVAL"
     --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
-    --tokenizer-worker-num 6
+    --tokenizer-worker-num "$TOKENIZER_WORKERS"
     --tokenizer-path "$MODEL"
     --reasoning-parser qwen3
     --tool-call-parser qwen3_coder
@@ -99,6 +144,7 @@ SGLANG_CMD=(
     --speculative-eagle-topk 1
     --speculative-num-draft-tokens 4
     --enable-metrics
+    --enable-cache-report
     "${CACHE_ARGS[@]}"
 )
 
@@ -107,12 +153,43 @@ printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
 "${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+capture_cache_metrics() {
+    {
+        echo "=== SGLang cache metrics snapshot $(date --iso-8601=seconds) ==="
+        curl -fsS "http://localhost:$SGLANG_BACKEND_PORT/metrics" 2>/dev/null \
+            | grep -E '^(sglang:(cache_hit_rate|cached_tokens_total|prompt_tokens_total|hicache_host_used_tokens|hicache_host_total_tokens|token_usage|num_requests_running|num_requests_waiting))' \
+            || true
+        echo "============================================================"
+    } >> "$SERVER_LOG"
+}
+
+wait_for_server_ready --port "$SGLANG_BACKEND_PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "$USE_SGLANG_ROUTER" = "true" ]; then
+    "${SGLANG_ROUTER_CMD[@]}" \
+        --worker-urls "http://localhost:$SGLANG_BACKEND_PORT" \
+        --policy consistent_hashing \
+        --request-id-headers x-correlation-id \
+        --dp-aware \
+        --host 0.0.0.0 \
+        --port "$PORT" \
+        --prometheus-host 127.0.0.1 \
+        --prometheus-port "$SGLANG_ROUTER_METRICS_PORT" \
+        --connect-timeout-secs 900 \
+        --request-timeout-secs 14400 \
+        --disable-health-check \
+        --disable-retries > "$ROUTER_LOG" 2>&1 &
+    ROUTER_PID=$!
+    wait_for_server_ready --port "$PORT" --server-log "$ROUTER_LOG" --server-pid "$ROUTER_PID"
+fi
+
+capture_cache_metrics
+trap capture_cache_metrics EXIT
 
 if [ "${EVAL_ONLY:-false}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"
-    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
+    REPLAY_CMD+=" --server-metrics http://localhost:$SGLANG_BACKEND_PORT/metrics"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 fi

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# AgentX trace replay for Qwen3.5-397B-A17B NVFP4 on B300 with SGLang
+# native NEXTN MTP. Throughput uses the committed golden synthetic AL; evals
+# retain real target-model verification.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+
+SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-10}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+nvidia-smi
+
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126_256k
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+CACHE_ARGS=()
+if require_agentic_kv_offload_backend hicache; then
+    HICACHE_HOST_POOL_COUNT="${HICACHE_HOST_POOL_COUNT:-2}"
+    MAX_HICACHE_SIZE_GB=$((TOTAL_CPU_DRAM_GB / TP / HICACHE_HOST_POOL_COUNT))
+    HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
+    if [ "$HICACHE_SIZE_GB" -lt 1 ] || [ "$HICACHE_SIZE_GB" -gt "$MAX_HICACHE_SIZE_GB" ]; then
+        echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB" >&2
+        exit 1
+    fi
+    CACHE_ARGS=(
+        --page-size 64
+        --enable-hierarchical-cache
+        --hicache-size "$HICACHE_SIZE_GB"
+        --hicache-io-backend kernel
+        --hicache-mem-layout page_first
+        --hicache-write-policy write_through_selective
+    )
+fi
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export PYTHONNOUSERSITE=1
+export NCCL_NVLS_ENABLE=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+export SGLANG_ENABLE_SPEC_V2=1
+
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    export SGLANG_SIMULATE_ACC_LEN=3.39
+    export SGLANG_SIMULATE_ACC_METHOD=match-expected
+    export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
+fi
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    --tensor-parallel-size "$TP"
+    --data-parallel-size 1
+    --expert-parallel-size "$EP_SIZE"
+    --enable-symm-mem
+    --quantization modelopt_fp4
+    --fp4-gemm-backend flashinfer_cutlass
+    --kv-cache-dtype fp8_e4m3
+    --mamba-ssm-dtype bfloat16
+    --attention-backend trtllm_mha
+    --moe-runner-backend flashinfer_trtllm
+    --cuda-graph-max-bs "$CONC"
+    --max-running-requests "$CONC"
+    --max-prefill-tokens 16384
+    --chunked-prefill-size 16384
+    --mem-fraction-static 0.80
+    --stream-interval 50
+    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    --tokenizer-worker-num 6
+    --tokenizer-path "$MODEL"
+    --reasoning-parser qwen3
+    --tool-call-parser qwen3_coder
+    --enable-auto-tool-choice
+    --speculative-algorithm NEXTN
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --enable-metrics
+    "${CACHE_ARGS[@]}"
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -114,5 +114,6 @@ if [ "${EVAL_ONLY:-false}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 fi

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -102,6 +102,9 @@ export PYTHONNOUSERSITE=1
 export NCCL_NVLS_ENABLE=1
 export SGL_ENABLE_JIT_DEEPGEMM=false
 export SGLANG_ENABLE_FLASHINFER_GEMM=true
+# Keep server-side connections alive beyond AIPerf's 300-second client pool
+# timeout so bursty AgentX trajectories cannot reuse a closing idle socket.
+export SGLANG_TIMEOUT_KEEP_ALIVE=1800
 
 if [ "${EVAL_ONLY:-false}" != "true" ]; then
     export SGLANG_SIMULATE_ACC_LEN=3.39

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -80,7 +80,6 @@ PARALLEL_ARGS=(
     --dp 1
     --ep-size "$EP_SIZE"
 )
-TOKENIZER_WORKERS=6
 STREAM_INTERVAL=50
 
 # AgentX concurrency counts live session trees rather than individual HTTP
@@ -124,7 +123,6 @@ SGLANG_CMD=(
     --mem-fraction-static 0.80
     --stream-interval "$STREAM_INTERVAL"
     --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
-    --tokenizer-worker-num "$TOKENIZER_WORKERS"
     --tokenizer-path "$MODEL"
     --reasoning-parser qwen3
     --tool-call-parser qwen3_coder

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -43,14 +43,28 @@ if require_agentic_kv_offload_backend hicache; then
         exit 1
     fi
     TOTAL_CPU_DRAM_GB="$REQUESTED_HICACHE_TOTAL_GB"
-    HICACHE_HOST_POOL_COUNT="${HICACHE_HOST_POOL_COUNT:-2}"
-    MAX_HICACHE_SIZE_GB=$((TOTAL_CPU_DRAM_GB / TP / HICACHE_HOST_POOL_COUNT))
+    # SGLang applies --hicache-size independently to Qwen's target KV and
+    # Mamba pools. Native NEXTN also creates a draft KV pool with the same
+    # slot count; its one attention layer adds 1/15 of the target KV bytes.
+    # Reserve 1 GB/rank for page alignment and enforce H * 31/15 per rank.
+    HICACHE_ALIGNMENT_RESERVE_GB=$TP
+    HICACHE_USABLE_TOTAL_GB=$((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$HICACHE_USABLE_TOTAL_GB" -lt 1 ]; then
+        echo "Error: insufficient DRAM after HiCache alignment reserve" >&2
+        exit 1
+    fi
+    MAX_HICACHE_SIZE_GB=$((HICACHE_USABLE_TOTAL_GB * 15 / TP / 31))
     HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
     if [ "$HICACHE_SIZE_GB" -lt 1 ] || [ "$HICACHE_SIZE_GB" -gt "$MAX_HICACHE_SIZE_GB" ]; then
         echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB" >&2
         exit 1
     fi
-    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB per rank per pool across TP=${TP}, pools=${HICACHE_HOST_POOL_COUNT}; node total <= ${TOTAL_CPU_DRAM_GB} GB"
+    PROJECTED_HICACHE_TOTAL_GB=$(((HICACHE_SIZE_GB * TP * 31 + 14) / 15 + HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$PROJECTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: projected HiCache use ${PROJECTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB target + Mamba + 1/15 draft per rank across TP=${TP}; projected node total ${PROJECTED_HICACHE_TOTAL_GB} GB <= ${TOTAL_CPU_DRAM_GB} GB"
     CACHE_ARGS=(
         --page-size 64
         --enable-hierarchical-cache

--- a/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh
@@ -94,7 +94,6 @@ SGLANG_CMD=(
     --tokenizer-path "$MODEL"
     --reasoning-parser qwen3
     --tool-call-parser qwen3_coder
-    --enable-auto-tool-choice
     --speculative-algorithm NEXTN
     --speculative-num-steps 3
     --speculative-eagle-topk 1

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7284,19 +7284,6 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
-# Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
-# TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
-# TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 no-offload peaks at c32. HiCache overlaps from c32; probes put
-# the throughput transition between c34 and c40, while host KV reaches 98% at
-# c52 and c56 is the last useful stress point. c64+ warmups only deepen the
-# queue and are excluded. TP4 no-offload remains healthy into the c56-72
-# neighborhood, which is sampled every four requests around the cache cliff.
-# TP4 HiCache is dominated there: c68 sustained 197k tok/s versus 224k for
-# no-offload c64, while c76 fell to 158k with host KV full. Clean HiCache c94
-# was also dominated by no-offload c56 (210k vs 234k tok/s, with 44 ms vs 7 ms
-# median ITL), so the TP4 HiCache arm is excluded.
-# DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7140,6 +7140,12 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
+# Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
+# TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
+# TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
+# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80,
+# while the 14.88M-token TP4 pool should bend around conc 88-128. DEP8 covers
+# the throughput end with session-sticky routing across attention-DP ranks.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7154,6 +7160,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
+      - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7183,7 +7183,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # hits by c96, placing its useful no-offload/offload crossover below c64.
 # TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
-# DEP8 probes the throughput end with session-sticky attention-DP routing.
+# DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7200,7 +7200,6 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
-      - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7287,8 +7287,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
-# hits by c96, placing its useful no-offload/offload crossover below c64.
+# p75 ISL, TP2 is healthy through c32 but falls to zero prefix hits by c56,
+# placing its useful no-offload/offload crossover below that point.
 # TP4 remains healthy through c88, while c96 loses roughly half its throughput
 # and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
 # c88-96 cliff and compare HiCache directly across that boundary.
@@ -7307,7 +7307,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7198,7 +7198,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7284,6 +7284,21 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
+qwen3.5-fp4-b300-sglang-agentic-mtp:
+  image: lmsysorg/sglang:nightly-dev-cu13-20260724-433429b1
+  model: nvidia/Qwen3.5-397B-A17B-NVFP4
+  model-prefix: qwen3.5
+  runner: cluster:b300-nv
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 16, 32] }
+
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7289,7 +7289,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
 # throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
-# from c32 and densely resolves that crossover for the one-hour sweep. TP4
+# from c32; warm-cache probes put a sharp transition between c36 and c40, so
+# c34/c38 densely resolve that crossover for the one-hour sweep. TP4
 # no-offload is healthy through c72, while c96 loses roughly
 # half its throughput as prefix hits fall. HiCache c88 is clean and dominates
 # no-offload c88. Both c80 trials produced shortened outputs, so that invalid
@@ -7310,7 +7311,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7284,6 +7284,12 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
+# Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
+# TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
+# TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
+# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80,
+# while the 14.88M-token TP4 pool should bend around conc 88-128. DEP8 covers
+# the throughput end with session-sticky routing across attention-DP ranks.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7298,6 +7304,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
+      - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7307,7 +7307,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7181,8 +7181,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64; HiCache sustains 90% prefix hits and >260k input
-# tok/s at c80, so resolve the crossover densely and carry offload past it.
+# TP4 remains healthy at c64, but HiCache c80 becomes invalid once its host
+# pool is full, so resolve c64-76 without carrying that offload tail forward.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7197,9 +7197,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7179,11 +7179,12 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 is healthy through c32 but falls to zero prefix hits by c56,
-# placing its useful no-offload/offload crossover below that point.
-# TP4 remains healthy through c88, while c96 loses roughly half its throughput
-# and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
-# c88-96 cliff and compare HiCache directly across that boundary.
+# p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
+# throughput with worse latency, and c56 loses all prefix hits. HiCache takes
+# over at c40. TP4 no-offload is healthy through c72, while c96 loses roughly
+# half its throughput as prefix hits fall. HiCache c88 is clean and dominates
+# no-offload c88. Both c80 trials produced shortened outputs, so that invalid
+# point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7197,9 +7198,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 88, 96] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7288,8 +7288,9 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
-# throughput with worse latency, and c56 loses all prefix hits. HiCache takes
-# over at c40. TP4 no-offload is healthy through c72, while c96 loses roughly
+# throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
+# from c32 and densely resolves that crossover for the one-hour sweep. TP4
+# no-offload is healthy through c72, while c96 loses roughly
 # half its throughput as prefix hits fall. HiCache c88 is clean and dominates
 # no-offload c88. Both c80 trials produced shortened outputs, so that invalid
 # point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
@@ -7309,7 +7310,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7180,8 +7180,9 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
-# throughput with worse latency, and c56 loses all prefix hits. HiCache takes
-# over at c40. TP4 no-offload is healthy through c72, while c96 loses roughly
+# throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
+# from c32 and densely resolves that crossover for the one-hour sweep. TP4
+# no-offload is healthy through c72, while c96 loses roughly
 # half its throughput as prefix hits fall. HiCache c88 is clean and dominates
 # no-offload c88. Both c80 trials produced shortened outputs, so that invalid
 # point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
@@ -7201,7 +7202,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7289,8 +7289,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64; HiCache sustains 90% prefix hits and >260k input
-# tok/s at c80, so resolve the crossover densely and carry offload past it.
+# TP4 remains healthy at c64, but HiCache c80 becomes invalid once its host
+# pool is full, so resolve c64-76 without carrying that offload tail forward.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7305,9 +7305,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7179,8 +7179,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
-# hits by c96, placing its useful no-offload/offload crossover below c64.
+# p75 ISL, TP2 is healthy through c32 but falls to zero prefix hits by c56,
+# placing its useful no-offload/offload crossover below that point.
 # TP4 remains healthy through c88, while c96 loses roughly half its throughput
 # and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
 # c88-96 cliff and compare HiCache directly across that boundary.
@@ -7199,7 +7199,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7159,7 +7159,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [80] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7296,8 +7296,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 16, 32] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7179,14 +7179,15 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
-# throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
-# from c32; warm-cache probes put a sharp transition between c36 and c40, so
-# c34/c38 densely resolve that crossover for the one-hour sweep. TP4
-# no-offload is healthy through c72, while c96 loses roughly
-# half its throughput as prefix hits fall. HiCache c88 is clean and dominates
-# no-offload c88. Both c80 trials produced shortened outputs, so that invalid
-# point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
+# p75 ISL, TP2 no-offload peaks at c32. HiCache overlaps from c32; probes put
+# the throughput transition between c34 and c40, while host KV reaches 98% at
+# c52 and c56 is the last useful stress point. c64+ warmups only deepen the
+# queue and are excluded. TP4 no-offload remains healthy into the c56-72
+# neighborhood, which is sampled every four requests around the cache cliff.
+# TP4 HiCache is dominated there: c68 sustained 197k tok/s versus 224k for
+# no-offload c64, while c76 fell to 158k with host KV full. Clean HiCache c94
+# was also dominated by no-offload c56 (210k vs 234k tok/s, with 44 ms vs 7 ms
+# median ITL), so the TP4 HiCache arm is excluded.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7200,10 +7201,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 60, 64, 68, 72] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7179,9 +7179,10 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80,
-# while the 14.88M-token TP4 pool should bend around conc 88-128. DEP8 covers
-# the throughput end with session-sticky routing across attention-DP ranks.
+# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80.
+# TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
+# tok/s at c80, so resolve the crossover densely and carry offload past it.
+# DEP8 probes the throughput end with session-sticky attention-DP routing.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7194,8 +7195,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [80] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7285,7 +7285,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 qwen3.5-fp4-b300-sglang-agentic-mtp:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260724-433429b1
+  image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
   runner: cluster:b300-nv

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7306,7 +7306,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7140,6 +7140,21 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
+qwen3.5-fp4-b300-sglang-agentic-mtp:
+  image: lmsysorg/sglang:nightly-dev-cu13-20260724-433429b1
+  model: nvidia/Qwen3.5-397B-A17B-NVFP4
+  model-prefix: qwen3.5
+  runner: cluster:b300-nv
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 16, 32] }
+
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0
   model: nvidia/Kimi-K2.5-NVFP4

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7289,8 +7289,9 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64, but HiCache c80 becomes invalid once its host
-# pool is full, so resolve c64-76 without carrying that offload tail forward.
+# TP4 remains healthy through c88, while c96 loses roughly half its throughput
+# and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
+# c88-96 cliff and compare HiCache directly across that boundary.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7305,7 +7306,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7152,8 +7152,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 16, 32] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7181,7 +7181,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
 # throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
-# from c32 and densely resolves that crossover for the one-hour sweep. TP4
+# from c32; warm-cache probes put a sharp transition between c36 and c40, so
+# c34/c38 densely resolve that crossover for the one-hour sweep. TP4
 # no-offload is healthy through c72, while c96 loses roughly
 # half its throughput as prefix hits fall. HiCache c88 is clean and dominates
 # no-offload c88. Both c80 trials produced shortened outputs, so that invalid
@@ -7202,7 +7203,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7141,7 +7141,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
       - { tp: 4, ep: 1, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48, 64] }
 
 qwen3.5-fp4-b300-sglang-agentic-mtp:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260724-433429b1
+  image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
   runner: cluster:b300-nv

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7303,7 +7303,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [80] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7179,7 +7179,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80.
+# p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
+# hits by c96, placing its useful no-offload/offload crossover below c64.
 # TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
 # DEP8 probes the throughput end with session-sticky attention-DP routing.
@@ -7197,8 +7198,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7199,7 +7199,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7287,14 +7287,15 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
-# throughput with worse latency, and c56 loses all prefix hits. HiCache overlaps
-# from c32; warm-cache probes put a sharp transition between c36 and c40, so
-# c34/c38 densely resolve that crossover for the one-hour sweep. TP4
-# no-offload is healthy through c72, while c96 loses roughly
-# half its throughput as prefix hits fall. HiCache c88 is clean and dominates
-# no-offload c88. Both c80 trials produced shortened outputs, so that invalid
-# point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
+# p75 ISL, TP2 no-offload peaks at c32. HiCache overlaps from c32; probes put
+# the throughput transition between c34 and c40, while host KV reaches 98% at
+# c52 and c56 is the last useful stress point. c64+ warmups only deepen the
+# queue and are excluded. TP4 no-offload remains healthy into the c56-72
+# neighborhood, which is sampled every four requests around the cache cliff.
+# TP4 HiCache is dominated there: c68 sustained 197k tok/s versus 224k for
+# no-offload c64, while c76 fell to 158k with host KV full. Clean HiCache c94
+# was also dominated by no-offload c56 (210k vs 234k tok/s, with 44 ms vs 7 ms
+# median ITL), so the TP4 HiCache arm is excluded.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7308,10 +7309,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 60, 64, 68, 72] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7289,7 +7289,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
+# TP4 remains healthy at c64; HiCache sustains 90% prefix hits and >260k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
@@ -7304,7 +7304,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7287,11 +7287,12 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, TP2 is healthy through c32 but falls to zero prefix hits by c56,
-# placing its useful no-offload/offload crossover below that point.
-# TP4 remains healthy through c88, while c96 loses roughly half its throughput
-# and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
-# c88-96 cliff and compare HiCache directly across that boundary.
+# p75 ISL, TP2 no-offload peaks at c32; c40/c48 plateau at the same input
+# throughput with worse latency, and c56 loses all prefix hits. HiCache takes
+# over at c40. TP4 no-offload is healthy through c72, while c96 loses roughly
+# half its throughput as prefix hits fall. HiCache c88 is clean and dominates
+# no-offload c88. Both c80 trials produced shortened outputs, so that invalid
+# point is excluded while the clean c72-96 cache-cliff neighborhood stays dense.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7305,9 +7306,9 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 88, 96] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7291,7 +7291,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # hits by c96, placing its useful no-offload/offload crossover below c64.
 # TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
-# DEP8 probes the throughput end with session-sticky attention-DP routing.
+# DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7308,7 +7308,6 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
-      - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7307,7 +7307,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:
   image: vllm/vllm-openai:v0.22.0

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7181,8 +7181,9 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64, but HiCache c80 becomes invalid once its host
-# pool is full, so resolve c64-76 without carrying that offload tail forward.
+# TP4 remains healthy through c88, while c96 loses roughly half its throughput
+# and raises p50 ITL from 15 ms to 44 ms as prefix hits fall. Resolve the
+# c88-96 cliff and compare HiCache directly across that boundary.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7197,7 +7198,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 80, 88, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7287,7 +7287,8 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80.
+# p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
+# hits by c96, placing its useful no-offload/offload crossover below c64.
 # TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
 # DEP8 probes the throughput end with session-sticky attention-DP routing.
@@ -7305,8 +7306,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }
 
 kimik2.5-fp4-b200-vllm-agentic-lmcache:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7199,7 +7199,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 68, 72, 76, 84, 88, 92, 94, 96] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80] }
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7181,7 +7181,7 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
 # p75 ISL, TP2 is healthy through c32 but reaches 97% GPU KV with zero prefix
 # hits by c96, placing its useful no-offload/offload crossover below c64.
-# TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
+# TP4 remains healthy at c64; HiCache sustains 90% prefix hits and >260k input
 # tok/s at c80, so resolve the crossover densely and carry offload past it.
 # DEP8 was rejected after fragmenting the trace across eight radix caches.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
@@ -7196,7 +7196,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 60, 64, 68, 72, 76, 80, 88] }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7287,9 +7287,10 @@ qwen3.5-fp8-b300-sglang-agentic-hicache:
 # Qwen3.5 target FP8 KV is 15,360 bytes/token before the native MTP layer.
 # TP4 replicates the model's two KV heads and measured 30.5 KB/token node-wide;
 # TP2 measured 15.3 KB/token. Against the 256k trace's 88.8k median and 148.8k
-# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80,
-# while the 14.88M-token TP4 pool should bend around conc 88-128. DEP8 covers
-# the throughput end with session-sticky routing across attention-DP ranks.
+# p75 ISL, the measured 9.56M-token TP2 pool should bend around conc 56-80.
+# TP4 remains healthy at c64; HiCache sustains 87% prefix hits and 234k input
+# tok/s at c80, so resolve the crossover densely and carry offload past it.
+# DEP8 probes the throughput end with session-sticky attention-DP routing.
 qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
@@ -7302,8 +7303,8 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 16, 32, 64, 96, 128] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [80] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 72, 80, 88, 96, 104, 112] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 8, 16, 32, 64, 96, 128, 192, 256] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [72] }
       - { tp: 8, ep: 8, dp-attn: true, spec-decoding: mtp, kv-offloading: none, conc-list: [64, 128, 256], router: { name: sglang-router, version: "0.3.2" } }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5311,3 +5311,10 @@
     - "Search space mirrors the non-MTP entry's KV arms -- TP8 GPU-resident and TP8 host-DRAM offload -- so the spec-decoding delta is readable at equal concurrency, but stops at conc 16 rather than 24. The non-MTP bring-up sweep (run 30326393603) showed the GPU-resident arm already thrashing at conc >= 16 (prefix cache hit rate 2.7%, TTFT p50 86-191s) because GPU KV holds only ~3.1 max-length requests, so conc 24 would spend a full job per arm re-measuring that regime; conc 16 still exercises the DRAM tier meaningfully (62% external prefix cache hit rate). TP8-only for the same memory reason: a ~1.5 TB MXFP4 checkpoint needs ~188 GB/GPU across 8 B300s and does not fit below 8 GPUs."
     - "Sets VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION=1, which the upstream recipe requires on both its blackwell and nvidia paths and which this repo had never set. It defaults to 0 and is threaded into LatentMoERunner as runner_args={\"enable_k3_latent_moe_tail_fusion\": ...} at vllm/models/kimi_k3/nvidia/model.py:549 -- the same runner whose shared-experts output buffer asserted (fused_moe/runner/shared_experts.py:165, all 8 TP ranks at once) when the wider flag alignment was attempted, so every K3 run here so far has been exercising a MoE tail path upstream does not use. Enabled on its own, ahead of re-attempting gpu-memory-utilization 0.95, max-num-seqs 32, --no-enable-flashinfer-autotune or VLLM_USE_V2_MODEL_RUNNER=1, to isolate its effect."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2418
+
+- config-keys:
+    - qwen3.5-fp4-b300-sglang-agentic-mtp
+  description:
+    - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
+    - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5345,5 +5345,6 @@
   description:
     - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
     - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Pin AIPerf trace idle-gap support and cap per-trace idle gaps at 300 seconds"
     - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5361,4 +5361,5 @@
   description:
     - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
     - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5317,4 +5317,5 @@
   description:
     - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
     - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5361,5 +5361,6 @@
   description:
     - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
     - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Use the shared AIPerf watchdog to cap whole-trajectory runtime idle gaps at 300 seconds"
     - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5355,3 +5355,10 @@
     - "Apply the accuracy-gated Kimi-K2.5 MXFP4 settings: tuned AITER MXFP4 MoE, fused shared experts, FP8 KV cache, block size 16, 16384 batched tokens, 512 sequences, async scheduling, gpu-memory-utilization 0.85 (headroom for CUDA-graph capture on MI355X), and the AITER BF16 GEMM path"
     - "Extend the TP4 and TP8 8k1k concurrency sweep from 64 to 128 (1k1k deprecated per #2263)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2213
+
+- config-keys:
+    - qwen3.5-fp4-b300-sglang-agentic-mtp
+  description:
+    - "Add Qwen3.5-397B-A17B NVFP4 AgentX benchmark on B300 with SGLang native NEXTN MTP"
+    - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2421


### PR DESCRIPTION
## Summary

Add Qwen3.5-397B-A17B NVFP4 AgentX coverage on B300 with SGLang native NEXTN MTP, golden synthetic acceptance, prefix caching, and the pinned 256k trace dataset.

Pin AIPerf to the exact validated revision with:
- flattened warmup-to-profiling timing for non-burst starts
- source-faithful request order and spawn/join gates
- a 300-second runtime idle cap per complete trajectory tree
- a separate 10-second whole-system idle guard

Dataset timestamps and derived end-to-start delays are not rewritten.