### PR TITLE
Instead of disabling agentic evals, run gsm8k

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -739,7 +739,7 @@ jobs:
             run-eval: true
             eval-only: true
 
-    # Agentic (SWE-bench) eval rows carry the agentic input shape, so they are
+    # Agentic GSM8K eval rows carry the agentic input shape, so they are
     # dispatched with sweep-agentic's inputs rather than sweep-evals' fixed-seq-len
     # inputs (isl/osl/max-model-len, which agentic rows don't have).
     sweep-agentic-evals:

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -1464,7 +1464,6 @@ run_eval() {
     local scenario_default="lm-eval"
     local scenario_is_agentic=0
     if [ "${IS_AGENTIC:-0}" = "1" ] || [ "${SCENARIO_TYPE:-}" = "agentic-coding" ]; then
-        scenario_default="swebench"
         scenario_is_agentic=1
     fi
 

--- a/utils/evals/EVALS.md
+++ b/utils/evals/EVALS.md
@@ -5,25 +5,6 @@ concurrency, kernels, and other throughput optimizations. They run separately
 from throughput; selection lives in `mark_eval_entries()` in
 `utils/matrix_logic/generate_sweep_configs.py`.
 
-## Status: agentic evals are disabled
-
-**Agentic (SWE-bench) evals are turned off repo-wide** by
-`AGENTIC_EVALS_DISABLED` in `utils/matrix_logic/generate_sweep_configs.py`.
-While it is set, no `agentic-coding` row is ever marked `run-eval`, so
-`run-sweep.yml`'s `sweep-agentic-evals` and `e2e-tests.yml`'s
-`test-sweep-agentic-evals` both find an empty matrix and skip — including
-under `--evals-only`, `--all-evals`, and the `evals-only` / `all-evals` PR
-labels. Agentic *throughput* coverage is unaffected, and fixed-sequence
-(`gsm8k`, `gpqa`, `swebench` on 8k1k) evals are unaffected.
-
-TODO(@adibarra): fix the agentic eval path and re-enable by flipping the flag
-to `False`. The selection policy below still has test coverage behind the
-`_agentic_evals_enabled()` helper in `test_generate_sweep_configs.py`, so the
-re-enable is a one-line change.
-
-The rest of this section describes the behaviour that returns when the flag is
-cleared.
-
 ## Selection
 
 - **Single-node:** 8k1k only; highest and median concurrency for every model,
@@ -39,7 +20,7 @@ Generator eval modes:
 - `--all-evals`: every fixed-sequence eval only; equivalent to
   `--evals-only --all-evals`. Multi-node topologies run all `conc-list` values
   sequentially on one engine. Agentic-coding configs are included and run
-  SWE-bench (they are excluded only from the default, non-eval sweep).
+  GSM8K (they are excluded only from the default, non-eval sweep).
 
 Changelog entries use `evals-only: true` and `all-evals: true`; `all-evals`
 implies eval-only there. On PRs, the same names are modifier labels:
@@ -60,7 +41,7 @@ malformed metadata, duplicates, or raw/aggregate mismatches are not. See
 ## How?
 `run_eval` in `benchmarks/benchmark_lib.sh` runs EleutherAI/lm-evaluation-harness against the server's OpenAI-compatible endpoint. Concurrency is set via `EVAL_CONCURRENT_REQUESTS` env var (not a CLI flag). Results are collected by `utils/collect_eval_results.py` and published as a summary table.
 
-The default eval framework is [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) (`lm-eval`).
+The default eval framework is [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) (`lm-eval`). Agentic eval-only matrix jobs inherit this default and therefore run the same GSM8K task as 8k1k; explicit agentic runs can still select SWE-bench.
 
 ### Benchmark script flow
 

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -41,15 +41,17 @@ def _dispatch(*, is_agentic: str = "0", eval_only: str = "false", cli_fw=None, e
 
 
 
-def test_agentic_scenario_defaults_to_swebench():
-    assert "DISPATCH=swebench" in _dispatch(is_agentic="1")
+def test_agentic_scenario_defaults_to_gsm8k_lm_eval():
+    assert "DISPATCH=lm-eval" in _dispatch(is_agentic="1")
 
 
 def test_fixed_seqlen_scenario_defaults_to_lm_eval():
     assert "DISPATCH=lm-eval" in _dispatch(is_agentic="0")
 
 def test_agentic_eval_only_stages_summary():
-    assert "STAGED=summary" in _dispatch(is_agentic="1", eval_only="true")
+    output = _dispatch(is_agentic="1", eval_only="true")
+    assert "DISPATCH=lm-eval" in output
+    assert "STAGED=summary" in output
 
 
 def test_fixed_seqlen_eval_only_leaves_staging_to_recipe():
@@ -168,6 +170,11 @@ def test_eval_limit_appended_when_set():
 def test_eval_limit_absent_when_unset():
     out = _run_lm_eval_cmdline(eval_limit=None)
     assert "--limit" not in out, f"Expected no '--limit' in output:\n{out}"
+
+
+def test_lm_eval_defaults_to_gsm8k():
+    out = _run_lm_eval_cmdline()
+    assert "utils/evals/gsm8k.yaml" in out
 
 
 

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -235,21 +235,6 @@ def _multinode_parallelism_key(entry: dict) -> tuple:
     ))
 
 
-# TEMPORARY: agentic (SWE-bench) evals are disabled repo-wide.
-#
-# TODO(@adibarra): fix the agentic eval path and re-enable by flipping this to
-# False (or deleting it and the two `if AGENTIC_EVALS_DISABLED` guards below).
-# Owner is back the week of 2026-08-03; nothing else needs to change to turn
-# them back on, and no throughput coverage is affected either way.
-#
-# This is the single choke point for both dispatch paths: run-sweep.yml's
-# `sweep-agentic-evals` job reads search-space-config.agentic_evals, which
-# process_changelog.py fills from agentic-coding rows carrying run-eval: True,
-# and e2e-tests.yml's `test-sweep-agentic-evals` filters the same flag. If no
-# agentic row is ever marked run-eval, neither job has a matrix and both skip.
-AGENTIC_EVALS_DISABLED = True
-
-
 def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) -> list[dict]:
     """Eval selection policy:
     - Single-node: only consider 8k1k (isl=8192, osl=1024).
@@ -262,8 +247,8 @@ def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) 
         - Ignore entries with all conc values < MIN_EVAL_CONC
         - Mark the entry containing its highest eligible concurrency
         - Set eval-conc to that highest eligible concurrency
-    - Agentic evals are opt-in to preserve default throughput coverage, and are
-      currently disabled outright by AGENTIC_EVALS_DISABLED.
+    - Agentic evals are opt-in to preserve default throughput coverage. They
+      run GSM8K through the same lm-eval path as fixed-sequence 8k1k evals.
     """
     from collections import defaultdict
 
@@ -327,7 +312,7 @@ def mark_eval_entries(matrix_values: list[dict], include_agentic: bool = False) 
         mn_eval_conc[best_idx] = best_eval_conc
 
     # Default sweeps preserve every agentic throughput result.
-    if include_agentic and not AGENTIC_EVALS_DISABLED:
+    if include_agentic:
         ag_sn_groups = defaultdict(list)
         for i, entry in enumerate(matrix_values):
             if entry.get(Fields.SCENARIO_TYPE.value) != 'agentic-coding':
@@ -361,7 +346,7 @@ def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
     Evals only run at 8k1k (matching mark_eval_entries), so entries at other
     sequence lengths (e.g. 1k1k) are passed through untouched rather than
     expanded into eval rows.
-    Single-node agentic entries use SWE-bench; multi-node eval is unsupported.
+    Single-node agentic entries use GSM8K; multi-node eval is unsupported.
     Multi-node rows with the same engine topology are merged into one eval row
     whose full concurrency list is run sequentially against the same engine.
     """
@@ -372,7 +357,7 @@ def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
 
     for entry in matrix_values:
         if entry.get(Fields.SCENARIO_TYPE.value) == 'agentic-coding':
-            if Fields.PREFILL.value not in entry and not AGENTIC_EVALS_DISABLED:
+            if Fields.PREFILL.value not in entry:
                 entry[Fields.RUN_EVAL.value] = True
             expanded_entries.append(entry)
             continue

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -1,9 +1,7 @@
 """Comprehensive tests for generate_sweep_configs.py"""
-import contextlib
 import pytest
 import argparse
 import copy
-import generate_sweep_configs
 from generate_sweep_configs import (
     MIN_EVAL_CONC,
     seq_len_stoi,
@@ -16,26 +14,6 @@ from generate_sweep_configs import (
     apply_node_type_defaults,
     expand_config_keys,
 )
-
-
-# =============================================================================
-# Helpers
-# =============================================================================
-
-@contextlib.contextmanager
-def _agentic_evals_enabled():
-    """Temporarily clear the AGENTIC_EVALS_DISABLED kill switch.
-
-    Agentic evals are disabled repo-wide pending TODO(@adibarra). The
-    underlying selection policy is still tested through this helper so the
-    re-enable is a one-line flip with coverage already in place.
-    """
-    previous = generate_sweep_configs.AGENTIC_EVALS_DISABLED
-    generate_sweep_configs.AGENTIC_EVALS_DISABLED = False
-    try:
-        yield
-    finally:
-        generate_sweep_configs.AGENTIC_EVALS_DISABLED = previous
 
 
 # =============================================================================
@@ -235,7 +213,7 @@ class TestSeqLenToStr:
 class TestMarkEvalEntries:
     """Tests for eval matrix selection policy."""
 
-    def test_marks_agentic_entry_for_swebench(self):
+    def test_marks_agentic_entry_for_gsm8k(self):
         matrix_values = [
             {
                 "scenario-type": "agentic-coding",
@@ -249,33 +227,11 @@ class TestMarkEvalEntries:
             },
         ]
 
-        # AGENTIC_EVALS_DISABLED is a temporary repo-wide kill switch
-        # (TODO(@adibarra)); this asserts the selection policy that returns
-        # when it is flipped back off.
-        with _agentic_evals_enabled():
-            result = mark_eval_entries(matrix_values, include_agentic=True)
+        result = mark_eval_entries(matrix_values, include_agentic=True)
 
         marked = [e for e in result if e.get("run-eval")]
         assert len(marked) == 1
         assert marked[0]["conc"] == 64
-
-    def test_disable_switch_suppresses_agentic_even_when_included(self):
-        matrix_values = [
-            {
-                "scenario-type": "agentic-coding",
-                "model": "m", "runner": "b300", "framework": "vllm",
-                "precision": "fp4", "tp": 8, "conc": 64,
-            },
-        ]
-
-        assert generate_sweep_configs.AGENTIC_EVALS_DISABLED is True
-
-        result = mark_eval_entries(matrix_values, include_agentic=True)
-
-        assert [e for e in result if e.get("run-eval")] == [], (
-            "AGENTIC_EVALS_DISABLED must win over include_agentic -- "
-            "--evals-only / --all-evals must not dispatch agentic evals"
-        )
 
     def test_default_mode_does_not_mark_agentic(self):
         matrix_values = [
@@ -707,7 +663,7 @@ class TestMarkAllEvalEntries:
         assert eight_k['eval-all-concs'] is True
         assert eight_k['conc'] == [8, 32]
 
-    def test_marks_agentic_entries_for_swebench(self):
+    def test_marks_agentic_entries_for_gsm8k(self):
         entries = [
             {
                 'scenario-type': 'agentic-coding',
@@ -717,30 +673,11 @@ class TestMarkAllEvalEntries:
             }
         ]
 
-        with _agentic_evals_enabled():
-            result = mark_all_eval_entries(copy.deepcopy(entries))
+        result = mark_all_eval_entries(entries)
 
         assert result[0]['run-eval'] is True
         assert 'eval-conc' not in result[0]
         assert 'eval-all-concs' not in result[0]
-
-    def test_disable_switch_suppresses_agentic_in_all_evals(self):
-        entries = [
-            {
-                'scenario-type': 'agentic-coding',
-                'model': 'm',
-                'runner': 'r',
-                'conc': 64,
-            }
-        ]
-
-        assert generate_sweep_configs.AGENTIC_EVALS_DISABLED is True
-
-        result = mark_all_eval_entries(entries)
-
-        assert result[0].get('run-eval') is not True, (
-            "AGENTIC_EVALS_DISABLED must win over --all-evals"
-        )
 
 
 # =============================================================================

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -291,7 +291,7 @@ class SingleNodeAgenticMatrixEntry(BaseModel):
     duration: int = Field(alias=Fields.DURATION.value)
     exp_name: str = Field(alias=Fields.EXP_NAME.value)
     scenario_type: str = Field(alias=Fields.SCENARIO_TYPE.value)
-    # Agentic eval rows (SWE-bench) carry run-eval/eval-only; benchmark rows
+    # Agentic GSM8K eval rows carry run-eval/eval-only; benchmark rows
     # omit them, and exclude_none keeps them out of dumped benchmark output.
     run_eval: Optional[bool] = Field(default=None, alias=Fields.RUN_EVAL.value)
     eval_only: Optional[bool] = Field(default=None, alias=Fields.EVAL_ONLY.value)
@@ -895,7 +895,7 @@ class ChangelogMatrixEntry(BaseModel):
     multi_node: dict[str, list[Union[MultiNodeMatrixEntry, MultiNodeAgenticMatrixEntry]]
                      ] = Field(default_factory=dict)
     evals: list[SingleNodeMatrixEntry] = Field(default_factory=list)
-    # Agentic (SWE-bench) eval rows live in their own bucket rather than a
+    # Agentic GSM8K eval rows live in their own bucket rather than a
     # union inside `evals`: each bucket maps 1:1 to a run-sweep.yml job with a
     # static input block, so an agentic row can never reach the fixed-seq-len
     # eval dispatch (which reads isl/osl/max-model-len and would launch the

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -289,7 +289,7 @@ def main():
             seq_len_str = seq_len_to_str(result["isl"], result["osl"])
             final_results["single_node"][seq_len_str].append(result)
 
-    # Agentic eval rows go to their own bucket so run-sweep.yml can dispatch
+    # Agentic GSM8K eval rows go to their own bucket so run-sweep.yml can dispatch
     # them with agentic inputs (scenario-type, kv-offloading, ...) instead of
     # the fixed-seq-len inputs (isl/osl/max-model-len) they don't have.
     single_node_evals = [e for e in all_eval_results if e.get("prefill") is None]

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -619,7 +619,7 @@ def test_eval_rows_split_into_fixed_and_agentic_buckets(
 ):
     """Realistic eval rows must pass final validation and land in the bucket
     matching their dispatch job: fixed-seq-len rows in `evals`, agentic
-    (SWE-bench) rows in `agentic_evals`."""
+    GSM8K rows in `agentic_evals`."""
     added_yaml = """
 - config-keys:
     - test-config


### PR DESCRIPTION
Re-enables agentic evals and defaults them to GSM8K through lm-eval.