### PR TITLE
Document AgentX engine, draft-model, and offloading policy

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -72,6 +72,25 @@ The table also records both the agreed plan-of-record (PoR) draft-model mapping 
 | GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 | Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 
+## KV cache offloading policy
+
+To align with the design principle of shipping quickly by limiting scope, the initial AgentX policy permits only CPU DRAM KV cache offloading, and its use is optional. Supported approaches include the vLLM Connector, LMCache, SGLang HiCache, Mooncake CPU DRAM Connector, Dynamo KVBM, CPU DRAM P2P pooling, and similar CPU-memory mechanisms. Vendors may enable or disable CPU KV cache offloading for each submission at their discretion, including disabling it when that produces better Pareto points.
+
+The amount of CPU DDR5 used for KV cache offloading must be proportional to the fraction of a server's GPUs used by the serving configuration:
+
+`allowed CPU DRAM = per-server baseline CPU DRAM × (GPUs used by the configuration / total GPUs in the server)`
+
+This rule applies independently to each server.
+
+| CPU DRAM capacity class | Example SKUs | Per-server baseline and limit |
+|---|---|---|
+| No standardized CPU DRAM capacity | HGX B200, HGX B300, MI355X chassis | At most 3 TB per server. A configuration using 4 of 8 GPUs may therefore use at most 1.5 TB of CPU DRAM for KV cache offloading. |
+| Standardized CPU DRAM capacity | TPUv7, GB200 NVL72, GB300 NVL72 | The SKU's standard installed CPU DRAM capacity is the baseline, with no additional per-server hard cap. The proportional-GPU rule still applies. |
+
+The 3 TB limit prevents an unrealistic memory-capacity race in which hardware vendors ask CSPs and OEMs to install the maximum number of high-capacity DIMMs, potentially reaching 6 TB per server. Total cost of ownership (TCO) per accelerator chip will be normalized by the cost of the server's total CPU DDR5 capacity.
+
+Other offloading tiers, including NVMe KV cache offloading, are outside the initial scope and may be introduced after the InferenceX v3 release. NVMe KV cache offloading is tentatively targeted as a fast follow-up in InferenceX v3.5 or as part of InferenceX v4.
+
 ## Model support matrix
 
 | Model architecture class | Prefix | Date added | Active scenarios | Deprecated scenarios |

--- a/MODELS.md
+++ b/MODELS.md
@@ -51,15 +51,15 @@ Speculative-decoding A/B retirements — in each pair below the spec-decode arm 
 
 ## Engine submission policy
 
-The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed native/upstream engine submissions have been made. The table records both the agreed plan-of-record (PoR) draft-model mapping and proposals that still require partner alignment.
+The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but normally only as second-priority submissions after the listed native/upstream engine submissions have been made. As an exception for newly supported hardware, a hardware-specific engine may be submitted first to enable initial support, with the expectation that the corresponding native/upstream vLLM or SGLang submission will follow shortly afterward. The table records both the agreed plan-of-record (PoR) draft-model mapping and proposals that still require partner alignment.
 
 | Model | Primary native/upstream engines | Agreed draft model(s) (PoR) | Proposed draft model(s) pending partner alignment | Secondary engines |
 |---|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | native MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` — proposed for AgentX only under the same synthetic-acceptance methodology; pending partner alignment. Single-turn 8k1k remains on the native MTP heads. | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
-| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | `Inferact/Kimi-K3-DSpark` | — | Hardware-specific engines, after a native/upstream vLLM engine submission |
-| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | — | Hardware-specific engines, after a native/upstream vLLM engine submission |
-| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines, after a native/upstream SGLang engine submission |
-| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines, after a native/upstream SGLang engine submission |
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | native MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` — proposed for AgentX only under the same synthetic-acceptance methodology; pending partner alignment. Single-turn 8k1k remains on the native MTP heads. | Hardware-specific engines; normally after native/upstream vLLM and SGLang engine submissions, subject to the new-hardware exception above |
+| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | `Inferact/Kimi-K3-DSpark` | — | Hardware-specific engines; normally after a native/upstream vLLM engine submission, subject to the new-hardware exception above |
+| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | — | Hardware-specific engines; normally after a native/upstream vLLM engine submission, subject to the new-hardware exception above |
+| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines; normally after a native/upstream SGLang engine submission, subject to the new-hardware exception above |
+| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines; normally after a native/upstream SGLang engine submission, subject to the new-hardware exception above |
 
 ## Model support matrix
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -51,15 +51,15 @@ Speculative-decoding A/B retirements — in each pair below the spec-decode arm 
 
 ## Engine submission policy
 
-The engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed primary-engine submissions have been made.
+The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed native/upstream engine submissions have been made. The table also records the speculative-decoding draft model or method used for Agentic coding.
 
-| Model | Primary engines | Secondary engines |
-|---|---|---|
-| DeepSeek-V4-Pro 1.6T (`dsv4`) | vLLM and SGLang | Hardware-specific engines, after vLLM and SGLang submissions |
-| Kimi-K3 (`kimik3`) | vLLM | Hardware-specific engines, after a vLLM submission |
-| MiniMax-M3 (`minimaxm3`) | vLLM | Hardware-specific engines, after a vLLM submission |
-| GLM-5.2 (`glm5.2`) | SGLang | Hardware-specific engines, after an SGLang submission |
-| Qwen3.5-397B-A17B (`qwen3.5`) | SGLang | Hardware-specific engines, after an SGLang submission |
+| Model | Primary native/upstream engines | Draft model/method | Secondary engines |
+|---|---|---|---|
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | MTP | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
+| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | DSpark | Hardware-specific engines, after a native/upstream vLLM engine submission |
+| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | EAGLE3 | Hardware-specific engines, after a native/upstream vLLM engine submission |
+| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | MTP | Hardware-specific engines, after a native/upstream SGLang engine submission |
+| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | MTP | Hardware-specific engines, after a native/upstream SGLang engine submission |
 
 ## Model support matrix
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -55,7 +55,7 @@ The native/upstream engines below are the primary allowed engines for each model
 
 | Model | Primary native/upstream engines | Draft model/method | Secondary engines |
 |---|---|---|---|
-| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | MTP | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | MTP; DSpark is allowed for AgentX only under the same synthetic-acceptance methodology. Single-turn 8k1k continues to use the native MTP heads. | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
 | Kimi-K3 (`kimik3`) | native/upstream vLLM engine | DSpark | Hardware-specific engines, after a native/upstream vLLM engine submission |
 | MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | EAGLE3 | Hardware-specific engines, after a native/upstream vLLM engine submission |
 | GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | MTP | Hardware-specific engines, after a native/upstream SGLang engine submission |

--- a/MODELS.md
+++ b/MODELS.md
@@ -51,15 +51,26 @@ Speculative-decoding A/B retirements — in each pair below the spec-decode arm 
 
 ## Engine submission policy
 
-The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but normally only as second-priority submissions after the listed native/upstream engine submissions have been made. As an exception for newly supported hardware, a hardware-specific engine may be submitted first to enable initial support, with the expectation that the corresponding native/upstream vLLM or SGLang submission will follow shortly afterward. The table records both the agreed plan-of-record (PoR) draft-model mapping and proposals that still require partner alignment.
+Based on feedback from Tier 1 AI labs and the broader ML community about what they want to see in InferenceX AgentX, InferenceX uses an explicit model-to-framework mapping. Labs have reported that proprietary or hardware-specific engines such as TensorRT-LLM and ATOM do not always provide every feature their AgentX workloads require.
 
-| Model | Primary native/upstream engines | Agreed draft model(s) (PoR) | Proposed draft model(s) pending partner alignment | Secondary engines |
+The native/upstream engines in the table below are the first-class engines for each model. If a provider supports both the native/upstream vLLM engine and native/upstream SGLang engine as first-class LLM engines, it must first submit the engine or engines assigned by this mapping before submitting additional non-vLLM/SGLang engines such as ATOM, TensorRT-LLM, or TokenSpeed. Multiple additional non-vLLM/SGLang engines may be submitted.
+
+There are two exceptions to this ordering guideline:
+
+1. Brand-new hardware SKUs, such as MI455X UALoE72, VR200 NVL72, Rubin NVL8, TPUv8t, and TPUv8i, may use a hardware-specific engine first for initial support. The corresponding native/upstream vLLM or SGLang submission is expected to follow shortly afterward.
+2. For a new model architecture, a provider may use another engine first if it cannot support the mapped native/upstream vLLM or SGLang engine as a first-class engine and can articulate to core maintainers a fundamental, first-principles reason why the mapped framework does not yet support the hardware-model combination.
+
+InferenceX supports the maintainers of both SGLang and vLLM and reflects feedback from AI labs and the ML community that want to see performance from both frameworks. Among models assigned to one primary framework, the mapping splits assignments evenly between vLLM and SGLang; models mapped to both provide shared coverage. This ensures that InferenceX tests both frameworks equally without favoring one over the other.
+
+The table also records both the agreed plan-of-record (PoR) draft-model mapping and proposals that still require partner alignment.
+
+| Model | Primary native/upstream engines | Agreed draft model(s) (PoR) | Proposed draft model(s) pending partner alignment | Additional engines |
 |---|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | native MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` — proposed for AgentX only under the same synthetic-acceptance methodology; pending partner alignment. Single-turn 8k1k remains on the native MTP heads. | Hardware-specific engines; normally after native/upstream vLLM and SGLang engine submissions, subject to the new-hardware exception above |
-| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | `Inferact/Kimi-K3-DSpark` | — | Hardware-specific engines; normally after a native/upstream vLLM engine submission, subject to the new-hardware exception above |
-| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | — | Hardware-specific engines; normally after a native/upstream vLLM engine submission, subject to the new-hardware exception above |
-| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines; normally after a native/upstream SGLang engine submission, subject to the new-hardware exception above |
-| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines; normally after a native/upstream SGLang engine submission, subject to the new-hardware exception above |
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | native MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` — proposed for AgentX only under the same synthetic-acceptance methodology; pending partner alignment. Single-turn 8k1k remains on the native MTP heads. | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
+| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | `Inferact/Kimi-K3-DSpark` | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
+| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
+| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
+| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 
 ## Model support matrix
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -51,15 +51,15 @@ Speculative-decoding A/B retirements — in each pair below the spec-decode arm 
 
 ## Engine submission policy
 
-The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed native/upstream engine submissions have been made. The table also records the speculative-decoding draft model or method used for Agentic coding.
+The native/upstream engines below are the primary allowed engines for each model. Hardware-specific engines are also allowed, but only as second-priority submissions after the listed native/upstream engine submissions have been made. The table records both the agreed plan-of-record (PoR) draft-model mapping and proposals that still require partner alignment.
 
-| Model | Primary native/upstream engines | Draft model/method | Secondary engines |
-|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | MTP; DSpark is allowed for AgentX only under the same synthetic-acceptance methodology. Single-turn 8k1k continues to use the native MTP heads. | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
-| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | DSpark | Hardware-specific engines, after a native/upstream vLLM engine submission |
-| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | EAGLE3 | Hardware-specific engines, after a native/upstream vLLM engine submission |
-| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | MTP | Hardware-specific engines, after a native/upstream SGLang engine submission |
-| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | MTP | Hardware-specific engines, after a native/upstream SGLang engine submission |
+| Model | Primary native/upstream engines | Agreed draft model(s) (PoR) | Proposed draft model(s) pending partner alignment | Secondary engines |
+|---|---|---|---|---|
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | native/upstream vLLM engine and native/upstream SGLang engine | native MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` — proposed for AgentX only under the same synthetic-acceptance methodology; pending partner alignment. Single-turn 8k1k remains on the native MTP heads. | Hardware-specific engines, after native/upstream vLLM and SGLang engine submissions |
+| Kimi-K3 (`kimik3`) | native/upstream vLLM engine | `Inferact/Kimi-K3-DSpark` | — | Hardware-specific engines, after a native/upstream vLLM engine submission |
+| MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | — | Hardware-specific engines, after a native/upstream vLLM engine submission |
+| GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines, after a native/upstream SGLang engine submission |
+| Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | — | Hardware-specific engines, after a native/upstream SGLang engine submission |
 
 ## Model support matrix
 

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -51,15 +51,15 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 ## 引擎提交策略
 
-下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列原生/上游引擎均已提交后方可提交。表中同时记录已达成一致的草稿模型规划（PoR）以及尚待合作伙伴对齐的提案。
+下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但通常仅作为次优先级，且须在所列原生/上游引擎均已提交后方可提交。新支持的硬件属于例外：为实现初始支持，可先提交硬件专用引擎，但预期相应的原生/上游 vLLM 或 SGLang 提交会在此后不久跟进。表中同时记录已达成一致的草稿模型规划（PoR）以及尚待合作伙伴对齐的提案。
 
 | 模型 | 首选原生/上游引擎 | 已达成一致的草稿模型（PoR） | 待合作伙伴对齐的草稿模型提案 | 次选引擎 |
 |---|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | 原生 MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` —— 仅提议用于 AgentX，并须遵循相同的合成接受方法；尚待合作伙伴对齐。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
-| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | `Inferact/Kimi-K3-DSpark` | — | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
-| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | — | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
-| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
-| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | 原生 MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` —— 仅提议用于 AgentX，并须遵循相同的合成接受方法；尚待合作伙伴对齐。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；通常须在原生/上游 vLLM 和 SGLang 引擎均已提交后，但适用上述新硬件例外 |
+| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | `Inferact/Kimi-K3-DSpark` | — | 硬件专用引擎；通常须在原生/上游 vLLM 引擎已提交后，但适用上述新硬件例外 |
+| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | — | 硬件专用引擎；通常须在原生/上游 vLLM 引擎已提交后，但适用上述新硬件例外 |
+| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；通常须在原生/上游 SGLang 引擎已提交后，但适用上述新硬件例外 |
+| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；通常须在原生/上游 SGLang 引擎已提交后，但适用上述新硬件例外 |
 
 ## 模型支持矩阵
 

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -55,7 +55,7 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 | 模型 | 首选原生/上游引擎 | 草稿模型/方法 | 次选引擎 |
 |---|---|---|---|
-| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | MTP；DSpark 仅允许用于 AgentX，并须遵循相同的合成接受方法。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
 | Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | DSpark | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
 | MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | EAGLE3 | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
 | GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -51,15 +51,26 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 ## 引擎提交策略
 
-下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但通常仅作为次优先级，且须在所列原生/上游引擎均已提交后方可提交。新支持的硬件属于例外：为实现初始支持，可先提交硬件专用引擎，但预期相应的原生/上游 vLLM 或 SGLang 提交会在此后不久跟进。表中同时记录已达成一致的草稿模型规划（PoR）以及尚待合作伙伴对齐的提案。
+根据 Tier 1 AI 实验室和更广泛的机器学习社区对 InferenceX AgentX 展示内容的反馈，InferenceX 采用明确的模型到框架映射。多家实验室反馈，TensorRT-LLM、ATOM 等专有或硬件专用引擎并不总能提供其 AgentX 工作负载所需的全部功能。
 
-| 模型 | 首选原生/上游引擎 | 已达成一致的草稿模型（PoR） | 待合作伙伴对齐的草稿模型提案 | 次选引擎 |
+下表中的原生/上游（native/upstream）引擎是各模型的一级支持引擎。如果某一提供方将原生/上游 vLLM 引擎和原生/上游 SGLang 引擎均作为一级支持的 LLM 引擎，则必须先按照本映射提交指定的一个或多个引擎，之后才能提交 ATOM、TensorRT-LLM、TokenSpeed 等其他非 vLLM/SGLang 引擎。允许提交多个其他非 vLLM/SGLang 引擎。
+
+该提交顺序指南有两项例外：
+
+1. 对于 MI455X UALoE72、VR200 NVL72、Rubin NVL8、TPUv8t、TPUv8i 等全新硬件 SKU，为实现初始支持，可先使用硬件专用引擎。预期相应的原生/上游 vLLM 或 SGLang 提交会在此后不久跟进。
+2. 对于新的模型架构，如果提供方无法将映射指定的原生/上游 vLLM 或 SGLang 引擎作为一级支持引擎，并能向核心维护者说明该框架尚不支持相应硬件—模型组合的根本性、第一性原理原因，则可先使用其他引擎。
+
+InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和机器学习社区希望看到两个框架性能数据的反馈。在仅指定一个主要框架的模型中，映射会将任务均衡分配给 vLLM 和 SGLang；同时指定两个框架的模型则提供共享覆盖。这确保 InferenceX 对两个框架进行同等测试，不偏向任何一方。
+
+表中还同时记录已达成一致的草稿模型规划（PoR）以及尚待合作伙伴对齐的提案。
+
+| 模型 | 首选原生/上游引擎 | 已达成一致的草稿模型（PoR） | 待合作伙伴对齐的草稿模型提案 | 其他引擎 |
 |---|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | 原生 MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` —— 仅提议用于 AgentX，并须遵循相同的合成接受方法；尚待合作伙伴对齐。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；通常须在原生/上游 vLLM 和 SGLang 引擎均已提交后，但适用上述新硬件例外 |
-| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | `Inferact/Kimi-K3-DSpark` | — | 硬件专用引擎；通常须在原生/上游 vLLM 引擎已提交后，但适用上述新硬件例外 |
-| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | — | 硬件专用引擎；通常须在原生/上游 vLLM 引擎已提交后，但适用上述新硬件例外 |
-| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；通常须在原生/上游 SGLang 引擎已提交后，但适用上述新硬件例外 |
-| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；通常须在原生/上游 SGLang 引擎已提交后，但适用上述新硬件例外 |
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | 原生 MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` —— 仅提议用于 AgentX，并须遵循相同的合成接受方法；尚待合作伙伴对齐。单轮 8k1k 继续使用原生 MTP 头。 | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
+| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | `Inferact/Kimi-K3-DSpark` | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
+| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
+| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
+| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 
 ## 模型支持矩阵
 

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -72,6 +72,25 @@ InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和
 | GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 | Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 
+## KV 缓存卸载策略
+
+为遵循“通过限制范围实现快速交付”的设计原则，AgentX 初始策略仅允许 CPU DRAM KV 缓存卸载，且该功能为可选项。支持的方案包括 vLLM Connector、LMCache、SGLang HiCache、Mooncake CPU DRAM Connector、Dynamo KVBM、CPU DRAM P2P 池化以及类似的 CPU 内存机制。供应商可自行决定是否为每项提交启用 CPU KV 缓存卸载；如果禁用后能得到更优的 Pareto 点，也可选择禁用。
+
+用于 KV 缓存卸载的 CPU DDR5 容量必须与推理配置实际使用的服务器 GPU 比例成正比：
+
+`允许的 CPU DRAM = 每服务器 CPU DRAM 基准容量 ×（配置使用的 GPU 数 / 服务器 GPU 总数）`
+
+该规则按每台服务器独立计算。
+
+| CPU DRAM 容量类别 | 示例 SKU | 每服务器基准与上限 |
+|---|---|---|
+| CPU DRAM 容量未标准化 | HGX B200、HGX B300、MI355X 机箱 | 每服务器最多 3 TB。因此，仅使用 8 块 GPU 中 4 块的配置最多可使用 1.5 TB CPU DRAM 进行 KV 缓存卸载。 |
+| CPU DRAM 容量已标准化 | TPUv7、GB200 NVL72、GB300 NVL72 | 以该 SKU 标准安装的 CPU DRAM 容量为基准，不另设每服务器硬上限，但仍须遵守 GPU 比例规则。 |
+
+3 TB 上限旨在避免不现实的内存容量竞赛，即各硬件供应商要求云服务提供商（CSP）和原始设备制造商（OEM）安装尽可能多的高容量 DIMM，导致每服务器容量可能达到 6 TB。每颗加速器芯片的总体拥有成本（TCO）将按服务器 CPU DDR5 总容量的成本进行归一化。
+
+其他卸载层级（包括 NVMe KV 缓存卸载）不属于初始范围，可在 InferenceX v3 发布后引入。NVMe KV 缓存卸载暂定在 InferenceX v3.5 中作为快速后续功能加入，或纳入 InferenceX v4。
+
 ## 模型支持矩阵
 
 | 模型架构类别 | 前缀 | 加入日期 | 启用场景 | 已弃用场景 |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -51,15 +51,15 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 ## 引擎提交策略
 
-下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列原生/上游引擎均已提交后方可提交。表中还列出了智能体编码所使用的投机解码草稿模型或方法。
+下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列原生/上游引擎均已提交后方可提交。表中同时记录已达成一致的草稿模型规划（PoR）以及尚待合作伙伴对齐的提案。
 
-| 模型 | 首选原生/上游引擎 | 草稿模型/方法 | 次选引擎 |
-|---|---|---|---|
-| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | MTP；DSpark 仅允许用于 AgentX，并须遵循相同的合成接受方法。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
-| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | DSpark | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
-| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | EAGLE3 | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
-| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
-| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
+| 模型 | 首选原生/上游引擎 | 已达成一致的草稿模型（PoR） | 待合作伙伴对齐的草稿模型提案 | 次选引擎 |
+|---|---|---|---|---|
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | 原生 MTP | `deepseek-ai/DeepSeek-V4-Pro-DSpark` —— 仅提议用于 AgentX，并须遵循相同的合成接受方法；尚待合作伙伴对齐。单轮 8k1k 继续使用原生 MTP 头。 | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
+| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | `Inferact/Kimi-K3-DSpark` | — | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
+| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | — | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
+| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
+| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | — | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
 
 ## 模型支持矩阵
 

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -51,15 +51,15 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 ## 引擎提交策略
 
-下表列出各模型优先允许的引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列首选引擎均已提交后方可提交。
+下表列出各模型优先允许的原生/上游（native/upstream）引擎。硬件专用引擎也允许提交，但优先级较低，且须在所列原生/上游引擎均已提交后方可提交。表中还列出了智能体编码所使用的投机解码草稿模型或方法。
 
-| 模型 | 首选引擎 | 次选引擎 |
-|---|---|---|
-| DeepSeek-V4-Pro 1.6T（`dsv4`） | vLLM 和 SGLang | 硬件专用引擎；须在 vLLM 和 SGLang 均已提交后 |
-| Kimi-K3（`kimik3`） | vLLM | 硬件专用引擎；须在 vLLM 已提交后 |
-| MiniMax-M3（`minimaxm3`） | vLLM | 硬件专用引擎；须在 vLLM 已提交后 |
-| GLM-5.2（`glm5.2`） | SGLang | 硬件专用引擎；须在 SGLang 已提交后 |
-| Qwen3.5-397B-A17B（`qwen3.5`） | SGLang | 硬件专用引擎；须在 SGLang 已提交后 |
+| 模型 | 首选原生/上游引擎 | 草稿模型/方法 | 次选引擎 |
+|---|---|---|---|
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 原生/上游 vLLM 引擎和原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 vLLM 和 SGLang 引擎均已提交后 |
+| Kimi-K3（`kimik3`） | 原生/上游 vLLM 引擎 | DSpark | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
+| MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | EAGLE3 | 硬件专用引擎；须在原生/上游 vLLM 引擎已提交后 |
+| GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
+| Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | MTP | 硬件专用引擎；须在原生/上游 SGLang 引擎已提交后 |
 
 ## 模型支持矩阵
 


### PR DESCRIPTION
## Summary

- Follow up on #2500 with an explicit AgentX model-to-framework policy based on feedback from Tier 1 AI labs and the broader ML community.
- Require providers that support native/upstream vLLM and SGLang as first-class engines to submit the mapped framework first, while allowing multiple additional non-vLLM/SGLang engines afterward.
- Define engine-ordering exceptions for initial enablement of brand-new hardware SKUs and fundamental framework support gaps for new model architectures.
- Explain the balanced vLLM/SGLang assignment principle so both frameworks receive equal coverage without favoritism.
- Record the agreed draft-model plan of record and separate the proposed DSV4 DSpark option pending partner alignment.
- Define the initial AgentX KV cache offloading policy: optional CPU DRAM offloading only, proportional memory allocation, SKU-specific baselines, a 3 TB cap for non-standardized servers, DDR5-aware TCO normalization, and a post-v3 path for NVMe offloading.
- Mirror the policies in MODELS_zh.md.

## Why

AI labs and ML community members want first-class vLLM and SGLang performance in AgentX because proprietary and hardware-specific engines do not always expose every required feature. The framework mapping establishes predictable submission order while retaining practical exceptions. The KV cache policy similarly limits initial scope while preventing unrealistic CPU-memory configurations from distorting performance or TCO comparisons.

## Impact

Documentation only. Contributors can identify the required first-class framework, understand engine-ordering exceptions, distinguish agreed draft models from proposals awaiting alignment, and apply consistent KV cache offloading capacity and cost rules.

## Checks

- git diff --check
- Cross-checked the agreed draft mapping and offloading rules against the supplied AgentX plan of record