### PR TITLE
fix(ci): keep successful external sweep dispatch green / 修复 CI：避免通知失败覆盖扫描调度成功

### DIFF
--- a/.github/workflows/trusted-external-sweep.yml
+++ b/.github/workflows/trusted-external-sweep.yml
@@ -15,8 +15,7 @@ on:
 permissions:
     actions: write
     contents: read
-    issues: write
-    pull-requests: read
+    pull-requests: write
 
 jobs:
     dispatch:
@@ -135,9 +134,15 @@ jobs:
                         `已为获批的外部提交 \`${pull.head.sha}\` 调度${runLink}。`,
                         '后续新提交不会自动获得信任；如需批准新的 SHA，请移除并重新添加主扫描标签。',
                       ].join('\n');
-                      await github.rest.issues.createComment({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: pull.number,
-                        body,
-                      });
+                      try {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: pull.number,
+                          body,
+                        });
+                      } catch (error) {
+                        core.warning(
+                          `Sweep dispatched successfully, but the PR comment failed: ${error.message}`,
+                        );
+                      }


### PR DESCRIPTION
## Summary

- grant the trusted external-sweep dispatcher `pull-requests: write` for PR run-link comments
- treat comment creation as best-effort after a successful workflow dispatch
- preserve the successful dispatch result even if GitHub rejects the notification call

## Root cause

In [run 30764133602](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30764133602), authorization and `workflow_dispatch` succeeded, creating [e2e run 30764143282](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30764143282). The dispatcher failed only afterward when the PR-comment endpoint returned `403 Resource not accessible by integration` despite the workflow requesting `issues: write`.

The endpoint advertises `pull_requests=write` as an accepted permission, so this switches to that repository-consistent permission. The fallback warning ensures a notification-policy failure cannot make an already-dispatched sweep appear unsuccessful.

## Validation

- `actionlint .github/workflows/trusted-external-sweep.yml`
- changelog, reuse, sweep-gating, priority, and eval tests: 171 passed

---

## 摘要

- 为可信外部扫描调度器授予 `pull-requests: write`，用于在 PR 中发布运行链接
- 工作流调度成功后，将评论创建视为尽力而为的通知
- 即使 GitHub 拒绝通知请求，也保留成功的扫描调度结果

## 根本原因

在[运行 30764133602](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30764133602)中，授权和 `workflow_dispatch` 均成功，并创建了 [e2e 运行 30764143282](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30764143282)。调度器只在随后调用 PR 评论接口时失败；尽管工作流请求了 `issues: write`，该接口仍返回 `403 Resource not accessible by integration`。

该接口将 `pull_requests=write` 列为可接受权限，因此本修复改用与仓库现有工作流一致的权限。警告回退保证通知策略失败不会让已成功调度的扫描显示为失败。

## 验证

- `actionlint .github/workflows/trusted-external-sweep.yml`
- changelog、复用、扫描门控、优先级和评测测试：171 项通过