### PR TITLE
[Klaud Cold] kimik2.6-fp4-b200-dynamo-vllm: remove no-enable-flashinfer-autotune, target b200-new / 移除 no-enable-flashinfer-autotune

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep4-dep8-c1024.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep4-dep8-c1024.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -95,7 +94,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep8-dep8-c2048.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep8-dep8-c2048.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -95,7 +94,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep8-tp8-c1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p1d-dep8-tp8-c1.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -93,7 +92,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p4d-dep4-tp4-c512.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p4d-dep4-tp4-c512.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -92,7 +91,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p8d-dep4-tp4-c128.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p8d-dep4-tp4-c128.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -92,7 +91,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p8d-dep4-tp4-c32.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-1p8d-dep4-tp4-c32.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -92,7 +91,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-2p1d-dep8-dep8-c8192.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/disagg-b200-2p1d-dep8-dep8-c8192.yaml
@@ -75,7 +75,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       attention-backend: FLASHINFER_MLA
       block-size: 128
       attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED"}'
@@ -95,7 +94,6 @@ backend:
       safetensors-load-strategy: prefetch
       trust-remote-code: true
       no-enable-prefix-caching: true
-      no-enable-flashinfer-autotune: true
       async-scheduling: true
       attention-backend: FLASHINFER_MLA
       block-size: 128

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -4981,7 +4981,7 @@ kimik2.6-fp4-b200-dynamo-vllm:
   image: vllm/vllm-openai:v0.25.1
   model: nvidia/Kimi-K2.6-NVFP4
   model-prefix: kimik2.6
-  runner: b200-multinode
+  runner: b200-new
   precision: fp4
   framework: dynamo-vllm
   router: { name: dynamo-router, version: "1.3.0.dev20260721" }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -4981,7 +4981,7 @@ kimik2.6-fp4-b200-dynamo-vllm:
   image: vllm/vllm-openai:v0.25.1
   model: nvidia/Kimi-K2.6-NVFP4
   model-prefix: kimik2.6
-  runner: b200-new
+  runner: b200-multinode
   precision: fp4
   framework: dynamo-vllm
   router: { name: dynamo-router, version: "1.3.0.dev20260721" }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5355,3 +5355,9 @@
     - "Apply the accuracy-gated Kimi-K2.5 MXFP4 settings: tuned AITER MXFP4 MoE, fused shared experts, FP8 KV cache, block size 16, 16384 batched tokens, 512 sequences, async scheduling, gpu-memory-utilization 0.85 (headroom for CUDA-graph capture on MI355X), and the AITER BF16 GEMM path"
     - "Extend the TP4 and TP8 8k1k concurrency sweep from 64 to 128 (1k1k deprecated per #2263)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2213
+
+- config-keys:
+    - kimik2.6-fp4-b200-dynamo-vllm
+  description:
+    - "Remove no-enable-flashinfer-autotune from Kimi K2.6 B200 disagg recipes, target runner b200-new"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5360,4 +5360,4 @@
     - kimik2.6-fp4-b200-dynamo-vllm
   description:
     - "Remove no-enable-flashinfer-autotune from Kimi K2.6 B200 disagg recipes, target runner b200-new"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2445


### PR DESCRIPTION
## Summary

Remove `no-enable-flashinfer-autotune: true` from all 7 `disagg-b200-*` recipe YAMLs under `benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/`.

## 中文说明

从 `benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k2.6/b200-fp4/8k1k/` 下所有 7 个 `disagg-b200-*` 配方 YAML 中移除 `no-enable-flashinfer-autotune: true`。