### PR TITLE
[Klaud Cold] codeowners: own MODELS.md and MODELS_zh.md / 为 MODELS.md 与 MODELS_zh.md 指定代码所有者

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,9 @@ configs/amd-master.yaml @billishyahao @chunfangamd @seungrokj @yctseng0211 @1am9
 # NVIDIA master config
 configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv @InferenceX/core
 
+# PoR for Models & general direction
+MODELS.md @ankur-singh @chunfangamd @InferenceX/core
+MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core
+
 # OperatorX experimental
 experimental/operatorx/ @hbarclay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@ configs/amd-master.yaml @billishyahao @chunfangamd @seungrokj @yctseng0211 @1am9
 configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv @InferenceX/core
 
 # PoR for Models & general direction
-MODELS.md @ankur-singh @chunfangamd @InferenceX/core
-MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core
+MODELS.md @ankur-singh @chunfangamd @InferenceX/core @InferenceX/vendor-number-3 @InferenceX/vendor-number-4
+MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core @InferenceX/vendor-number-3 @InferenceX/vendor-number-4
 
 # OperatorX experimental
 experimental/operatorx/ @hbarclay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@ configs/amd-master.yaml @billishyahao @chunfangamd @seungrokj @yctseng0211 @1am9
 configs/nvidia-master.yaml @ankur-singh @kedarpotdar-nv @InferenceX/core
 
 # PoR for Models & general direction
-MODELS.md @ankur-singh @chunfangamd @InferenceX/core @InferenceX/vendor-number-3 @InferenceX/vendor-number-4
-MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core @InferenceX/vendor-number-3 @InferenceX/vendor-number-4
+MODELS.md @ankur-singh @chunfangamd @InferenceX/core
+MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core
 
 # OperatorX experimental
 experimental/operatorx/ @hbarclay


### PR DESCRIPTION
Adds named CODEOWNERS for `MODELS.md` and `MODELS_zh.md`.

```
MODELS.md    @ankur-singh @chunfangamd @InferenceX/core
MODELS_zh.md @ankur-singh @chunfangamd @InferenceX/core
```

## Why

`MODELS.md` is the source of truth for which scenarios are active per model and for the deprecation calendar, but until now it only matched the `* @InferenceX/core` catch-all — so a change to a retirement date needed no vendor-side review.

That matters more than it used to:

- Enactment PRs do exactly what the file says. #2493 removed 54 config keys on its authority, and #2527 removes 17 more.
- `.github/codeowner-signoff-verify-prompt.md`'s deprecated-model check (Check 7) reads the file directly, and has already **rejected** #2512 and #2513 on it. Editing `MODELS.md` can flip that gate for other PRs.

## Owner choice

The union of the two master-config reviewer sets, because the file spans both vendors:

| Owner | Also owns |
|---|---|
| `@ankur-singh` | `configs/nvidia-master.yaml` |
| `@chunfangamd` | `configs/amd-master.yaml` |
| `@InferenceX/core` | repo catch-all |

All three already appear in `.github/CODEOWNERS`, so no new handles are introduced.

Both files carry the identical list because `AGENTS.md` requires an English doc and its `_zh` counterpart to be edited in the same PR — split ownership would let the pair drift.

## Notes

- Placed after the master-config rules and before `experimental/operatorx/`. CODEOWNERS is last-match-wins; these are exact-path rules and no later pattern matches them, so the placement is safe.
- No behavior change outside review routing. One file, one hunk.

---

## 中文说明

为 `MODELS.md` 与 `MODELS_zh.md` 指定具名代码所有者。

**背景**：`MODELS.md` 是各模型启用场景与弃用时间表的权威来源，但此前仅由 `* @InferenceX/core` 兜底匹配，修改退役日程无需厂商侧评审。当前该文件的影响已显著提升：退役执行 PR 完全依据其内容（#2493 据此移除 54 个配置项，#2527 再移除 17 个）；且 `.github/codeowner-signoff-verify-prompt.md` 的弃用模型检查（Check 3/7）直接读取该文件，已据此驳回 #2512 与 #2513 —— 修改 `MODELS.md` 可能改变其他 PR 的合入门槛。

**所有者选择**：取两份主配置评审人的并集，因为该文件同时覆盖两家厂商 —— `@ankur-singh`（NVIDIA 主配置）、`@chunfangamd`（AMD 主配置）、`@InferenceX/core`（仓库兜底）。三者均已存在于 `.github/CODEOWNERS`，未引入新账号。两个文件使用完全相同的所有者列表，因为 `AGENTS.md` 要求英文文档与其 `_zh` 对应文件在同一 PR 中同步修改，所有权若分离会导致两者脱节。

**说明**：规则置于主配置规则之后、`experimental/operatorx/` 之前；CODEOWNERS 采用「最后匹配优先」，这两条为精确路径规则且其后无可匹配的模式，放置位置安全。除评审路由外无任何行为变更，仅涉及一个文件、一处改动。
