### PR TITLE
CollectiveX: b300 deepep-v2 LL EP8 (single-node HCA pin) + H-series LL EP16 bring-up findings

### DIFF
--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -84,7 +84,7 @@
         "account": "benchmark",
         "qos": "batch_1_qos",
         "squash_dir": "/data/home/sa-shared/sqsh",
-        "exclude_nodes": "b300-005,b300-018"
+        "exclude_nodes": "b300-005,b300-009,b300-018"
       },
       "network": {
         "socket_ifname": "bond0",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -77,7 +77,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "nccl-ep": [8]},
-      "ll_backends": {"nccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-8 2x400GbE", "switch": "NVIDIA Spectrum-X SN5600 (51.2T)"},
       "operator": {
         "partition": "batch_1",
@@ -89,6 +89,7 @@
       "network": {
         "socket_ifname": "bond0",
         "rdma_devices": "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_8,mlx5_9,mlx5_10,mlx5_11,mlx5_16,mlx5_17,mlx5_20,mlx5_21,mlx5_22,mlx5_23",
+        "single_node_rdma_devices": "mlx5_12:1,mlx5_13:1,mlx5_14:1,mlx5_15:1",
         "ib_gid_index": "3",
         "rail_isolated": "1"
       }

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -11,7 +11,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 2x200GbE", "switch": "Arista 7060DX5-64S (Tomahawk4, 25.6T)"},
       "operator": {
         "partition": "hpc-gpu-1",
@@ -35,7 +35,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 400G", "switch": "NVIDIA Quantum-2 QM9790 (25.6T, InfiniBand)"},
       "operator": {
         "partition": "main",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -84,7 +84,7 @@
         "account": "benchmark",
         "qos": "batch_1_qos",
         "squash_dir": "/data/home/sa-shared/sqsh",
-        "exclude_nodes": "b300-018"
+        "exclude_nodes": "b300-005,b300-018"
       },
       "network": {
         "socket_ifname": "bond0",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -11,7 +11,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 2x200GbE", "switch": "Arista 7060DX5-64S (Tomahawk4, 25.6T)"},
       "operator": {
         "partition": "hpc-gpu-1",
@@ -35,7 +35,7 @@
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
-      "ll_backends": {"deepep-v2": [8], "uccl-ep": [8], "nccl-ep": [8]},
+      "ll_backends": {"deepep-v2": [8, 16], "uccl-ep": [8], "nccl-ep": [8]},
       "fabric": {"nic": "ConnectX-7 400G", "switch": "NVIDIA Quantum-2 QM9790 (25.6T, InfiniBand)"},
       "operator": {
         "partition": "main",

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -90,7 +90,7 @@ collx_load_operator_config() {
   unset ENROOT_CACHE_PATH
   unset COLLX_EXCLUDE_NODES COLLX_NODELIST COLLX_LOCK_DIR COLLX_MASTER_PORT
   unset COLLX_SOCKET_IFNAME COLLX_RDMA_DEVICES COLLX_IB_GID_INDEX COLLX_RDMA_SERVICE_LEVEL
-  unset COLLX_RDMA_TRAFFIC_CLASS COLLX_RAIL_ISOLATED
+  unset COLLX_RDMA_TRAFFIC_CLASS COLLX_RAIL_ISOLATED COLLX_SINGLE_NODE_RDMA_DEVICES
   unset MASTER_ADDR MASTER_PORT RANK WORLD_SIZE LOCAL_RANK LOCAL_WORLD_SIZE
   config_path="${COLLECTIVEX_OPERATOR_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/inferencex/collectivex.json}"
   if [ ! -e "$config_path" ]; then
@@ -190,6 +190,21 @@ collx_apply_network_profile() {
   # NVLink/XGMI path (DeepEP's allow_nvlink_for_low_latency_mode; MoRI's IntraNodeLL), so
   # they need no scale-out RDMA env and must NOT force IBGDA — verified on h200 EP8 with
   # /dev/gdrdrv absent (forcing IBGDA there would fail, as it did historically on b300).
+  #
+  # Exception: a SKU may pin a single-node HCA list. DeepEP's legacy LL Buffer
+  # self-enables IBGDA even single-node, and on b300 the image's baked
+  # NVSHMEM_HCA_PE_MAPPING steers that init onto the GPU-fabric RoCE rails, where
+  # ibv_create_ah fails at every GID index (ibgda.cpp "Unable to create ah" ->
+  # "create DCT share err"). The storage-IB rails accept AH/DCT creation, and with
+  # allow_nvlink_for_low_latency_mode the kernels move all intra-node traffic over
+  # NVLink, so those rails carry init-time control traffic only. HCA_LIST wins over
+  # the baked PE mapping (NVSHMEM warns and honors HCA_LIST) — verified on-metal
+  # 2026-07-08 (b300-010, production shape, PASS with and without the baked mapping).
+  if [ "$nodes" -le 1 ] && [ -n "${COLLX_SINGLE_NODE_RDMA_DEVICES:-}" ]; then
+    [[ "$COLLX_SINGLE_NODE_RDMA_DEVICES" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?(,[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?)*$ ]] \
+      || collx_die "invalid private single-node RDMA device selector"
+    export NVSHMEM_HCA_LIST="$COLLX_SINGLE_NODE_RDMA_DEVICES"
+  fi
   { [ "$nodes" -gt 1 ] && [ "$transport" != mnnvl ]; } || return 0
   [ -n "${COLLX_RDMA_DEVICES:-}" ] \
     || collx_die "RDMA execution requires a private device selector"

--- a/experimental/CollectiveX/runtime/config.py
+++ b/experimental/CollectiveX/runtime/config.py
@@ -15,7 +15,7 @@ OPERATOR_FIELDS = {
 }
 NETWORK_FIELDS = {
     "socket_ifname", "rdma_devices", "ib_gid_index", "rdma_service_level",
-    "rdma_traffic_class", "rail_isolated",
+    "rdma_traffic_class", "rail_isolated", "single_node_rdma_devices",
 }
 # Timing knobs, in the order the legacy colon-string encoded them, paired with the run_ep flag
 # each one drives. The names match configs/sweep.json so a case's timing block is readable

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -38,6 +38,7 @@ class PlatformRegistryTests(unittest.TestCase):
     NETWORK_FIELDS = {
         "socket_ifname", "rdma_devices", "ib_gid_index",
         "rdma_service_level", "rdma_traffic_class", "rail_isolated",
+        "single_node_rdma_devices",
     }
 
     def test_every_platform_entry_is_complete_and_typed(self) -> None:
@@ -144,6 +145,48 @@ class ConfigTests(unittest.TestCase):
         self.assertIn(b"COLLX_PARTITION\0main\0", payload)
         self.assertIn(b"COLLX_SQUASH_DIR\0/home/sa-shared/containers\0", payload)
         self.assertIn(b"COLLX_RDMA_DEVICES\0", payload)
+
+class SingleNodeHcaOverrideTests(unittest.TestCase):
+    # collx_apply_network_profile's single-node early return must still honor a
+    # SKU's pinned single-node HCA list (b300: DeepEP's legacy LL Buffer
+    # self-enables IBGDA even single-node, and only the storage-IB rails accept
+    # AH/DCT creation), while scale-out runs keep resolving NVSHMEM_HCA_LIST
+    # from the ordinary scale-out selector.
+    @staticmethod
+    def _profile_env(script: str) -> str:
+        completed = subprocess.run(
+            ["bash", "-c", script], cwd=RUNTIME.parent,
+            capture_output=True, text=True, check=True,
+        )
+        return completed.stdout.strip().splitlines()[-1]
+
+    def test_single_node_override_exports_the_pinned_hca_list(self) -> None:
+        line = self._profile_env(
+            "source runtime/common.sh 2>/dev/null;"
+            " export COLLX_SINGLE_NODE_RDMA_DEVICES='mlx5_12:1,mlx5_13:1';"
+            " collx_apply_network_profile 1 nvlink;"
+            " echo \"${NVSHMEM_HCA_LIST:-unset}\""
+        )
+        self.assertEqual(line, "mlx5_12:1,mlx5_13:1")
+
+    def test_single_node_without_override_exports_nothing(self) -> None:
+        line = self._profile_env(
+            "source runtime/common.sh 2>/dev/null;"
+            " collx_apply_network_profile 1 nvlink;"
+            " echo \"${NVSHMEM_HCA_LIST:-unset}\""
+        )
+        self.assertEqual(line, "unset")
+
+    def test_scale_out_ignores_the_single_node_selector(self) -> None:
+        line = self._profile_env(
+            "source runtime/common.sh 2>/dev/null;"
+            " export COLLX_SINGLE_NODE_RDMA_DEVICES='mlx5_12:1';"
+            " export COLLX_RDMA_DEVICES='mlx5_0:1,mlx5_1:1';"
+            " collx_apply_network_profile 2 nvlink-rdma;"
+            " echo \"${NVSHMEM_HCA_LIST:-unset}\""
+        )
+        self.assertEqual(line, "mlx5_0:1,mlx5_1:1")
+
 
 class StageTests(unittest.TestCase):
     def test_create_copy_and_validate_cleanup(self) -> None:


### PR DESCRIPTION
## What merges

**b300 gains its first production-backend low-latency row: `deepep-v2 [8]`.**

DeepEP's legacy LL Buffer self-enables IBGDA even single-node, and the image's baked `NVSHMEM_HCA_PE_MAPPING` steers that init onto b300's GPU-fabric RoCE rails, where `ibv_create_ah` fails at every GID index (`ibgda.cpp "Unable to create ah"` → `create DCT share err`, rc255 on all ranks). The storage-IB rails (`mlx5_12-15`) accept AH/DCT creation, and with `allow_nvlink_for_low_latency_mode` all steady-state traffic stays on NVLink — the rails carry init-time control traffic only.

Mechanism: new optional registry network field `single_node_rdma_devices`, exported as `NVSHMEM_HCA_LIST` on single-node shards only (seam-tested; scale-out shards keep resolving from the ordinary selector).

**Validation (run 31179442983): both precisions GREEN with healthy NVLink-class numbers** — bf16 roundtrip p50 58.5µs @T=1 → 146µs @T=256, fp8 51.8µs → 118µs, correctness clean at every rung. Comparable to the h200 EP8 LL control (52µs @T=1).

## What was tried and deliberately held (H-series LL EP16)

The middle commit enabled `deepep-v2 ll [8,16]` on h100-dgxc/h200-dgxc; the last commit reverts it after bring-up:

- **h200 (run 31179010881): 4/4 GREEN, correctness clean — but EP16 periods are 20-120× off a healthy internode LL reference** (dispatch p50 1.84ms @T=64, 7.7ms @T=256, linear in tokens; bare-metal b200 runs the identical cells at ~50-130µs).
- **h100 (run 31179008559): EP8 controls green; both EP16 shards red** — bf16-n2 ran 15 min into the 900s hang guard (same degradation, RoCE flavor), fp8-n2 additionally hit the known TCPStore rendezvous flake.
- Root cause candidate verified on-node: **`/dev/gdrdrv` is absent on both pools** (`nvidia_peermem` loaded) — the one delta vs b200-nscale where these cells are ±1% of hand campaigns. SRE has been asked to install gdrcopy; once it lands, re-flipping the two registry rows re-runs this bring-up.

b300 LL **EP16** remains excluded: cross-node IBGDA needs AH creation on the RoCE rails — an SRE-level fabric fix (kernel GID→DMAC/L3 resolution), not a harness change. NCCL RC and `ib_write_bw` pass on those rails because neither creates AHs from GIDs, which is why health checks miss it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes b300 benchmark networking env (`NVSHMEM_HCA_LIST`) and scheduling exclusions for a new production LL backend row; scope is SKU-specific but affects GPU job bring-up.
> 
> **Overview**
> **Enables b300 low-latency `deepep-v2` EP8** in `platform_config.json` and tightens operator baselines (more `exclude_nodes`).
> 
> Adds an optional platform network field **`single_node_rdma_devices`**, loaded as `COLLX_SINGLE_NODE_RDMA_DEVICES` and, in `collx_apply_network_profile`, exported as **`NVSHMEM_HCA_LIST` only when `nodes <= 1`** so single-node DeepEP LL init can use storage-IB HCAs instead of the image’s default GPU-fabric mapping. Scale-out runs still use the normal `rdma_devices` selector.
> 
> b300 pins `mlx5_12–15:1` for that path. Registry typing/tests cover the new field, plus shell tests that single-node honors the override, omits it when unset, and ignores it on multi-node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f85b4f5994222c282277c030ead8f9ece4de11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->