### PR TITLE
Make staging status comments English-only

### DIFF
--- a/.github/workflows/stage-results-callback.yml
+++ b/.github/workflows/stage-results-callback.yml
@@ -4,7 +4,7 @@ run-name: Report staged run ${{ github.event.client_payload.run-id }} to PR #${{
 
 on:
   repository_dispatch:
-    types: [stage-results-completed]
+    types: [stage-results-started, stage-results-completed]
 
 permissions: {}
 
@@ -32,6 +32,7 @@ jobs:
             const appRunId = String(payload['app-run-id'] ?? '');
             const commentId = String(payload['comment-id'] ?? '');
             const succeeded = String(payload['stage-succeeded'] ?? '');
+            const callbackType = context.payload.action;
 
             if (payload['source-repository'] !== 'SemiAnalysisAI/InferenceX-app') {
               core.setFailed('Unsupported staging callback source');
@@ -53,30 +54,29 @@ jobs:
               core.setFailed('Callback requester is not a valid GitHub login');
               return;
             }
-            if (!['true', 'false'].includes(succeeded)) {
+            if (!['stage-results-started', 'stage-results-completed'].includes(callbackType)) {
+              core.setFailed('Unsupported staging callback type');
+              return;
+            }
+            if (callbackType === 'stage-results-completed' && !['true', 'false'].includes(succeeded)) {
               core.setFailed('Callback stage-succeeded value must be true or false');
               return;
             }
 
             const appRunUrl = `${context.serverUrl}/SemiAnalysisAI/InferenceX-app/actions/runs/${appRunId}`;
+            const sourceRunUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
             const stagingSite = 'https://inferencemax-app-git-staging-semianalysisai.vercel.app';
             const entry = encodeURIComponent(`${runDate}~r${runId}`);
             const chartUrl = `${stagingSite}/inference?i_dates=${entry}`;
-            const body = succeeded === 'true'
+            const body = callbackType === 'stage-results-started'
+              ? `@${requestedBy} staging [run ${runId}](${sourceRunUrl}). [InferenceX-app staging workflow](${appRunUrl}) is now running. Existing staged runs will be preserved; this comment will be updated when staging completes.`
+              : succeeded === 'true'
               ? [
                   `@${requestedBy} staged run ${runId}: ${chartUrl}`,
                   '',
                   `This run remains available across future \`/stage-results\` requests. Staging the same run ID again updates its staged data. [Staging workflow](${appRunUrl})`,
-                  '',
-                  `@${requestedBy} 已将运行 ${runId} 发布到预发布环境：${chartUrl}`,
-                  '',
-                  `后续的 \`/stage-results\` 请求不会移除此运行；再次发布相同的运行 ID 会更新其预发布数据。[预发布工作流](${appRunUrl})`,
                 ].join('\n')
-              : [
-                  `@${requestedBy} staging run ${runId} failed. [Inspect the staging workflow](${appRunUrl}).`,
-                  '',
-                  `@${requestedBy} 预发布运行 ${runId} 失败。[查看预发布工作流](${appRunUrl})。`,
-                ].join('\n');
+              : `@${requestedBy} staging run ${runId} failed. [Inspect the staging workflow](${appRunUrl}).`;
 
             if (commentId) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -20,9 +20,9 @@ jobs:
       startsWith(github.event.comment.body, '/stage-results')
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      issues: read
+      actions: read # Validate the source workflow run and its artifacts
+      contents: read # Resolve pull-request commits
+      issues: read # Read labels and label-history timeline events
       pull-requests: write # Post staging status as github-actions rather than a PAT user
     steps:
       - name: Authorize request and resolve source run
@@ -256,11 +256,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const body = [
-              `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). Existing staged runs will be preserved; a completion link will be posted here.`,
-              '',
-              `@${process.env.REQUESTED_BY} 正在将[运行 ${process.env.RUN_ID}](${process.env.RUN_URL})发布到预发布环境。已有的预发布运行会继续保留；完成后将在此处提供链接。`,
-            ].join('\n');
+            const body = `@${process.env.REQUESTED_BY} staging [run ${process.env.RUN_ID}](${process.env.RUN_URL}). Existing staged runs will be preserved; a completion link will be posted here.`;
             const comment = await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- remove the Chinese translations from `/stage-results` acknowledgment, success, and failure comments
- accept a new `stage-results-started` callback from InferenceX-app
- edit the acknowledgment comment at staging start to include the live InferenceX-app Actions run link
- preserve the existing final callback behavior, which replaces the same comment with the staged chart link or failure status

## Coordination

This is paired with the InferenceX-app PR that emits the new early callback. Merge this PR first so the receiver exists before the sender begins dispatching `stage-results-started`.

## Validation

- `actionlint .github/workflows/stage-results.yml .github/workflows/stage-results-callback.yml`
- `uvx --exclude-newer P1D zizmor@latest --strict-collection --pedantic --no-ignores .github/workflows/stage-results.yml .github/workflows/stage-results-callback.yml`
- `git diff --check`
- no benchmark or E2E sweep was run because the change is limited to control-plane workflow comments and callback handling