### PR TITLE
[Klaud Cold] kimik2.5-fp4-b200/b300-vllm: v0.26.0 image, extend conc to 512, add DEP4 arm / 升级 Kimi K2.5 NVFP4 B200/B300 vLLM 镜像至 v0.26.0，扩展并发至 512，新增 DEP4 配置

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b200.sh
@@ -12,6 +12,21 @@ check_env_vars \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION:-false}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+PREFILL_SCHEDULE_ARGS=()
+if [ "${DP_ATTENTION:-false}" = "true" ]; then
+    PREFILL_SCHEDULE_ARGS=(--prefill-schedule-interval 4)
+fi
+
 if [[ -n "$SLURM_JOB_ID" ]]; then
   echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
 fi
@@ -41,7 +56,9 @@ export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
 
 set -x
 vllm serve $MODEL --host 0.0.0.0 --port $PORT \
---tensor-parallel-size=$TP \
+"${PARALLEL_ARGS[@]}" \
+"${EP_ARGS[@]}" \
+"${PREFILL_SCHEDULE_ARGS[@]}" \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs $CONC \

--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -16,6 +16,21 @@ check_env_vars \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION:-false}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+PREFILL_SCHEDULE_ARGS=()
+if [ "${DP_ATTENTION:-false}" = "true" ]; then
+    PREFILL_SCHEDULE_ARGS=(--prefill-schedule-interval 4)
+fi
+
 # `hf download` creates the target dir if missing and is itself idempotent. 
 # When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
 # Either way, MODEL_PATH is what the server is launched with.
@@ -49,7 +64,9 @@ start_gpu_monitor
 
 set -x
 vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
---tensor-parallel-size $TP \
+"${PARALLEL_ARGS[@]}" \
+"${EP_ARGS[@]}" \
+"${PREFILL_SCHEDULE_ARGS[@]}" \
 --gpu-memory-utilization 0.90 \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs $CONC \

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1520,8 +1520,9 @@ kimik2.5-fp4-b200-vllm:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 512 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
 
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
@@ -1540,8 +1541,9 @@ kimik2.5-fp4-b300-vllm:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
+      - { tp: 8, ep: 1, conc-start: 1, conc-end: 512 }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 512 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
 
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1508,7 +1508,7 @@ kimik2.5-int4-h200-vllm-agentic:
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b200-vllm:
-  image: vllm/vllm-openai:v0.22.0
+  image: vllm/vllm-openai:v0.26.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b200
@@ -1528,7 +1528,7 @@ kimik2.5-fp4-b200-vllm:
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.22.0
+  image: vllm/vllm-openai:v0.26.0
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5361,7 +5361,7 @@
     - kimik2.5-fp4-b300-vllm
   description:
     - "Bump Kimi K2.5 NVFP4 B200/B300 vLLM image from v0.22.0 to v0.26.0"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2441
 
 - config-keys:
     - kimik2.5-fp4-b200-vllm
@@ -5370,4 +5370,4 @@
     - "Bump Kimi K2.5 NVFP4 B200/B300 vLLM image from v0.22.0 to v0.26.0"
     - "Extend TP8/TP4 concurrency sweep to 512"
     - "Add DEP4 arm (tp4 ep4 dp-attn) with --prefill-schedule-interval 4, conc 128-512"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2441

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5362,3 +5362,12 @@
   description:
     - "Bump Kimi K2.5 NVFP4 B200/B300 vLLM image from v0.22.0 to v0.26.0"
   pr-link: TBD
+
+- config-keys:
+    - kimik2.5-fp4-b200-vllm
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Bump Kimi K2.5 NVFP4 B200/B300 vLLM image from v0.22.0 to v0.26.0"
+    - "Extend TP8/TP4 concurrency sweep to 512"
+    - "Add DEP4 arm (tp4 ep4 dp-attn) with --prefill-schedule-interval 4, conc 128-512"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5355,3 +5355,10 @@
     - "Apply the accuracy-gated Kimi-K2.5 MXFP4 settings: tuned AITER MXFP4 MoE, fused shared experts, FP8 KV cache, block size 16, 16384 batched tokens, 512 sequences, async scheduling, gpu-memory-utilization 0.85 (headroom for CUDA-graph capture on MI355X), and the AITER BF16 GEMM path"
     - "Extend the TP4 and TP8 8k1k concurrency sweep from 64 to 128 (1k1k deprecated per #2263)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2213
+
+- config-keys:
+    - kimik2.5-fp4-b200-vllm
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Bump Kimi K2.5 NVFP4 B200/B300 vLLM image from v0.22.0 to v0.26.0"
+  pr-link: TBD


### PR DESCRIPTION
## Summary

- **Image**: `vllm/vllm-openai:v0.22.0` → `vllm/vllm-openai:v0.26.0` for both `kimik2.5-fp4-b200-vllm` and `kimik2.5-fp4-b300-vllm`
- **TP arms**: extended concurrency from `conc-end: 4` / `conc-end: 128` → `conc-end: 512` for both TP8 and TP4 arms
- **New DEP4 arm**: `tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512`
- **Bench scripts**: both `kimik2.5_fp4_b200.sh` and `kimik2.5_fp4_b300.sh` updated to handle `DP_ATTENTION`, switching `--tensor-parallel-size` → `--data-parallel-size` and adding `--enable-expert-parallel` + `--prefill-schedule-interval 4` when DEP4 is active

---

## 中文说明

- **镜像**：`kimik2.5-fp4-b200-vllm` 和 `kimik2.5-fp4-b300-vllm` 从 `v0.22.0` 升级至 `vllm/vllm-openai:v0.26.0`
- **TP 配置**：TP8 和 TP4 并发上限均从原始值扩展至 `conc-end: 512`
- **新增 DEP4 配置**：`tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512`
- **基准脚本**：`kimik2.5_fp4_b200.sh` 和 `kimik2.5_fp4_b300.sh` 均新增 `DP_ATTENTION` 处理逻辑，DEP4 模式下自动切换为 `--data-parallel-size`，并启用 `--enable-expert-parallel` 和 `--prefill-schedule-interval 4`