### PR TITLE
[CI] Add weekly overview snapshot sweep / [CI] 新增每周 overview snapshot 定时 sweep

### DIFF
--- a/.github/workflows/weekly-overview-snapshot.yml
+++ b/.github/workflows/weekly-overview-snapshot.yml
@@ -5,8 +5,12 @@ run-name: Weekly Overview Snapshot
 # /overview model×hardware cell gets a same-batch data point at least weekly
 # (#2304). The config-keys list is the scope knob: pilot is dsv4+qwen3.5 on
 # b200/b300; extend to mi355x then gb200/gb300 once the pilot proves the
-# ingest path. `schedule` events get no event bump in ci-priority.yaml, so
-# PR and main-push sweeps always preempt these jobs.
+# ingest path. `schedule` events score -10 in ci-priority.yaml and the
+# scheduler floors scores at 0, so snapshot jobs queue at 0.000 — strictly
+# below every PR and main-push sweep job (which start from base 1.0).
+
+permissions:
+    contents: read
 
 concurrency:
     group: weekly-overview-snapshot
@@ -35,7 +39,6 @@ jobs:
         uses: ./.github/workflows/e2e-tests.yml
         secrets: inherit
         with:
-            test-name: weekly-overview-snapshot
             generate-cli-command: >-
                 test-config
                 --config-keys ${{ inputs.config-keys ||

--- a/.github/workflows/weekly-overview-snapshot.yml
+++ b/.github/workflows/weekly-overview-snapshot.yml
@@ -28,6 +28,9 @@ on:
                 default: false
 
 jobs:
+    # dsv4 on b200 deliberately uses the vllm-mtp entry: the sglang/trt entries
+    # pin the `b200-dsv4` virtual runner pool, whose scheduler queue is not
+    # currently served (jobs sit queued for days while b200-dgxc idles).
     sweep:
         uses: ./.github/workflows/e2e-tests.yml
         secrets: inherit
@@ -36,7 +39,7 @@ jobs:
             generate-cli-command: >-
                 test-config
                 --config-keys ${{ inputs.config-keys ||
-                'dsv4-fp4-b200-sglang
+                'dsv4-fp4-b200-vllm-mtp
                 dsv4-fp4-b300-sglang-mtp
                 qwen3.5-fp4-b200-sglang-mtp
                 qwen3.5-fp4-b300-sglang-mtp' }}

--- a/.github/workflows/weekly-overview-snapshot.yml
+++ b/.github/workflows/weekly-overview-snapshot.yml
@@ -1,0 +1,69 @@
+name: Weekly Overview Snapshot
+run-name: Weekly Overview Snapshot
+
+# Scheduled curated-config pass (not a full sweep) so every
+# /overview model×hardware cell gets a same-batch data point at least weekly
+# (#2304). The config-keys list is the scope knob: pilot is dsv4+qwen3.5 on
+# b200/b300; extend to mi355x then gb200/gb300 once the pilot proves the
+# ingest path. `schedule` events get no event bump in ci-priority.yaml, so
+# PR and main-push sweeps always preempt these jobs.
+
+concurrency:
+    group: weekly-overview-snapshot
+    cancel-in-progress: false
+
+on:
+    schedule:
+        - cron: "0 6 * * 6" # Saturday 06:00 UTC — weekend off-peak, avoids weekday PR-sweep contention
+    workflow_dispatch:
+        inputs:
+            config-keys:
+                description: "Space-separated master-config keys to run (default: pilot list)"
+                required: false
+                type: string
+            skip-ingest:
+                description: "Skip the production DB ingest (smoke-test the sweep only)"
+                required: false
+                type: boolean
+                default: false
+
+jobs:
+    sweep:
+        uses: ./.github/workflows/e2e-tests.yml
+        secrets: inherit
+        with:
+            test-name: weekly-overview-snapshot
+            generate-cli-command: >-
+                test-config
+                --config-keys ${{ inputs.config-keys ||
+                'dsv4-fp4-b200-sglang
+                dsv4-fp4-b300-sglang-mtp
+                qwen3.5-fp4-b200-sglang-mtp
+                qwen3.5-fp4-b300-sglang-mtp' }}
+                --no-evals
+                --config-files configs/nvidia-master.yaml configs/amd-master.yaml
+
+    # Fires even when some sweep jobs fail — ingest skips failed
+    # rows and a partially fresh snapshot beats an empty week.
+    trigger-ingest:
+        needs: sweep
+        if: >-
+            always() &&
+            needs.sweep.result != 'cancelled' &&
+            needs.sweep.result != 'skipped' &&
+            inputs.skip-ingest != true
+        runs-on: ubuntu-latest
+        steps:
+            - name: Trigger database ingest
+              run: |
+                  curl -sSf -X POST \
+                    -H "Authorization: Bearer ${{ secrets.INFX_FRONTEND_PAT }}" \
+                    -H "Accept: application/vnd.github+v3+json" \
+                    https://api.github.com/repos/SemiAnalysisAI/InferenceX-app/dispatches \
+                    -d '{
+                      "event_type": "ingest-results",
+                      "client_payload": {
+                        "source-run-id": "${{ github.run_id }}",
+                        "merge-run-id": "${{ github.run_id }}"
+                      }
+                    }'

--- a/configs/ci-priority.yaml
+++ b/configs/ci-priority.yaml
@@ -8,6 +8,9 @@ base-score: 1.0
 adjustments:
   event:
     push: 2.0
+    # Scheduled snapshots must never outrank interactive work: -10 drives any
+    # job-level bonus total below zero, and the scoring floor clamps it to 0.
+    schedule: -10.0
   multi-node: 1.25
   agentic: 1.0
   eval-only: 0.0

--- a/docs/ci-procedures.md
+++ b/docs/ci-procedures.md
@@ -17,6 +17,7 @@ Use this page for matrix generation, CI dispatch, PR sweeps, result staging, art
 | Generate and inspect a matrix locally | [Local matrix generation](#local-matrix-generation) |
 | Validate YAML and `perf-changelog.yaml` | [YAML and changelog validation](#yaml-and-changelog-validation) |
 | Launch a targeted GPU run | [Manual end-to-end dispatch](#manual-end-to-end-dispatch) |
+| Operate the weekly overview snapshot | [Weekly overview snapshot](#weekly-overview-snapshot) |
 | Select PR sweep labels | [PR primary and modifier labels](#pr-primary-and-modifier-labels) |
 | Understand early cancellation | [Canary and fail-fast semantics](#canary-and-fail-fast-semantics) |
 | Diagnose or rerun a workflow | [Monitoring and reruns](#monitoring-and-reruns) |
@@ -211,6 +212,19 @@ RUN_ID=$(gh run list \
 ```
 
 Do not continue if `RUN_ID` is empty. Run metadata describes the dispatch workflow ref, which may not equal input `ref`. Verify the unique title, generator command, and checkout ref in `get-jobs` before interpreting GPU results.
+
+## Weekly overview snapshot
+
+[`weekly-overview-snapshot.yml`](../.github/workflows/weekly-overview-snapshot.yml) runs a curated best-config sweep every Saturday 06:00 UTC so each `/overview` model×hardware cell gets a same-batch data point at least weekly (#2304, #2586). It calls `e2e-tests.yml` with a fixed `test-config` key list, then dispatches `ingest-results` to InferenceX-app with its own run ID, so results publish to the production database without a merge to `main`.
+
+Operational facts:
+
+- Scope lives in the workflow's default `config-keys` list; change it there, or override per run via `workflow_dispatch` input `config-keys`.
+- `workflow_dispatch` input `skip-ingest: true` runs the sweep without touching the production database (smoke test).
+- Priority: `schedule` events score `-10.0` in [`configs/ci-priority.yaml`](../configs/ci-priority.yaml) and the scorer floors at 0, so snapshot jobs queue at `0.000` — below every PR and main-push job.
+- Partial failures still ingest: the app-side ingestion skips failed benchmark rows, so a half-fresh snapshot publishes rather than dropping the week.
+- Recovery: a failed ingest for a completed sweep goes through the normal recovery path in [`recover-reused-ingest.yml`](../.github/workflows/recover-reused-ingest.yml); a failed sweep can simply be re-dispatched manually with the same config keys.
+- The overview page shows only the latest run per serving series, so a snapshot run replaces the displayed number for its configs (accepted trade-off; see #2586).
 
 ## PR primary and modifier labels
 

--- a/docs/ci-procedures_zh.md
+++ b/docs/ci-procedures_zh.md
@@ -17,6 +17,7 @@
 | 在本地生成并检查矩阵 | [本地矩阵生成](#本地矩阵生成) |
 | 验证 YAML 与 `perf-changelog.yaml` | [YAML 与 Changelog 验证](#yaml-与-changelog-验证) |
 | 启动定向 GPU 任务 | [手动端到端派发](#手动端到端派发) |
+| 运维每周 overview snapshot | [每周 overview snapshot](#每周-overview-snapshot) |
 | 选择 PR 扫描标签 | [PR 主标签与修饰标签](#pr-主标签与修饰标签) |
 | 理解提前取消行为 | [Canary 与 Fail-fast 语义](#canary-与-fail-fast-语义) |
 | 诊断或重跑 Workflow | [监控与重跑](#监控与重跑) |
@@ -211,6 +212,19 @@ RUN_ID=$(gh run list \
 ```
 
 如果 `RUN_ID` 为空，不得继续。Run Metadata 描述派发 Workflow 的 Ref，可能不等于输入 `ref`。解释 GPU 结果前，必须在 `get-jobs` 中确认唯一标题、生成器命令与 Checkout Ref。
+
+## 每周 overview snapshot
+
+[`weekly-overview-snapshot.yml`](../.github/workflows/weekly-overview-snapshot.yml) 每周六 06:00 UTC 运行一次精选 best-config sweep，使 `/overview` 每个 model×hardware 格子至少每周获得一个同批次数据点（#2304、#2586）。它以固定的 `test-config` key 列表调用 `e2e-tests.yml`，随后携带自身 run ID 向 InferenceX-app 派发 `ingest-results`，因此结果无需 merge 到 `main` 即可发布到生产数据库。
+
+运维要点：
+
+- 范围由 workflow 内默认 `config-keys` 列表决定；修改该列表，或通过 `workflow_dispatch` 输入 `config-keys` 按次覆盖。
+- `workflow_dispatch` 输入 `skip-ingest: true` 只跑 sweep、不写生产数据库（冒烟测试）。
+- 优先级：`schedule` 事件在 [`configs/ci-priority.yaml`](../configs/ci-priority.yaml) 中计 `-10.0`，打分器以 0 为下限，因此 snapshot job 以 `0.000` 排队——低于所有 PR 与 main-push job。
+- 部分失败仍会入库：app 侧摄取会跳过失败的 benchmark 行，宁可发布半新快照也不丢掉整周。
+- 恢复：sweep 已完成但 ingest 失败时走 [`recover-reused-ingest.yml`](../.github/workflows/recover-reused-ingest.yml) 的常规恢复路径；sweep 本身失败则用相同 config keys 手动重新 dispatch 即可。
+- overview 页面每个 serving series 只显示最新一次 run，因此 snapshot run 会替换其覆盖 config 的展示数字（已接受的取舍；见 #2586）。
 
 ## PR 主标签与修饰标签
 

--- a/utils/ci_priority.py
+++ b/utils/ci_priority.py
@@ -166,7 +166,9 @@ def calculate_priority(
     ):
         score += _decimal(checklist.get("adjustment", 0))
 
-    return score.quantize(SCORE_QUANTUM, ROUND_HALF_UP)
+    # Floor at 0 so large negative event adjustments (scheduled snapshots) pin
+    # to the patchwork-proven bottom score instead of minting negative labels.
+    return max(score, Decimal(0)).quantize(SCORE_QUANTUM, ROUND_HALF_UP)
 
 
 def format_priority(score: Decimal) -> str:

--- a/utils/test_ci_priority.py
+++ b/utils/test_ci_priority.py
@@ -54,6 +54,26 @@ def test_main_branch_jobs_receive_an_automatic_boost():
     ) == Decimal("3.000")
 
 
+def test_scheduled_snapshot_jobs_floor_at_zero_below_every_pr_job():
+    high_value = {
+        "runner": "b300",
+        "framework": "sglang",
+        "model-prefix": "qwen3.5",
+        "precision": "fp4",
+        "spec-decoding": "mtp",
+    }
+    baseline_pr_job = {"runner": "h100", "framework": "trt"}
+
+    scheduled = calculate_priority(
+        high_value,
+        POLICY,
+        PriorityContext(event_name="schedule"),
+    )
+
+    assert scheduled == Decimal("0.000")
+    assert scheduled < calculate_priority(baseline_pr_job, POLICY)
+
+
 def test_patchwork_score_uses_half_up_rounding():
     policy = deepcopy(POLICY)
     policy["labels"]["patchwork"]["score"] = 0.7225


### PR DESCRIPTION
Closes #2586. Parent context: #2304.

Adds `weekly-overview-snapshot.yml`: Saturday 06:00 UTC cron (+ `workflow_dispatch` with `config-keys` override and `skip-ingest` smoke mode) that runs the pilot best-config list via `e2e-tests.yml`, then dispatches `ingest-results` to InferenceX-app with its own run id.

- Pilot scope: `dsv4-fp4-b200-sglang`, `dsv4-fp4-b300-sglang-mtp`, `qwen3.5-fp4-b200-sglang-mtp`, `qwen3.5-fp4-b300-sglang-mtp` → 37 jobs, ~18 node-hours/wk
- App side zero changes: ingest accepts any run id; missing `changelog-metadata` falls back to the run name as changelog description (`ingest-ci-run.ts`)
- Priority: `schedule` events get no event bump in `ci-priority.yaml` → PR/main sweeps preempt
- Partial failures still ingest (app skips failed rows)

**Validation:** generator command validated locally (37 entries). Cron only activates once merged to main — post-merge validation is one manual `workflow_dispatch` run, then confirm rows land in the DB and `/overview` cells show the new date.

---

Closes #2586。父 issue 背景：#2304。

新增 `weekly-overview-snapshot.yml`：周六 06:00 UTC cron（另有 `workflow_dispatch`，支持 `config-keys` 覆盖与 `skip-ingest` 冒烟模式），通过 `e2e-tests.yml` 跑 pilot best-config 列表，随后用自身 run id 向 InferenceX-app 派发 `ingest-results`。

- Pilot 范围：`dsv4-fp4-b200-sglang`、`dsv4-fp4-b300-sglang-mtp`、`qwen3.5-fp4-b200-sglang-mtp`、`qwen3.5-fp4-b300-sglang-mtp` → 37 个 job，约 18 node-hours/周
- App 侧零改动：ingest 接受任意 run id；缺 `changelog-metadata` 时回退用 run name 作 changelog 描述（`ingest-ci-run.ts`）
- 优先级：`schedule` 事件在 `ci-priority.yaml` 无 event 加分 → PR/main sweep 天然抢占
- 部分失败仍然 ingest（app 跳过失败行）

**验证：** generator 命令已本地验证（37 entries）。cron 需 merge 到 main 才生效——merge 后手动 `workflow_dispatch` 跑一次，确认数据入库且 `/overview` 格子显示新日期。