### PR TITLE
[AMD][AgentX] Pin aiperf venv to Python 3.11 to fix mi355x agentic install

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1624,7 +1624,7 @@ install_agentic_deps() {
     mkdir -p "$AIPERF_UV_CACHE_DIR"
 
     UV_CACHE_DIR="$AIPERF_UV_CACHE_DIR" \
-        "$AIPERF_UV_BIN" venv --python "$(command -v python3)" "$AIPERF_VENV"
+        "$AIPERF_UV_BIN" venv --python "${AIPERF_PYTHON_VERSION:-3.11}" "$AIPERF_VENV"
     UV_CACHE_DIR="$AIPERF_UV_CACHE_DIR" \
         "$AIPERF_UV_BIN" pip install --python "$AIPERF_PYTHON" \
         -r "$AGENTIC_DIR/requirements.txt" \


### PR DESCRIPTION
## Summary
- The agentic benchmark harness built the isolated aiperf venv on the container's default `python3`. On the MI355X `sglang-rocm` image that default is CPython 3.10.12.
- `aiperf` (utils/aiperf, currently 0.12.0) declares `requires-python = ">=3.11,<3.14"`, so `uv pip install -e /workspace/utils/aiperf` fails to resolve on 3.10 → server never starts → sweep job fails with "Benchmark result ... not found".
- Fix: create the venv with `uv venv --python "${AIPERF_PYTHON_VERSION:-3.11}"` in `benchmarks/benchmark_lib.sh::install_agentic_deps`, defaulting to 3.11 and overridable via `AIPERF_PYTHON_VERSION`.

## Test plan
- [ ] Re-run the `dsv4-fp4-mi355x-sglang-agentic-mtp` agentic sweep and confirm the aiperf venv resolves on Python 3.11 and the benchmark produces a result JSON.
- [ ] Confirm other clusters (whose default python3 is already >=3.11) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)