### PR TITLE
[AMD][AgentX] Kimi-K3 MI355X DSpark wrapper (kimik3_fp4_mi355x_mtp.sh)

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DSpark variant of kimik3_fp4_mi355x.sh. The MI355X launcher routes
+# spec-decoding=mtp rows to this suffix, while the shared base recipe owns the
+# model, AgentX replay, and eval plumbing.
+#
+# Keep this wrapper aligned with the upstream AMD Kimi-K3 DSpark reproducer.
+# The first AgentX validation is deliberately GPU-only at c1 so a server or
+# kernel failure has nowhere else to hide.
+export SPEC_DECODE=true
+export KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-auto}"
+export GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.95}"
+export MAX_NUM_SEQS="${MAX_NUM_SEQS:-16}"
+export EVAL_MAX_NUM_SEQS="${EVAL_MAX_NUM_SEQS:-128}"
+export MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-4096}"
+export LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-false}"
+export PREFIX_CACHING="${PREFIX_CACHING:-auto}"
+export ENFORCE_EAGER="${ENFORCE_EAGER:-false}"
+
+exec "$(dirname "$0")/kimik3_fp4_mi355x.sh" "$@"


### PR DESCRIPTION
## Summary

Standalone split of `benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh` out of #2403.

The MI355X launcher derives the benchmark script name from `spec-decoding`, not from the config key, so a `spec-decoding: mtp` row resolves to the `_mtp` suffix. This wrapper pins the upstream AMD Kimi-K3 DSpark reproducer values and `exec`s the shared base recipe, which owns the model, AgentX replay and eval plumbing.

| knob | value |
|---|---|
| `SPEC_DECODE` | `true` |
| `KV_CACHE_DTYPE` | `auto` → **bf16** (base recipe defaults to `fp8`; this overrides it) |
| `GPU_MEM_UTIL` | `0.95` |
| `MAX_NUM_SEQS` / `EVAL_MAX_NUM_SEQS` | `16` / `128` |
| `MAX_NUM_BATCHED_TOKENS` | `4096` |
| `PREFIX_CACHING` / `ENFORCE_EAGER` / `LANGUAGE_MODEL_ONLY` | `auto` / `false` / `false` |

## ⚠️ Merge order

**This depends on #2403 and cannot merge first.** The wrapper `exec`s `benchmarks/single_node/agentic/kimik3_fp4_mi355x.sh`, which does not exist on `main` — #2403 adds it. Landing this alone leaves a dangling reference.

`bash -n` clean.
