### PR TITLE
Add Qwen3.5 FP8 B200 AgentX MTP

### DIFF
--- a/benchmarks/single_node/agentic/qwen3.5_fp8_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp8_b200_sglang_mtp.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# AgentX trace replay for Qwen3.5-397B-A17B FP8 on B200 with SGLang
+# native NEXTN MTP. Throughput uses the committed golden synthetic AL; evals
+# retain real target-model verification.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+# Use the lightweight GSM8K eval instead of the AgentX SWE-bench default.
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+
+SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-10}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+nvidia-smi
+
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126_256k
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+CACHE_ARGS=()
+if require_agentic_kv_offload_backend hicache; then
+    REQUESTED_HICACHE_TOTAL_GB="${HICACHE_TOTAL_CPU_DRAM_GB:-$TOTAL_CPU_DRAM_GB}"
+    if [ "$REQUESTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: requested HiCache pool ${REQUESTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    TOTAL_CPU_DRAM_GB="$REQUESTED_HICACHE_TOTAL_GB"
+    # SGLang applies --hicache-size independently to Qwen's target KV and
+    # Mamba pools. Native NEXTN also creates a draft KV pool with the same
+    # slot count; its one attention layer adds 1/15 of the target KV bytes.
+    # Reserve 1 GB/rank for page alignment and enforce H * 31/15 per rank.
+    HICACHE_ALIGNMENT_RESERVE_GB=$TP
+    HICACHE_USABLE_TOTAL_GB=$((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$HICACHE_USABLE_TOTAL_GB" -lt 1 ]; then
+        echo "Error: insufficient DRAM after HiCache alignment reserve" >&2
+        exit 1
+    fi
+    MAX_HICACHE_SIZE_GB=$((HICACHE_USABLE_TOTAL_GB * 15 / TP / 31))
+    HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
+    if [ "$HICACHE_SIZE_GB" -lt 1 ] || [ "$HICACHE_SIZE_GB" -gt "$MAX_HICACHE_SIZE_GB" ]; then
+        echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB" >&2
+        exit 1
+    fi
+    PROJECTED_HICACHE_TOTAL_GB=$(((HICACHE_SIZE_GB * TP * 31 + 14) / 15 + HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$PROJECTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: projected HiCache use ${PROJECTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB target + Mamba + 1/15 draft per rank across TP=${TP}; projected node total ${PROJECTED_HICACHE_TOTAL_GB} GB <= ${TOTAL_CPU_DRAM_GB} GB"
+    CACHE_ARGS=(
+        --page-size 64
+        --enable-hierarchical-cache
+        --hicache-size "$HICACHE_SIZE_GB"
+        --hicache-io-backend kernel
+        --hicache-mem-layout page_first
+        --hicache-write-policy write_through_selective
+    )
+fi
+
+PARALLEL_ARGS=(
+    --tp "$TP"
+    --dp 1
+    --ep-size "$EP_SIZE"
+)
+
+# Parallel tokenization keeps 256k AgentX warmups below the client timeout.
+TOKENIZER_ARGS=(--tokenizer-worker-num 6)
+
+# AgentX concurrency counts live session trees rather than individual HTTP
+# requests. Leave room for subagent fan-out and avoid spending HBM on graphs
+# above the batch sizes that remain useful for this long-context workload.
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+CUDA_GRAPH_MAX_BS="$CONC"
+[ "$CUDA_GRAPH_MAX_BS" -gt 64 ] && CUDA_GRAPH_MAX_BS=64
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export PYTHONNOUSERSITE=1
+export NCCL_NVLS_ENABLE=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+# Keep server-side connections alive beyond AIPerf's 300-second client pool
+# timeout so bursty AgentX trajectories cannot reuse a closing idle socket.
+export SGLANG_TIMEOUT_KEEP_ALIVE=1800
+
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    export SGLANG_SIMULATE_ACC_LEN=3.39
+    export SGLANG_SIMULATE_ACC_METHOD=match-expected
+    export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
+fi
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    "${PARALLEL_ARGS[@]}"
+    --enable-symm-mem
+    --quantization fp8
+    --kv-cache-dtype fp8_e4m3
+    --mamba-ssm-dtype bfloat16
+    --attention-backend trtllm_mha
+    --moe-runner-backend flashinfer_trtllm
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --max-prefill-tokens 16384
+    --chunked-prefill-size 16384
+    --mem-fraction-static 0.80
+    --stream-interval 50
+    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    "${TOKENIZER_ARGS[@]}"
+    --tokenizer-path "$MODEL"
+    --reasoning-parser qwen3
+    --tool-call-parser qwen3_coder
+    --speculative-algorithm NEXTN
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --enable-metrics
+    --enable-cache-report
+    "${CACHE_ARGS[@]}"
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+capture_cache_metrics() {
+    {
+        echo "=== SGLang cache metrics snapshot $(date --iso-8601=seconds) ==="
+        curl -fsS "http://localhost:$PORT/metrics" 2>/dev/null \
+            | grep -E '^(sglang:(cache_hit_rate|cached_tokens_total|prompt_tokens_total|hicache_host_used_tokens|hicache_host_total_tokens|token_usage|num_requests_running|num_requests_waiting))' \
+            || true
+        echo "============================================================"
+    } >> "$SERVER_LOG"
+}
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+capture_cache_metrics
+trap capture_cache_metrics EXIT
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1231,7 +1231,10 @@ qwen3.5-fp8-b200-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+      - { tp: 8, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 60, 62, 64] }
+      - { tp: 8, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 66, 68, 70, 72, 76] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 14] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 18, 20, 22, 24, 28, 32] }
 
 qwen3.5-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.14-cu130

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1219,6 +1219,20 @@ qwen3.5-fp8-b200-sglang-agentic:
     - search-space:
       - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
 
+qwen3.5-fp8-b200-sglang-agentic-mtp:
+  image: lmsysorg/sglang:v0.5.16-cu130
+  model: Qwen/Qwen3.5-397B-A17B-FP8
+  model-prefix: qwen3.5
+  runner: cluster:b200-dgxc
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 2, 4, 8, 16, 32] }
+
 qwen3.5-fp4-b200-sglang:
   image: lmsysorg/sglang:v0.5.14-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5535,6 +5535,6 @@
   description:
     - "Add Qwen3.5-397B-A17B FP8 AgentX on B200 with SGLang native NEXTN MTP"
     - "Mirror the FP4 AgentX MTP concurrency and HiCache grids, scaling TP2 to TP4 and TP4 to TP8 for the larger FP8 checkpoint"
-    - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Use golden synthetic acceptance length 3.39"
     - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2514

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5527,3 +5527,13 @@
     - "Record the recipes' active HiCache host-DRAM tier and, for disaggregated points, Dynamo router commit 5a638087 in nvidia-master metadata so generated artifacts no longer report kv_offloading=none, allocated_cpu_dram_gb=0, or a null router."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2477
   
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add Qwen3.5-397B-A17B FP8 AgentX on B200 with SGLang native NEXTN MTP"
+    - "Use the existing FP8 AgentX TP8 concurrency grid with the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Image: lmsysorg/sglang:v0.5.16-cu130"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2514

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5534,6 +5534,7 @@
     - agentic-coding
   description:
     - "Add Qwen3.5-397B-A17B FP8 AgentX on B200 with SGLang native NEXTN MTP"
-    - "Use the existing FP8 AgentX TP8 concurrency grid with the 256k trace dataset and golden synthetic acceptance length 3.39"
+    - "Mirror the FP4 AgentX MTP concurrency and HiCache grids, scaling TP2 to TP4 and TP4 to TP8 for the larger FP8 checkpoint"
+    - "Use the 256k trace dataset and golden synthetic acceptance length 3.39"
     - "Image: lmsysorg/sglang:v0.5.16-cu130"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2514


### PR DESCRIPTION
## Summary

- Add a B200 Qwen3.5 FP8 AgentX scenario with native SGLang NEXTN MTP.
- Mirror the FP4 AgentX MTP concurrency and HiCache grids, scaling FP4 TP2 to FP8 TP4 and FP4 TP4 to FP8 TP8 because the staged 379 GB FP8 checkpoint cannot fit across two 180 GB B200s.
- Use the validated Qwen AgentX trace, cache-metric, and synthetic-acceptance setup.
- Keep synthetic acceptance disabled during evals so accuracy uses real target-model verification.

## Why

InferenceX has Qwen3.5 FP8 AgentX and fixed-sequence FP8 MTP coverage on B200, but no scenario combining AgentX with FP8 MTP. This adds that missing benchmark path alongside the existing FP4 AgentX MTP scenario.

## Validation

- `bash -n benchmarks/single_node/agentic/qwen3.5_fp8_b200_sglang_mtp.sh`
- `python utils/matrix_logic/generate_sweep_configs.py test-config --config-files configs/nvidia-master.yaml --config-keys qwen3.5-fp8-b200-sglang-agentic-mtp`
- `python -m pytest utils/matrix_logic/ -q` (224 passed)
- Confirmed the FP8 checkpoint is present on B200 cluster storage.
