### PR TITLE
fix(agentx): bump AIPerf to v1.0.5 and propagate MI355X failures

### DIFF
--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -322,6 +322,7 @@ else
         --container-remap-root \
         --no-container-entrypoint --export=ALL,AIPERF_DATASET_MMAP_CACHE_DIR=/aiperf_mmap_cache \
         bash "$BENCHMARK_SCRIPT"
+    benchmark_rc=$?
 
     scancel $JOB_ID
 
@@ -329,4 +330,6 @@ else
         echo "gpucore files exist. not good"
         rm -f gpucore.*
     fi
+
+    exit "$benchmark_rc"
 fi


### PR DESCRIPTION
## Summary

- bump `utils/aiperf` from `agentx-v1.0.4` to [`agentx-v1.0.5`](https://github.com/SemiAnalysisAI/aiperf/releases/tag/agentx-v1.0.5)
- propagate the single-node MI355X benchmark exit code after Slurm cleanup

## Behavior

AIPerf now allows a three-minute sparse tail in one-hour AgentX profiles while still failing when neither TTFT nor inter-token latency reaches 95% of the profile. This fixes healthy c1 profiles rejected at 97.2% coverage.

The MI355X launcher previously followed a failing container `srun` with a successful `scancel`, masking the benchmark failure from GitHub Actions. It now preserves the `srun` result, performs cleanup, and exits with that result.

Evidence: [TP2 c1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31558297538/job/93995347699), [TP4 c1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31558297538/job/93995347676), [AIPerf #41](https://github.com/SemiAnalysisAI/aiperf/pull/41).

## Validation

- AIPerf: 103 focused tests, Ruff/format, and all pre-commit hooks passed
- InferenceX: `bash -n runners/launch_mi355x-amds.sh` and `git diff --check` passed
- no inference-server, workload, routing, or performance configuration changes