### PR TITLE
[AMD] [AGENTX] Probe MiniMax-M3 TP8 on MI355X

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_mtp.sh
@@ -229,7 +229,10 @@ write_command "$RESULT_DIR/server_command.txt" "${VLLM_CMD[@]}"
 SERVER_PID=$!
 echo "Server PID: $SERVER_PID"
 
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+wait_for_ready \
+    --endpoint "http://0.0.0.0:${PORT}/health" \
+    --log "$SERVER_LOG" \
+    --pid "$SERVER_PID"
 
 # ---- Run benchmark ----------------------------------------------------------
 if [ "${EVAL_ONLY}" = "true" ]; then

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1645,9 +1645,7 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.20
       search-space:
-      - { tp: 4, kv-offloading: none, conc-list: [1, 2, 4, 5, 8, 10, 12, 15, 20, 24, 28, 32], spec-decoding: mtp }
-      - { tp: 2, kv-offloading: none, conc-list: [1, 2, 5], spec-decoding: mtp }
-      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.3" }, conc-list: [32, 40], spec-decoding: mtp }
+      - { tp: 8, kv-offloading: none, conc-list: [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 64], spec-decoding: mtp }
 
 # GLM-5.2 FP4 agentic-coding benchmark on MI355X via SGLang with MTP speculative
 # decoding. TP=4 EP=4 with KV offloading to DRAM (hicache backend) to support

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5837,3 +5837,9 @@
     - "Collect and require SGLang Prometheus metrics from the aggregate engine endpoint"
     - "Image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2563
+
+- config-keys:
+    - minimaxm3-fp4-mi355x-vllm-agentic-mtp
+  description:
+    - "Evaluate a TP8 GPU-resident MiniMax-M3 AgentX MTP curve from concurrency 1 through 64 against the published TP2/TP4 frontier."
+  pr-link: XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5842,4 +5842,4 @@
     - minimaxm3-fp4-mi355x-vllm-agentic-mtp
   description:
     - "Evaluate a TP8 GPU-resident MiniMax-M3 AgentX MTP curve from concurrency 1 through 64 against the published TP2/TP4 frontier."
-  pr-link: XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2574


### PR DESCRIPTION
## Summary

- isolate a TP8 GPU-resident MiniMax-M3 AgentX MTP discovery curve at concurrency 1–64
- compare low-latency and high-concurrency TP8 behavior with the merged TP2/TP4 frontier
- use the generic `wait_for_ready` helper directly for server readiness

## Validation

- perf-changelog validator
- YAML parse
- 61 changelog and sweep-gating tests
- `git diff --check`

This replaces #2574, which GitHub made unreopenable after the closed branch was rebased. It starts in `agentx-fast` discovery mode. Every point will be allowed to finish before the final full-sweep matrix is selected.