### PR TITLE
[3/4] [Power] feat: enable official dcgm energy lane for gb200/gb300 1p1d / 打开 gb200/gb300 官方 1P1D 能耗采集

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -370,6 +370,12 @@ jobs:
         env:
           RUNNER_TYPE: ${{ inputs.runner }}
         run: |
+          # Launcher stamp supplies the producer SHA unless the
+          # power-producer-sha input is set as a manual override
+          if [ -z "$POWER_PRODUCER_SHA" ] && [ -f power-producer-sha.txt ]; then
+            export POWER_PRODUCER_SHA="$(cat power-producer-sha.txt)"
+            echo "POWER_PRODUCER_SHA derived from launcher stamp: $POWER_PRODUCER_SHA"
+          fi
           # Process each result file
           for result_file in ${RESULT_FILENAME}_*.json; do
             if [ -f "$result_file" ]; then

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -362,7 +362,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.eval-only && 'eval_gpu_metrics_' || 'gpu_metrics_' }}${{ env.RESULT_FILENAME }}
-          path: gpu_metrics.csv
+          path: |
+            gpu_metrics.csv
+            gpu_metrics_energy_start.csv
+            gpu_metrics_energy_end.csv
+            gpu_metrics_identity.json
           if-no-files-found: ignore
 
       - name: Upload power audit bundle
@@ -374,6 +378,9 @@ jobs:
             ${{ env.RESULT_FILENAME }}.json
             agg_${{ env.RESULT_FILENAME }}.json
             gpu_metrics.csv
+            gpu_metrics_energy_start.csv
+            gpu_metrics_energy_end.csv
+            gpu_metrics_identity.json
             power_validation_${{ env.RESULT_FILENAME }}.json
           if-no-files-found: ignore
 

--- a/.github/workflows/test-process-result.yml
+++ b/.github/workflows/test-process-result.yml
@@ -8,12 +8,18 @@ on:
       - '.github/workflows/e2e-tests.yml'
       - '.github/workflows/test-process-result.yml'
       - 'benchmarks/benchmark_lib.sh'
+      - 'benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml'
+      - 'benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/8k1k/1p1d-tp4-tp4.yaml'
+      - 'runners/launch_gb200-nv.sh'
+      - 'runners/launch_gb300-nv.sh'
       - 'utils/aggregate_power.py'
       - 'utils/aggregate_power_multinode.py'
       - 'utils/bench_serving/benchmark_serving.py'
       - 'utils/process_result.py'
       - 'utils/test_aggregate_power.py'
       - 'utils/test_aggregate_power_multinode.py'
+      - 'utils/test_gb200_power_official_contract.py'
+      - 'utils/test_gb300_power_official_contract.py'
       - 'utils/test_process_result.py'
 
 permissions:
@@ -37,9 +43,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest pyyaml
 
       - name: Run pytest
         run: |
           cd utils
-          python -m pytest test_aggregate_power.py test_aggregate_power_multinode.py test_process_result.py -v
+          python -m pytest test_aggregate_power.py test_aggregate_power_multinode.py test_gb200_power_official_contract.py test_gb300_power_official_contract.py test_process_result.py -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,8 @@ For `dynamo-sglang` / `dynamo-trt` disaggregated multi-node configs, see `benchm
 
 Multi-node srt-slurm changes must edit the recipe yaml AND `nvidia-master.yaml` together. `srtctl` reads only the recipe (`model.container`, resources, prefill/decode workers); the sweep generator (`utils/matrix_logic/generate_sweep_configs.py`) reads `nvidia-master.yaml` for frontend labels - its prefill/decode numbers never reach `srtctl`. Recipe-only edits mislabel results, master-only edits don't take effect. For image bumps, `model.container` must equal `image:`, since the launcher uses the latter as the container-alias key.
 
+Power lanes: a recipe `telemetry:` block with `provider: dcgm-power` enables official energy collection for that config. The launcher (`runners/launch_gb200-nv.sh`, `launch_gb300-nv.sh`) is the single source of truth for the producer pin (`POWER_SRT_SLURM_PIN`); CI derives `POWER_PRODUCER_SHA` from the launcher's stamp file, and `utils/test_gb200_power_official_contract.py` / `test_gb300_power_official_contract.py` lock the recipe↔launcher contract. dcgm-power lanes are validated for `PRECISION=fp8` only.
+
 ### Updating Docker images
 
 Update the image tag in the relevant `configs/*-master.yaml` and/or `benchmarks/*.sh`, update any related env vars / config params, and append a `perf-changelog.yaml` entry (required - triggers benchmarks):

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -110,6 +110,7 @@ unset _benchmark_caller
 
 GPU_MONITOR_PID=""
 GPU_MONITOR_VENDOR=""
+GPU_MONITOR_INTERVAL=1
 GPU_METRICS_CSV="${GPU_METRICS_CSV:-gpu_metrics.csv}"
 NVIDIA_GPU_MONITOR_QUERY="timestamp,index,power.draw,temperature.gpu,clocks.current.sm,clocks.current.memory,utilization.gpu,utilization.memory"
 export GPU_METRICS_CSV
@@ -130,6 +131,7 @@ start_gpu_monitor() {
     done
 
     GPU_METRICS_CSV="$output"
+    GPU_MONITOR_INTERVAL="$interval"
     export GPU_METRICS_CSV
 
     if command -v nvidia-smi &>/dev/null; then
@@ -141,10 +143,18 @@ start_gpu_monitor() {
     elif command -v amd-smi &>/dev/null; then
         GPU_MONITOR_VENDOR="amd"
         # Use amd-smi native watch mode (-w) which includes timestamps automatically.
-        # Pipe through awk to: skip preamble lines, keep first CSV header, skip repeated headers.
-        amd-smi metric -p -c -t -u -w "$interval" --csv 2>/dev/null \
-            | awk '/^timestamp,/{if(!h){print;h=1};next} h{print}' > "$output" &
+        # PYTHONUNBUFFERED defeats the tool's own stdout block buffering (amd-smi is
+        # Python; measured on MI355X: trailing ticks were lost at kill without it).
+        # Pipe through awk to: skip preamble lines, keep first CSV header, skip repeated
+        # headers, and flush every row so killing the pipe cannot discard buffered samples.
+        PYTHONUNBUFFERED=1 amd-smi metric -p -c -t -u -w "$interval" --csv 2>/dev/null \
+            | awk '/^timestamp,/{if(!h){print;h=1};next} h{print;fflush()}' > "$output" &
         GPU_MONITOR_PID=$!
+        # Hardware energy-accumulator + identity snapshots; the end-side twin in
+        # stop_gpu_monitor lets auditors cross-check the integrated energy
+        # against the accumulator delta.
+        _write_amd_smi_sidecar "${output%.csv}_energy_start.csv" metric -E --csv
+        _write_amd_smi_sidecar "${output%.csv}_identity.json" static --json
         echo "[GPU Monitor] Started AMD (PID=$GPU_MONITOR_PID, interval=${interval}s, output=$output)"
     else
         GPU_MONITOR_VENDOR=""
@@ -156,33 +166,31 @@ start_gpu_monitor() {
 # Stop the background GPU monitor and report file size.
 stop_gpu_monitor() {
     if [[ -n "$GPU_MONITOR_PID" ]] && kill -0 "$GPU_MONITOR_PID" 2>/dev/null; then
+        # benchmark_end_time_unix is recorded shortly before the benchmark
+        # process exits, so the stream must cover one more sample past it for
+        # deterministic boundary interpolation. NVIDIA appends a one-shot
+        # post-exit sample below; amd-smi one-shot CSV has no timestamp column,
+        # so the AMD path instead lets the watch stream emit final ticks before
+        # the kill. Two extra intervals: amd-smi stamps integer seconds, so a
+        # tick in the same second as the window end still fails bracketing —
+        # the stream needs a tick at the NEXT whole second (measured on MI355X:
+        # end=...153.325 vs last sample ...153.0).
+        if [[ "$GPU_MONITOR_VENDOR" == "amd" ]]; then
+            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
+        fi
         kill "$GPU_MONITOR_PID" 2>/dev/null
         wait "$GPU_MONITOR_PID" 2>/dev/null || true
-        # benchmark_end_time_unix is recorded shortly before the benchmark
-        # process exits. For the NVIDIA PR1 canary, append one post-exit sample
-        # so boundary interpolation is deterministic even when the run ends
-        # between 1 Hz monitor ticks. AMD one-shot CSV schemas vary by amd-smi
-        # version, so strict AMD lifecycle validation remains follow-up work.
         case "$GPU_MONITOR_VENDOR" in
             nvidia)
-                local append_final_nvidia_sample=true
-                local repaired_metrics="${GPU_METRICS_CSV}.repair.$$"
-                if [[ -s "$GPU_METRICS_CSV" ]] &&
-                    ! tail -c 1 "$GPU_METRICS_CSV" | grep -q '^$'; then
-                    if sed '$d' "$GPU_METRICS_CSV" > "$repaired_metrics" &&
-                        mv "$repaired_metrics" "$GPU_METRICS_CSV"; then
-                        echo "[GPU Monitor] Dropped truncated trailing sample"
-                    else
-                        rm -f "$repaired_metrics"
-                        append_final_nvidia_sample=false
-                        echo "[GPU Monitor] Warning: could not repair truncated trailing sample" >&2
-                    fi
-                fi
-                if [[ "$append_final_nvidia_sample" == true ]]; then
+                if _repair_truncated_gpu_metrics_tail; then
                     nvidia-smi --query-gpu="$NVIDIA_GPU_MONITOR_QUERY" \
                         --format=csv,noheader >> "$GPU_METRICS_CSV" 2>/dev/null ||
                         echo "[GPU Monitor] Warning: final NVIDIA sample failed" >&2
                 fi
+                ;;
+            amd)
+                _repair_truncated_gpu_metrics_tail || true
+                _write_amd_smi_sidecar "${GPU_METRICS_CSV%.csv}_energy_end.csv" metric -E --csv
                 ;;
         esac
         echo "[GPU Monitor] Stopped (PID=$GPU_MONITOR_PID)"
@@ -194,6 +202,35 @@ stop_gpu_monitor() {
     fi
     GPU_MONITOR_PID=""
     GPU_MONITOR_VENDOR=""
+}
+
+# Drop a partial trailing row left behind when the monitor dies mid-write.
+# Returns non-zero when a truncated row was detected but could not be removed.
+_repair_truncated_gpu_metrics_tail() {
+    local repaired_metrics="${GPU_METRICS_CSV}.repair.$$"
+    if [[ -s "$GPU_METRICS_CSV" ]] &&
+        ! tail -c 1 "$GPU_METRICS_CSV" | grep -q '^$'; then
+        if sed '$d' "$GPU_METRICS_CSV" > "$repaired_metrics" &&
+            mv "$repaired_metrics" "$GPU_METRICS_CSV"; then
+            echo "[GPU Monitor] Dropped truncated trailing sample"
+        else
+            rm -f "$repaired_metrics"
+            echo "[GPU Monitor] Warning: could not repair truncated trailing sample" >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Write one best-effort amd-smi snapshot; remove the file rather than keep a
+# partial one when the invocation fails.
+_write_amd_smi_sidecar() {
+    local out="$1"
+    shift
+    if ! amd-smi "$@" > "$out" 2>/dev/null; then
+        rm -f "$out"
+        echo "[GPU Monitor] Warning: amd-smi $1 sidecar failed" >&2
+    fi
 }
 
 # Block until the GPUs have released a prior job's memory before starting a run.

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
@@ -119,3 +119,16 @@ benchmark:
   req_rate: "inf"
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128"
+
+telemetry:
+  enabled: true
+  provider: dcgm-power
+  default_frequency: 1.0
+  storage_subdir: power
+  required: true
+  startup_timeout_seconds: 120
+  request_timeout_seconds: 2
+  collector_join_timeout_seconds: 10
+  dcgm_exporter:
+    container_image: dcgm-exporter
+    port: 9401

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/8k1k/1p1d-tp4-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/8k1k/1p1d-tp4-tp4.yaml
@@ -119,3 +119,18 @@ benchmark:
   req_rate: "inf"
   random_range_ratio: 0.8
   concurrencies: "1x2x4x8x16x32x64x128"
+
+telemetry:
+  enabled: true
+  provider: dcgm-power
+  default_frequency: 1.0
+  storage_subdir: power
+  required: true
+  startup_timeout_seconds: 120
+  request_timeout_seconds: 2
+  collector_join_timeout_seconds: 10
+  dcgm_exporter:
+    container_image: dcgm-exporter
+    # 9401 is already bound by the cluster-level exporter on im-gb300 nodes;
+    # use a port outside that range.
+    port: 19401

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -10,6 +10,12 @@ export SLURM_PARTITION="batch"
 export SLURM_ACCOUNT="benchmark"
 SQUASH_DIR="/mnt/lustre01/users-public/sa-shared"
 
+# dcgm-power producer pin — single source of truth for power lanes. Swap
+# URL+PIN here (and identically in launch_gb300-nv.sh) when the upstream
+# srt-slurm merge lands.
+POWER_SRT_SLURM_URL="https://github.com/edwingao28/srt-slurm.git"
+POWER_SRT_SLURM_PIN="6fc1bed01a0b82dae0088a105c03ce0cfb353443"
+
 if [[ "$FRAMEWORK" == "llmd-vllm" ]]; then
     if [[ "$MODEL_PREFIX" == "dsv4" && "$PRECISION" == "fp4" ]]; then
         export MODEL_PATH="/mnt/numa1/models/DeepSeek-V4-Pro"
@@ -282,6 +288,41 @@ import_squash() {
 import_squash "$SQUASH_FILE" "$IMAGE"
 import_squash "$NGINX_SQUASH_FILE" "$NGINX_IMAGE"
 
+# Power lane is recipe-driven: on iff the recipe this run resolves carries an
+# enabled dcgm-power telemetry block. Read the workspace mirror (it overlays
+# the srt-slurm clone later), since the pin decision precedes the clone.
+USES_DCGM_POWER=0
+_RECIPE_REL="${CONFIG_FILE%%:*}"
+_RECIPE_SRC="$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/${_RECIPE_REL#recipes/}"
+# Note (wenyao): a stray "enabled: true" outside the telemetry block must
+# not flip the lane, so the match is scoped instead of file-wide greps.
+if [[ -n "$CONFIG_FILE" && -f "$_RECIPE_SRC" ]] && awk '
+    /^telemetry:/ { t = 1; next }
+    t && /^[^ ]/  { t = 0 }
+    t && /^  provider: dcgm-power$/ { p = 1 }
+    t && /^  enabled: true$/        { e = 1 }
+    END { exit !(p && e) }
+' "$_RECIPE_SRC"; then
+    USES_DCGM_POWER=1
+fi
+
+# Note (wenyao): the producer pin descends from the fp8 srt-slurm lineage
+# (cargo/maturin bootstrap); a non-fp8 power recipe would silently clone the
+# wrong lineage, so fail fast instead.
+if [[ "$USES_DCGM_POWER" == "1" && "$PRECISION" != "fp8" ]]; then
+    echo "Error: dcgm-power lanes are only validated for PRECISION=fp8, got: $PRECISION" >&2
+    exit 1
+fi
+
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    DCGM_EXPORTER_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.6.0-4.8.3-distroless"
+    DCGM_EXPORTER_SQSH="${SQUASH_DIR}/$(echo "$DCGM_EXPORTER_IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    import_squash "$DCGM_EXPORTER_SQSH" "$DCGM_EXPORTER_IMAGE"
+    test -r "$DCGM_EXPORTER_SQSH" || { echo "Error: DCGM exporter squash not readable: $DCGM_EXPORTER_SQSH" >&2; exit 1; }
+    unsquashfs -l "$DCGM_EXPORTER_SQSH" > /dev/null || { echo "Error: DCGM exporter squash invalid: $DCGM_EXPORTER_SQSH" >&2; exit 1; }
+    sha256sum "$DCGM_EXPORTER_SQSH" > "$GITHUB_WORKSPACE/exporter-image.sha256"
+fi
+
 export EVAL_ONLY="${EVAL_ONLY:-false}"
 
 export ISL="$ISL"
@@ -401,8 +442,18 @@ elif [[ $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "glm5.1" ]]; then
     mkdir -p recipes/sglang/glm5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5" recipes/sglang/glm5
 elif [[ $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "qwen3.5" ]]; then
-    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
-    cd "$SRT_REPO_DIR"
+    if [[ "$USES_DCGM_POWER" == "1" ]]; then
+        # Power lanes run the exact pinned producer SHA, never a moving
+        # branch; CI derives POWER_PRODUCER_SHA from the stamp file.
+        git clone "$POWER_SRT_SLURM_URL" "$SRT_REPO_DIR"
+        cd "$SRT_REPO_DIR"
+        git checkout "$POWER_SRT_SLURM_PIN" || exit 1
+        test "$(git rev-parse HEAD)" = "$POWER_SRT_SLURM_PIN" || { echo "Error: srt-slurm HEAD does not match POWER_SRT_SLURM_PIN=$POWER_SRT_SLURM_PIN" >&2; exit 1; }
+        git rev-parse HEAD > "$GITHUB_WORKSPACE/power-producer-sha.txt"
+    else
+        git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
+        cd "$SRT_REPO_DIR"
+    fi
     mkdir -p recipes/sglang/qwen3.5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5" recipes/sglang/qwen3.5
 elif [[ $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "glm5.1" ]]; then
@@ -528,6 +579,13 @@ use_segment_sbatch_directive: false
 ${DEFAULT_MOUNTS_BLOCK}
 EOF
 
+# Appended via sed so non-power lanes' generated yaml stays byte-identical.
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    sed -i "/^  nginx-sqsh:/a\\  dcgm-exporter: ${DCGM_EXPORTER_SQSH}" srtslurm.yaml
+    # Note (wenyao): sed's append is a silent no-op if the anchor drifts.
+    grep -q "^  dcgm-exporter: " srtslurm.yaml || { echo "Error: dcgm-exporter injection failed: nginx-sqsh anchor not found in srtslurm.yaml" >&2; exit 1; }
+fi
+
 echo "Generated srtslurm.yaml:"
 cat srtslurm.yaml
 
@@ -631,6 +689,13 @@ echo "Collecting results..."
 
 if [ -d "$LOGS_DIR" ]; then
     echo "Found logs directory: $LOGS_DIR"
+    # Provenance markers travel inside the server-logs bundle so the offline
+    # audit can tie artifacts to the exact producer SHA and exporter image.
+    if [[ "$USES_DCGM_POWER" == "1" ]]; then
+        mkdir -p "$LOGS_DIR/power"
+        cp "$GITHUB_WORKSPACE/exporter-image.sha256" "$LOGS_DIR/power/exporter-image.sha256"
+        cp "$GITHUB_WORKSPACE/power-producer-sha.txt" "$LOGS_DIR/power/power-producer-sha.txt"
+    fi
     cp -r "$LOGS_DIR" "$GITHUB_WORKSPACE/LOGS"
     bundle_server_logs "$LOGS_DIR" "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz"
 else

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -127,6 +127,52 @@ import_squash() {
 import_squash "$SQUASH_FILE" "$IMAGE"
 import_squash "$NGINX_SQUASH_FILE" "$NGINX_IMAGE"
 
+# Power lane detection: a recipe opts in via an enabled dcgm-power telemetry
+# block. CONFIG_FILE is srt-slurm-relative; resolve it against the workspace
+# recipe mirror (the same tree the clone step overlays), since the checkout
+# doesn't exist yet. Recipes that only exist upstream stay non-power.
+USES_DCGM_POWER=0
+_RECIPE_REL="${CONFIG_FILE%%:*}"
+_RECIPE_SRC="$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/${_RECIPE_REL#recipes/}"
+# Note (wenyao): a stray "enabled: true" outside the telemetry block must
+# not flip the lane, so the match is scoped instead of file-wide greps.
+if [[ -n "$CONFIG_FILE" && -f "$_RECIPE_SRC" ]] && awk '
+    /^telemetry:/ { t = 1; next }
+    t && /^[^ ]/  { t = 0 }
+    t && /^  provider: dcgm-power$/ { p = 1 }
+    t && /^  enabled: true$/        { e = 1 }
+    END { exit !(p && e) }
+' "$_RECIPE_SRC"; then
+    USES_DCGM_POWER=1
+fi
+
+# Note (wenyao): the producer pin descends from the fp8 v1.0.25 lineage
+# (cargo/maturin bootstrap); an fp4 power recipe would silently skip the
+# sa-submission branch it needs, so fail fast instead.
+if [[ "$USES_DCGM_POWER" == "1" && "$PRECISION" != "fp8" ]]; then
+    echo "Error: dcgm-power lanes are only validated for PRECISION=fp8, got: $PRECISION" >&2
+    exit 1
+fi
+
+# dcgm-power producer pin — single source of truth for power lanes. Swap
+# URL+PIN here (and identically in launch_gb200-nv.sh) when the upstream
+# srt-slurm merge lands.
+POWER_SRT_SLURM_URL="https://github.com/edwingao28/srt-slurm.git"
+POWER_SRT_SLURM_PIN="6fc1bed01a0b82dae0088a105c03ce0cfb353443"
+
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    DCGM_EXPORTER_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.6.0-4.8.3-distroless"
+    DCGM_EXPORTER_SQSH="/data/home/sa-shared/gharunners/squash/$(echo "$DCGM_EXPORTER_IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    # Note (wenyao): import_squash treats an existing unsquashfs-valid file
+    # as a cache hit but does not re-validate a fresh import, so check
+    # explicitly — on a compute node, like the import itself (login node is
+    # x86, nodes aarch64).
+    import_squash "$DCGM_EXPORTER_SQSH" "$DCGM_EXPORTER_IMAGE"
+    test -r "$DCGM_EXPORTER_SQSH" || { echo "Error: DCGM exporter squash not readable: $DCGM_EXPORTER_SQSH" >&2; exit 1; }
+    srun --partition=$SLURM_PARTITION --exclusive --time=30 bash -c "unsquashfs -l \"$DCGM_EXPORTER_SQSH\" > /dev/null" || { echo "Error: DCGM exporter squash invalid: $DCGM_EXPORTER_SQSH" >&2; exit 1; }
+    sha256sum "$DCGM_EXPORTER_SQSH" > "$GITHUB_WORKSPACE/exporter-image.sha256"
+fi
+
 export EVAL_ONLY="${EVAL_ONLY:-false}"
 
 export ISL="$ISL"
@@ -214,12 +260,21 @@ elif [[ $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "qwen3.5" ]]; then
     # Same branch the identical gb200-fp8 recipes run on. fp4 recipes pin
     # dynamo by version (pip install) and stay on the submission branch they
     # were validated against.
-    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
-    cd "$SRT_REPO_DIR"
-    if [[ $PRECISION == "fp8" ]]; then
-        git checkout v1.0.25
+    if [[ "$USES_DCGM_POWER" == "1" ]]; then
+        git clone "$POWER_SRT_SLURM_URL" "$SRT_REPO_DIR"
+        cd "$SRT_REPO_DIR"
+        git checkout "$POWER_SRT_SLURM_PIN" || exit 1
+        # The power lane must run the exact pinned producer SHA, never a moving branch.
+        test "$(git rev-parse HEAD)" = "$POWER_SRT_SLURM_PIN" || { echo "Error: srt-slurm HEAD does not match POWER_SRT_SLURM_PIN=$POWER_SRT_SLURM_PIN" >&2; exit 1; }
+        git rev-parse HEAD > "$GITHUB_WORKSPACE/power-producer-sha.txt"
     else
-        git checkout sa-submission-q2-2026
+        git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
+        cd "$SRT_REPO_DIR"
+        if [[ $PRECISION == "fp8" ]]; then
+            git checkout v1.0.25
+        else
+            git checkout sa-submission-q2-2026
+        fi
     fi
     mkdir -p recipes/sglang/qwen3.5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5" recipes/sglang/qwen3.5
@@ -316,6 +371,13 @@ containers:
 use_segment_sbatch_directive: false
 EOF
 
+# Appended via sed so non-power lanes' generated yaml stays byte-identical.
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    sed -i "/^  nginx-sqsh:/a\\  dcgm-exporter: ${DCGM_EXPORTER_SQSH}" srtslurm.yaml
+    # Note (wenyao): sed's append is a silent no-op if the anchor drifts.
+    grep -q "^  dcgm-exporter: " srtslurm.yaml || { echo "Error: dcgm-exporter injection failed: nginx-sqsh anchor not found in srtslurm.yaml" >&2; exit 1; }
+fi
+
 echo "Generated srtslurm.yaml:"
 cat srtslurm.yaml
 
@@ -394,6 +456,14 @@ LOG_FILE="$LOGS_DIR/sweep_${JOB_ID}.log"
 # for narrative continuity in normal (non-cancel) runs.
 _snapshot_server_logs() {
     if [ -n "${LOGS_DIR:-}" ] && [ -d "$LOGS_DIR" ] && [ -n "${GITHUB_WORKSPACE:-}" ]; then
+        # Note (wenyao): provenance markers are copied in the trap, not the
+        # main flow, so cancel paths that fire the trap early still bundle
+        # them for the offline audit.
+        if [[ "$USES_DCGM_POWER" == "1" ]]; then
+            mkdir -p "$LOGS_DIR/power" 2>/dev/null || true
+            cp "$GITHUB_WORKSPACE/exporter-image.sha256" "$LOGS_DIR/power/exporter-image.sha256" 2>/dev/null || true
+            cp "$GITHUB_WORKSPACE/power-producer-sha.txt" "$LOGS_DIR/power/power-producer-sha.txt" 2>/dev/null || true
+        fi
         # Copy + tar are independent best-effort; an in-flight write
         # from a worker .out file at SIGTERM time would otherwise abort
         # the whole script before either succeeds.
@@ -436,8 +506,9 @@ echo "Collecting results..."
 
 if [ -d "$LOGS_DIR" ]; then
     echo "Found logs directory: $LOGS_DIR"
-    # Tarball + LOGS copy are produced by the EXIT trap defined near
-    # JOB_ID extraction (so cancel paths also get them); just log here.
+    # Tarball + LOGS copy + power provenance markers are produced by the EXIT
+    # trap defined near JOB_ID extraction (so cancel paths also get them);
+    # just log here.
     echo "multinode_server_logs.tar.gz will be (re)produced on script EXIT."
 else
     echo "Warning: Logs directory not found at $LOGS_DIR"

--- a/utils/aggregate_power.py
+++ b/utils/aggregate_power.py
@@ -35,6 +35,7 @@ _NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
 
 _INTEGRATION_METHOD = "per_device_trapezoidal_with_linear_boundary_interpolation"
 _DEFAULT_MAX_SAMPLE_GAP_S = 3.0
+_ACCUMULATOR_TOLERANCE = 0.05
 _POWER_METRIC_KEYS = {
     "avg_power_w",
     "avg_total_gpu_power_w",
@@ -501,6 +502,135 @@ def integrate_power(
     )
 
 
+def _read_energy_snapshot(path: Path) -> dict[str, float] | None:
+    """Map GPU id to accumulator joules from one ``amd-smi metric -E`` snapshot."""
+    with path.open("r", newline="", encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f, skipinitialspace=True)
+        header = [column.strip() for column in (reader.fieldnames or [])]
+        reader.fieldnames = header
+        if "gpu" not in header or "total_energy_consumption" not in header:
+            return None
+        energy_by_gpu: dict[str, float] = {}
+        for row in reader:
+            gpu_id = (row.get("gpu") or "").strip()
+            if not gpu_id:
+                continue
+            try:
+                energy_j = float((row.get("total_energy_consumption") or "").strip())
+            except ValueError:
+                continue
+            if math.isfinite(energy_j):
+                energy_by_gpu[gpu_id] = energy_j
+    return energy_by_gpu or None
+
+
+def _stream_samples_by_gpu(csv_path: Path) -> dict[str, list[tuple[float, float]]]:
+    """Group every parseable (timestamp, watt) sample per GPU, sorted in time."""
+    samples: dict[str, list[tuple[float, float]]] = {}
+    with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
+        reader = csv.DictReader(f, skipinitialspace=True)
+        header = [column.strip() for column in (reader.fieldnames or [])]
+        reader.fieldnames = header
+        timestamp_col, power_col, gpu_col = _detect_columns(header)
+        if not timestamp_col or not power_col or not gpu_col:
+            return {}
+        for row in reader:
+            timestamp = _parse_timestamp((row.get(timestamp_col) or "").strip())
+            power = _parse_power((row.get(power_col) or "").strip())
+            gpu_id = (row.get(gpu_col) or "").strip()
+            if timestamp is None or power is None or not gpu_id:
+                continue
+            if not math.isfinite(timestamp) or not math.isfinite(power):
+                continue
+            samples.setdefault(gpu_id, []).append((timestamp, power))
+    return {gpu_id: sorted(values) for gpu_id, values in samples.items()}
+
+
+def _trapezoid(samples: list[tuple[float, float]]) -> float:
+    """Integrate consecutive (timestamp, watt) samples with no window clipping."""
+    return float(
+        sum(
+            (right_time - left_time) * (left_power + right_power) / 2.0
+            for (left_time, left_power), (right_time, right_power) in zip(
+                samples, samples[1:]
+            )
+        )
+    )
+
+
+def cross_check_accumulator(csv_path: Path) -> dict | None:
+    """Compare the hardware energy-accumulator delta with the full stream integral.
+
+    The snapshots bracket the whole monitor lifetime rather than one benchmark
+    window, so the comparison integrates the entire stream span: it validates the
+    sampling instrument, not a window's metrics. Advisory only — the result never
+    affects ``power_valid`` or the validation reason codes.
+    """
+    start_path = csv_path.with_name(f"{csv_path.stem}_energy_start.csv")
+    end_path = csv_path.with_name(f"{csv_path.stem}_energy_end.csv")
+    start_exists = start_path.is_file()
+    end_exists = end_path.is_file()
+    if not start_exists and not end_exists:
+        return None
+    if not start_exists:
+        return {"available": False, "reason": "missing_start_snapshot"}
+    if not end_exists:
+        return {"available": False, "reason": "missing_end_snapshot"}
+
+    start_energy = _read_energy_snapshot(start_path)
+    if start_energy is None:
+        return {"available": False, "reason": "unparseable_start_snapshot"}
+    end_energy = _read_energy_snapshot(end_path)
+    if end_energy is None:
+        return {"available": False, "reason": "unparseable_end_snapshot"}
+
+    matched_gpu_ids = sorted(set(start_energy) & set(end_energy), key=_gpu_sort_key)
+    per_gpu_delta_j = {
+        gpu_id: end_energy[gpu_id] - start_energy[gpu_id] for gpu_id in matched_gpu_ids
+    }
+    unmatched_gpus = sorted(set(start_energy) ^ set(end_energy), key=_gpu_sort_key)
+    negative_delta_gpus = [
+        gpu_id for gpu_id, delta in per_gpu_delta_j.items() if delta < 0
+    ]
+
+    stream = _stream_samples_by_gpu(csv_path)
+    integrated_gpu_ids = sorted(set(stream) & set(per_gpu_delta_j), key=_gpu_sort_key)
+    integrated_stream_j = float(
+        sum(_trapezoid(stream[gpu_id]) for gpu_id in integrated_gpu_ids)
+    )
+    boundaries = [
+        timestamp
+        for gpu_id in integrated_gpu_ids
+        for timestamp in (stream[gpu_id][0][0], stream[gpu_id][-1][0])
+    ]
+    stream_span_s = max(boundaries) - min(boundaries) if boundaries else 0.0
+
+    accumulator_delta_j = float(sum(per_gpu_delta_j.values()))
+    relative_error: float | None = None
+    within_tolerance = False
+    if accumulator_delta_j > 0:
+        relative_error = (
+            abs(accumulator_delta_j - integrated_stream_j) / accumulator_delta_j
+        )
+        within_tolerance = (
+            not negative_delta_gpus and relative_error <= _ACCUMULATOR_TOLERANCE
+        )
+
+    return {
+        "available": True,
+        "accumulator_delta_j": accumulator_delta_j,
+        "integrated_stream_j": integrated_stream_j,
+        "relative_error": relative_error,
+        "within_tolerance": within_tolerance,
+        "tolerance": _ACCUMULATOR_TOLERANCE,
+        "per_gpu_delta_j": per_gpu_delta_j,
+        "integrated_gpu_ids": integrated_gpu_ids,
+        "unmatched_gpus": unmatched_gpus,
+        "negative_delta_gpus": negative_delta_gpus,
+        "stream_span_s": stream_span_s,
+    }
+
+
 def _load_benchmark_data(
     bench_result_path: Path,
 ) -> tuple[BenchmarkData | None, list[str]]:
@@ -646,6 +776,7 @@ def _validation_payload(
     power_valid: bool,
     reasons: list[str],
     metrics: dict[str, float],
+    accumulator_check: dict | None,
 ) -> dict:
     """Build the complete auditable power-validation sidecar payload."""
     benchmark_window = None
@@ -674,6 +805,7 @@ def _validation_payload(
         "per_gpu_max_sample_gap_s": integration.per_gpu_max_sample_gap_s,
         "per_gpu_energy_j": integration.per_gpu_energy_j,
         "device_issues": integration.device_issues,
+        "accumulator_check": accumulator_check,
         "metrics": {
             key: round(value, 6)
             for key, value in metrics.items()
@@ -736,6 +868,11 @@ def run(
             print(f"[aggregate_power] Failed to patch {agg_result}: {exc}", file=sys.stderr)
 
     try:
+        accumulator_check = cross_check_accumulator(csv_path)
+    except (OSError, csv.Error):
+        accumulator_check = {"available": False, "reason": "cross_check_error"}
+
+    try:
         _write_json_atomic(
             validation_result,
             _validation_payload(
@@ -746,6 +883,7 @@ def run(
                 power_valid=power_valid,
                 reasons=reasons,
                 metrics=metrics,
+                accumulator_check=accumulator_check,
             ),
         )
     except OSError as exc:

--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -90,6 +90,7 @@ def record_power_internal_error(
             power_valid=False,
             reasons=reasons,
             metrics={},
+            accumulator_check=None,
         )
         validation_data["internal_error"] = {
             "type": type(error).__name__,

--- a/utils/test_aggregate_power.py
+++ b/utils/test_aggregate_power.py
@@ -10,6 +10,7 @@ Covers:
   - Whole-deployment power/energy/J-query/J-token metric semantics
   - Best-effort invalid results and REQUIRE_POWER strict failures
   - Atomic aggregate and validation artifacts
+  - Advisory energy-accumulator cross-check against the AMD sidecar snapshots
 """
 from __future__ import annotations
 
@@ -27,6 +28,7 @@ from aggregate_power import (  # noqa: E402
     _parse_power,
     _parse_timestamp,
     aggregate_power,
+    cross_check_accumulator,
     integrate_power,
     main,
     patch_agg_result,
@@ -70,6 +72,23 @@ def test_detect_columns_nvidia():
 
 def test_detect_columns_amd():
     header = ["timestamp", "gpu", "socket_power", "temperature"]
+    ts, pw, gpu = _detect_columns(header)
+    assert ts == "timestamp"
+    assert pw == "socket_power"
+    assert gpu == "gpu"
+
+
+def test_detect_columns_amd_watch_mode_real_header():
+    # AMDSMI 26.2.0 `metric -p -c -t -u -w 1 --csv` header (order-faithful
+    # subset, measured on MI355X): socket_power must win even though
+    # power_management also matches the power pattern later in the row.
+    header = [
+        "timestamp", "gpu", "gfx_activity", "umc_activity", "mm_activity",
+        "vcn_activity", "jpeg_activity", "gfx_busy_inst_xcp_0",
+        "jpeg_busy_xcp_0", "vcn_busy_xcp_0", "socket_power", "gfx_voltage",
+        "soc_voltage", "mem_voltage", "throttle_status", "power_management",
+        "gfx_0_clk", "mem_0_clk", "edge", "hotspot", "mem",
+    ]
     ts, pw, gpu = _detect_columns(header)
     assert ts == "timestamp"
     assert pw == "socket_power"
@@ -759,6 +778,8 @@ def test_run_emits_complete_whole_deployment_metric_contract(tmp_path: Path):
     assert audit["integration_method"] == (
         "per_device_trapezoidal_with_linear_boundary_interpolation"
     )
+    # No vendor accumulator sidecars: the advisory check stays absent.
+    assert audit["accumulator_check"] is None
 
 
 def test_run_best_effort_marks_invalid_power_and_preserves_benchmark(tmp_path: Path):
@@ -873,6 +894,285 @@ def test_run_invalid_benchmark_denominator_is_auditable(tmp_path: Path):
     assert json.loads(validation.read_text())["reasons"] == [
         "invalid_successful_query_count"
     ]
+
+
+# --------------------------------------------------------------------------- #
+# Advisory hardware energy-accumulator cross-check
+# --------------------------------------------------------------------------- #
+
+_ENERGY_SNAPSHOT_HEADER = (
+    "gpu,socket_power,gfx_voltage,soc_voltage,mem_voltage,"
+    "throttle_status,power_management,total_energy_consumption"
+)
+
+
+def _write_energy_snapshot(path: Path, energy_by_gpu: dict[str, float]) -> None:
+    """`amd-smi metric -E --csv` shape measured on MI355X, N/A cells included."""
+    lines = [_ENERGY_SNAPSHOT_HEADER]
+    for gpu_id, energy_j in energy_by_gpu.items():
+        lines.append(f"{gpu_id},238,N/A,N/A,N/A,N/A,ENABLED,{energy_j}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_snapshot_pair(
+    csv: Path,
+    *,
+    start: dict[str, float],
+    end: dict[str, float],
+) -> None:
+    """Sidecars named exactly as start_gpu_monitor/stop_gpu_monitor write them."""
+    _write_energy_snapshot(csv.parent / "gpu_metrics_energy_start.csv", start)
+    _write_energy_snapshot(csv.parent / "gpu_metrics_energy_end.csv", end)
+
+
+def _write_flat_stream(csv: Path, *, base: float, watts_by_gpu: dict[int, float]) -> None:
+    """11 samples at 1 Hz, so each GPU's full-stream span is exactly 10s."""
+    _write_amd_csv(
+        csv,
+        [
+            (base + offset, gpu, watts)
+            for gpu, watts in watts_by_gpu.items()
+            for offset in range(11)
+        ],
+    )
+
+
+def test_cross_check_accumulator_matches_full_stream_integral(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+    _write_snapshot_pair(csv, start={"0": 1_000_000.0}, end={"0": 1_005_000.0})
+
+    result = cross_check_accumulator(csv)
+
+    assert result is not None
+    assert result["available"] is True
+    assert result["accumulator_delta_j"] == pytest.approx(5_000.0)
+    assert result["integrated_stream_j"] == pytest.approx(5_000.0)
+    assert result["relative_error"] < 0.05
+    assert result["within_tolerance"] is True
+    assert result["tolerance"] == 0.05
+    assert result["per_gpu_delta_j"] == pytest.approx({"0": 5_000.0})
+    assert result["integrated_gpu_ids"] == ["0"]
+    assert result["unmatched_gpus"] == []
+    assert result["negative_delta_gpus"] == []
+    assert result["stream_span_s"] == pytest.approx(10.0)
+
+
+def test_cross_check_accumulator_flags_disagreement_beyond_tolerance(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    # 400 W sampled against a 5_000 J accumulator delta: the stream is 20% low.
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 400.0})
+    _write_snapshot_pair(csv, start={"0": 1_000_000.0}, end={"0": 1_005_000.0})
+
+    result = cross_check_accumulator(csv)
+
+    assert result["available"] is True
+    assert result["integrated_stream_j"] == pytest.approx(4_000.0)
+    assert result["relative_error"] == pytest.approx(0.2)
+    assert result["within_tolerance"] is False
+
+
+def test_cross_check_accumulator_without_snapshots_returns_none(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+
+    assert cross_check_accumulator(csv) is None
+
+
+def test_cross_check_accumulator_reports_missing_end_snapshot(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+    _write_energy_snapshot(tmp_path / "gpu_metrics_energy_start.csv", {"0": 1_000_000.0})
+
+    assert cross_check_accumulator(csv) == {
+        "available": False,
+        "reason": "missing_end_snapshot",
+    }
+
+
+def test_cross_check_accumulator_reports_unparseable_snapshot(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+    _write_energy_snapshot(tmp_path / "gpu_metrics_energy_start.csv", {"0": 1_000_000.0})
+    (tmp_path / "gpu_metrics_energy_end.csv").write_text(
+        "gpu,socket_power\n0,238\n", encoding="utf-8"
+    )
+
+    assert cross_check_accumulator(csv) == {
+        "available": False,
+        "reason": "unparseable_end_snapshot",
+    }
+
+
+def test_cross_check_accumulator_flags_negative_delta(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 400.0, 1: 0.0})
+    # GPU 1's counter wrapped. The summed delta still matches the stream, so a
+    # False verdict here can only come from the wrap itself.
+    _write_snapshot_pair(
+        csv,
+        start={"0": 1_000_000.0, "1": 2_000_000.0},
+        end={"0": 1_005_000.0, "1": 1_999_000.0},
+    )
+
+    result = cross_check_accumulator(csv)
+
+    assert result["negative_delta_gpus"] == ["1"]
+    assert result["accumulator_delta_j"] == pytest.approx(4_000.0)
+    assert result["integrated_stream_j"] == pytest.approx(4_000.0)
+    assert result["relative_error"] == pytest.approx(0.0)
+    assert result["within_tolerance"] is False
+
+
+def test_cross_check_accumulator_excludes_unmatched_gpu(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    # GPU 1 draws 10x GPU 0 but is absent from the end snapshot: counting it
+    # would blow the integral past tolerance.
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0, 1: 5_000.0})
+    _write_energy_snapshot(
+        tmp_path / "gpu_metrics_energy_start.csv",
+        {"0": 1_000_000.0, "1": 3_000_000.0},
+    )
+    _write_energy_snapshot(
+        tmp_path / "gpu_metrics_energy_end.csv",
+        {"0": 1_005_000.0},
+    )
+
+    result = cross_check_accumulator(csv)
+
+    assert result["unmatched_gpus"] == ["1"]
+    assert list(result["per_gpu_delta_j"]) == ["0"]
+    assert result["integrated_gpu_ids"] == ["0"]
+    assert result["accumulator_delta_j"] == pytest.approx(5_000.0)
+    assert result["integrated_stream_j"] == pytest.approx(5_000.0)
+    assert result["within_tolerance"] is True
+
+
+def test_cross_check_accumulator_guards_zero_accumulator_delta(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+    _write_snapshot_pair(csv, start={"0": 1_000_000.0}, end={"0": 1_000_000.0})
+
+    result = cross_check_accumulator(csv)
+
+    assert result["accumulator_delta_j"] == pytest.approx(0.0)
+    assert result["relative_error"] is None
+    assert result["within_tolerance"] is False
+
+
+def test_cross_check_accumulator_parses_real_amd_smi_snapshot(tmp_path: Path):
+    """Verbatim AMDSMI 26.2.0 rows: N/A cells, and an N/A accumulator reading."""
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_flat_stream(csv, base=1_700_000_000.0, watts_by_gpu={0: 500.0})
+    (tmp_path / "gpu_metrics_energy_start.csv").write_text(
+        f"{_ENERGY_SNAPSHOT_HEADER}\n"
+        "0,238,N/A,N/A,N/A,N/A,ENABLED,178319501.682\n"
+        "1,241,N/A,N/A,N/A,N/A,ENABLED,178400000.000\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "gpu_metrics_energy_end.csv").write_text(
+        f"{_ENERGY_SNAPSHOT_HEADER}\n"
+        "0,240,N/A,N/A,N/A,N/A,ENABLED,178324501.682\n"
+        "1,239,N/A,N/A,N/A,N/A,ENABLED,N/A\n",
+        encoding="utf-8",
+    )
+
+    result = cross_check_accumulator(csv)
+
+    assert result["available"] is True
+    assert result["per_gpu_delta_j"] == pytest.approx({"0": 5_000.0})
+    assert result["unmatched_gpus"] == ["1"]
+    assert result["within_tolerance"] is True
+
+
+def test_run_records_advisory_accumulator_check(tmp_path: Path):
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_constant_window_samples(
+        csv,
+        start=base,
+        end=base + 10,
+        watts_per_gpu=500.0,
+        num_gpus=2,
+    )
+    # The monitor lifetime spans 12s (one sample either side of the formal
+    # window), so the accumulator delta legitimately exceeds window energy.
+    _write_snapshot_pair(
+        csv,
+        start={"0": 1_000_000.0, "1": 2_000_000.0},
+        end={"0": 1_006_000.0, "1": 2_006_000.0},
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    validation = tmp_path / "power_validation.json"
+    _write_bench_result(
+        bench,
+        start=base,
+        end=base + 10,
+        duration=10.0,
+        completed=10,
+        total_input=10_000,
+        total_output=2_000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x"}), encoding="utf-8")
+
+    exit_code = run(csv, bench, agg, expected_num_gpus=2, validation_result=validation)
+
+    assert exit_code == 0
+    patched = json.loads(agg.read_text())
+    assert patched["power_valid"] == 1
+    assert patched["total_gpu_energy_j"] == pytest.approx(10_000.0)
+
+    audit = json.loads(validation.read_text())
+    assert audit["power_valid"] is True
+    assert audit["reasons"] == []
+    check = audit["accumulator_check"]
+    assert check["available"] is True
+    assert check["within_tolerance"] is True
+    assert check["accumulator_delta_j"] == pytest.approx(12_000.0)
+    assert check["integrated_stream_j"] == pytest.approx(12_000.0)
+    assert check["stream_span_s"] == pytest.approx(12.0)
+
+
+def test_run_accumulator_mismatch_leaves_power_validity_untouched(tmp_path: Path):
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_constant_window_samples(
+        csv,
+        start=base,
+        end=base + 10,
+        watts_per_gpu=500.0,
+        num_gpus=2,
+    )
+    _write_snapshot_pair(
+        csv,
+        start={"0": 1_000_000.0, "1": 2_000_000.0},
+        end={"0": 1_000_100.0, "1": 2_000_100.0},
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    validation = tmp_path / "power_validation.json"
+    _write_bench_result(
+        bench,
+        start=base,
+        end=base + 10,
+        duration=10.0,
+        completed=10,
+        total_input=10_000,
+        total_output=2_000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x"}), encoding="utf-8")
+
+    exit_code = run(csv, bench, agg, expected_num_gpus=2, validation_result=validation)
+
+    assert exit_code == 0
+    patched = json.loads(agg.read_text())
+    assert patched["power_valid"] == 1
+    assert patched["avg_power_w"] == pytest.approx(500.0)
+    audit = json.loads(validation.read_text())
+    assert audit["power_valid"] is True
+    assert audit["reasons"] == []
+    assert audit["accumulator_check"]["within_tolerance"] is False
 
 
 def test_cli_requires_expected_gpu_count(monkeypatch: pytest.MonkeyPatch):

--- a/utils/test_gb200_power_official_contract.py
+++ b/utils/test_gb200_power_official_contract.py
@@ -1,0 +1,203 @@
+"""Static contract for the official GB200 dcgm-power lane.
+
+Power behavior is recipe-gated: a run turns power on iff the recipe it
+resolves carries an enabled dcgm-power telemetry block, and only then
+provisions the exporter and clones the pinned producer fork. These tests read
+launcher/recipe/workflow text; nothing is executed. Cross-launcher and
+repo-wide invariants live here; the GB300 twin imports the shared helpers.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RECIPE_PATH = REPO_ROOT / "benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml"
+GB200_LAUNCHER = REPO_ROOT / "runners/launch_gb200-nv.sh"
+GB300_LAUNCHER = REPO_ROOT / "runners/launch_gb300-nv.sh"
+TMPL_PATH = REPO_ROOT / ".github/workflows/benchmark-multinode-tmpl.yml"
+
+STAMP_NAME = "power-producer-sha.txt"
+EXPORTER_IMAGE = "nvcr.io/nvidia/k8s/dcgm-exporter:4.6.0-4.8.3-distroless"
+
+
+def launcher_power_constants(path):
+    """Derive URL+PIN from a launcher — their literals live nowhere else."""
+    text = path.read_text()
+    url = re.search(r'^POWER_SRT_SLURM_URL="([^"]+)"$', text, re.M)
+    pin = re.search(r'^POWER_SRT_SLURM_PIN="([0-9a-f]{40})"$', text, re.M)
+    assert url and pin, path
+    return url.group(1), pin.group(1)
+
+
+FORK_URL, PRODUCER_PIN = launcher_power_constants(GB200_LAUNCHER)
+
+
+def git_grep_lines(*args):
+    proc = subprocess.run(
+        ["git", "grep", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    # git grep exits 1 when nothing matches.
+    assert proc.returncode in (0, 1), proc.stderr
+    return proc.stdout.splitlines()
+
+
+def assert_recipe_driven_detection(launcher):
+    assert "USES_DCGM_POWER=0" in launcher
+    assert '_RECIPE_REL="${CONFIG_FILE%%:*}"' in launcher
+    assert (
+        '_RECIPE_SRC="$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/${_RECIPE_REL#recipes/}"'
+        in launcher
+    )
+    # Upstream-only recipes have no workspace mirror and must stay non-power.
+    assert '-f "$_RECIPE_SRC"' in launcher
+    assert "/^telemetry:/ { t = 1; next }" in launcher
+    assert "t && /^  provider: dcgm-power$/ { p = 1 }" in launcher
+    assert "t && /^  enabled: true$/        { e = 1 }" in launcher
+    assert "USES_DCGM_POWER=1" in launcher
+    assert (
+        'if [[ "$USES_DCGM_POWER" == "1" && "$PRECISION" != "fp8" ]]; then'
+        in launcher
+    )
+    # Exporter provisioning, pinned clone, srtslurm.yaml injection, and audit
+    # copies are each gated so non-power lanes keep the pre-existing path.
+    assert launcher.count('if [[ "$USES_DCGM_POWER" == "1" ]]; then') >= 4
+
+
+def assert_pinned_clone_contract(launcher):
+    assert f'POWER_SRT_SLURM_URL="{FORK_URL}"' in launcher
+    assert f'POWER_SRT_SLURM_PIN="{PRODUCER_PIN}"' in launcher
+    assert 'git clone "$POWER_SRT_SLURM_URL" "$SRT_REPO_DIR"' in launcher
+    assert 'git checkout "$POWER_SRT_SLURM_PIN" || exit 1' in launcher
+    assert 'test "$(git rev-parse HEAD)" = "$POWER_SRT_SLURM_PIN"' in launcher
+    assert f'git rev-parse HEAD > "$GITHUB_WORKSPACE/{STAMP_NAME}"' in launcher
+
+
+def assert_exporter_provisioning(launcher):
+    assert f'DCGM_EXPORTER_IMAGE="{EXPORTER_IMAGE}"' in launcher
+    assert 'import_squash "$DCGM_EXPORTER_SQSH" "$DCGM_EXPORTER_IMAGE"' in launcher
+    assert 'test -r "$DCGM_EXPORTER_SQSH"' in launcher
+    assert (
+        'sha256sum "$DCGM_EXPORTER_SQSH" > "$GITHUB_WORKSPACE/exporter-image.sha256"'
+        in launcher
+    )
+    # Container line lands after the unique nginx-sqsh key so the heredoc
+    # output of non-power lanes stays byte-identical.
+    assert '"/^  nginx-sqsh:/a' in launcher
+    assert 'dcgm-exporter: ${DCGM_EXPORTER_SQSH}" srtslurm.yaml' in launcher
+    assert 'grep -q "^  dcgm-exporter: " srtslurm.yaml || ' in launcher
+    assert (
+        'cp "$GITHUB_WORKSPACE/exporter-image.sha256" "$LOGS_DIR/power/exporter-image.sha256"'
+        in launcher
+    )
+    assert f'cp "$GITHUB_WORKSPACE/{STAMP_NAME}" "$LOGS_DIR/power/{STAMP_NAME}"' in launcher
+
+
+def test_recipe_declares_enabled_dcgm_power_lane():
+    recipe = yaml.safe_load(RECIPE_PATH.read_text())
+
+    telemetry = recipe["telemetry"]
+    assert telemetry["enabled"] is True
+    assert telemetry["provider"] == "dcgm-power"
+    assert telemetry["required"] is True
+    assert telemetry["dcgm_exporter"]["container_image"] == "dcgm-exporter"
+    assert telemetry["dcgm_exporter"]["port"] == 9401
+
+    # Official recipes keep the full sweep ladder; only the telemetry block
+    # was added.
+    assert recipe["benchmark"]["concurrencies"] == "1x2x4x8x16x32x64x128"
+    assert recipe["resources"]["prefill_nodes"] == 1
+    assert recipe["resources"]["decode_nodes"] == 1
+    assert recipe["resources"]["gpus_per_node"] == 4
+
+
+def test_launcher_detects_power_lane_from_recipe():
+    assert_recipe_driven_detection(GB200_LAUNCHER.read_text())
+
+
+def test_launcher_provisions_exporter_through_squash_dir_cache():
+    launcher = GB200_LAUNCHER.read_text()
+    assert_exporter_provisioning(launcher)
+    assert 'DCGM_EXPORTER_SQSH="${SQUASH_DIR}/' in launcher
+    assert 'unsquashfs -l "$DCGM_EXPORTER_SQSH"' in launcher
+
+
+def test_launcher_pins_power_producer_and_keeps_nonpower_clone():
+    launcher = GB200_LAUNCHER.read_text()
+    assert_pinned_clone_contract(launcher)
+    # Non-power qwen3.5 keeps the upstream clone with no ref pin.
+    assert 'git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"' in launcher
+    assert "v1.0.25" not in launcher
+
+
+def test_pin_constants_identical_across_launchers():
+    assert launcher_power_constants(GB300_LAUNCHER) == (FORK_URL, PRODUCER_PIN)
+    assert re.fullmatch(r"[0-9a-f]{40}", PRODUCER_PIN)
+    assert FORK_URL.startswith("https://") and FORK_URL.endswith("/srt-slurm.git")
+
+
+def test_pin_literal_lives_only_in_the_two_launchers():
+    hits = git_grep_lines("-lF", PRODUCER_PIN)
+    assert sorted(hits) == [
+        "runners/launch_gb200-nv.sh",
+        "runners/launch_gb300-nv.sh",
+    ]
+
+
+def test_exactly_two_recipes_opt_into_dcgm_power():
+    hits = git_grep_lines(
+        "-lF", "provider: dcgm-power", "--", "benchmarks/multi_node/srt-slurm-recipes"
+    )
+    assert sorted(hits) == [
+        "benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml",
+        "benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/8k1k/1p1d-tp4-tp4.yaml",
+    ]
+
+
+def test_lane_and_pin_have_no_env_override_backdoor():
+    # All assignments are literals: no environment variable can flip the
+    # lane or redirect the pinned clone.
+    for path in (GB200_LAUNCHER, GB300_LAUNCHER):
+        text = path.read_text()
+        assert re.findall(r"^\s*USES_DCGM_POWER=(\S+)$", text, re.M) == ["0", "1"], path
+        for name in ("POWER_SRT_SLURM_URL", "POWER_SRT_SLURM_PIN"):
+            values = re.findall(rf"^\s*{name}=(.*)$", text, re.M)
+            assert len(values) == 1 and "$" not in values[0], (path, name)
+
+
+def test_workflows_carry_no_producer_sha_literal():
+    offenders = []
+    for wf in sorted((REPO_ROOT / ".github/workflows").iterdir()):
+        if wf.suffix not in (".yml", ".yaml"):
+            continue
+        for lineno, line in enumerate(wf.read_text().splitlines(), 1):
+            # Action pins ("uses: ...@<sha>") are the only allowed 40-hex.
+            if "uses:" in line:
+                continue
+            if re.search(r"\b[0-9a-f]{40}\b", line):
+                offenders.append(f"{wf.name}:{lineno}")
+    assert offenders == []
+
+
+def test_stamp_filename_agrees_between_launchers_and_template():
+    stamp_writes = set()
+    for path in (GB200_LAUNCHER, GB300_LAUNCHER):
+        match = re.search(
+            r'git rev-parse HEAD > "\$GITHUB_WORKSPACE/([^"]+)"', path.read_text()
+        )
+        assert match, path
+        stamp_writes.add(match.group(1))
+
+    tmpl = TMPL_PATH.read_text()
+    read_match = re.search(r'export POWER_PRODUCER_SHA="\$\(cat ([^)]+)\)"', tmpl)
+    assert read_match
+    assert stamp_writes == {STAMP_NAME} == {read_match.group(1)}
+
+    # The manual input stays the override: the stamp only fills an empty env.
+    assert f'if [ -z "$POWER_PRODUCER_SHA" ] && [ -f {STAMP_NAME} ]; then' in tmpl
+    assert "POWER_PRODUCER_SHA: ${{ inputs.power-producer-sha }}" in tmpl

--- a/utils/test_gb300_power_official_contract.py
+++ b/utils/test_gb300_power_official_contract.py
@@ -1,0 +1,58 @@
+"""Static contract for the official GB300 dcgm-power lane.
+
+Shares helpers with the GB200 contract; GB300 specifics are the literal
+shared squash cache path (no SQUASH_DIR var in this launcher), the 19401
+exporter port, and the preserved v1.0.25/sa-submission non-power refs.
+"""
+
+import yaml
+
+from test_gb200_power_official_contract import (
+    REPO_ROOT,
+    assert_exporter_provisioning,
+    assert_pinned_clone_contract,
+    assert_recipe_driven_detection,
+)
+
+RECIPE_PATH = REPO_ROOT / "benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp8/8k1k/1p1d-tp4-tp4.yaml"
+LAUNCHER_PATH = REPO_ROOT / "runners/launch_gb300-nv.sh"
+
+
+def test_recipe_declares_enabled_dcgm_power_lane():
+    recipe = yaml.safe_load(RECIPE_PATH.read_text())
+
+    telemetry = recipe["telemetry"]
+    assert telemetry["enabled"] is True
+    assert telemetry["provider"] == "dcgm-power"
+    assert telemetry["required"] is True
+    assert telemetry["dcgm_exporter"]["container_image"] == "dcgm-exporter"
+    # 9401 is already bound by the cluster-level exporter on im-gb300 nodes.
+    assert telemetry["dcgm_exporter"]["port"] == 19401
+
+    assert recipe["benchmark"]["concurrencies"] == "1x2x4x8x16x32x64x128"
+    assert recipe["resources"]["prefill_nodes"] == 1
+    assert recipe["resources"]["decode_nodes"] == 1
+    assert recipe["resources"]["gpus_per_node"] == 4
+
+
+def test_launcher_detects_power_lane_from_recipe():
+    assert_recipe_driven_detection(LAUNCHER_PATH.read_text())
+
+
+def test_launcher_provisions_exporter_through_shared_squash_path():
+    launcher = LAUNCHER_PATH.read_text()
+    assert_exporter_provisioning(launcher)
+    # No SQUASH_DIR var here; the /data/ mount avoids the /home NFS ELOOP bug.
+    assert 'DCGM_EXPORTER_SQSH="/data/home/sa-shared/gharunners/squash/' in launcher
+    assert 'srun --partition=$SLURM_PARTITION --exclusive --time=30 bash -c "unsquashfs -l' in launcher
+
+
+def test_launcher_pins_power_producer():
+    assert_pinned_clone_contract(LAUNCHER_PATH.read_text())
+
+
+def test_non_power_lane_keeps_existing_ref_logic():
+    launcher = LAUNCHER_PATH.read_text()
+    assert 'git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"' in launcher
+    assert "git checkout v1.0.25" in launcher
+    assert "git checkout sa-submission-q2-2026" in launcher

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -1029,6 +1029,154 @@ stop_gpu_monitor
             final_sample,
         ]
 
+    def test_stop_gpu_monitor_amd_waits_one_tick_and_snapshots_energy(self, tmp_path):
+        """AMD stop lets the watch stream bracket the window, then snapshots energy."""
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        args_log = tmp_path / "amd_args.txt"
+        fake_amd_smi = fake_bin / "amd-smi"
+        fake_amd_smi.write_text(
+            "#!/usr/bin/env bash\n"
+            f"printf '%s\\n' \"$*\" >> {str(args_log)!r}\n"
+            "printf 'gpu,total_energy_consumption\\n0,178319501.7\\n'\n"
+        )
+        fake_amd_smi.chmod(0o755)
+        sleep_log = tmp_path / "sleep_args.txt"
+        contents = "timestamp,gpu,socket_power\n1785881113,0,238\n"
+        metrics = tmp_path / "gpu_metrics.csv"
+        metrics.write_text(contents)
+        benchmark_lib = Path(__file__).parents[1] / "benchmarks/benchmark_lib.sh"
+        script = f"""
+source {str(benchmark_lib)!r}
+kill() {{ return 0; }}
+wait() {{ return 0; }}
+sleep() {{ printf '%s\\n' "$1" > {str(sleep_log)!r}; }}
+GPU_MONITOR_PID=999
+GPU_MONITOR_VENDOR=amd
+GPU_MONITOR_INTERVAL=3
+GPU_METRICS_CSV={str(metrics)!r}
+stop_gpu_monitor
+"""
+        env = {
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert sleep_log.read_text().strip() == "5"
+        assert metrics.read_text() == contents
+        assert "metric -E --csv" in args_log.read_text()
+        energy_end = tmp_path / "gpu_metrics_energy_end.csv"
+        assert energy_end.read_text().startswith("gpu,total_energy_consumption")
+
+    def test_stop_gpu_monitor_amd_drops_truncated_row_without_append(self, tmp_path):
+        """The AMD path repairs a partial trailing row but appends no sample."""
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_amd_smi = fake_bin / "amd-smi"
+        fake_amd_smi.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf 'gpu,total_energy_consumption\\n0,178319501.7\\n'\n"
+        )
+        fake_amd_smi.chmod(0o755)
+        header = "timestamp,gpu,socket_power"
+        complete_sample = "1785881113,0,238"
+        metrics = tmp_path / "gpu_metrics.csv"
+        metrics.write_text(f"{header}\n{complete_sample}\n1785881114,0,2")
+        benchmark_lib = Path(__file__).parents[1] / "benchmarks/benchmark_lib.sh"
+        script = f"""
+source {str(benchmark_lib)!r}
+kill() {{ return 0; }}
+wait() {{ return 0; }}
+sleep() {{ return 0; }}
+GPU_MONITOR_PID=999
+GPU_MONITOR_VENDOR=amd
+GPU_METRICS_CSV={str(metrics)!r}
+stop_gpu_monitor
+"""
+        env = {
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert metrics.read_text().splitlines() == [header, complete_sample]
+        assert (tmp_path / "gpu_metrics_energy_end.csv").exists()
+
+    def test_start_stop_gpu_monitor_amd_lifecycle(self, tmp_path):
+        """Watch rows survive the kill and both boundary snapshots are written."""
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_amd_smi = fake_bin / "amd-smi"
+        fake_amd_smi.write_text(
+            "#!/usr/bin/env bash\n"
+            'if [[ "$*" == *" -w "* ]]; then\n'
+            "    echo \"'CTRL' + 'C' to stop watching output:\"\n"
+            "    echo 'timestamp,gpu,socket_power,power_management'\n"
+            "    for _ in $(seq 1 30); do\n"
+            "        echo \"$(date +%s),0,238,ENABLED\"\n"
+            "        echo 'timestamp,gpu,socket_power,power_management'\n"
+            "        sleep 0.2\n"
+            "    done\n"
+            'elif [[ "$*" == *"metric -E --csv"* ]]; then\n'
+            "    printf 'gpu,total_energy_consumption\\n0,178319501.7\\n'\n"
+            'elif [[ "$1" == "static" ]]; then\n'
+            "    printf '{\"gpu_data\": []}\\n'\n"
+            "fi\n"
+        )
+        fake_amd_smi.chmod(0o755)
+        metrics = tmp_path / "gpu_metrics.csv"
+        benchmark_lib = Path(__file__).parents[1] / "benchmarks/benchmark_lib.sh"
+        script = f"""
+source {str(benchmark_lib)!r}
+start_gpu_monitor --output {str(metrics)!r} --interval 1
+sleep 0.8
+stop_gpu_monitor
+"""
+        env = {
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+
+        result = subprocess.run(
+            ["bash", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, result.stderr
+        lines = metrics.read_text().splitlines()
+        assert lines[0] == "timestamp,gpu,socket_power,power_management"
+        assert sum(1 for line in lines if line.startswith("timestamp,")) == 1
+        assert "CTRL" not in metrics.read_text()
+        data_rows = [line for line in lines[1:] if line]
+        assert len(data_rows) >= 2
+        assert all(row.split(",")[2] == "238" for row in data_rows)
+        energy_start = tmp_path / "gpu_metrics_energy_start.csv"
+        assert energy_start.read_text().startswith("gpu,total_energy_consumption")
+        assert (tmp_path / "gpu_metrics_energy_end.csv").exists()
+        identity = json.loads((tmp_path / "gpu_metrics_identity.json").read_text())
+        assert identity == {"gpu_data": []}
+
 
 # =============================================================================
 # Integration: multinode power aggregation patches the agg JSON


### PR DESCRIPTION
**Merge strategy: this PR merges with a fork pin.** The producer pin points at edwingao28/srt-slurm@6fc1bed (the reviewed v2 producer branch; immutable SHA, additionally protected by fork branch `wenyao/pr2-pin-validated-v2`). The upstream NVIDIA/srt-slurm PR proceeds independently; once it merges, a one-line follow-up PR swaps URL+SHA to upstream and re-smokes both platforms. Pin-swap re-smoke evidence for 6fc1bed: GB200 [30969382477](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30969382477) (full ladder, 8/8 power_valid=1, manifest producer==6fc1bed, offline validator exit 0), GB300 [30981806370](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30981806370) (full ladder, 8/8 power_valid=1, manifest producer==6fc1bed). The N=3 ladder tables below were measured under the functionally identical v1 pin (6609d46); the v2 runs reproduce them (gb200 c4 5.180 vs N=3 mean 5.219; gb300 c4 4.586 vs 4.593, c128 1.011 vs 1.010).

中文:本 PR 以 fork pin 合入(SHA 内容寻址不可变 + 兜底保护分支),上游 PR 独立推进,合入后一个 one-line 跟进 PR 换成 upstream SHA 并双平台 re-smoke。

Stacked on #2437 (multinode consumer), which stacks on #2323 (single-node).

**What this adds**

- telemetry block in the two official 1P1D 8k1k recipes. gb300 uses port 19401: 9401 is already bound by the cluster-level exporter on im-gb300 nodes.
- lane-scoped provisioning in the gb200/gb300 launchers: a run opts in only when its recipe carries an enabled dcgm-power block. Every other model/recipe keeps the exact same path as before.
- producer pin contract: power lanes clone the pinned SHA, assert HEAD matches, and write power-producer-sha.txt. CI derives POWER_PRODUCER_SHA from that stamp; the workflow input stays as a manual override.
- contract tests for the above (utils/test_gb200_power_official_contract.py, utils/test_gb300_power_official_contract.py).

**Scope**: 1P1D only. No nvidia-master.yaml change. Dispatches for this PR use exact-key test-config, not full-sweep.

**Validation so far** (fork pin): GB200 run 30618706258 (340.5 W/GPU avg, 193,404 J), GB300 run 30663050396 (349.3 W/GPU avg, 172,800 J), both with power_valid=1 and stored==recomputed sidecars. Local: 124 tests pass.

中文:为 gb200/gb300 官方 1P1D lane 打开 DCGM 能耗采集。recipe 声明 telemetry(gb300 用 19401 端口),launcher 按 recipe 判定是否 provision exporter 与 pin producer(非 power lane 路径不变),CI 从 launcher stamp 读取 POWER_PRODUCER_SHA。当前 pin 指向已验证的 fork SHA,upstream merge 后换 pin 并重跑双平台 c4 smoke,再转正式 review。


---

**Official ladder results** (D1 runs on this branch, fork pin; one dispatch per platform runs the recipe's full concurrency sweep): GB200 [30951410151](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30951410151), GB300 [30951412632](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30951412632). All 16 windows power_valid=1, manifest producer SHA == pin, stored == recomputed sidecars, per-GPU sample gaps ≤ 1.03 s.

| hw | conc | power_valid | W/GPU | total W | total J | prefill J | decode J | J/1k out-tok | J/1k in-tok | out tok/s/GPU | mean TTFT s | mean TPOT s |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| gb200 | 1 | 1 | 283.0 | 2,263.8 | 131,153.9 | 54,320.9 | 76,833.0 | 14,098.03 | 1,772.52 | 40.1 | 0.339 | 0.0059 |
| gb200 | 2 | 1 | 310.8 | 2,486.8 | 147,494.7 | 59,213.5 | 88,281.1 | 7,885.31 | 996.42 | 78.8 | 0.366 | 0.0059 |
| gb200 | 4 | 1 | 347.1 | 2,777.1 | 189,752.8 | 74,233.4 | 115,519.4 | 5,155.63 | 645.13 | 134.7 | 0.538 | 0.0066 |
| gb200 | 8 | 1 | 405.2 | 3,241.2 | 258,333.2 | 98,373.9 | 159,959.3 | 3,487.74 | 441.62 | 232.3 | 0.634 | 0.0077 |
| gb200 | 16 | 1 | 472.2 | 3,777.8 | 362,887.9 | 141,556.9 | 221,331.0 | 2,478.30 | 308.75 | 381.1 | 0.768 | 0.0093 |
| gb200 | 32 | 1 | 557.3 | 4,458.0 | 550,756.1 | 220,795.0 | 329,961.1 | 1,859.76 | 234.09 | 599.3 | 1.042 | 0.0118 |
| gb200 | 64 | 1 | 662.8 | 5,302.5 | 827,651.4 | 359,795.6 | 467,855.8 | 1,402.97 | 175.02 | 944.9 | 1.355 | 0.0149 |
| gb200 | 128 | 1 | 786.6 | 6,292.5 | 1,273,182.6 | 614,364.1 | 658,818.6 | 1,081.18 | 134.63 | 1,455.0 | 2.163 | 0.0190 |
| gb300 | 1 | 1 | 289.8 | 2,318.5 | 113,820.3 | 47,056.1 | 66,764.3 | 12,234.80 | 1,538.26 | 47.4 | 0.352 | 0.0049 |
| gb300 | 2 | 1 | 313.5 | 2,508.1 | 133,353.4 | 53,740.4 | 79,612.9 | 7,129.29 | 900.89 | 88.0 | 0.513 | 0.0051 |
| gb300 | 4 | 1 | 354.1 | 2,833.1 | 169,519.3 | 66,519.6 | 102,999.7 | 4,605.88 | 576.34 | 153.8 | 0.463 | 0.0058 |
| gb300 | 8 | 1 | 410.3 | 3,282.4 | 233,869.5 | 90,374.3 | 143,495.2 | 3,157.45 | 399.80 | 259.9 | 0.586 | 0.0068 |
| gb300 | 16 | 1 | 477.9 | 3,823.5 | 332,993.4 | 129,314.6 | 203,678.9 | 2,274.14 | 283.31 | 420.3 | 0.751 | 0.0084 |
| gb300 | 32 | 1 | 563.9 | 4,511.5 | 513,995.9 | 205,957.3 | 308,038.6 | 1,735.63 | 218.47 | 649.8 | 0.982 | 0.0109 |
| gb300 | 64 | 1 | 663.1 | 5,305.2 | 768,153.2 | 334,258.7 | 433,894.5 | 1,302.12 | 162.44 | 1,018.6 | 1.233 | 0.0139 |
| gb300 | 128 | 1 | 780.9 | 6,247.0 | 1,191,762.0 | 578,366.1 | 613,395.9 | 1,012.03 | 126.02 | 1,543.2 | 2.192 | 0.0177 |

中文:上表为两平台正式 ladder(每平台一次 dispatch 覆盖 c1–128 全部 8 窗)。GB300 每输出 token 能耗全程低于 GB200(c4 低 ~10.7%,c128 低 ~6.4%),且 TPOT 同步更优;两平台到 c128 尚未出现能效饱和。

---

**Reproducibility, N=3 per platform** (mean over 3 independent dispatches; CV% in parentheses). GB200: [30951410151](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30951410151), [30960242894](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30960242894), [30962794356](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30962794356). GB300: [30951412632](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30951412632), [30958592389](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30958592389), [30958596147](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30958596147). All 48 windows power_valid=1. Worst CV across the 16 (platform, conc) cells: 1.59% on J/out-tok, 1.10% on W/GPU.

| hw | conc | N | J/out-tok (CV%) | W/GPU (CV%) | J/query | out tok/s/GPU | TTFT s | TPOT s |
|---|---|---|---|---|---|---|---|---|
| gb200 | 1 | 3 | 14.162 (0.77) | 282.3 (0.28) | 13,174.9 | 39.9 | 0.346 | 0.0059 |
| gb200 | 2 | 3 | 7.905 (0.24) | 310.5 (0.10) | 7,393.3 | 78.6 | 0.368 | 0.0059 |
| gb200 | 4 | 3 | 5.219 (1.59) | 346.9 (0.06) | 4,802.3 | 133.0 | 0.544 | 0.0067 |
| gb200 | 8 | 3 | 3.497 (0.24) | 406.4 (0.31) | 3,237.4 | 232.4 | 0.631 | 0.0077 |
| gb200 | 16 | 3 | 2.477 (0.16) | 470.9 (0.25) | 2,266.7 | 380.2 | 0.794 | 0.0093 |
| gb200 | 32 | 3 | 1.864 (0.36) | 557.2 (0.10) | 1,724.6 | 598.0 | 1.067 | 0.0118 |
| gb200 | 64 | 3 | 1.402 (0.35) | 663.1 (0.05) | 1,292.8 | 945.6 | 1.359 | 0.0149 |
| gb200 | 128 | 3 | 1.081 (0.28) | 787.2 (0.16) | 994.1 | 1,457.1 | 2.100 | 0.0190 |
| gb300 | 1 | 3 | 12.282 (0.67) | 289.1 (1.10) | 11,426.4 | 47.1 | 0.412 | 0.0049 |
| gb300 | 2 | 3 | 7.104 (0.60) | 313.1 (0.78) | 6,644.2 | 88.2 | 0.480 | 0.0051 |
| gb300 | 4 | 3 | 4.593 (0.61) | 352.8 (0.73) | 4,225.8 | 153.6 | 0.460 | 0.0058 |
| gb300 | 8 | 3 | 3.165 (0.58) | 408.9 (0.54) | 2,930.7 | 258.3 | 0.611 | 0.0068 |
| gb300 | 16 | 3 | 2.274 (0.06) | 477.7 (0.07) | 2,081.3 | 420.1 | 0.735 | 0.0084 |
| gb300 | 32 | 3 | 1.728 (0.41) | 562.0 (0.30) | 1,598.7 | 650.7 | 0.967 | 0.0109 |
| gb300 | 64 | 3 | 1.302 (0.27) | 661.9 (0.18) | 1,199.7 | 1,017.0 | 1.252 | 0.0139 |
| gb300 | 128 | 3 | 1.010 (0.26) | 782.8 (0.37) | 929.3 | 1,549.9 | 2.098 | 0.0177 |

中文:每平台 3 次独立 dispatch(重新部署、重新采样)后按窗口聚合。16 个 (平台, 并发) 单元格里 J/out-tok 的 CV 最差 1.59%(gb200 c4),其余全部 ≤0.77%;W/GPU 最差 1.10%。仪器与结果均可复现。两次 gb200 失败 run(30958590082/30958594280)为同集群并发 dispatch 导致的冷启动互踩、非仪器问题,已剔除并以串行重跑替代。
