### PR TITLE
Refresh Qwen3.5 FP4 GB300 AgentX

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5374,3 +5374,9 @@
     - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2420
   
+- config-keys:
+    - qwen3.5-fp4-gb300-dynamo-sglang-agentic-agg
+    - qwen3.5-fp4-gb300-dynamo-sglang-agentic-disagg
+  description:
+    - "Refresh with corrected AgentX harness"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5379,4 +5379,4 @@
     - qwen3.5-fp4-gb300-dynamo-sglang-agentic-disagg
   description:
     - "Refresh with corrected AgentX harness"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2474


### PR DESCRIPTION
## Summary

Refresh the existing Qwen3.5 FP4 GB300 AgentX aggregate and disaggregated submissions with the corrected AgentX harness. The search space is unchanged.

## Validation

- Generated both GB300 AgentX configuration keys successfully: 9 search-space points.
- `git diff --check`
