### PR TITLE
[Klaud Cold] chore(evals): disable agentic evals repo-wide behind AGENTIC_EVALS_DISABLED / 全仓库停用智能体评测（AGENTIC_EVALS_DISABLED 开关）

### DIFF
--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -5,6 +5,25 @@ concurrency, kernels, and other throughput optimizations. They run separately
 from throughput; selection lives in `mark_eval_entries()` in
 `utils/matrix_logic/generate_sweep_configs.py`.
 
+## Status: agentic evals are disabled
+
+**Agentic (SWE-bench) evals are turned off repo-wide** by
+`AGENTIC_EVALS_DISABLED` in `utils/matrix_logic/generate_sweep_configs.py`.
+While it is set, no `agentic-coding` row is ever marked `run-eval`, so
+`run-sweep.yml`'s `sweep-agentic-evals` and `e2e-tests.yml`'s
+`test-sweep-agentic-evals` both find an empty matrix and skip — including
+under `--evals-only`, `--all-evals`, and the `evals-only` / `all-evals` PR
+labels. Agentic *throughput* coverage is unaffected, and fixed-sequence
+(`gsm8k`, `gpqa`, `swebench` on 8k1k) evals are unaffected.
+
+TODO(@adibarra): fix the agentic eval path and re-enable by flipping the flag
+to `False`. The selection policy below still has test coverage behind the
+`_agentic_evals_enabled()` helper in `test_generate_sweep_configs.py`, so the
+re-enable is a one-line change.
+
+The rest of this section describes the behaviour that returns when the flag is
+cleared.
+
 ## Selection
 
 - **Single-node:** 8k1k only; highest and median concurrency for every model,

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -235,6 +235,21 @@ def _multinode_parallelism_key(entry: dict) -> tuple:
     ))
 
 
+# TEMPORARY: agentic (SWE-bench) evals are disabled repo-wide.
+#
+# TODO(@adibarra): fix the agentic eval path and re-enable by flipping this to
+# False (or deleting it and the two `if AGENTIC_EVALS_DISABLED` guards below).
+# Owner is back the week of 2026-08-03; nothing else needs to change to turn
+# them back on, and no throughput coverage is affected either way.
+#
+# This is the single choke point for both dispatch paths: run-sweep.yml's
+# `sweep-agentic-evals` job reads search-space-config.agentic_evals, which
+# process_changelog.py fills from agentic-coding rows carrying run-eval: True,
+# and e2e-tests.yml's `test-sweep-agentic-evals` filters the same flag. If no
+# agentic row is ever marked run-eval, neither job has a matrix and both skip.
+AGENTIC_EVALS_DISABLED = True
+
+
 def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) -> list[dict]:
     """Eval selection policy:
     - Single-node: only consider 8k1k (isl=8192, osl=1024).
@@ -247,7 +262,8 @@ def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) 
         - Ignore entries with all conc values < MIN_EVAL_CONC
         - Mark the entry containing its highest eligible concurrency
         - Set eval-conc to that highest eligible concurrency
-    - Agentic evals are opt-in to preserve default throughput coverage.
+    - Agentic evals are opt-in to preserve default throughput coverage, and are
+      currently disabled outright by AGENTIC_EVALS_DISABLED.
     """
     from collections import defaultdict
 
@@ -311,7 +327,7 @@ def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) 
         mn_eval_conc[best_idx] = best_eval_conc
 
     # Default sweeps preserve every agentic throughput result.
-    if include_agentic:
+    if include_agentic and not AGENTIC_EVALS_DISABLED:
         ag_sn_groups = defaultdict(list)
         for i, entry in enumerate(matrix_values):
             if entry.get(Fields.SCENARIO_TYPE.value) != 'agentic-coding':
@@ -356,7 +372,7 @@ def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
 
     for entry in matrix_values:
         if entry.get(Fields.SCENARIO_TYPE.value) == 'agentic-coding':
-            if Fields.PREFILL.value not in entry:
+            if Fields.PREFILL.value not in entry and not AGENTIC_EVALS_DISABLED:
                 entry[Fields.RUN_EVAL.value] = True
             expanded_entries.append(entry)
             continue

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -1,7 +1,9 @@
 """Comprehensive tests for generate_sweep_configs.py"""
+import contextlib
 import pytest
 import argparse
 import copy
+import generate_sweep_configs
 from generate_sweep_configs import (
     MIN_EVAL_CONC,
     seq_len_stoi,
@@ -14,6 +16,26 @@ from generate_sweep_configs import (
     apply_node_type_defaults,
     expand_config_keys,
 )
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+@contextlib.contextmanager
+def _agentic_evals_enabled():
+    """Temporarily clear the AGENTIC_EVALS_DISABLED kill switch.
+
+    Agentic evals are disabled repo-wide pending TODO(@adibarra). The
+    underlying selection policy is still tested through this helper so the
+    re-enable is a one-line flip with coverage already in place.
+    """
+    previous = generate_sweep_configs.AGENTIC_EVALS_DISABLED
+    generate_sweep_configs.AGENTIC_EVALS_DISABLED = False
+    try:
+        yield
+    finally:
+        generate_sweep_configs.AGENTIC_EVALS_DISABLED = previous
 
 
 # =============================================================================
@@ -227,11 +249,33 @@ class TestMarkEvalEntries:
             },
         ]
 
-        result = mark_eval_entries(matrix_values, include_agentic=True)
+        # AGENTIC_EVALS_DISABLED is a temporary repo-wide kill switch
+        # (TODO(@adibarra)); this asserts the selection policy that returns
+        # when it is flipped back off.
+        with _agentic_evals_enabled():
+            result = mark_eval_entries(matrix_values, include_agentic=True)
 
         marked = [e for e in result if e.get("run-eval")]
         assert len(marked) == 1
         assert marked[0]["conc"] == 64
+
+    def test_disable_switch_suppresses_agentic_even_when_included(self):
+        matrix_values = [
+            {
+                "scenario-type": "agentic-coding",
+                "model": "m", "runner": "b300", "framework": "vllm",
+                "precision": "fp4", "tp": 8, "conc": 64,
+            },
+        ]
+
+        assert generate_sweep_configs.AGENTIC_EVALS_DISABLED is True
+
+        result = mark_eval_entries(matrix_values, include_agentic=True)
+
+        assert [e for e in result if e.get("run-eval")] == [], (
+            "AGENTIC_EVALS_DISABLED must win over include_agentic -- "
+            "--evals-only / --all-evals must not dispatch agentic evals"
+        )
 
     def test_default_mode_does_not_mark_agentic(self):
         matrix_values = [
@@ -673,11 +717,30 @@ class TestMarkAllEvalEntries:
             }
         ]
 
-        result = mark_all_eval_entries(entries)
+        with _agentic_evals_enabled():
+            result = mark_all_eval_entries(copy.deepcopy(entries))
 
         assert result[0]['run-eval'] is True
         assert 'eval-conc' not in result[0]
         assert 'eval-all-concs' not in result[0]
+
+    def test_disable_switch_suppresses_agentic_in_all_evals(self):
+        entries = [
+            {
+                'scenario-type': 'agentic-coding',
+                'model': 'm',
+                'runner': 'r',
+                'conc': 64,
+            }
+        ]
+
+        assert generate_sweep_configs.AGENTIC_EVALS_DISABLED is True
+
+        result = mark_all_eval_entries(entries)
+
+        assert result[0].get('run-eval') is not True, (
+            "AGENTIC_EVALS_DISABLED must win over --all-evals"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
Turns agentic (SWE-bench) evals off repo-wide behind a single flag, until the agentic eval path is fixed.

## @adibarra — TODO

**Re-enable is one line:** flip `AGENTIC_EVALS_DISABLED` to `False` in `utils/matrix_logic/generate_sweep_configs.py` (or delete it and the two `if AGENTIC_EVALS_DISABLED` guards). Nothing else has to change. The `TODO(@adibarra)` marker is on the flag itself and in `utils/evals/EVALS.md`.

The existing selection policy keeps its test coverage behind the new `_agentic_evals_enabled()` helper in `test_generate_sweep_configs.py`, so the behaviour you're turning back on is already asserted — you should see those tests go green against the real code path the moment you flip it.

## Why one flag is enough

Both dispatch paths key off the same thing — an `agentic-coding` row carrying `run-eval: True`:

- `run-sweep.yml` → `sweep-agentic-evals` reads `search-space-config.agentic_evals`, which `process_changelog.py` fills by splitting eval rows on `scenario-type == 'agentic-coding'`.
- `e2e-tests.yml` → `test-sweep-agentic-evals` filters `get-jobs` output on the same flag.

So suppressing the mark in `generate_sweep_configs.py` leaves both jobs with an empty matrix, and both skip on their existing `!= '[]'` guards. No workflow YAML changes.

Worth knowing: `process_changelog.py` runs a **second `--evals-only` pass for every changelog entry** (`utils/process_changelog.py`, the `eval_groups` loop), and `--evals-only` sets `include_agentic=True`. That is why agentic eval jobs were dispatching on every agentic PR regardless of labels — e.g. #2447 and #2448 each got one without asking. The flag wins over `--evals-only`, `--all-evals`, and the `evals-only` / `all-evals` PR labels alike.

## Blast radius

Measured against `configs/nvidia-master.yaml`, before vs after:

| | before | after |
|---|---|---|
| agentic eval rows, `glm5.2-fp4-b300-sglang-agentic --evals-only` | 1 | **0** |
| fixed-seq-len eval rows, `dsv4-fp4-b200-vllm --evals-only` | 4 | 4 |
| default throughput matrix, same key | 7 rows, 0 evals | identical |

Agentic **throughput** coverage is untouched, and `gsm8k` / `gpqa` / 8k1k `swebench` are untouched. Only the agentic eval job goes away.

## Changes

| File | Change |
|---|---|
| `utils/matrix_logic/generate_sweep_configs.py` | `AGENTIC_EVALS_DISABLED = True` + two guards: the `include_agentic` block in `mark_eval_entries()` and the unconditional agentic marking in `mark_all_eval_entries()`. |
| `utils/matrix_logic/test_generate_sweep_configs.py` | `_agentic_evals_enabled()` context manager so the two existing policy tests keep testing the policy; two new tests pin that the switch beats `--evals-only` and `--all-evals`. |
| `utils/evals/EVALS.md` | Status section at the top saying what is off, what is unaffected, and how to turn it back on. |

No config, no `perf-changelog.yaml` entry, no GPU jobs — `[skip-sweep]` on the head commit.

## Validation

`pytest utils/` — 570 passed, 104 of them in `test_generate_sweep_configs.py`. Two failures in `utils/evals/test_run_eval_dispatch.py` (`test_agentic_generation_invokes_mini_swe_agent`, `test_agent_sandbox_cpu_knob`) reproduce identically on a clean `main` in this environment — a missing local `mini-swe-agent` fixture, not this change.
