### PR TITLE
minimaxm3-fp4-b300-dynamo-vllm-mtp-min-lat: add low latency B300 dynamo config / 新增 B300 低延迟配置

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml
@@ -67,7 +67,7 @@ backend:
       trust-remote-code: true
       no-enable-prefix-caching: true
       kv-transfer-config: '{"kv_connector": "NixlConnector", "kv_role": "kv_both"}'
-      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8", "minimax_m3_msa_decode_backend": "cutlass"}'
+      attention-config: '{"backend": "FLASHINFER", "use_trtllm_attention": true, "indexer_kv_dtype": "fp8"}'
       block-size: 128
       kv-cache-dtype: fp8
       gpu-memory-utilization: 0.95

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7814,20 +7814,6 @@ minimaxm3-fp4-b300-dynamo-vllm-mtp:
           ep: 1
           dp-attn: false
       - spec-decoding: "mtp"
-        conc-list: [4, 8, 64]
-        prefill:
-          num-worker: 1
-          tp: 2
-          ep: 2
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml"
-        decode:
-          num-worker: 4
-          tp: 4
-          ep: 1
-          dp-attn: false
-      - spec-decoding: "mtp"
         conc-list: [4, 32, 64]
         prefill:
           num-worker: 1
@@ -7867,6 +7853,37 @@ minimaxm3-fp4-b300-dynamo-vllm-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/2p3d-dep2-tp4-eagle3-8k1k.yaml"
         decode:
           num-worker: 3
+          tp: 4
+          ep: 1
+          dp-attn: false
+
+minimaxm3-fp4-b300-dynamo-vllm-mtp-min-lat:
+  image: vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
+  model: nvidia/MiniMax-M3-NVFP4
+  model-prefix: minimaxm3
+  runner: b300
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.3.0.dev20260710" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      - spec-decoding: "mtp"
+        conc-list: [4, 8, 64]
+        prefill:
+          num-worker: 1
+          tp: 2
+          ep: 2
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/b300-fp4/8k1k/mtp/1p4d-dep2-tp4-eagle3-8k1k.yaml"
+        decode:
+          num-worker: 4
           tp: 4
           ep: 1
           dp-attn: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5425,3 +5425,9 @@
   description:
     - "Extend the search space to include the TP2EP1 configuration for fixed seq len 8k1k"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2446
+
+- config-keys:
+    - minimaxm3-fp4-b300-dynamo-vllm-mtp-min-lat
+  description:
+    - "Add low latency B300 dynamo config (1p4d-dep2-tp4, conc 4/8/64)"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2491


### PR DESCRIPTION
## Summary

- Move `1p4d-dep2-tp4-eagle3-8k1k.yaml` (conc 4/8/64) from `minimaxm3-fp4-b300-dynamo-vllm-mtp` into a dedicated `minimaxm3-fp4-b300-dynamo-vllm-mtp-min-lat` config key optimized for low latency
- Remove `minimax_m3_msa_decode_backend=cutlass` from the recipe

## 中文说明

- 将 `1p4d-dep2-tp4-eagle3-8k1k.yaml`（并发 4/8/64）从 `minimaxm3-fp4-b300-dynamo-vllm-mtp` 移至专用低延迟配置键 `minimaxm3-fp4-b300-dynamo-vllm-mtp-min-lat`
- 同时移除配方中的 `minimax_m3_msa_decode_backend=cutlass`