### PR TITLE
 MI355X MiniMax M3 MTP

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_vllm_mtp.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 set -x
 
-# Agentic trace replay benchmark for Minimax-M3 FP4 on MI355X using vLLM.
+# Agentic trace replay benchmark for MiniMax-M3 FP4 on MI355X using vLLM
+# EAGLE3 speculative decoding.
 #
 # Required env vars:
-#   MODEL, MODEL_PATH, TP, CONC, KV_OFFLOADING, KV_OFFLOAD_BACKEND,
+#   MODEL, MODEL_PATH, TP, CONC, KV_OFFLOADING,
 #   TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION, EP_SIZE, DP_ATTENTION
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
@@ -17,11 +18,15 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 # setting it here makes the effective framework always lm-eval, never swebench.
 export EVAL_FRAMEWORK="lm-eval"
 
-check_env_vars MODEL TP CONC KV_OFFLOADING KV_OFFLOAD_BACKEND TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
 
 echo "MODEL=$MODEL TP=$TP CONC=$CONC KV_OFFLOADING=$KV_OFFLOADING TOTAL_CPU_DRAM_GB=$TOTAL_CPU_DRAM_GB RESULT_DIR=$RESULT_DIR DURATION=$DURATION EP_SIZE=$EP_SIZE DP_ATTENTION=$DP_ATTENTION"
 
-PORT=8888
+DRAFT_MODEL="Inferact/MiniMax-M3-EAGLE3-GQA"
+NUM_SPEC_TOKENS=3
+# golden_al_distribution/minimaxm3_eagle3_gqa.yaml:
+# minimax-m3.thinking_on[3]
+SYNTHETIC_ACCEPT_LEN=2.78
 
 if [[ -n "${SLURM_JOB_ID+x}" ]]; then
     echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
@@ -40,6 +45,7 @@ else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"
 fi
+hf download "$DRAFT_MODEL"
 
 rocm-smi || true
 amd-smi || true
@@ -49,16 +55,33 @@ install_agentic_deps
 
 # ---- Server config ----------------------------------------------------------
 SERVER_LOG="$RESULT_DIR/server.log"
-LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
 mkdir -p "$RESULT_DIR"
 
-OFFLOAD_ARGS=(--no-enable-prefix-caching)
+SERVER_PID=""
+cleanup_agentic_services() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "vLLM server" 60
+    exit "$exit_code"
+}
+trap cleanup_agentic_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-case "$KV_OFFLOAD_BACKEND" in
-    vllm-simple)
+# AgentX replays growing multi-turn prefixes, so keep prefix caching enabled
+# for both GPU-resident and native-offload configurations.
+OFFLOAD_ARGS=()
+
+case "${KV_OFFLOAD_BACKEND:-}" in
+    "")
+        require_agentic_kv_offload_none
+        ;;
+    vllm-native)
+        require_agentic_kv_offload_backend vllm-native
         unset VLLM_USE_SIMPLE_KV_OFFLOAD
         # Use vLLM's regular native KV-offload path (OffloadingConnector),
-        # NOT the SimpleCPUOffloadConnector. The "native" backend resolves to
+        # NOT the SimpleCPUOffloadConnector. The "vllm-native" backend resolves to
         # OffloadingConnector by default; setting VLLM_USE_SIMPLE_KV_OFFLOAD=1
         # would switch it to SimpleCPUOffloadConnector. We intentionally leave
         # that env var UNSET here so the regular OffloadingConnector path is
@@ -73,28 +96,39 @@ case "$KV_OFFLOAD_BACKEND" in
             --kv_offloading_size "$TOTAL_CPU_DRAM_GB"
         )
         ;;
+    *)
+        echo "Unsupported KV_OFFLOAD_BACKEND: ${KV_OFFLOAD_BACKEND:-}" >&2
+        exit 1
+        ;;
 esac
 
 # ---- LLM server config ----------------------------------------------------------
 PARALLEL_ARGS=(--tensor-parallel-size "$TP")
-if [ "${DP_ATTENTION}" = "true" ]; then
-    PARALLEL_ARGS=(
-        --tensor-parallel-size 1
-        --data-parallel-size "$TP"
-        --enable-expert-parallel
-    )
-elif [ "$EP_SIZE" -gt 1 ]; then
+if [ "$EP_SIZE" -gt 1 ]; then
     PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
+
+# Synthetic acceptance standardizes throughput against the committed golden
+# EAGLE3-GQA curve. Accuracy evals must use real target verification.
+if [ "${EVAL_ONLY}" = "true" ]; then
+    SPEC_CONFIG="{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"TRITON_ATTN\"}"
+else
+    SPEC_CONFIG="{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"TRITON_ATTN\", \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_length\": $SYNTHETIC_ACCEPT_LEN}"
 fi
 
 echo "Starting vllm server..."
 export PYTHONNOUSERSITE=1
 
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 export VLLM_USE_BREAKABLE_CUDAGRAPH=0
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_USE_AITER_MOE=1
 export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
+# The official MiniMax-M3 MI355X EAGLE3 baseline uses the native page-128
+# layout. The shuffled AITER page-16 path is a separate high-concurrency mode
+# and must only be enabled after that band is validated independently.
+export VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT=0
 # INT4 quantized all-reduce for the (~1.5 MB) decode all-reduces, which are the
 # single biggest decode kernel at high concurrency. The MIN_SIZE_KB override is
 # required: vLLM's default INT4 quick-reduce size gate for (bf16, TP4) is 16 MB,
@@ -113,11 +147,13 @@ VLLM_CMD=(
     --block-size 128
     --gpu-memory-utilization 0.85
     --language-model-only
+    --enable-prefix-caching
     --attention-backend TRITON_ATTN
     --moe-backend aiter
     --kv-cache-dtype fp8
     --tool-call-parser minimax_m3
     --enable-auto-tool-choice
+    --default-chat-template-kwargs '{"thinking_mode":"enabled"}'
     # NOTE: --reasoning-parser minimax_m3 is intentionally OMITTED.
     # MiniMax-M3 is an interleaved-thinking model: its <mm:think>...</mm:think>
     # block MUST be round-tripped back into the conversation history every turn
@@ -129,6 +165,7 @@ VLLM_CMD=(
     # inline in message.content, so the client preserves it across turns. The
     # tool-call parser above still extracts tool calls from the full output.
     --max-num-seqs "$CONC"
+    --speculative-config "$SPEC_CONFIG"
     "${OFFLOAD_ARGS[@]}"
 )
 printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -2231,8 +2231,8 @@ minimaxm3-fp8-mi325x-vllm-agentic:
       - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32] }
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [24, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96], router: { name: vllm-router, version: "0.1.14" } }
 
-minimaxm3-fp4-mi355x-vllm-agentic:
-  image: vllm/vllm-openai-rocm:nightly-dcfebf93f4eccf30f71872283331eee757915daf
+minimaxm3-fp4-mi355x-vllm-agentic-mtp:
+  image: vllm/vllm-openai-rocm:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
   runner: cluster:mi355x-amds
@@ -2241,9 +2241,11 @@ minimaxm3-fp4-mi355x-vllm-agentic:
   multinode: false
   scenarios:
     agentic-coding:
-    - dram-utilization: 0.80
+    - dram-utilization: 0.20
       search-space:
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [1, 4, 8, 16] }
+      - { tp: 4, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24] }
+      - { tp: 4, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: vllm-native }, conc-list: [28] }
+      - { tp: 8, ep: 8, spec-decoding: mtp, kv-offloading: none, conc-list: [20, 28, 36] }
 
 dsv4-fp4-mi355x-sglang-disagg-agentic-hicache:
   image: lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260710

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5425,3 +5425,9 @@
   description:
     - "Extend the search space to include the TP2EP1 configuration for fixed seq len 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2446
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm-agentic-mtp
+  description:
+    - "Initial MI355X MiniMax M3 with new AgentX harness"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2458


### PR DESCRIPTION
## Summary

- Run MiniMax-M3 MXFP4 on MI355X with the validated EAGLE3-GQA recipe: three speculative tokens, synthetic acceptance length 2.78, block-128 Triton attention for target and draft, FP8 KV cache, AITER MoE, and INT4 QuickReduce.
- Keep TP4 concurrency 1-24 GPU-resident, use vLLM native DRAM KV offload at concurrency 28, and use TEP8 at concurrency 20, 28, and 36.
- Rename the benchmark script and configuration as the MTP variant.

## Validation

- 224 matrix-logic tests pass.
- Targeted MI355X runs validated [TP4 c24 GPU-resident](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30931035940), [TP4 c28 native offload and TEP8 c28](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30933280651), and [TEP8 c36](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30930677218).
- TP4 c28 passed with 99.9% TTFT coverage, 100% inter-token coverage, and zero request errors. DEP was tested and removed because it was materially slower than TEP.

## 中文说明

- 在 MI355X 上使用已验证的 EAGLE3-GQA 方案运行 MiniMax-M3 MXFP4：3 个投机 token、合成接受长度 2.78、目标模型与草稿模型均采用 block-128 Triton 注意力，并启用 FP8 KV 缓存、AITER MoE 和 INT4 QuickReduce。
- TP4 并发 1-24 保持 KV 缓存驻留 GPU，并发 28 使用 vLLM 原生 DRAM KV 卸载；TEP8 使用并发 20、28、36。
- 将基准脚本和配置重命名为 MTP 版本。

## 验证

- 224 项矩阵逻辑测试通过。
- MI355X 定向测试已验证 [TP4 c24 GPU 常驻](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30931035940)、[TP4 c28 原生卸载与 TEP8 c28](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30933280651) 以及 [TEP8 c36](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30930677218)。
- TP4 c28 的 TTFT 覆盖率为 99.9%，token 间延迟覆盖率为 100%，请求错误为零。DEP 经测试后因明显慢于 TEP 而移除。