### PR TITLE
Remove mi325x-tw runners

### DIFF
--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -281,11 +281,6 @@ labels:
     - mi325x-amds_07
     - mi325x-amds_08
     - mi325x-amds_09
-  cluster:mi325x-tw:
-    - mi325x-tw_00
-    - mi325x-tw_01
-    - mi325x-tw_02
-    - mi325x-tw_03
   cluster:mi355x-amds:
     - mi355x-amds_00
     - mi355x-amds_01
@@ -335,9 +330,6 @@ hardware:
     gpus-per-node: 8
   cluster:mi325x-amds:
     available-cpu-dram-mib: 3_091_589
-    gpus-per-node: 8
-  cluster:mi325x-tw:
-    available-cpu-dram-mib: 3_095_792
     gpus-per-node: 8
   cluster:mi355x-amds:
     available-cpu-dram-mib: 3_095_781


### PR DESCRIPTION
## What changed

- Removed the `cluster:mi325x-tw` runner list from `configs/runners.yaml`.
- Removed the corresponding `cluster:mi325x-tw` hardware metadata.

## Why

The TensorWave MI325X runner pool has been retired and its GitHub runner registrations were removed, so sweep scheduling should no longer target it.

## Impact

InferenceX will no longer schedule workloads against the retired `mi325x-tw` runner names.

## Validation

- `git diff --check`
- Loaded and validated `configs/runners.yaml` with `utils.matrix_logic.validation.load_runner_file`
- `pytest -q utils/matrix_logic/test_validation.py -k 'TestLoadRunnerFile'` (4 passed)