### PR TITLE
Add MI300X GLM-5.2 FP8 AgentX MTP

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -10,7 +10,9 @@ export EVAL_FRAMEWORK="lm-eval"
 
 check_env_vars \
     MODEL TP CONC EP_SIZE KV_OFFLOADING PORT EVAL_ONLY \
-    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+    RESULT_DIR DURATION
+
+require_agentic_kv_offload_none
 
 if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
@@ -37,30 +39,6 @@ install_agentic_deps
 SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 SERVER_PID=""
-
-CACHE_ARGS=()
-if require_agentic_kv_offload_backend hicache; then
-    # SGLang allocates one target and one much smaller EAGLE draft host pool
-    # per rank. Use the generated node-total DRAM budget, reserving one GB per
-    # rank for alignment; 64 GB per pool is enough to exercise eviction while
-    # preserving host headroom for model loading on MI300X nodes.
-    HICACHE_ALIGNMENT_RESERVE_GB=$TP
-    HICACHE_MAX_SIZE_GB=$(((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB) / TP / 2))
-    HICACHE_SIZE_GB=64
-    if [ "$HICACHE_SIZE_GB" -gt "$HICACHE_MAX_SIZE_GB" ]; then
-        echo "Error: HiCache requires ${HICACHE_SIZE_GB} GB per rank pool but the configured limit is ${HICACHE_MAX_SIZE_GB} GB" >&2
-        exit 1
-    fi
-    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB per rank pool across TP=${TP}, within ${TOTAL_CPU_DRAM_GB} GB node budget"
-    CACHE_ARGS=(
-        --page-size 64
-        --enable-hierarchical-cache
-        --hicache-size "$HICACHE_SIZE_GB"
-        --hicache-io-backend kernel
-        --hicache-mem-layout page_first
-        --hicache-write-policy write_through_selective
-    )
-fi
 
 cleanup_agentic_services() {
     local exit_code=$?
@@ -119,7 +97,6 @@ SGLANG_CMD=(
     --watchdog-timeout 1800
     --enable-metrics
     --enable-cache-report
-    "${CACHE_ARGS[@]}"
 )
 
 write_command "$RESULT_DIR/sglang_command.txt" "${SGLANG_CMD[@]}"

--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -86,8 +86,8 @@ SGLANG_CMD=(
     --max-total-tokens 1048576
     --chunked-prefill-size 131072
     # Full 131072-token DSA prefills need transient workspace beyond the KV
-    # pool; 0.80 leaves enough headroom on 192 GB MI300X ranks.
-    --mem-fraction-static 0.80
+    # pool; 0.75 leaves enough headroom on 192 GB MI300X ranks.
+    --mem-fraction-static 0.75
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --cuda-graph-max-bs "$MAX_RUNNING_REQUESTS"
     --speculative-algorithm EAGLE

--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -10,9 +10,7 @@ export EVAL_FRAMEWORK="lm-eval"
 
 check_env_vars \
     MODEL TP CONC EP_SIZE KV_OFFLOADING PORT EVAL_ONLY \
-    RESULT_DIR DURATION
-
-require_agentic_kv_offload_none
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 
 if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
@@ -39,6 +37,30 @@ install_agentic_deps
 SERVER_LOG="$RESULT_DIR/server.log"
 mkdir -p "$RESULT_DIR"
 SERVER_PID=""
+
+CACHE_ARGS=()
+if require_agentic_kv_offload_backend hicache; then
+    # SGLang allocates one target and one much smaller EAGLE draft host pool
+    # per rank. Use the generated node-total DRAM budget, reserving one GB per
+    # rank for alignment; 64 GB per pool is enough to exercise eviction while
+    # preserving host headroom for model loading on MI300X nodes.
+    HICACHE_ALIGNMENT_RESERVE_GB=$TP
+    HICACHE_MAX_SIZE_GB=$(((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB) / TP / 2))
+    HICACHE_SIZE_GB=64
+    if [ "$HICACHE_SIZE_GB" -gt "$HICACHE_MAX_SIZE_GB" ]; then
+        echo "Error: HiCache requires ${HICACHE_SIZE_GB} GB per rank pool but the configured limit is ${HICACHE_MAX_SIZE_GB} GB" >&2
+        exit 1
+    fi
+    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB per rank pool across TP=${TP}, within ${TOTAL_CPU_DRAM_GB} GB node budget"
+    CACHE_ARGS=(
+        --page-size 64
+        --enable-hierarchical-cache
+        --hicache-size "$HICACHE_SIZE_GB"
+        --hicache-io-backend kernel
+        --hicache-mem-layout page_first
+        --hicache-write-policy write_through_selective
+    )
+fi
 
 cleanup_agentic_services() {
     local exit_code=$?
@@ -97,6 +119,7 @@ SGLANG_CMD=(
     --watchdog-timeout 1800
     --enable-metrics
     --enable-cache-report
+    "${CACHE_ARGS[@]}"
 )
 
 write_command "$RESULT_DIR/sglang_command.txt" "${SGLANG_CMD[@]}"

--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -eo pipefail
+set -x
+
+# GLM-5.2 FP8 on one 8xMI300X node with native EAGLE MTP.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    RESULT_DIR DURATION
+
+require_agentic_kv_offload_none
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+rocm-smi || true
+amd-smi || true
+
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+SERVER_PID=""
+
+cleanup_agentic_services() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "SGLang server" 60
+    exit "$exit_code"
+}
+trap cleanup_agentic_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+export PYTHONNOUSERSITE=1
+export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
+export SGLANG_TIMEOUT_KEEP_ALIVE=900
+export SGLANG_DSA_FUSE_TOPK=false
+export SGLANG_OPT_USE_TOPK_V2=false
+
+# Throughput replays use the committed GLM-5.2 thinking-on K=3 golden AL;
+# evals retain real target-model verification.
+if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
+    export SGLANG_SIMULATE_ACC_LEN=2.99
+    export SGLANG_SIMULATE_ACC_METHOD=match-expected
+    export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
+fi
+
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    --tp "$TP"
+    --ep-size "$EP_SIZE"
+    --dsa-prefill-backend tilelang
+    --dsa-decode-backend tilelang
+    --dsa-topk-backend torch
+    --kv-cache-dtype bfloat16
+    --tool-call-parser glm47
+    --reasoning-parser glm45
+    --context-length 1048576
+    --max-total-tokens 1048576
+    --chunked-prefill-size 131072
+    --mem-fraction-static 0.85
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --cuda-graph-max-bs "$MAX_RUNNING_REQUESTS"
+    --speculative-algorithm EAGLE
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --watchdog-timeout 1800
+    --enable-metrics
+    --enable-cache-report
+)
+
+write_command "$RESULT_DIR/sglang_command.txt" "${SGLANG_CMD[@]}"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [[ "${EVAL_ONLY:-false}" == "true" ]]; then
+    export SWEBENCH_AGENT_STEP_LIMIT=150
+    run_eval --port "$PORT"
+else
+    # Aggregate serving exposes one logical SGLang Prometheus target.
+    export AIPERF_SERVER_METRICS_URLS="http://localhost:$PORT/metrics"
+    export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="sglang:"
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --benchmark-grace-period 1800"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -86,8 +86,8 @@ SGLANG_CMD=(
     --max-total-tokens 1048576
     --chunked-prefill-size 131072
     # Full 131072-token DSA prefills need transient workspace beyond the KV
-    # pool; 0.75 leaves enough headroom on 192 GB MI300X ranks.
-    --mem-fraction-static 0.75
+    # pool; 0.70 leaves enough headroom on 192 GB MI300X ranks.
+    --mem-fraction-static 0.70
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --cuda-graph-max-bs "$MAX_RUNNING_REQUESTS"
     --speculative-algorithm EAGLE

--- a/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh
@@ -9,7 +9,7 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 export EVAL_FRAMEWORK="lm-eval"
 
 check_env_vars \
-    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING PORT EVAL_ONLY \
     RESULT_DIR DURATION
 
 require_agentic_kv_offload_none
@@ -85,7 +85,9 @@ SGLANG_CMD=(
     --context-length 1048576
     --max-total-tokens 1048576
     --chunked-prefill-size 131072
-    --mem-fraction-static 0.85
+    # Full 131072-token DSA prefills need transient workspace beyond the KV
+    # pool; 0.80 leaves enough headroom on 192 GB MI300X ranks.
+    --mem-fraction-static 0.80
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --cuda-graph-max-bs "$MAX_RUNNING_REQUESTS"
     --speculative-algorithm EAGLE

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1539,8 +1539,8 @@ glm5.2-fp8-mi325x-sglang-agentic-mtp:
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 8] }
 
-# Fast discovery found a sharp quality cliff after c3. Keep TP c1/c3 plus TEP
-# c3; TP c2 exhausted HBM in two identical official long-context warmups.
+# Fast discovery found a sharp quality cliff after c3. Keep the verified TP and
+# TEP c3 points; lower concurrency repeatedly failed quality or memory gates.
 glm5.2-fp8-mi300x-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
   model: zai-org/GLM-5.2-FP8
@@ -1553,7 +1553,7 @@ glm5.2-fp8-mi300x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 3] }
+      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [3] }
       - { tp: 8, ep: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [3] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1539,8 +1539,8 @@ glm5.2-fp8-mi325x-sglang-agentic-mtp:
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 8] }
 
-# Fast discovery found a sharp quality cliff after c3. Keep TP c1-c3 plus TEP
-# c3, whose lower TTFT trades slightly lower input throughput than TP c3.
+# Fast discovery found a sharp quality cliff after c3. Keep TP c1/c3 plus TEP
+# c3; TP c2 exhausted HBM in two identical official long-context warmups.
 glm5.2-fp8-mi300x-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
   model: zai-org/GLM-5.2-FP8
@@ -1553,7 +1553,7 @@ glm5.2-fp8-mi300x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3] }
+      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 3] }
       - { tp: 8, ep: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [3] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1553,8 +1553,7 @@ glm5.2-fp8-mi300x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 7, 8] }
-      - { tp: 8, ep: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 7, 8] }
+      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, spec-decoding: mtp, conc-list: [3] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:
   image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1539,6 +1539,23 @@ glm5.2-fp8-mi325x-sglang-agentic-mtp:
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 8] }
 
+# Dense discovery around the MI325X c3-c5 HBM knee. MI300X has 25% less HBM,
+# so sample every concurrency through c8 for both TP and expert-parallel MoE.
+glm5.2-fp8-mi300x-sglang-agentic-mtp:
+  image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
+  model: zai-org/GLM-5.2-FP8
+  model-prefix: glm5.2
+  runner: cluster:mi300x-amds
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 7, 8] }
+      - { tp: 8, ep: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 7, 8] }
+
 minimaxm3-fp8-mi325x-vllm-agentic:
   image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914
   model: MiniMaxAI/MiniMax-M3-MXFP8

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1539,8 +1539,8 @@ glm5.2-fp8-mi325x-sglang-agentic-mtp:
       search-space:
       - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3, 4, 5, 6, 8] }
 
-# Dense discovery around the MI325X c3-c5 HBM knee. MI300X has 25% less HBM,
-# so sample every concurrency through c8 for both TP and expert-parallel MoE.
+# Fast discovery found a sharp quality cliff after c3. Keep TP c1-c3 plus TEP
+# c3, whose lower TTFT trades slightly lower input throughput than TP c3.
 glm5.2-fp8-mi300x-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
   model: zai-org/GLM-5.2-FP8
@@ -1553,7 +1553,8 @@ glm5.2-fp8-mi300x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, ep: 8, kv-offloading: dram, kv-offload-backend: { name: hicache }, spec-decoding: mtp, conc-list: [3] }
+      - { tp: 8, ep: 1, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 3] }
+      - { tp: 8, ep: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [3] }
 
 minimaxm3-fp8-mi325x-vllm-agentic:
   image: vllm/vllm-openai-rocm:nightly-04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5924,5 +5924,5 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Add MI300X GLM-5.2 FP8 AgentX with native SGLang EAGLE MTP and the verified resident Pareto matrix: TP8 c1-c3 plus TEP8 c3."
+    - "Add MI300X GLM-5.2 FP8 AgentX with native SGLang EAGLE MTP and the verified resident Pareto matrix: TP8 c1/c3 plus TEP8 c3."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2581

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5918,3 +5918,11 @@
     - "Add a TEP2 arm (tp 2, ep 2) to the qwen3.5-fp4-b200-sglang-mtp 8k/1k sweep at concurrency 16, 32, and 64"
     - "Rides on the NVFP4-V2 checkpoint switch from #2205"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2550
+
+- config-keys:
+    - glm5.2-fp8-mi300x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add MI300X GLM-5.2 FP8 AgentX discovery with native SGLang EAGLE MTP, golden AL 2.99, required SGLang metrics, and dense TP8/TEP8 c1-c8 resident sweeps."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5924,5 +5924,5 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Add MI300X GLM-5.2 FP8 AgentX with native SGLang EAGLE MTP and the verified resident Pareto matrix: TP8 c1/c3 plus TEP8 c3."
+    - "Add MI300X GLM-5.2 FP8 AgentX with native SGLang EAGLE MTP and the verified resident Pareto matrix: TP8 c3 plus TEP8 c3."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2581

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5925,4 +5925,4 @@
     - agentic-coding
   description:
     - "Add MI300X GLM-5.2 FP8 AgentX discovery with native SGLang EAGLE MTP, golden AL 2.99, required SGLang metrics, and dense TP8/TEP8 c1-c8 resident sweeps."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2581

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5924,5 +5924,5 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Add MI300X GLM-5.2 FP8 AgentX discovery with native SGLang EAGLE MTP, golden AL 2.99, required SGLang metrics, and dense TP8/TEP8 c1-c8 resident sweeps."
+    - "Add MI300X GLM-5.2 FP8 AgentX with native SGLang EAGLE MTP and the verified resident Pareto matrix: TP8 c1-c3 plus TEP8 c3."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2581


### PR DESCRIPTION
## Summary

- add native upstream SGLang EAGLE MTP serving for GLM-5.2 FP8 on one 8xMI300X node
- run the verified resident Pareto matrix: TP8 c3 plus TEP8 c3
- collect and require SGLang metrics from the aggregate localhost endpoint

## Search-space rationale

Complete c1-c8 TP8/TEP8 fast discovery found a sharp content-quality cliff after c3. TP c1 repeatedly produced 3 metadata-only responses in 28 requests and exceeded the unchanged 10% quality gate; TP c2 exhausted HBM in two identical official long-context warmups. Both are excluded. TEP c1-c2 are dominated, and c4+ are unstable or off-frontier. An isolated TEP c3 HiCache test also exhausted device resources, so the official matrix remains GPU-resident.

## Validation

- generated and schema-validated the exact two-entry matrix
- `bash -n benchmarks/single_node/agentic/glm5.2_fp8_mi300x_mtp.sh`
- `uv run pytest utils/matrix_logic -q` (231 passed)
- `python3 utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark harness and YAML matrix registration only; no changes to serving core logic or auth/data paths.
> 
> **Overview**
> Adds **agentic-coding** coverage for **GLM-5.2 FP8** on a single **8×MI300X** node with upstream **SGLang EAGLE MTP**, wired through a new launch script and AMD master config key `glm5.2-fp8-mi300x-sglang-agentic-mtp`.
> 
> The launch script starts SGLang with long-context/DSA settings, **EAGLE** speculative decoding, GLM tool/reasoning parsers, and either **SWE-bench eval** or **trace replay**. Throughput replays use simulated acceptance length against the committed golden trace; replays also **require `sglang:` Prometheus metrics** from `localhost/metrics`. A **perf-changelog** entry documents the new matrix.
> 
> The official search space is intentionally narrow after fast discovery: only **TP8 @ c3** and **TEP8 @ c3** (GPU-resident KV, no offloading)—lower concurrency failed quality gates and higher concurrency hit quality or memory cliffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d22a04cb78d73116285396dee086cf23b49f113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->