### PR TITLE
chore(runners): add B300 runner 18 / 添加 B300 第 18 个运行器

### DIFF
--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -154,6 +154,7 @@ labels:
     - b300-nv_15
     - b300-nv_16
     - b300-nv_17
+    - b300-nv_18
   b300-p1:
     - b300-nv_13
     - b300-nv_14
@@ -247,6 +248,7 @@ labels:
     - b300-nv_15
     - b300-nv_16
     - b300-nv_17
+    - b300-nv_18
   cluster:gb200-nv:
     - gb200-nv_0
     - gb200-nv_1


### PR DESCRIPTION
## Summary

- Add `b300-nv_18` to the general `b300` scheduling pool.
- Add `b300-nv_18` to the `cluster:b300-nv` scheduling pool.
- The independently hosted runner is registered and online with matching labels.

## Validation

- `python -m pytest utils/matrix_logic/ -v` — 224 passed

## 中文说明

- 将 `b300-nv_18` 加入通用 `b300` 调度池。
- 将 `b300-nv_18` 加入 `cluster:b300-nv` 调度池。
- 独立运行的 runner 已完成注册并上线，标签与仓库配置一致。

## 验证

- `python -m pytest utils/matrix_logic/ -v` — 224 项测试通过