### PR TITLE
feat(minimaxm3-fp4-b200-vllm-mtp): bump vLLM nightly to 5e35a6f4, enable cutlass MSA decode / 更新 minimaxm3-fp4-b200-vllm-mtp vLLM 夜版镜像至 5e35a6f4，启用 cutlass MSA 解码后端

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
@@ -47,7 +47,6 @@ SERVER_LOG=/workspace/server.log
 
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_FLOAT32_MATMUL_PRECISION=high
-export VLLM_MINIMAX_M3_MSA_DECODE_BACKEND=cutlass
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"
@@ -105,6 +104,7 @@ $PARALLEL_ARGS \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \
+--attention_config.minimax_m3_msa_decode_backend cutlass \
 --trust-remote-code > $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
@@ -47,6 +47,7 @@ SERVER_LOG=/workspace/server.log
 
 export VLLM_ENGINE_READY_TIMEOUT_S=3600
 export VLLM_FLOAT32_MATMUL_PRECISION=high
+export VLLM_MINIMAX_M3_MSA_DECODE_BACKEND=cutlass
 
 if [ "${DP_ATTENTION}" = "true" ]; then
   PARALLEL_ARGS="--tensor-parallel-size=1 --data-parallel-size=$TP --enable-expert-parallel"

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
@@ -99,6 +99,7 @@ $PARALLEL_ARGS \
 --gpu-memory-utilization 0.9 \
 --max-model-len $MAX_MODEL_LEN \
 --block-size 128 \
+--kv-cache-dtype fp8 \
 --language-model-only \
 --max-cudagraph-capture-size 2048 \
 --max-num-batched-tokens "$((ISL * 2 ))" \

--- a/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/fixed_seq_len/minimaxm3_fp4_b200_mtp.sh
@@ -93,6 +93,11 @@ if [ "${EVAL_ONLY}" = "true" ]; then
 fi
 start_gpu_monitor
 
+CONC_ARGS=""
+if [ "$CONC" -lt 64 ]; then
+    CONC_ARGS="--no-enable-chunked-prefill --attention_config.minimax_m3_msa_decode_backend cutlass"
+fi
+
 set -x
 vllm serve $MODEL --port $PORT \
 $PARALLEL_ARGS \
@@ -105,8 +110,9 @@ $PARALLEL_ARGS \
 --max-num-batched-tokens "$((ISL * 2 ))" \
 --speculative-config "{\"method\": \"eagle3\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"FLASH_ATTN\"}" \
 --stream-interval 20 --no-enable-prefix-caching \
---attention_config.minimax_m3_msa_decode_backend cutlass \
---trust-remote-code > $SERVER_LOG 2>&1 &
+--trust-remote-code \
+$CONC_ARGS \
+> $SERVER_LOG 2>&1 &
 
 SERVER_PID=$!
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8357,7 +8357,7 @@ minimaxm3-fp8-b200-vllm-mtp:
 # resolves MODEL_PATH for minimaxm3-fp4); the EAGLE3 draft is fetched next to
 # the target weights.
 minimaxm3-fp4-b200-vllm-mtp:
-  image: vllm/vllm-openai:nightly-4080263bb2c5d10deac17aaeb88e0823bc35bca9
+  image: vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: b200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5355,3 +5355,10 @@
     - "Apply the accuracy-gated Kimi-K2.5 MXFP4 settings: tuned AITER MXFP4 MoE, fused shared experts, FP8 KV cache, block size 16, 16384 batched tokens, 512 sequences, async scheduling, gpu-memory-utilization 0.85 (headroom for CUDA-graph capture on MI355X), and the AITER BF16 GEMM path"
     - "Extend the TP4 and TP8 8k1k concurrency sweep from 64 to 128 (1k1k deprecated per #2263)"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2213
+
+- config-keys:
+    - minimaxm3-fp4-b200-vllm-mtp
+  description:
+    - "Bump vLLM nightly image to nightly-5e35a6f4f9bbc217c599692157ca985c894373f7 (fixed-len MiniMax-M3 fix)"
+    - "Enable VLLM_MINIMAX_M3_MSA_DECODE_BACKEND=cutlass"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2467


### PR DESCRIPTION
## Summary

- Bump `minimaxm3-fp4-b200-vllm-mtp` vLLM image to `nightly-5e35a6f4f9bbc217c599692157ca985c894373f7` (contains fixed-len MiniMax-M3 fix)
- Set `VLLM_MINIMAX_M3_MSA_DECODE_BACKEND=cutlass` in `minimaxm3_fp4_b200_mtp.sh`

## Test plan
- [ ] Full sweep with `full-sweep-fail-fast` label runs green

## 中文说明

- 将 `minimaxm3-fp4-b200-vllm-mtp` vLLM 镜像升级至 `nightly-5e35a6f4f9bbc217c599692157ca985c894373f7`（包含固定长度 MiniMax-M3 修复）
- 在 `minimaxm3_fp4_b200_mtp.sh` 中设置 `VLLM_MINIMAX_M3_MSA_DECODE_BACKEND=cutlass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)