### PR TITLE
[AMD] dsv4-fp4-mi355x-vllm-agentic-mtp: pin VLLM_USE_BREAKABLE_CUDAGRAPH=0, fix unbound EVAL_ONLY / 钉住 VLLM_USE_BREAKABLE_CUDAGRAPH=0 并修复 EVAL_ONLY 未定义

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_vllm_mtp.sh
@@ -454,6 +454,34 @@ echo "Starting vllm server..."
 set -x
 export VLLM_ROCM_USE_AITER=1
 export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+# The recipe pins -cc.mode=3 (VLLM_COMPILE) below, but vLLM auto-enables
+# VLLM_USE_BREAKABLE_CUDAGRAPH on this model and then logs "disabling vLLM's
+# torch.compile pipeline. Equivalent to -cc.mode=none", silently downgrading
+# that request: the engine dump reports 'mode': <CompilationMode.NONE: 0> and
+# only 16 decode graphs get captured. Pinning it to 0 restores the compiled
+# path (33 graphs, ~55s capture, 0.50 GiB). The other AMD agentic recipes
+# already do this (minimaxm3_fp8_mi300x.sh, minimaxm3_fp8_mi325x.sh,
+# minimaxm3_fp4_mi355x.sh).
+export VLLM_USE_BREAKABLE_CUDAGRAPH="${VLLM_USE_BREAKABLE_CUDAGRAPH:-0}"
+
+# Opt-in, off by default: this recipe serves deepseek-ai/DeepSeek-V4-Pro, which
+# does not need shared-expert fusion. It is required only when MODEL points at
+# an AMD-Quark OCP-MXFP4 checkpoint such as amd/DeepSeek-V4-Pro-MXFP4. vLLM
+# reroutes those onto the deepseek_v4_fp8 path (models/deepseek_v4/
+# quant_config.py: override_quantization_method + _is_quark_mxfp4_ocp), which
+# assumes the shared expert is already fused into the routed-expert grouped
+# GEMM. Without the flag _fuse_shared_experts_enabled() (models/deepseek_v4/
+# amd/model.py) returns False, .ffn.shared_experts.w{1,3} is never redirected
+# to .ffn.experts.{n_routed}.w, and the tensors fall through to the ordinary
+# merged-column loader, which does not understand the FP4-packed layout: all TP
+# workers then die on a bare
+#   assert param_data.shape == loaded_weight.shape
+# with param (768, 7168) vs checkpoint (3072, 3584) at
+# layers.0.ffn.shared_experts.gate_up_proj.weight. Verified on 8x MI355X
+# (gfx950): with the flag the MXFP4 checkpoint serves and scores 95.15%
+# strict-match on the full 1319-question gsm8k set. The fusion self-disables
+# under expert parallelism, so exporting it is safe for the EP arms too.
+export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS="${VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS:-0}"
 
 sleep 180
 
@@ -511,7 +539,7 @@ if [ "$USE_VLLM_ROUTER" = "true" ]; then
     wait_for_server_ready --port "$PORT" --server-log "$ROUTER_LOG" --server-pid "$ROUTER_PID"
 fi
 
-if [ "${EVAL_ONLY}" = "true" ]; then
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"


### PR DESCRIPTION
Stacked on #2381 (base is `amd/agentx_dsv4_vllm_mtp_0728`, so the diff here is just my three lines plus comments). These can be cherry-picked into #2381 and this PR closed instead of merged; I opened a separate PR rather than pushing to that branch so the author keeps control of their submission.

## `VLLM_USE_BREAKABLE_CUDAGRAPH=0`

The recipe already asks for `-cc.mode=3` (`VLLM_COMPILE`) through `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_DECODE_ONLY"}'`. That request does not survive: vLLM auto-enables `VLLM_USE_BREAKABLE_CUDAGRAPH` for this model and logs

```
disabling vLLM's torch.compile pipeline. Equivalent to -cc.mode=none
```

and the engine dump then reports `'mode': <CompilationMode.NONE: 0>` with only 16 decode graphs captured. So the recipe has been running eager + cudagraph, not the compiled path it asks for.

Pinning the variable to `0` restores it — 33 graphs, ~55 s capture, 0.50 GiB:

```
Capturing CUDA graphs (decode, FULL): 100%|##########| 33/33 [00:53<00:00, 1.63s/it]
Graph capturing finished in 55 secs, took 0.50 GiB
```

This is not a novel setting for this repo — the other AMD agentic recipes already pin it: `minimaxm3_fp8_mi300x.sh:33`, `minimaxm3_fp8_mi325x.sh:33`, `minimaxm3_fp4_mi355x.sh:94`, and `perf-changelog.yaml` carries several "set `VLLM_USE_BREAKABLE_CUDAGRAPH=0` per AMD guidance" entries. The dsv4 recipe just missed it.

Written as `${VLLM_USE_BREAKABLE_CUDAGRAPH:-0}` so it stays overridable.

## Unbound `EVAL_ONLY`

Line 514 dereferenced `${EVAL_ONLY}` with no default while line 428 already used `${EVAL_ONLY:-false}`. The script runs under `set -u`, so outside CI it aborts with

```
EVAL_ONLY: unbound variable
```

immediately after `Application startup complete` — throwing away a ~20 minute model load. CI always exports the variable, which is why this never fired there.

## `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS` (documentation only, defaults to 0)

No behaviour change for this recipe as submitted. `deepseek-ai/DeepSeek-V4-Pro` does not need shared-expert fusion, and the flag defaults to `0`.

It matters if you repoint `MODEL` at an AMD-Quark OCP-MXFP4 checkpoint such as `amd/DeepSeek-V4-Pro-MXFP4`. vLLM reroutes those onto the `deepseek_v4_fp8` path (`models/deepseek_v4/quant_config.py`: `override_quantization_method` + `_is_quark_mxfp4_ocp`), which assumes the shared expert is already fused into the routed-expert grouped GEMM. Without the flag, `_fuse_shared_experts_enabled()` returns False, `.ffn.shared_experts.w{1,3}` is never redirected to `.ffn.experts.{n_routed}.w`, and the tensors fall through to the ordinary merged-column loader, which does not understand the FP4-packed layout. Every TP worker then dies on a bare

```
assert param_data.shape == loaded_weight.shape
```

with param `(768, 7168)` vs checkpoint `(3072, 3584)` at `layers.0.ffn.shared_experts.gate_up_proj.weight`. The assert prints no shapes, so this needs a patch to diagnose — hence the comment. With the flag, that checkpoint serves and scores **95.15%** strict-match on the full 1319-question gsm8k set. The fusion self-disables under expert parallelism, so exporting it is safe for the commented-out EP arms too.

## Verification

8× MI355X (gfx950), TP8 / EP1 / no DPA / MTP, `agentic-coding` replay against `semianalysis_cc_traces_weka_062126`, concurrency 32, 1200 s window. **1067 requests, zero errors**, run exited 0 with full artifacts.

| metric | value |
| --- | --- |
| Total throughput per GPU | **10,803 tok/s** |
| Input throughput (node) | 85,836 tok/s |
| Output throughput (node) | 592 tok/s |
| TTFT p50 / p90 | 757 ms / 2,741 ms |
| ITL p50 | 35.8 ms |
| Interactivity p50 / p90 | 27.9 / 49.4 tok/s/user |
| ISL p50 | 78,794 tokens |
| OSL p50 | 257 tokens |
| Theoretical prefix cache hit | 95.85% |

For reference, the conc-32 point from the full sweep on #2381 (run 30529648050) was 8,053 tok/s/GPU.

**Caveat, stated plainly:** that run also used a newer vLLM nightly (`0.26.1rc1.dev255+g5e35a6f4f`) than the image the recipe pins, so the gap versus CI mixes the cudagraph pin with four days of upstream changes. I have not run the single-variable A/B, and I am not claiming the delta for this one line. The argument for the pin is that the recipe currently does not get the compilation mode it explicitly requests — the numbers are context, not the justification.

gsm8k on the same arm is unchanged from what #2381's sweep reported (0.9522 strict).

## 中文说明

本 PR 基于 #2381 的分支，diff 只有我加的几行。这几行可以直接 cherry-pick 进 #2381 然后关掉本 PR —— 另开 PR 而不是直接推到那个分支，是为了不影响原作者对自己提交的控制。

**1. `VLLM_USE_BREAKABLE_CUDAGRAPH=0`。** 配方通过 `--compilation-config` 请求 `-cc.mode=3`，但 vLLM 会自动开启 `VLLM_USE_BREAKABLE_CUDAGRAPH` 并打印 "disabling vLLM's torch.compile pipeline. Equivalent to -cc.mode=none"，静默降级该请求；引擎 dump 显示 `'mode': <CompilationMode.NONE: 0>`，只捕获 16 张 decode 图。也就是说配方一直跑在 eager + cudagraph 路径上，而不是它自己要求的编译路径。钉为 0 后恢复正常：33 张图，约 55 秒捕获，0.50 GiB。这不是新做法 —— 其他三个 AMD agentic 配方都已经钉了这个变量，perf-changelog 里也有多条相关记录，dsv4 配方只是漏了。写成 `${...:-0}` 保留覆盖能力。

**2. `EVAL_ONLY` 未定义。** 第 514 行引用了无默认值的 `${EVAL_ONLY}`，而第 428 行已经用了 `${EVAL_ONLY:-false}`。脚本在 `set -u` 下运行，容器外会在 "Application startup complete" 之后立即崩溃，白白浪费约 20 分钟的模型加载。CI 总是显式导出该变量，所以一直没暴露。

**3. `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`（仅文档，默认 0）。** 对本配方无行为改变。只有当 `MODEL` 指向 `amd/DeepSeek-V4-Pro-MXFP4` 这类 AMD-Quark OCP-MXFP4 权重时才必需：vLLM 会把这类权重路由到 `deepseek_v4_fp8` 路径，该路径假定共享专家已融合进 routed expert 的 grouped GEMM；不开这个开关时所有 TP worker 会在加载权重时因裸 assert 失败（param `(768, 7168)` vs checkpoint `(3072, 3584)`），而该 assert 不打印任何 shape，必须打补丁才能定位。开启后该权重可正常服务，full gsm8k 1319 题 strict-match 95.15%。融合在 expert parallel 下自动禁用，所以对 EP arm 也是安全的。

**4. 验证。** 8 卡 MI355X，TP8/EP1/无 DPA/MTP，并发 32，1200 秒窗口，1067 个请求零错误，每卡总吞吐 10,803 tok/s（#2381 sweep 的 conc-32 点是 8,053）。**需要说明的是**：这一轮同时用了比配方钉死的镜像更新的 vLLM nightly，所以与 CI 的差距里混了四天的上游改动，我没有做单变量 A/B，也不把这个差距归给这一行。支持这个改动的理由是"配方没有拿到它自己明确请求的编译模式"，性能数字只是上下文。

