### PR TITLE
perf(agentx): refresh Qwen3.5 GB300 runs with correct metrics / 使用正确指标刷新 Qwen3.5 GB300 运行

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -2006,6 +2006,36 @@ write_agentic_result_json() {
     "$AIPERF_PYTHON" "$INFMAX_CONTAINER_WORKSPACE/utils/generate_aiperf_plots.py" "$result_dir" 2>&1 || true
 }
 
+validate_required_agentic_server_metrics() {
+    local result_dir="$1"
+    local required_prefix="${AIPERF_REQUIRED_SERVER_METRIC_PREFIX:-}"
+    local metrics_dir="$result_dir/aiperf_artifacts"
+    local metrics_json="$metrics_dir/server_metrics_export.json"
+    local metrics_csv="$metrics_dir/server_metrics_export.csv"
+
+    # Opt-in so existing AgentX configurations retain their current contract.
+    # Recipes that require trace charts set a metric prefix (for example
+    # `sglang:`) and fail loudly instead of publishing a partial trace artifact.
+    if [ -z "$required_prefix" ]; then
+        return 0
+    fi
+
+    if [ ! -s "$metrics_json" ] || [ ! -s "$metrics_csv" ]; then
+        echo "ERROR: required AIPerf server metrics artifacts are missing or empty in $metrics_dir" >&2
+        return 1
+    fi
+
+    # Avoid parsing the potentially multi-GiB JSON into memory. AIPerf writes
+    # metric names as JSON object keys, so a fixed-string scan establishes that
+    # backend engine metrics—not only frontend/router metrics—were captured.
+    if ! grep -F -m 1 -q "\"${required_prefix}" "$metrics_json"; then
+        echo "ERROR: $metrics_json contains no metric with required prefix '$required_prefix'" >&2
+        return 1
+    fi
+
+    echo "Validated required AIPerf server metrics prefix '$required_prefix'"
+}
+
 run_agentic_replay_and_write_outputs() {
     local result_dir="$1"
     local replay_rc
@@ -2044,4 +2074,6 @@ run_agentic_replay_and_write_outputs() {
         echo "ERROR: agentic trace replay produced invalid results after writing available artifacts" >&2
         return "$validation_rc"
     fi
+
+    validate_required_agentic_server_metrics "$result_dir"
 }

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c1-mtp-hicache-jid2530006.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c1-mtp-hicache-jid2530006.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c24-mtp-hicache-jid2530012.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c24-mtp-hicache-jid2530012.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c32-mtp-hicache-jid2530013.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c32-mtp-hicache-jid2530013.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c40-mtp-hicache-jid2530015.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c40-mtp-hicache-jid2530015.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c48-mtp-hicache-jid2530017.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c48-mtp-hicache-jid2530017.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c52-mtp-hicache-jid2527406.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c52-mtp-hicache-jid2527406.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c64-mtp-hicache-jid2527410.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c64-mtp-hicache-jid2527410.yaml
@@ -32,6 +32,7 @@ backend:
     aggregated:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       tensor-parallel-size: 2
@@ -87,3 +88,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp2-tp2-c72-mtp-hicache-session-jid2527415.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp2-tp2-c72-mtp-hicache-session-jid2527415.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -150,6 +151,7 @@ backend:
       speculative-num-draft-tokens: 4
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -201,3 +203,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c128-mtp-hicache-session-jid2527417.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c128-mtp-hicache-session-jid2527417.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c16-mtp-hicache-session-jid2530027.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c16-mtp-hicache-session-jid2530027.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c32-mtp-hicache-session-jid2530028.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c32-mtp-hicache-session-jid2530028.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c64-mtp-hicache-session-jid2530029.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c64-mtp-hicache-session-jid2530029.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c8-mtp-hicache-session-jid2530030.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c8-mtp-hicache-session-jid2530030.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c96-mtp-hicache-session-jid2527409.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/agentic/disagg-gb300-1p1d-tp4-tp4-c96-mtp-hicache-session-jid2527409.yaml
@@ -108,6 +108,7 @@ backend:
     decode:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       trust-remote-code: true
       quantization: modelopt_fp4
@@ -145,6 +146,7 @@ backend:
     prefill:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4
       enable-cache-report: true
+      enable-metrics: true
       model-path: /model/
       quantization: modelopt_fp4
       kv-cache-dtype: fp8_e4m3
@@ -196,3 +198,4 @@ benchmark:
     HF_HUB_CACHE: /hf_hub_cache
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5468,3 +5468,13 @@
     - "The 30-minute local re-sweep covered low, mid, and high concurrency across aggregate TP2, disaggregate TP2/TP2, and disaggregate TP4/TP4. All 33 new-client steady-state samples completed with zero request errors and zero retract events; using the same historical output-token-throughput-per-user p50 metric as the old curve, the fourteen submitted points are the strict non-dominated set. The InferenceMAX sweep keeps the canonical 60-minute AgentX benchmark duration."
     - "Align both configurations on the 2026-07-24 SGLang container, current aiperf be758d6, the merged Dynamo #12081 commit 5a638087, X-Dynamo-Session-ID affinity with the removed legacy conv-aware CLI path explicitly disabled, and NVIDIA/srt-slurm v1.0.36 while keeping the recipe and nvidia-master entries synchronized."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2477
+
+- config-keys:
+    - qwen3.5-fp4-gb300-dynamo-sglang-agentic-agg
+    - qwen3.5-fp4-gb300-dynamo-sglang-agentic-disagg
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Refresh the Qwen3.5 GB300 AgentX runs with correct SGLang backend metric collection while preserving the exact fourteen-point configuration from PR #2477."
+    - "Use NVIDIA/srt-slurm v1.0.38 logical worker metric endpoint injection and enable metrics on every aggregate, prefill, and decode engine."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2505

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -185,7 +185,7 @@ SRTCTL_SETUP_SCRIPT=""
 rm -rf "$SRT_REPO_DIR"
 
 if [[ "$IS_AGENTIC" == "1" && $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == "qwen3.5" ]]; then
-    # Qwen3.5 agentic uses NVIDIA/srt-slurm v1.0.36: the two features the
+    # Qwen3.5 agentic uses NVIDIA/srt-slurm v1.0.38: the two features the
     # cquil11 fork was pinned for are merged upstream (present in v1.0.36) —
     #   - `srtctl apply --no-preflight` (skip the in-process model FS check):
     #     model.path resolves to /scratch/models/Qwen3.5-397B-A17B-NVFP4
@@ -195,9 +195,13 @@ if [[ "$IS_AGENTIC" == "1" && $FRAMEWORK == "dynamo-sglang" && $MODEL_PREFIX == 
     #     genuinely missing on the compute node.
     #   - benchmark_stage propagates srun_options (container-remap-root must
     #     reach the agentic_srt.sh srun).
+    # v1.0.38 additionally injects AIPERF_SERVER_METRICS_URLS for custom
+    # benchmarks using each logical SGLang worker leader. This is required for
+    # complete AgentX trace artifacts; the public frontend alone may expose no
+    # Prometheus endpoint or only Dynamo frontend metrics.
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
-    git checkout v1.0.36
+    git checkout v1.0.38
     mkdir -p recipes/sglang/qwen3.5
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5" \
         recipes/sglang/qwen3.5


### PR DESCRIPTION
## Summary

- Re-run the exact 14-point Qwen3.5 GB300 AgentX configuration from #2477 with correct SGLang backend metric collection.
- Upgrade this Qwen3.5 AgentX path from NVIDIA/srt-slurm v1.0.36 to v1.0.38, which includes NVIDIA/srt-slurm@c180328 and injects `AIPERF_SERVER_METRICS_URLS` for logical worker leaders in custom benchmarks.
- Enable SGLang Prometheus metrics on every aggregate, prefill, and decode engine.
- Reject incomplete trace artifacts that lack non-empty server metrics or any `sglang:*` backend series.

## Root cause

The original recipes enabled cache reporting but not SGLang metrics, and v1.0.36 predates logical-worker metric URL injection for custom benchmarks. Aggregate runs therefore produced no server-metrics artifacts, while disaggregated runs could capture only Dynamo frontend metrics.

## Validation

- The generated sweep remains exactly 14 unique configurations: seven aggregate and seven disaggregated.
- All 14 recipes parse successfully, with metrics enabled on all 21 aggregate/prefill/decode engine roles.
- 50 existing result-processing tests and 224 matrix tests pass.
- Shell syntax and `git diff --check` pass.

This is stacked on #2477 so its diff contains only the corrected metric collection. Retarget it to `main` after #2477 merges.

## 摘要

- 使用正确的 SGLang 后端指标采集，重新运行 #2477 中完全相同的 14 点 Qwen3.5 GB300 AgentX 配置。
- 将此 Qwen3.5 AgentX 路径从 NVIDIA/srt-slurm v1.0.36 升级到 v1.0.38；该版本包含 NVIDIA/srt-slurm@c180328，并为自定义基准测试的逻辑 worker leader 注入 `AIPERF_SERVER_METRICS_URLS`。
- 为所有聚合、预填充和解码 SGLang 引擎启用 Prometheus 指标。
- 拒绝缺少非空 server metrics 或任何 `sglang:*` 后端序列的不完整 trace 产物。

## 根因

原始配方启用了缓存报告，但未启用 SGLang 指标；同时 v1.0.36 早于自定义基准测试的逻辑 worker 指标 URL 注入功能。因此，聚合运行没有生成 server-metrics 产物，而解耦运行可能只采集到 Dynamo 前端指标。

## 验证

- 生成的扫描仍准确包含 14 个唯一配置：7 个聚合和 7 个解耦。
- 全部 14 个配方均可成功解析，21 个聚合、预填充和解码引擎角色全部启用指标。
- 50 个现有结果处理测试和 224 个矩阵测试通过。
- Shell 语法检查和 `git diff --check` 均通过。

此 PR 堆叠在 #2477 上，因此差异仅包含正确的指标采集。#2477 合并后请将其目标分支改为 `main`。
