### PR TITLE
[Klaud Cold] qwen3.5-fp4-mi355x-sglang-agentic-mtp: add HiCache DRAM offload arms / 为 MI355X Qwen3.5 FP4 SGLang AgentX MTP 新增 HiCache DRAM 卸载分支

### DIFF
--- a/benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh
@@ -11,7 +11,8 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 export EVAL_FRAMEWORK="lm-eval"
 
 check_env_vars \
-    MODEL TP CONC EP_SIZE RESULT_DIR DURATION
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 
 SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-30}
 
@@ -53,6 +54,99 @@ trap cleanup_agentic_services EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
+# Resident arms keep the page size the TP2/EP2 and TP4 sweeps were measured
+# with. HiCache arms move to 64 because Qwen3.5's hybrid attention/Mamba host
+# pools transfer page-first, and page size 1 fails the EAGLE verify-graph
+# compile on gfx950.
+CACHE_ARGS=()
+PAGE_SIZE=16
+if require_agentic_kv_offload_backend hicache; then
+    PAGE_SIZE=64
+
+    # sgl-project/sglang#30393 (merged 2026-08-06) routes an MTP draft KV cache
+    # to either a packed or a sidecar HiCache pool. Qwen3.5 conditional-
+    # generation checkpoints keep their language-model attributes in the nested
+    # text_config, and SGLang normalizes the draft depth only on the parent HF
+    # config, so ModelConfig.num_nextn_predict_layers stays None, the draft is
+    # misrouted to the sidecar path, and the scheduler dies during startup with
+    #   AttributeError: 'HybridLinearKVPool' object has no attribute 'layer_num'
+    # Apply the one-line fix from sgl-project/sglang#34560 until it ships in an
+    # MI355X image. Resident runs never reach this routing, so the patch stays
+    # scoped to the HiCache arms and leaves the measured resident data alone.
+    python3 - /sgl-workspace/sglang/python/sglang/srt/configs/model_config.py <<'PYPATCH'
+import sys
+
+path = sys.argv[1]
+anchor = 'self.hf_config.architectures[0] = "Qwen3_5ForCausalLMMTP"'
+assign = "self.hf_config.num_nextn_predict_layers = 1"
+fix = "self.hf_text_config.num_nextn_predict_layers = 1"
+
+with open(path) as fh:
+    lines = fh.readlines()
+
+matches = [i for i, line in enumerate(lines) if line.strip() == anchor]
+if len(matches) != 1:
+    sys.exit(f"sglang#34560: expected 1 Qwen3.5 MTP anchor in {path}, found {len(matches)}")
+
+i = matches[0]
+if lines[i + 1].strip() != assign:
+    sys.exit(f"sglang#34560: unexpected line after anchor in {path}: {lines[i + 1]!r}")
+if lines[i + 2].strip() == fix:
+    print("sglang#34560 already applied")
+    sys.exit(0)
+
+indent = lines[i + 1][: len(lines[i + 1]) - len(lines[i + 1].lstrip())]
+lines.insert(i + 2, f"{indent}{fix}\n")
+with open(path, "w") as fh:
+    fh.writelines(lines)
+print("sglang#34560 applied")
+PYPATCH
+
+    # --hicache-size is the per-rank budget SGLang splits across Qwen3.5's two
+    # hybrid host pools, not a per-pool figure: on this image at TP4 with
+    # --hicache-size 144 the ranks allocated 93.37 GB target KV + 50.65 GB Mamba
+    # = 144.02 GB each. Packed NEXTN then adds its single draft layer on top of
+    # the 60 transferred target layers. Hold the node to 80% of the workflow
+    # DRAM budget so the draft layer, page alignment, and the trace-replay
+    # client cannot walk the host into the OOM killer mid-storm.
+    HICACHE_ALIGNMENT_RESERVE_GB=$TP
+    HICACHE_USABLE_TOTAL_GB=$((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$HICACHE_USABLE_TOTAL_GB" -lt 1 ]; then
+        echo "Error: insufficient DRAM after HiCache alignment reserve." >&2
+        exit 1
+    fi
+    MAX_HICACHE_SIZE_GB=$((HICACHE_USABLE_TOTAL_GB * 80 / 100 * 60 / 61 / TP))
+    # 144 GB/rank is the largest pool observed to allocate on this image; 180
+    # is a bounded step up from it. Raise once a run confirms the larger pinned
+    # allocation stays inside the watchdog.
+    HICACHE_MAX_SIZE_GB_PER_RANK=${HICACHE_MAX_SIZE_GB_PER_RANK:-180}
+    if [ "$MAX_HICACHE_SIZE_GB" -gt "$HICACHE_MAX_SIZE_GB_PER_RANK" ]; then
+        MAX_HICACHE_SIZE_GB="$HICACHE_MAX_SIZE_GB_PER_RANK"
+    fi
+    HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
+    if [ "$HICACHE_SIZE_GB" -lt 1 ] || [ "$HICACHE_SIZE_GB" -gt "$MAX_HICACHE_SIZE_GB" ]; then
+        echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB." >&2
+        exit 1
+    fi
+    PROJECTED_HICACHE_TOTAL_GB=$(((HICACHE_SIZE_GB * TP * 61 + 59) / 60 + HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$PROJECTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: projected HiCache use ${PROJECTED_HICACHE_TOTAL_GB} GB exceeds configured ${TOTAL_CPU_DRAM_GB} GB." >&2
+        exit 1
+    fi
+    echo "HiCache pools: ${HICACHE_SIZE_GB} GB per rank across TP=${TP}; projected node total ${PROJECTED_HICACHE_TOTAL_GB} GB of ${TOTAL_CPU_DRAM_GB} GB."
+
+    # kernel + page_first is the transfer path the hybrid KV/Mamba stack already
+    # builds on gfx950 (both host pools and the pool-stack attach complete under
+    # it). write_through_selective matches the B300 Qwen3.5 MTP sibling.
+    CACHE_ARGS=(
+        --enable-hierarchical-cache
+        --hicache-size "$HICACHE_SIZE_GB"
+        --hicache-io-backend kernel
+        --hicache-mem-layout page_first
+        --hicache-write-policy write_through_selective
+    )
+fi
+
 PARALLEL_ARGS=(
     --tp "$TP"
     --dp 1
@@ -93,7 +187,7 @@ SGLANG_CMD=(
     --mem-fraction-static 0.80
     --model-loader-extra-config '{"enable_multithread_load": true}'
     --watchdog-timeout 1200
-    --page-size 16
+    --page-size "$PAGE_SIZE"
     --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --max-prefill-tokens 32768
@@ -110,6 +204,7 @@ SGLANG_CMD=(
     --speculative-num-draft-tokens 4
     --enable-metrics
     --enable-cache-report
+    "${CACHE_ARGS[@]}"
 )
 
 printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -386,10 +386,16 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+      # Isolating one HiCache point to prove sgl-project/sglang#34560 clears the
+      # HybridLinearKVPool draft-sidecar crash on gfx950. The resident arms are
+      # already merged and measured (#2562), so they stay commented out to keep
+      # this iteration off the MI355X node; restore all four rows once the
+      # HiCache path boots.
+      # - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
+      # - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
+      # - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+      # - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16] }
 
 qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -387,7 +387,9 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
 
 qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5903,4 +5903,4 @@
     - "Add HiCache DRAM KV-offload arms mirroring the resident TP2/EP2 and TP4 EAGLE MTP concurrency points, so every measured resident point has a host-tier counterpart."
     - "Run the HiCache arms at page size 64 with kernel io-backend and page_first layout, sized to 80 percent of the workflow DRAM budget at a 180 GB per-rank ceiling."
     - "Patch sgl-project/sglang#34560 into the container for the HiCache arms only: Qwen3.5 leaves num_nextn_predict_layers unset on hf_text_config, which misroutes the MTP draft cache to the sidecar path and aborts startup."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2582

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5894,3 +5894,13 @@
     - "Cover the measured resident TP2/EP2 and TP4 Pareto ranges through their HBM capacity knees, with required SGLang metrics exports."
     - "Use SGLang v0.5.17 and disable unstable AITER all-reduce fusion for TP2/EP2 EAGLE rank consistency."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2562
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add HiCache DRAM KV-offload arms mirroring the resident TP2/EP2 and TP4 EAGLE MTP concurrency points, so every measured resident point has a host-tier counterpart."
+    - "Run the HiCache arms at page size 64 with kernel io-backend and page_first layout, sized to 80 percent of the workflow DRAM budget at a 180 GB per-rank ceiling."
+    - "Patch sgl-project/sglang#34560 into the container for the HiCache arms only: Qwen3.5 leaves num_nextn_predict_layers unset on hf_text_config, which misroutes the MTP draft cache to the sidecar path and aborts startup."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5900,7 +5900,7 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Add HiCache DRAM KV-offload arms mirroring the resident TP2/EP2 and TP4 EAGLE MTP concurrency points, so every measured resident point has a host-tier counterpart."
-    - "Run the HiCache arms at page size 64 with kernel io-backend and page_first layout, sized to 80 percent of the workflow DRAM budget at a 180 GB per-rank ceiling."
+    - "Add HiCache DRAM KV-offload support to the recipe and isolate a single TP4 concurrency 16 point to prove the path boots on gfx950; the resident arms and the remaining HiCache points stay commented out for this iteration."
+    - "Run the HiCache arm at page size 64 with kernel io-backend and page_first layout, sized to 80 percent of the workflow DRAM budget at a 180 GB per-rank ceiling."
     - "Patch sgl-project/sglang#34560 into the container for the HiCache arms only: Qwen3.5 leaves num_nextn_predict_layers unset on hf_text_config, which misroutes the MTP draft cache to the sidecar path and aborts startup."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2582


### PR DESCRIPTION
## Summary / 概述

Adds HiCache DRAM KV-offload arms to `qwen3.5-fp4-mi355x-sglang-agentic-mtp`, mirroring **every** resident concurrency point merged in #2562 so each measured resident point has a host-tier counterpart. The resident arms are unchanged.

为 `qwen3.5-fp4-mi355x-sglang-agentic-mtp` 新增 HiCache DRAM KV 卸载分支，与 #2562 中合入的**每一个**常驻并发点一一对应，使每个已测常驻点都有对应的主机层数据点。常驻分支保持不变。

```yaml
- { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
+ { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
- { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+ { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
```

Generated matrix: 32 configs (6 + 6 + 10 + 10). / 生成的矩阵共 32 个配置（6 + 6 + 10 + 10）。

## Why the HiCache arms were dropped from #2562 / #2562 中删除 HiCache 分支的原因

Both HiCache arms attempted on `v0.5.17-rocm720-mi35x-20260811` ([run 31579113764](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31579113764)) died in scheduler init:

在 `v0.5.17-rocm720-mi35x-20260811` 上尝试的两个 HiCache 分支均在调度器初始化阶段失败：

```
File "sglang/srt/mem_cache/kv_cache_builder.py", line 81, in maybe_register_hicache_draft
File "sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py", line 936, in build_full_draft_pools
  if pool.layer_num == 0:
AttributeError: 'HybridLinearKVPool' object has no attribute 'layer_num'
```

The hybrid stack itself is healthy on gfx950 — the same logs show `93.37 GB` target KV and `50.65 GB` Mamba host pools allocating per rank under `page_first`, then `Attached hybrid pool stack to UnifiedRadixCache: pools=KV + MAMBA, transfer_layer_num=60`. Only the **MTP draft** pool crashes.

混合池本身在 gfx950 上是正常的：同一份日志显示每个 rank 在 `page_first` 布局下成功分配了 `93.37 GB` 目标 KV 与 `50.65 GB` Mamba 主机池，并完成 `Attached hybrid pool stack to UnifiedRadixCache`。仅 **MTP draft** 池崩溃。

Root cause (confirmed by upstream [sgl-project/sglang#34560](https://github.com/sgl-project/sglang/pull/34560)): Qwen3.5 conditional-generation checkpoints keep language-model attributes in the nested `text_config`. SGLang normalizes the MTP draft depth on the parent HF config only, so `ModelConfig.num_nextn_predict_layers` (derived from `hf_text_config`) stays `None`. The packed-vs-sidecar draft routing added in [sgl-project/sglang#30393](https://github.com/sgl-project/sglang/pull/30393) therefore misclassifies the draft cache as a *sidecar* and hits `pool.layer_num` on a pool that has no such attribute.

根因（已由上游 [sgl-project/sglang#34560](https://github.com/sgl-project/sglang/pull/34560) 确认）：Qwen3.5 将语言模型属性存放在嵌套的 `text_config` 中，而 SGLang 仅在父 HF config 上归一化 MTP draft 深度，导致由 `hf_text_config` 推导的 `ModelConfig.num_nextn_predict_layers` 保持为 `None`。[sgl-project/sglang#30393](https://github.com/sgl-project/sglang/pull/30393) 引入的 packed/sidecar 路由因此将 draft cache 误判为 *sidecar*，并在无该属性的池上访问 `pool.layer_num`。

**No image can avoid this.** #30393 merged 2026-08-06; the GDN chunked-extend padding fix this recipe requires for TP2/EP2 MTP ([sgl-project/sglang#33810](https://github.com/sgl-project/sglang/pull/33810)) merged 2026-08-07. There is no `sglang-rocm` mi35x build with the GDN fix and without the HiCache regression, and #34560 is still open upstream.

**无法通过换镜像规避。** #30393 于 2026-08-06 合入；本配方 TP2/EP2 MTP 所需的 GDN chunked-extend padding 修复（[#33810](https://github.com/sgl-project/sglang/pull/33810)）于 2026-08-07 合入。不存在既包含 GDN 修复又不含该 HiCache 回归的 `sglang-rocm` mi35x 构建，且 #34560 在上游仍未合入。

## Changes / 变更内容

- **`configs/amd-master.yaml`** — two HiCache rows mirroring the resident conc-lists. Image unchanged (`v0.5.17-rocm720-mi35x-20260811`). / 新增两行 HiCache 配置，镜像不变。
- **`benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh`**
  - Applies #34560's one-line fix to the in-container `model_config.py`, **gated to the HiCache arms** so the merged resident data stays byte-identical. The patcher is idempotent, derives its own indentation, and **exits non-zero if the anchor moves** so an image bump cannot silently skip it. Same precedent as the `qwen3.5_fp8_h200_mtp.sh` / `qwen3.5_fp8_h100_mtp.sh` in-container `sed`. / 仅在 HiCache 分支内对容器中的 `model_config.py` 应用 #34560 的单行修复；幂等、自动推导缩进，锚点失配时以非零码退出。
  - `--page-size 64` under HiCache (resident stays `16`), `--hicache-io-backend kernel`, `--hicache-mem-layout page_first`, `--hicache-write-policy write_through_selective` — matching the validated B300 Qwen3.5 MTP sibling and the transfer path the gfx950 logs already exercise. / HiCache 分支使用 page size 64 等参数，与已验证的 B300 Qwen3.5 MTP 同类配方一致。
  - Sizing corrected against measurement: `--hicache-size` is the **per-rank total** SGLang splits across the two hybrid pools (observed `144` → `93.37 + 50.65 = 144.02` GB/rank), not a per-pool figure as the earlier #2562 draft assumed. Budget is 80% of workflow DRAM, capped at 180 GB/rank, both overridable. / 依据实测修正容量计算：`--hicache-size` 是 SGLang 在两个混合池之间切分的**每 rank 总量**。
- **`perf-changelog.yaml`** — appended entry. / 追加条目。

## Validation / 验证

- `bash -n` on the recipe. / 配方通过 `bash -n`。
- Patcher unit-tested against the real upstream `model_config.py`: produces exactly #34560's one-line diff, is idempotent on re-run, and exits 1 when the anchor is absent. / 补丁脚本已针对真实上游 `model_config.py` 验证：产生与 #34560 完全一致的单行改动、可重复执行、锚点缺失时退出码为 1。
- `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD` → passed. / 通过。
- `utils/matrix_logic/test_generate_sweep_configs.py` → 105 passed. / 105 项通过。
- Matrix generation → 32 configs with the expected TP/EP/offload split and `TOTAL_CPU_DRAM_GB` 1199 (TP4) / 599 (TP2). / 矩阵生成结果符合预期。

The HiCache arms themselves are **unproven on hardware** — no MI355X run has gotten past scheduler init with HiCache + MTP on this model. The full sweep is the validation. / HiCache 分支**尚未经过硬件验证**，以完整 sweep 作为验证手段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
