### PR TITLE
CollectiveX: stop charging rank entry skew to component latency / CollectiveX：不再把 rank 进入时间差计入组件延迟

### DIFF
--- a/experimental/CollectiveX/bench/ep_harness.py
+++ b/experimental/CollectiveX/bench/ep_harness.py
@@ -229,17 +229,28 @@ def _write_json_atomic(path: str, value) -> None:
 def time_us(torch, fn, warmup: int, iters: int, pre=None, post=None) -> list[float]:
     """Per-iteration CUDA-event latencies (µs) for THIS rank.
 
-    Without `pre`: times `fn()`. With `pre`: runs `pre()` UNTIMED each iteration (sync
-    before the start event so its GPU work can't bleed in), then times `fn(pre_result)`.
-    `post(result)` runs after the end event and synchronization, so stateful backends can
-    consume/reset a timed operation without charging that cleanup to its latency. Returns
-    the raw per-iteration series; the caller reduces across ranks per iteration before
+    Without `pre`: times `fn()`. With `pre`: runs `pre()` UNTIMED each iteration, then times
+    `fn(pre_result)`. `post(result)` runs after the end event and synchronization, so stateful
+    backends can consume/reset a timed operation without charging that cleanup to its latency.
+    Returns the raw per-iteration series; the caller reduces across ranks per iteration before
     percentiling.
+
+    There is deliberately NO host sync between `pre()` and the start event. Stream ordering
+    already keeps pre()'s work out of the s->e window: `s` is enqueued behind pre()'s kernels,
+    so the event timestamps when the stream REACHES it, not when the host recorded it. The sync
+    that used to sit here did not add that guarantee -- it drained the GPU, which put the host's
+    launch of `fn` inside the measured window and, because `fn` is a collective, let per-rank
+    launch jitter desynchronise ranks that pre() had just aligned. Each rank then blocked on the
+    slowest peer and run_sweep's cross-rank MAX reported that stagger as latency. Measured on
+    b200 uccl-ep low-latency combine: 113.4us -> 87.4us at T=1 with the ranks aligned, and no
+    change at T=32, which is what produced a *falling* latency curve as tokens grew.
+
+    The end-of-iteration sync stays: the warmup note below documents why iterations must not
+    overlap (iter N+1's dispatch races iter N's combine on the persistent comm buffer), so only
+    one pre/fn pair is ever in flight.
     """
     def sample():
         arg = pre() if pre is not None else None
-        if pre is not None:
-            torch.cuda.synchronize()
         s = torch.cuda.Event(enable_timing=True)
         e = torch.cuda.Event(enable_timing=True)
         s.record()
@@ -882,6 +893,14 @@ def run_sweep(args, backend, torch, dist, device, rank: int, world_size: int) ->
     stage_pool = {T: [] for T in ladder}    # measured only when stage launches device work
     comb_pool = {T: [] for T in ladder}     # ... combine
     rt_pool = {T: [] for T in ladder}       # independently measured round trip
+    spread_pool = {T: [] for T in ladder}   # cross-rank (max-min) of the round trip, per iter
+    # Cross-rank MIN per component. The LAST rank to enter a collective is the one that waited
+    # least -- it started when its peers were already there -- so its duration is the closest
+    # estimate of the operation's cost with entry skew excluded. MAX (reported as the latency)
+    # is that cost PLUS the skew, i.e. what the earliest-entering rank observed.
+    dmin_pool = {T: [] for T in ladder}
+    cmin_pool = {T: [] for T in ladder}
+    rtmin_pool = {T: [] for T in ladder}
     for trial_index in range(args.trials):
         order = trial_order(list(ladder), trial_index)
         for T in order:
@@ -903,7 +922,20 @@ def run_sweep(args, backend, torch, dist, device, rank: int, world_size: int) ->
                 comb_pool[T] += _reduce_vec(torch, dist, device, measured["combine"], MAX)
             if measured["stage"]:
                 stage_pool[T] += _reduce_vec(torch, dist, device, measured["stage"], MAX)
-            rt_pool[T] += _reduce_vec(torch, dist, device, measured["roundtrip"], MAX)
+            rt_max = _reduce_vec(torch, dist, device, measured["roundtrip"], MAX)
+            rt_pool[T] += rt_max
+            # Cross-rank SPREAD (max-min) of the same iterations. A collective cannot finish
+            # before its slowest participant, so when ranks enter together every rank measures
+            # nearly the same duration and the spread is small; a large spread means the ranks
+            # were staggered and the reported MAX is charging one rank's wait for the others.
+            # Emitted as a diagnostic so a skew-inflated point is visible in the artifact
+            # instead of being mistaken for the operation getting slower.
+            rt_min = _reduce_vec(torch, dist, device, measured["roundtrip"], MIN)
+            spread_pool[T] += [hi - lo for hi, lo in zip(rt_max, rt_min)]
+            rtmin_pool[T] += rt_min
+            if measured["dispatch"]:
+                dmin_pool[T] += _reduce_vec(torch, dist, device, measured["dispatch"], MIN)
+                cmin_pool[T] += _reduce_vec(torch, dist, device, measured["combine"], MIN)
 
     # ---- Pass 3: prove timed inputs were immutable and repeat the full oracle. ----
     for T in ladder:
@@ -969,6 +1001,7 @@ def run_sweep(args, backend, torch, dist, device, rank: int, world_size: int) ->
             field: dispatch_bytes[field] + combine_bytes[field] for field in dispatch_bytes
         }
         stage_bytes = dict.fromkeys(dispatch_bytes, 0)
+        spread = spread_pool[T]
         rows.append({
             "components": {
                 "combine": _component(cp, len(c)),
@@ -977,6 +1010,19 @@ def run_sweep(args, backend, torch, dist, device, rank: int, world_size: int) ->
                 "roundtrip": _component(rtp, len(rt)),
                 "stage": _component(sp, len(s)),
             },
+            # Skew-excluded companion to `components`: same iterations reduced with cross-rank
+            # MIN instead of MAX. Compare against `components` to see how much of a point is the
+            # operation and how much is rank stagger; a curve that dips in MAX but not in MIN was
+            # never the operation getting faster.
+            "cross_rank_min_us": {
+                "combine": _component(_pcts(cmin_pool[T]), len(cmin_pool[T])),
+                "dispatch": _component(_pcts(dmin_pool[T]), len(dmin_pool[T])),
+                "roundtrip": _component(_pcts(rtmin_pool[T]), len(rtmin_pool[T])),
+            },
+            # Diagnostic, NOT a latency: per-iteration cross-rank (max-min) of the round trip.
+            # Small => ranks entered together and the reported MAX is the operation's cost.
+            # Large relative to the roundtrip => the point is skew-inflated; read it with care.
+            "cross_rank_spread_us": _component(_pcts(spread), len(spread)),
             "correctness": {
                 # Max elementwise relative error (COMBINE_MAG_FLOOR-clamped)
                 # against the BF16-faithful expected combine.


### PR DESCRIPTION
## Why

`time_us` synchronised between `pre()` and the start event, on the stated grounds that pre()'s GPU work would otherwise bleed into the measured window. Stream ordering already guarantees that: `s` is enqueued behind pre()'s kernels and timestamps when the stream *reaches* it, not when the host recorded it. Every adapter enqueues on the current stream — nccl-ep's `_stream()` returns `torch.cuda.current_stream()`, uccl-ep passes `async_finish=False` at all three call sites, deepep-v2's LL calls pass `async_with_compute_stream=False`, and no adapter creates a `torch.cuda.Stream` — so the sync was never load-bearing for that isolation.

What it did add is the bug. Draining the GPU put the host's launch of `fn` **inside** the measured window, and because `fn` is a collective, per-rank launch jitter desynchronised the ranks that `pre()` had just aligned. Each rank then blocked on its slowest peer, and `run_sweep`'s cross-rank MAX reported that stagger as the component's latency.

Isolated on b200 uccl-ep low-latency combine, with the sync as the only variable:

| tokens/rank | p50 with sync | p50 without | delta |
|---|---|---|---|
| 1 | 113.4 us | 87.4 us | **-23%** |
| 32 | (unchanged) | (unchanged) | — |

So a component could appear to get *faster* as tokens grew. That curve was an artifact of how much skew each rung happened to accumulate — the larger preceding dispatch self-aligns the ranks — not a property of the operation.

Scope is narrower than it looks: `pre=` is used by exactly two measurements, `benchmark_stage` (pre = dispatch) and `benchmark_combine` when `combine_needs_redispatch` (MoRI always; deepep-v2 and uccl-ep in LL). The round trip, dispatch, and non-redispatch combine never carried this sync.

## What changed

1. **Drop the sync** (`bench/ep_harness.py`). The end-of-iteration sync stays, because iterations still must not overlap: iter N+1's dispatch would race iter N's combine on the backend's persistent comm buffer.

2. **Emit the skew instead of asserting it is gone.** Removing the sync narrows the stagger but cannot prove it absent, so each row gains two additive fields. `cross_rank_min_us` reduces the same iterations with cross-rank MIN per component — the last rank to enter waited least, so its duration is the closest estimate of the cost with skew excluded. `cross_rank_spread_us` is the per-iteration max-min of the round trip, a **diagnostic and not a latency**. A dip visible in MAX but not in MIN was never the operation speeding up, and a point whose spread is large relative to its round trip is charging one rank's wait to the collective.

The new MIN block's `if measured["dispatch"]` guard deliberately mirrors the existing MAX block, which already couples combine to dispatch's truthiness (the round-trip-only contract yields neither). Empty pools degrade through `_pcts` -> `_component` to the standard `availability: "unavailable"` shape, so a round-trip-only backend emits the fields without values rather than failing. The extra reductions run after a point's components are measured, outside every timed window.

## Verification

- 64 CollectiveX tests pass; `py_compile` clean on the touched module.
- Branched at `origin/main`, so the additions-only `perf-changelog.yaml` gate is satisfied.
- The b200 figures above come from the original investigation, not from a sweep on this branch. **This changes reported small-T latencies, so it wants a single-node sweep compared against the durable store before anything is published off it.**

## Open question: artifact version

`configs/sweep.json` carries `version: 1`, stamped into every case-attempt and carried forward in the durable store. Because this shifts small-T latencies by design, v1 rows written before and after this change are not one comparable series. Left at 1 here deliberately — bumping to 2 segments the carried-forward store, which is a publishing decision rather than part of this fix.

## Known asymmetry, left alone

The warmup loop still syncs between `pre()` and `fn()`. It is untimed so it cannot bias a measurement, but warmup iterations no longer reproduce the timed samples' host-launch pattern. Worth removing for symmetry if a reviewer prefers; kept minimal here.

---

## 中文说明

### 为什么

`time_us` 过去在 `pre()` 与起始 event 之间做了一次 host 端同步，理由是避免 `pre()` 的 GPU 工作混入测量窗口。但流(stream)顺序本身已经保证了这一点：起始 event 排在 `pre()` 的 kernel 之后入队，它记录的是流「执行到」该 event 的时刻，而不是 host 记录它的时刻。本目录下所有 adapter 都在当前流上入队 —— nccl-ep 的 `_stream()` 返回 `torch.cuda.current_stream()`，uccl-ep 三处调用均传 `async_finish=False`，deepep-v2 的 low-latency 调用传 `async_with_compute_stream=False`，且没有任何 adapter 创建 `torch.cuda.Stream` —— 所以这次同步对隔离性并非必要。

它真正引入的是问题本身：排空 GPU 队列使 `fn` 的 host 端 launch 落进了测量窗口；而 `fn` 是一个 collective，各 rank 的 launch 抖动会把 `pre()` 刚刚对齐的 rank 重新打散。于是每个 rank 都在等最慢的 peer，`run_sweep` 的跨 rank MAX 便把这段错位记成了组件延迟。

在 b200 uccl-ep low-latency combine 上以该同步为唯一变量做隔离验证：T=1 时 p50 从 113.4us 降至 87.4us(-23%)，T=32 无变化。也就是说，组件延迟可能表现为随 token 数增大反而「变快」—— 这是各档累积错位多少的产物(更大的前置 dispatch 会让各 rank 自然对齐)，而非该操作本身的性质。

影响范围比 diff 看起来更小：`pre=` 只被两处测量使用 —— `benchmark_stage`(pre = dispatch)，以及 `combine_needs_redispatch` 为真时的 `benchmark_combine`(MoRI 始终为真；deepep-v2 与 uccl-ep 在 low-latency 下为真)。round trip、dispatch 以及无需重新 dispatch 的 combine 从未包含这次同步。

### 改了什么

1. **去掉该同步**(`bench/ep_harness.py`)。每次迭代结束处的同步保留：迭代之间仍不可重叠，否则第 N+1 次的 dispatch 会与第 N 次的 combine 在后端持久通信缓冲区上产生竞争。

2. **把错位写入产物，而不是宣称它已消失。** 去掉同步只能缩小错位、无法证明其消失，因此每行新增两个可加字段。`cross_rank_min_us` 对同一批迭代改用跨 rank MIN 归约 —— 最后进入 collective 的 rank 等待最少，其耗时最接近排除 skew 后的真实成本。`cross_rank_spread_us` 是 round trip 的逐迭代跨 rank max-min，属于**诊断量，不是延迟**。只在 MAX 中出现、在 MIN 中不出现的下降，从来不是操作变快；而 spread 相对 round trip 偏大的点，说明它把某个 rank 的等待算进了该 collective。

新增 MIN 代码块中的 `if measured["dispatch"]` 判断有意与既有 MAX 代码块保持一致 —— 后者本就把 combine 与 dispatch 的判断耦合在一起(仅测 round trip 的契约下两者都不产生数据)。空池经 `_pcts` → `_component` 退化为标准的 `availability: "unavailable"` 结构，因此仅测 round trip 的后端会输出这两个字段但不带数值，而不是直接失败。新增的归约都在某个测点的各组件测完之后执行，位于所有计时窗口之外。

### 验证

- CollectiveX 64 项测试通过；改动模块 `py_compile` 通过。
- 基于 `origin/main` 建分支，因此满足 `perf-changelog.yaml` 仅允许新增的校验。
- 上文 b200 数据来自最初的排查，不是本分支跑出的扫描结果。**本改动会使小 T 的上报延迟发生变化，因此在据此发布任何数据之前，需要跑一次单节点扫描并与 durable store 对比。**

### 待确认：产物 version

`configs/sweep.json` 中 `version: 1` 会写入每个 case-attempt，并在 durable store 中延续。由于本改动按设计会改变小 T 延迟，改动前后写入的 v1 数据不构成同一条可比序列。此处有意保留为 1：升到 2 会切分延续下来的 store，那属于发布决策，而非本修复的一部分。

### 已知的不对称之处(暂不处理)

warmup 循环仍在 `pre()` 与 `fn()` 之间同步。它不计时，因此不会影响测量结果，但 warmup 迭代已不再复现计时样本的 host launch 模式。若 reviewer 倾向于对称，可以一并去掉；此处保持最小改动。
