### PR TITLE
[Klaud Cold] kimik2.5-fp4-b300-vllm: v0.26.0 image, extend conc to 512, add DEP4 arm / 升级 B300 镜像至 v0.26.0，扩展并发，新增 DEP4

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/kimik2.5_fp4_b300.sh
@@ -16,6 +16,21 @@ check_env_vars \
     RANDOM_RANGE_RATIO \
     RESULT_FILENAME
 
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+GMU=0.90
+PREFILL_SCHEDULE_ARGS=()
+if [ "${DP_ATTENTION:-false}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+    GMU=0.85
+    PREFILL_SCHEDULE_ARGS=(--prefill-schedule-interval 4)
+fi
+
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+
 # `hf download` creates the target dir if missing and is itself idempotent. 
 # When MODEL_PATH is unset (stand-alone runs), fall back to the HF_HUB_CACHE
 # Either way, MODEL_PATH is what the server is launched with.
@@ -37,6 +52,9 @@ nvidia-smi
 
 export TORCH_CUDA_ARCH_LIST="10.0"
 export PYTHONNOUSERSITE=1
+export VLLM_USE_V2_MODEL_RUNNER=0
+export VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS=""
+export VLLM_RPC_TIMEOUT=600000
 
 SERVER_LOG=/workspace/server.log
 
@@ -49,13 +67,20 @@ start_gpu_monitor
 
 set -x
 vllm serve $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
---tensor-parallel-size $TP \
---gpu-memory-utilization 0.90 \
+"${PARALLEL_ARGS[@]}" \
+"${EP_ARGS[@]}" \
+"${PREFILL_SCHEDULE_ARGS[@]}" \
+--gpu-memory-utilization "$GMU" \
 --max-model-len $MAX_MODEL_LEN \
 --max-num-seqs $CONC \
 --reasoning-parser kimi_k2 \
 --tool-call-parser kimi_k2 \
 --compilation_config.pass_config.fuse_allreduce_rms true \
+--kv-cache-dtype fp8 \
+--max-cudagraph-capture-size "$((CONC * 2))" \
+--stream-interval 32 \
+--attention-config '{"mla_prefill_backend":"FLASHINFER","use_prefill_query_quantization":true}' \
+--linear-backend flashinfer_cutlass \
 --no-enable-prefix-caching \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1436,7 +1436,7 @@ kimik2.5-fp4-b200-vllm:
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
 
 kimik2.5-fp4-b300-vllm:
-  image: vllm/vllm-openai:v0.22.0
+  image: vllm/vllm-openai:nightly-e2fa28594f7baad142a426b0b6a2cfe2c79201c7
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
   runner: b300
@@ -1448,9 +1448,11 @@ kimik2.5-fp4-b300-vllm:
     - isl: 8192
       osl: 1024
       search-space:
-      - { tp: 8, ep: 1, conc-start: 1, conc-end: 4 }
-      - { tp: 4, ep: 1, conc-start: 1, conc-end: 128 }
-
+      - { tp: 8, ep: 1, conc-list: [1] }
+      - { tp: 4, ep: 1, conc-start: 1, conc-end: 512 }
+      - { tp: 8, ep: 8, dp-attn: false, conc-list: [1] }
+      - { tp: 4, ep: 4, dp-attn: false, conc-start: 1, conc-end: 512 }
+      - { tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512 }
 dsr1-fp8-b200-sglang-mtp:
   image: lmsysorg/sglang:v0.5.12-cu130
   model: deepseek-ai/DeepSeek-R1-0528

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5515,3 +5515,9 @@
     - "Serve shape is the validated STP script unchanged outside the speculative and simulated-acceptance blocks: cookbook B300 NVFP4 low-latency arm (TP8, --kv-cache-dtype fp8_e4m3, --bf16-gemm-backend cutedsl, --max-prefill-tokens 8192, --chunked-prefill-size 8192, --mem-fraction-static 0.85, glm47 tool-call parser, glm45 reasoning parser) with HiCache host-DRAM offload at hicache-ratio 0.75 / write_back / direct / page_first_direct. mem-fraction-static stays at 0.85, which is also what the GLM-5.2 GB300 aggregated MTP recipe uses; the hicache ratio is relative to the device pool, so the nextn layer's own KV only shrinks the host pool."
     - "Search space is one arm on the AgentX MTP concurrency grid: TP8 + HiCache at conc [1, 4, 8, 12, 16]. Steps of at least 2 because single-step sampling cannot separate configurations by more than run-to-run noise on the agentic corpus, and a hard stop at conc 16. The STP entry's DEP (attention-DP + EP8) throughput arm is not carried over: its frontier peak is conc 48, above that cap, and at conc <= 16 attention-DP leaves 2 sessions per rank and is strictly dominated by TP8, so it would spend one GPU job per point re-measuring a worse curve. The DEP branch is kept in the benchmark script -- including the --speculative-moe-a2a-backend none / --speculative-moe-runner-backend triton pair that GLM-5.2-NVFP4's unquantized bf16 nextn layer needs once expert parallelism puts an all-to-all in the MoE path -- so the throughput arm can be added later without re-deriving it."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2447
+
+- config-keys:
+    - kimik2.5-fp4-b300-vllm
+  description:
+    - "Kimi K2.5 NVFP4 B300 vLLM: nightly image, TP/DEP/TEP sweep, TP8 conc-1 only, DEP gmu 0.85"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2442


### PR DESCRIPTION
## Summary

- **Image**: `v0.22.0` → `vllm/vllm-openai:v0.26.0`
- **TP arms**: TP8 and TP4 extended to `conc-end: 512`
- **New DEP4 arm**: `tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512`
- **Bench script** (`kimik2.5_fp4_b200.sh`): `DP_ATTENTION` handling added — switches to `--data-parallel-size`, adds `--enable-expert-parallel` and `--prefill-schedule-interval 4` in DEP4 mode

## 中文说明

- **镜像**：`v0.22.0` → `vllm/vllm-openai:v0.26.0`
- **TP 配置**：TP8 和 TP4 并发上限均扩展至 `conc-end: 512`
- **新增 DEP4 配置**：`tp: 4, ep: 4, dp-attn: true, conc-start: 128, conc-end: 512`
- **基准脚本**（`kimik2.5_fp4_b200.sh`）：新增 `DP_ATTENTION` 处理逻辑，DEP4 模式下切换为 `--data-parallel-size`，并启用 `--enable-expert-parallel` 和 `--prefill-schedule-interval 4`