### PR TITLE
Add GLM-5.2-FP8 H200 llmd-vllm P/D disagg benchmark recipes

### DIFF
--- a/benchmarks/multi_node/glm5.2_fp8_h200_llmd-vllm-disagg.sh
+++ b/benchmarks/multi_node/glm5.2_fp8_h200_llmd-vllm-disagg.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Wrapper for the GLM-5.2-FP8 H200 llmd-vllm P/D disagg benchmark.
+# The runner resolves this script via
+#   SCRIPT_NAME="${EXP_NAME%%_*}_${PRECISION}_h200_llmd-vllm-disagg.sh"
+# from launch_h200-dgxc-slurm.sh.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../benchmark_lib.sh"
+
+check_env_vars \
+    CONC_LIST \
+    ISL \
+    OSL \
+    IMAGE \
+    MODEL_PATH \
+    PREFILL_NODES \
+    DECODE_NODES \
+    RANDOM_RANGE_RATIO
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on $SLURMD_NODENAME"
+fi
+
+set -x
+
+cd "$GITHUB_WORKSPACE/benchmarks/multi_node/llm-d" || exit 1
+
+# H200 DGX = 8 GPUs per node (submit.sh defaults to 8, explicit for clarity).
+export GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+
+export TIME_LIMIT="${TIME_LIMIT:-08:00:00}"
+export MODEL_PATH=$MODEL_PATH
+export MODEL_NAME=$MODEL_NAME
+export CONTAINER_IMAGE=$IMAGE
+
+export PREFILL_WORKERS="${PREFILL_WORKERS:-${PREFILL_NUM_WORKERS:-1}}"
+export DECODE_WORKERS="${DECODE_WORKERS:-${DECODE_NUM_WORKERS:-1}}"
+
+JOB_ID=$(bash ./submit.sh \
+    "$PREFILL_NODES" \
+    "$DECODE_NODES" \
+    "$ISL" "$OSL" "${CONC_LIST// /x}" inf \
+    "$RANDOM_RANGE_RATIO")
+
+if [[ -z "$JOB_ID" ]]; then
+    echo "Failed to submit job" >&2
+    exit 1
+fi
+
+echo "$JOB_ID"

--- a/benchmarks/multi_node/llm-d-recipes/glm5.2-fp8-h200-mtp.yaml
+++ b/benchmarks/multi_node/llm-d-recipes/glm5.2-fp8-h200-mtp.yaml
@@ -1,0 +1,89 @@
+# GLM-5.2-FP8 (753B MoE) on H200, DEP P/D disagg via llmd-vllm.
+# MTP speculative decoding variant (3 tokens). Identical to glm5.2-fp8-h200.yaml
+# except --speculative-config is added to both prefill and decode extra-args,
+# matching the K8s reference ENABLE_MTP=1 default.
+#
+# See glm5.2-fp8-h200.yaml for topology and env var documentation.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+
+plugins:
+  - name: file-disc
+    type: file-discovery
+    parameters:
+      path: /tmp/endpoints.yaml
+      watchFile: false
+
+  - type: disagg-headers-handler
+  - type: always-disagg-pd-decider
+  - type: disagg-profile-handler
+    parameters:
+      deciderPluginName: always-disagg-pd-decider
+  - type: prefill-filter
+  - type: decode-filter
+  - type: prefix-cache-scorer
+  - type: queue-scorer
+  - type: active-request-scorer
+  - type: max-score-picker
+
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: active-request-scorer
+        weight: 2
+      - pluginRef: max-score-picker
+  - name: decode
+    plugins:
+      - pluginRef: decode-filter
+      - pluginRef: active-request-scorer
+      - pluginRef: max-score-picker
+
+dataLayer:
+  discovery:
+    pluginRef: file-disc
+
+prefill:
+  tp: 1
+  enable-expert-parallel: true
+  extra-args: >-
+    --kv-cache-dtype fp8
+    --gpu-memory-utilization 0.935
+    --max-model-len auto
+    --max-num-batched-tokens 2048
+    --moe-backend deep_gemm
+    --all2all-backend deepep_high_throughput
+    --speculative-config {"method":"mtp","num_speculative_tokens":3}
+  env:
+    VLLM_USE_V2_MODEL_RUNNER: "0"
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "1"
+    TRITON_LIBCUDA_PATH: /usr/lib64
+    VLLM_HTTP_TIMEOUT_KEEP_ALIVE: "120"
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+
+decode:
+  tp: 1
+  enable-expert-parallel: true
+  extra-args: >-
+    --kv-cache-dtype fp8
+    --gpu-memory-utilization 0.95
+    --max-model-len auto
+    --max-num-seqs 64
+    --max-num-batched-tokens 64
+    --all2all-backend deepep_v2
+    --language-model-only
+    --block-size 256
+    --speculative-config {"method":"mtp","num_speculative_tokens":3}
+  env:
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "1"
+    TRITON_LIBCUDA_PATH: /usr/lib64
+    VLLM_HTTP_TIMEOUT_KEEP_ALIVE: "120"
+    NVSHMEM_QP_DEPTH: "130"
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+
+slurm:
+  time_limit: "08:00:00"

--- a/benchmarks/multi_node/llm-d-recipes/glm5.2-fp8-h200.yaml
+++ b/benchmarks/multi_node/llm-d-recipes/glm5.2-fp8-h200.yaml
@@ -1,0 +1,107 @@
+# GLM-5.2-FP8 (753B MoE) on H200, DEP P/D disagg via llmd-vllm.
+#
+# Per-engine shape (H200 = 8 GPUs/node):
+#   Each engine is DEP (TP=1, DP=N, EP=N) with DP-attention + DeepGemm MoE
+#   backend. Prefill uses DeepEP high-throughput all-to-all; decode uses
+#   DeepEP v2 (low-latency) with --language-model-only.
+#
+# Topology set by nvidia-master.yaml additional-settings:
+#   fixed-seq-len (p1w1d1w1): 1P DEP8 + 1D DEP8, 2 H200 nodes / 16 GPUs
+#     PREFILL_NODES=1 DECODE_NODES=1 GPUS_PER_NODE=8
+#   agentic (p1w2d1w2):       1P DEP16 + 1D DEP16, 4 H200 nodes / 32 GPUs
+#     PREFILL_NODES=2 DECODE_NODES=2 GPUS_PER_NODE=8
+#
+# Flags and env vars match the llm-d K8s P/D reference deployment
+# (guides/wide-ep-lws/modelserver/gpu/vllm-glm-5.2/base/{prefill,decode}.yaml).
+# No MTP speculative decoding — see glm5.2-fp8-h200-mtp.yaml for the MTP variant.
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+
+plugins:
+  - name: file-disc
+    type: file-discovery
+    parameters:
+      path: /tmp/endpoints.yaml
+      watchFile: false
+
+  - type: disagg-headers-handler
+  - type: always-disagg-pd-decider
+  - type: disagg-profile-handler
+    parameters:
+      deciderPluginName: always-disagg-pd-decider
+  - type: prefill-filter
+  - type: decode-filter
+  - type: prefix-cache-scorer
+  - type: queue-scorer
+  - type: active-request-scorer
+  - type: max-score-picker
+
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-filter
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: active-request-scorer
+        weight: 2
+      - pluginRef: max-score-picker
+  - name: decode
+    plugins:
+      - pluginRef: decode-filter
+      - pluginRef: active-request-scorer
+      - pluginRef: max-score-picker
+
+dataLayer:
+  discovery:
+    pluginRef: file-disc
+
+# ---- Per-role vLLM flags ----
+# Prefill: DEP (TP=1, EP on). DeepGemm MoE backend + DeepEP high-throughput
+# all-to-all. gpu-memory-utilization 0.935 matches the K8s reference default
+# for single-node; multi-node (LWS_GROUP_SIZE>1) gets NVSHMEM_SYMMETRIC_SIZE=16G
+# from server.sh, which reserves VRAM for the symmetric heap automatically.
+prefill:
+  tp: 1
+  enable-expert-parallel: true
+  extra-args: >-
+    --kv-cache-dtype fp8
+    --gpu-memory-utilization 0.935
+    --max-model-len auto
+    --max-num-batched-tokens 2048
+    --moe-backend deep_gemm
+    --all2all-backend deepep_high_throughput
+  env:
+    VLLM_USE_V2_MODEL_RUNNER: "0"
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "1"
+    TRITON_LIBCUDA_PATH: /usr/lib64
+    VLLM_HTTP_TIMEOUT_KEEP_ALIVE: "120"
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+
+# Decode: DEP (TP=1, EP on). DeepEP v2 low-latency all-to-all.
+# --language-model-only + --block-size 256 for efficient KV consumption.
+# max-num-seqs/batched-tokens 64 matches K8s MAX_TOKENS_PER_NODE=32 * 2 nodes
+# (the primary DEP16 topology); safe for DEP8 (slightly overprovisioned).
+# NVSHMEM_QP_DEPTH = (64+1)*2 = 130 (DeepEP low-latency requirement).
+decode:
+  tp: 1
+  enable-expert-parallel: true
+  extra-args: >-
+    --kv-cache-dtype fp8
+    --gpu-memory-utilization 0.95
+    --max-model-len auto
+    --max-num-seqs 64
+    --max-num-batched-tokens 64
+    --all2all-backend deepep_v2
+    --language-model-only
+    --block-size 256
+  env:
+    VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: "1"
+    TRITON_LIBCUDA_PATH: /usr/lib64
+    VLLM_HTTP_TIMEOUT_KEEP_ALIVE: "120"
+    NVSHMEM_QP_DEPTH: "130"
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: "1800"
+
+slurm:
+  time_limit: "08:00:00"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7879,6 +7879,118 @@ glm5.2-fp4-b300-sglang-agentic:
       # strictly dominated by conc 48 on both throughput and interactivity.
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [48], router: { name: sglang-router, version: "0.3.2" } }
 
+# GLM-5.2 FP8 H200 llmd-vllm P/D disagg recipes. The model is zai-org/GLM-5.2-FP8
+# (753B MoE, DeepGemm MoE backend, DeepEP all-to-all). Prefill uses
+# deepep_high_throughput; decode uses deepep_v2 (low-latency) with
+# --language-model-only. Flags and env vars match the llm-d K8s P/D
+# reference deployment (wide-ep-lws/modelserver/gpu/vllm-glm-5.2).
+#
+# Topologies:
+#   fixed-seq-len: 1P DEP8 + 1D DEP8 (p1w1d1w1, 2 H200 nodes / 16 GPUs)
+#   agentic:       1P DEP16 + 1D DEP16 (p1w2d1w2, 4 H200 nodes / 32 GPUs)
+# Both STP and MTP (3-token speculative decoding) arms.
+glm5.2-fp8-h200-llmd-vllm:
+  image: vllm/vllm-openai:nightly
+  model: zai-org/GLM-5.2-FP8
+  model-prefix: glm5.2
+  runner: cluster:h200-dgxc
+  precision: fp8
+  framework: llmd-vllm
+  router: { name: llm-d-router, version: "0.9.0" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    fixed-seq-len:
+    - isl: 8192
+      osl: 1024
+      search-space:
+      # STP: 1 prefill DEP8 + 1 decode DEP8 (2 nodes, 16 GPUs).
+      - spec-decoding: "none"
+        conc-list: [1, 16, 64, 128, 256]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "GPUS_PER_NODE=8"
+          - "CONFIG_FILE=glm5.2-fp8-h200.yaml"
+        decode:
+          num-worker: 1
+          tp: 1
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "GPUS_PER_NODE=8"
+
+      # MTP: same topology with 3-token speculative decoding.
+      - spec-decoding: mtp
+        conc-list: [1, 16, 64, 128, 256]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "PREFILL_NODES=1"
+          - "GPUS_PER_NODE=8"
+          - "CONFIG_FILE=glm5.2-fp8-h200-mtp.yaml"
+        decode:
+          num-worker: 1
+          tp: 1
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "DECODE_NODES=1"
+          - "GPUS_PER_NODE=8"
+
+    agentic-coding:
+    - search-space:
+      # STP: 1 prefill DEP16 + 1 decode DEP16 (4 nodes, 32 GPUs).
+      - spec-decoding: "none"
+        conc-list: [1, 2, 4, 8, 16]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 16
+          dp-attn: true
+          additional-settings:
+          - "PREFILL_NODES=2"
+          - "GPUS_PER_NODE=8"
+          - "CONFIG_FILE=glm5.2-fp8-h200.yaml"
+        decode:
+          num-worker: 1
+          tp: 1
+          ep: 16
+          dp-attn: true
+          additional-settings:
+          - "DECODE_NODES=2"
+          - "GPUS_PER_NODE=8"
+
+      # MTP: same topology with 3-token speculative decoding.
+      - spec-decoding: mtp
+        conc-list: [1, 2, 4, 8, 16]
+        prefill:
+          num-worker: 1
+          tp: 1
+          ep: 16
+          dp-attn: true
+          additional-settings:
+          - "PREFILL_NODES=2"
+          - "GPUS_PER_NODE=8"
+          - "CONFIG_FILE=glm5.2-fp8-h200-mtp.yaml"
+        decode:
+          num-worker: 1
+          tp: 1
+          ep: 16
+          dp-attn: true
+          additional-settings:
+          - "DECODE_NODES=2"
+          - "GPUS_PER_NODE=8"
+
 qwen3.5-fp8-gb200-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7901,52 +7901,6 @@ glm5.2-fp8-h200-llmd-vllm:
   multinode: true
   disagg: true
   scenarios:
-    fixed-seq-len:
-    - isl: 8192
-      osl: 1024
-      search-space:
-      # STP: 1 prefill DEP8 + 1 decode DEP8 (2 nodes, 16 GPUs).
-      - spec-decoding: "none"
-        conc-list: [1, 16, 64, 128, 256]
-        prefill:
-          num-worker: 1
-          tp: 1
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=1"
-          - "GPUS_PER_NODE=8"
-          - "CONFIG_FILE=glm5.2-fp8-h200.yaml"
-        decode:
-          num-worker: 1
-          tp: 1
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "GPUS_PER_NODE=8"
-
-      # MTP: same topology with 3-token speculative decoding.
-      - spec-decoding: mtp
-        conc-list: [1, 16, 64, 128, 256]
-        prefill:
-          num-worker: 1
-          tp: 1
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "PREFILL_NODES=1"
-          - "GPUS_PER_NODE=8"
-          - "CONFIG_FILE=glm5.2-fp8-h200-mtp.yaml"
-        decode:
-          num-worker: 1
-          tp: 1
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "DECODE_NODES=1"
-          - "GPUS_PER_NODE=8"
-
     agentic-coding:
     - search-space:
       # STP: 1 prefill DEP16 + 1 decode DEP16 (4 nodes, 32 GPUs).

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7905,7 +7905,7 @@ glm5.2-fp8-h200-llmd-vllm:
     - search-space:
       # STP: 1 prefill DEP16 + 1 decode DEP16 (4 nodes, 32 GPUs).
       - spec-decoding: "none"
-        conc-list: [1, 2, 4, 8, 16]
+        conc-list: [1, 16, 32, 64]
         prefill:
           num-worker: 1
           tp: 1
@@ -7926,7 +7926,7 @@ glm5.2-fp8-h200-llmd-vllm:
 
       # MTP: same topology with 3-token speculative decoding.
       - spec-decoding: mtp
-        conc-list: [1, 2, 4, 8, 16]
+        conc-list: [1, 16, 32, 64]
         prefill:
           num-worker: 1
           tp: 1

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5454,7 +5454,6 @@
     - glm5.2-fp8-h200-llmd-vllm
   description:
     - "Add GLM-5.2-FP8 (753B MoE) H200 llmd-vllm P/D disagg benchmark recipes matching the K8s wide-ep-lws reference deployment"
-    - "Fixed-seq-len: 1P DEP8 + 1D DEP8 (2 nodes / 16 GPUs), STP and MTP arms"
     - "Agentic: 1P DEP16 + 1D DEP16 (4 nodes / 32 GPUs), STP and MTP arms"
     - "DeepGemm MoE backend, DeepEP high-throughput prefill / DeepEP v2 low-latency decode, NIXL KV transfer"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5449,3 +5449,12 @@
     - "Enable prefill-only INT4 quick-reduce: set VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 and VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB=2048 on the prefill workers via a new prefill_env channel (mirrors the existing decode_env path in server_vllm.sh)."
     - "Cap the 1P1D TP4 concurrency sweep at 256 (was 512); drop the 2P1D TP4 layout (128/256/512) as it is CI-flaky with negligible curve impact."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1943
+
+- config-keys:
+    - glm5.2-fp8-h200-llmd-vllm
+  description:
+    - "Add GLM-5.2-FP8 (753B MoE) H200 llmd-vllm P/D disagg benchmark recipes matching the K8s wide-ep-lws reference deployment"
+    - "Fixed-seq-len: 1P DEP8 + 1D DEP8 (2 nodes / 16 GPUs), STP and MTP arms"
+    - "Agentic: 1P DEP16 + 1D DEP16 (4 nodes / 32 GPUs), STP and MTP arms"
+    - "DeepGemm MoE backend, DeepEP high-throughput prefill / DeepEP v2 low-latency decode, NIXL KV transfer"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PLACEHOLDER

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -12,7 +12,56 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
     # MODEL_PATH: Override with pre-downloaded paths on H200 runner
     # The yaml files specify HuggingFace model IDs for portability, but we use
     # local paths to avoid repeated downloading on the shared H200 cluster.
-    if [[ $FRAMEWORK == "dynamo-sglang" ]]; then
+    if [[ $FRAMEWORK == "llmd-vllm" ]]; then
+        if [[ $MODEL_PREFIX == "glm5.2" && $PRECISION == "fp8" ]]; then
+            export MODEL_PATH="/models/GLM-5.2-FP8"
+            export MODEL_NAME="zai-org/GLM-5.2-FP8"
+        else
+            echo "Unsupported MODEL_PREFIX/PRECISION for llmd-vllm on H200: $MODEL_PREFIX/$PRECISION" >&2
+            exit 1
+        fi
+
+        export DOCKER_IMAGE_NAME=$IMAGE
+        export BENCHMARK_LOGS_DIR="$GITHUB_WORKSPACE/benchmark_logs"
+        mkdir -p "$BENCHMARK_LOGS_DIR"
+
+        SCRIPT_NAME="${EXP_NAME%%_*}_${PRECISION}_h200_llmd-vllm-disagg.sh"
+        BENCH_SCRIPT="benchmarks/multi_node/${SCRIPT_NAME}"
+        if [[ ! -f "$BENCH_SCRIPT" ]]; then
+            echo "Error: llm-d wrapper not found: $BENCH_SCRIPT" >&2
+            exit 1
+        fi
+
+        source "$(dirname "${BASH_SOURCE[0]}")/slurm_utils.sh"
+
+        JOB_ID=$(bash "$BENCH_SCRIPT")
+        if [[ -z "$JOB_ID" ]]; then
+            echo "Error: failed to submit llm-d job" >&2
+            exit 1
+        fi
+        echo "Submitted llm-d job: $JOB_ID"
+
+        trap 'bundle_server_logs "$BENCHMARK_LOGS_DIR" "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz"; scancel "$JOB_ID" 2>/dev/null || true' EXIT INT TERM HUP
+
+        LOG_FILE="${BENCHMARK_LOGS_DIR}/slurm_job-${JOB_ID}.out"
+        stream_slurm_job_log "$JOB_ID" "$LOG_FILE" || exit 1
+
+        while IFS= read -r -d '' result_file; do
+            copy_to_workspace "$result_file" "$GITHUB_WORKSPACE/$(basename "$result_file")" || exit 1
+        done < <(find "$BENCHMARK_LOGS_DIR" -name "${RESULT_FILENAME}*.json" -print0 2>/dev/null)
+
+        if [[ "${RUN_EVAL:-false}" == "true" ]]; then
+            EVAL_DIR=$(find "$BENCHMARK_LOGS_DIR" -type d -name eval_results -print -quit 2>/dev/null)
+            if [[ -z "$EVAL_DIR" ]]; then
+                EVAL_DIR="$BENCHMARK_LOGS_DIR/eval_results"
+            fi
+            copy_eval_artifacts "$EVAL_DIR" "$GITHUB_WORKSPACE" || exit 1
+        fi
+
+        scancel "$JOB_ID" 2>/dev/null || true
+        exit 0
+
+    elif [[ $FRAMEWORK == "dynamo-sglang" ]]; then
         if [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp8" ]]; then
             export MODEL_PATH="/models/DeepSeek-R1-0528"
             export SRT_SLURM_MODEL_PREFIX="dsr1-fp8"
@@ -30,7 +79,7 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
             exit 1
         fi
     else
-        echo "Unsupported framework: $FRAMEWORK. Supported frameworks are: dynamo-trt, dynamo-sglang"
+        echo "Unsupported framework: $FRAMEWORK. Supported frameworks are: llmd-vllm, dynamo-trt, dynamo-sglang"
         exit 1
     fi
 


### PR DESCRIPTION
Add GLM-5.2-FP8 (753B MoE) H200 benchmark configs using the llmd-vllm disaggregated P/D 

Fixed seq-len uses 1P DEP8 + 1D DEP8 (2 nodes / 16 GPUs).

Agentic uses 1P DEP16 + 1D DEP16 (4 nodes / 32 GPUs). 

Both scenarios include STP and MTP (3-token) arms. DeepGemm MoE backend, DeepEP high-throughput prefill, DeepEP v2 low-latency decode.