### PR TITLE
Document model engine submission policy

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -49,6 +49,18 @@ Speculative-decoding A/B retirements — in each pair below the spec-decode arm 
 | Single-turn 1k1k | 1024 / 1024 | **Deprecated for all models** since 2026-07-17 ([#2263](https://github.com/SemiAnalysisAI/InferenceX/pull/2263)), to save GPU cluster time for higher-priority real-world agentic-coding benchmarks and new frontier models. Archived configs live in [`configs/deprecated/`](configs/deprecated/). |
 | Single-turn 1k8k | 1024 / 8192 | **Deprecated for all models** since 2026-03-27 ([#911](https://github.com/SemiAnalysisAI/InferenceX/pull/911)), to save GPU cluster time for higher-priority real-world agentic-coding benchmarks and new frontier models. Configs were removed, not archived. |
 
+## Engine submission policy
+
+The engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed primary-engine submissions have been made.
+
+| Model | Primary engines | Secondary engines |
+|---|---|---|
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | vLLM and SGLang | Hardware-specific engines, after vLLM and SGLang submissions |
+| Kimi-K3 (`kimik3`) | vLLM | Hardware-specific engines, after a vLLM submission |
+| MiniMax-M3 (`minimaxm3`) | vLLM | Hardware-specific engines, after a vLLM submission |
+| GLM-5.2 (`glm5.2`) | SGLang | Hardware-specific engines, after an SGLang submission |
+| Qwen3.5-397B-A17B (`qwen3.5`) | SGLang | Hardware-specific engines, after an SGLang submission |
+
 ## Model support matrix
 
 | Model architecture class | Prefix | Date added | Active scenarios | Deprecated scenarios |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -49,6 +49,18 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 | 单轮 1k1k | 1024 / 1024 | **对所有模型均已弃用**，自 2026-07-17 起（[#2263](https://github.com/SemiAnalysisAI/InferenceX/pull/2263)），以便将 GPU 集群时间留给优先级更高的真实场景智能体编码基准测试与新的前沿模型。归档配置位于 [`configs/deprecated/`](configs/deprecated/)。 |
 | 单轮 1k8k | 1024 / 8192 | **对所有模型均已弃用**，自 2026-03-27 起（[#911](https://github.com/SemiAnalysisAI/InferenceX/pull/911)），以便将 GPU 集群时间留给优先级更高的真实场景智能体编码基准测试与新的前沿模型。相关配置已删除，未归档。 |
 
+## 引擎提交策略
+
+下表列出各模型优先允许的引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列首选引擎均已提交后方可提交。
+
+| 模型 | 首选引擎 | 次选引擎 |
+|---|---|---|
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | vLLM 和 SGLang | 硬件专用引擎；须在 vLLM 和 SGLang 均已提交后 |
+| Kimi-K3（`kimik3`） | vLLM | 硬件专用引擎；须在 vLLM 已提交后 |
+| MiniMax-M3（`minimaxm3`） | vLLM | 硬件专用引擎；须在 vLLM 已提交后 |
+| GLM-5.2（`glm5.2`） | SGLang | 硬件专用引擎；须在 SGLang 已提交后 |
+| Qwen3.5-397B-A17B（`qwen3.5`） | SGLang | 硬件专用引擎；须在 SGLang 已提交后 |
+
 ## 模型支持矩阵
 
 | 模型架构类别 | 前缀 | 加入日期 | 启用场景 | 已弃用场景 |


### PR DESCRIPTION
## Summary

- Document the primary allowed inference engines for DeepSeek-V4-Pro, Kimi-K3, MiniMax-M3, GLM-5.2, and Qwen3.5.
- Clarify that hardware-specific engines are allowed as second-priority submissions only after the listed primary-engine submissions.
- Add the matching policy to MODELS_zh.md.

## Why

MODELS.md describes scenario support and speculative-decoding policy but does not currently state the engine submission priority for each frontier model.

## Impact

Documentation only. This gives contributors an explicit engine eligibility and ordering policy when preparing model submissions.

## Checks

- git diff --check