### PR TITLE
[AMD] dsr1 mi355x disagg 8k1k mtp: fix gsm8k collapse at conc >= 1024

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -983,7 +983,7 @@ dsr1-fp4-mi355x-sglang-disagg:
           - "DECODE_MTP_SIZE=0"
 
 dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
+  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260729
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
   runner: mi355x-disagg
@@ -1150,6 +1150,21 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
           additional-settings:
           - "DECODE_NODES=1"
           - "DECODE_MTP_SIZE=1"
+          # job.slurm defaults SGLANG_AITER_MLA_PERSIST to 0, i.e. the
+          # NON-persistent aiter MLA decode. That path leaves num_kv_splits to
+          # aiter's python-side auto-search in mla_decode_fwd; under CUDA
+          # graphs that python runs only at capture, so the split count and the
+          # partial buffers sized from it are frozen and reused for every
+          # replay. Above ~128 running requests per DP rank the frozen choice
+          # corrupts decode. This is the only entry of this config that gets
+          # there (1024/8 = 128 and up); conc <= 640 stays below it.
+          # Measured, 2 prefill + 1 decode node, conc 2048, full gsm8k 5-shot:
+          #   SGLANG_AITER_MLA_PERSIST=0  ->  0.0023
+          #   SGLANG_AITER_MLA_PERSIST=1  ->  0.9469
+          # Safe only on an aiter carrying cdd6628f9 (s_barrier ->
+          # __syncthreads in mla_reduce_v1_impl_massive); that is why the image
+          # above is pinned to 20260729. Do not enable this on an older image.
+          - "SGLANG_AITER_MLA_PERSIST=1"
 
 
 dsv4-fp4-mi355x-sglang-disagg:


### PR DESCRIPTION
Opened as a **draft** — the change is validated on hardware, but I am not requesting merge until a maintainer confirms the scoping is what you want.

## Problem

The 2P1D entry of `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` collapses on gsm8k at high concurrency. On 2 prefill + 1 decode node, conc 2048, full gsm8k 5-shot: **strict-match 0.0023**. Generations are truncated after a handful of tokens rather than wrong, which is why it reads as a total failure rather than a quality regression.

## Cause

`job.slurm` defaults `SGLANG_AITER_MLA_PERSIST` to `0`, selecting the **non-persistent** aiter MLA decode. That path leaves `num_kv_splits` to aiter's python-side auto-search in `mla_decode_fwd`. Under CUDA graphs that python runs **once, at capture** — so the split count, and the partial buffers sized from it, are frozen and reused for every replay. Above roughly **128 running requests per DP rank** the frozen choice corrupts decode.

Only this entry reaches that point: with dp8, per-rank batch is conc/8, so conc 1024 → 128 and up. conc ≤ 640 stays below it and is unaffected.

## Evidence

Single-node bisection, image `20260729`, client concurrency 2048, varying **only** the server admission cap:

| cap | peak batch/rank | strict-match |
|---|---|---|
| 256 | 32 | 0.9530 |
| 512 | 64 | 0.9500 |
| 1024 | 128 | 0.9530 |
| 2048 | 165 | **0.0356** |

Same failing point, one variable changed at a time:

| change | strict-match |
|---|---|
| `SGLANG_AITER_MLA_PERSIST=1` | **0.9530** |
| `--disable-cuda-graph` | **0.9492** |
| speculative decoding off | 0.0879 (still broken — not an MTP defect) |
| bf16 KV instead of fp8 | 0.0265 (still broken — not a KV defect) |

Two prefill + one decode node, conc 2048 — the configuration this entry actually runs:

| | strict-match | flexible-extract |
|---|---|---|
| `SGLANG_AITER_MLA_PERSIST=0` | 0.0023 | 0.0023 |
| `SGLANG_AITER_MLA_PERSIST=1` | **0.9469** | 0.9477 |

An accept-length of 1.997 (ceiling 2.0) in the failing runs initially looked like a speculative-decode verification defect; disabling speculative decoding entirely still fails, so that was a symptom, not the cause.

## Why scoped rather than flipping the job.slurm default

The persistent MLA reduce had its own defect — an LDS write-after-read race in `mla_reduce_v1_impl_massive`, where `__builtin_amdgcn_s_barrier()` emits no `s_waitcnt lgkmcnt(0)` and no memory fence, so wave 1 reads `p_lds_lse_scale` before wave 0's writes land and corrupts output channels `[256, 512)`. aiter fixed that in `cdd6628f9`. Configs still pinned to an older image must keep the non-persistent path, so flipping the global default would trade this bug for that one on every other AMD multi-node config.

Hence: the image here is pinned to `20260729` (which carries `cdd6628f9`) **and** the persistent path is enabled for this one entry only. The inline comment states that dependency so the two are not separated later.

Note `dsr1-fp4-mi355x-sglang-disagg-mtp` has a structurally identical 2P1D entry but a different image; I have deliberately not touched it.

## Verification

CI dispatched on this branch for `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp --conc 2048 --evals-only` (2P1D, eval-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)