### PR TITLE
[Klaud Cold] minimaxm3-fp4-b200-vllm-agentic-mtp: long-prefill-token-threshold 512 / 设置 long-prefill-token-threshold 512

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_b200_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_b200_mtp.sh
@@ -194,6 +194,7 @@ VLLM_CMD=(
     --max-cudagraph-capture-size 512
     --max-num-batched-tokens 16384
     --stream-interval 20
+    --long-prefill-token-threshold 512 \
     --trust-remote-code
     --speculative-config "$SPEC_CONFIG"
     "${OFFLOAD_ARGS[@]}"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5688,3 +5688,9 @@
     - "Use the official lmsysorg/sglang:v0.5.16-rocm720-mi30x image, enable SGLang prompt-cache reporting, and pass the backend Prometheus metrics endpoint explicitly to AIPerf"
     - "Allow up to 30 minutes for healthy AgentX responses admitted near the end of the measurement window to drain before AIPerf finalizes profile metric coverage"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2528
+
+- config-keys:
+    - minimaxm3-fp4-b200-vllm-agentic-mtp
+  description:
+    - "Set --long-prefill-token-threshold 512 for MiniMax M3 NVFP4 b200 AgentX MTP"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2538


### PR DESCRIPTION
Add `--long-prefill-token-threshold 512` to `minimaxm3_fp4_b200_mtp.sh`.

## 中文说明
在 `minimaxm3_fp4_b200_mtp.sh` 中添加 `--long-prefill-token-threshold 512`。