### PR TITLE
fix(evals): preserve GPQA reasoning responses / 修复 GPQA 推理响应截断

### DIFF
--- a/utils/evals/gpqa_diamond.yaml
+++ b/utils/evals/gpqa_diamond.yaml
@@ -21,6 +21,16 @@ doc_to_text: |
   Express your final answer as the corresponding option 'A', 'B', 'C', or 'D'.
 doc_to_target: answer
 
+# lm-eval defaults generate_until tasks without explicit kwargs to stopping at
+# a blank line. Reasoning models commonly use blank lines before their final
+# answer, so that default truncates the response before the A-D choice.
+generation_kwargs:
+  until:
+    - "</s>"
+    - "<|im_end|>"
+  do_sample: false
+  temperature: 0.0
+
 filter_list:
   - name: extract_abcd
     filter:

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 BENCHMARK_LIB = Path(__file__).resolve().parents[2] / "benchmarks" / "benchmark_lib.sh"
+GPQA_RECIPE = Path(__file__).with_name("gpqa_diamond.yaml")
 
 _SCRIPT = r'''
 source "$BENCHMARK_LIB"
@@ -175,6 +176,14 @@ def test_eval_limit_absent_when_unset():
 def test_lm_eval_defaults_to_gsm8k():
     out = _run_lm_eval_cmdline()
     assert "utils/evals/gsm8k.yaml" in out
+
+
+def test_gpqa_recipe_does_not_stop_at_reasoning_paragraph_breaks():
+    recipe = GPQA_RECIPE.read_text(encoding="utf-8")
+    generation = recipe.split("generation_kwargs:", 1)[1].split("filter_list:", 1)[0]
+    assert "</s>" in generation
+    assert "<|im_end|>" in generation
+    assert "\\n\\n" not in generation
 
 
 


### PR DESCRIPTION
Summary:
- Add explicit EOS stop tokens to the GPQA generation recipe.
- Prevent lm-eval from applying its implicit blank-line stop to reasoning responses.
- Add a regression test for the recipe contract.

Observed failure:
A live DeepSeek V4 Flash qualification produced 250 invalid extractions out of 396 because generation stopped at the first blank line. The resulting 9.34% score is invalid evidence and will be rerun after this fix.

Validation:
- New focused regression test: passed.
- Full test_run_eval_dispatch.py: 33 passed; 2 unrelated local failures because subprocess Python lacks PyYAML in this macOS environment.
- git diff --check: passed.

中文摘要：
- 为 GPQA 生成任务显式添加 EOS 停止标记。
- 防止 lm-eval 使用空行作为默认停止条件而截断推理响应。
- 添加任务配方回归测试。