### PR TITLE
[NV][AgentX] Add GB200 GLM-5.2 FP4 MTP sweep

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml
@@ -50,26 +50,30 @@ backend:
       max-prefill-tokens: 8192
       context-length: 1048576
       speculative-algorithm: EAGLE
-      speculative-num-steps: 4
+      speculative-num-steps: 3
       speculative-eagle-topk: 1
-      speculative-num-draft-tokens: 5
+      speculative-num-draft-tokens: 4
       nsa-prefill-backend: trtllm
       nsa-decode-backend: trtllm
+      bf16-gemm-backend: cutedsl
       moe-runner-backend: flashinfer_trtllm
       fp4-gemm-backend: flashinfer_trtllm
       disable-shared-experts-fusion: true
       enable-flashinfer-allreduce-fusion: true
       weight-loader-prefetch-checkpoints: true
       model-loader-extra-config: '{"enable_multithread_load": true}'
-      mem-fraction-static: 0.8
+      mem-fraction-static: 0.83
       enable-hierarchical-cache: true
       hicache-write-policy: write_back
       hicache-size: 135
       hicache-io-backend: direct
+      hicache-mem-layout: page_first_direct
+      watchdog-timeout: 1800
       enable-metrics: true
       enable-cache-report: true
   aggregated_environment:
     TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+    SGLANG_TIMEOUT_KEEP_ALIVE: '900'
     PYTHONUNBUFFERED: '1'
     DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
     MC_TE_METRIC: 'true'
@@ -84,7 +88,7 @@ backend:
     SGLANG_MOE_NVFP4_DISPATCH: '1'
     SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE: '1'
     SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION: '8'
-    SGLANG_SIMULATE_ACC_LEN: '3.33'
+    SGLANG_SIMULATE_ACC_LEN: '2.99'
     SGLANG_SIMULATE_ACC_METHOD: match-expected
     SGLANG_SIMULATE_ACC_TOKEN_MODE: real-draft-token
     PIP_BREAK_SYSTEM_PACKAGES: '1'
@@ -107,6 +111,9 @@ benchmark:
     PORT: '8000'
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_HTTP_TCP_USER_TIMEOUT: '900000'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
 infra:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml
@@ -1,0 +1,120 @@
+name: gb200-fp4-glm5.2-agentx-agg
+model:
+  path: glm-5.2-fp4
+  container: dynamo-sglang
+  precision: fp4
+identity:
+  model:
+    repo: nvidia/GLM-5.2-NVFP4
+    revision: aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa
+  container:
+    image: lmsysorg/sglang:v0.5.17-cu130
+  frameworks:
+    dynamo: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
+    sglang: 0.5.17
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+  gpus_per_agg: 8
+frontend:
+  type: dynamo
+  env:
+    PIP_BREAK_SYSTEM_PACKAGES: '1'
+  args:
+    router-mode: kv
+    active-decode-blocks-threshold: None
+    active-prefill-tokens-threshold: None
+    active-prefill-tokens-threshold-frac: None
+    router-session-affinity-ttl-secs: 3600
+dynamo:
+  hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
+  install: true
+backend:
+  type: sglang
+  sglang_config:
+    aggregated:
+      served-model-name: nvidia/GLM-5.2-NVFP4
+      trust-remote-code: true
+      quantization: modelopt_fp4
+      kv-cache-dtype: fp8_e4m3
+      tensor-parallel-size: 8
+      data-parallel-size: 1
+      expert-parallel-size: 1
+      enable-dp-attention: false
+      enable-dp-lm-head: false
+      max-running-requests: 10
+      cuda-graph-max-bs: 10
+      chunked-prefill-size: 8192
+      max-prefill-tokens: 8192
+      context-length: 1048576
+      speculative-algorithm: EAGLE
+      speculative-num-steps: 4
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 5
+      nsa-prefill-backend: trtllm
+      nsa-decode-backend: trtllm
+      moe-runner-backend: flashinfer_trtllm
+      fp4-gemm-backend: flashinfer_trtllm
+      disable-shared-experts-fusion: true
+      enable-flashinfer-allreduce-fusion: true
+      weight-loader-prefetch-checkpoints: true
+      model-loader-extra-config: '{"enable_multithread_load": true}'
+      mem-fraction-static: 0.8
+      enable-hierarchical-cache: true
+      hicache-write-policy: write_back
+      hicache-size: 135
+      hicache-io-backend: direct
+      enable-metrics: true
+      enable-cache-report: true
+  aggregated_environment:
+    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+    PYTHONUNBUFFERED: '1'
+    DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
+    MC_TE_METRIC: 'true'
+    NCCL_CUMEM_ENABLE: '1'
+    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: '0'
+    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: '1'
+    SGLANG_ENABLE_THINKING: '1'
+    SGLANG_REASONING_EFFORT: max
+    SGLANG_ENABLE_UNIFIED_RADIX_TREE: '1'
+    SGLANG_HICACHE_DEBUG_LOG: '1'
+    SGLANG_HICACHE_DEBUG_SAMPLE_RATE: '16384'
+    SGLANG_MOE_NVFP4_DISPATCH: '1'
+    SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE: '1'
+    SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION: '8'
+    SGLANG_SIMULATE_ACC_LEN: '3.33'
+    SGLANG_SIMULATE_ACC_METHOD: match-expected
+    SGLANG_SIMULATE_ACC_TOKEN_MODE: real-draft-token
+    PIP_BREAK_SYSTEM_PACKAGES: '1'
+    SGLANG_DG_CACHE_DIR: /deepgemm_cache
+    FLASHINFER_WORKSPACE_BASE: /flashinfer_cache
+    MC_FORCE_MNNVL: '1'
+    NCCL_MNNVL_ENABLE: '1'
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
+    UCX_TLS: ib,cuda_copy,cuda_ipc,sm,self
+    NVSHMEM_REMOTE_TRANSPORT: none
+health_check:
+  max_attempts: 1440
+  interval_seconds: 10
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 64
+sbatch_directives:
+  mem: '0'
+  cpus-per-task: '144'
+srun_options:
+  mem: '0'
+  container-remap-root: ''

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml
@@ -25,6 +25,9 @@ base:
       PIP_BREAK_SYSTEM_PACKAGES: '1'
     args:
       router-mode: kv
+      router-kv-events: true
+      router-temperature: 0
+      kv-cache-block-size: 64
       active-decode-blocks-threshold: None
       active-prefill-tokens-threshold: None
       active-prefill-tokens-threshold-frac: None
@@ -34,8 +37,10 @@ base:
     install: true
   backend:
     type: sglang
+    kv_events_config: true
     prefill_environment:
       TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+      SGLANG_TIMEOUT_KEEP_ALIVE: '900'
       PYTHONUNBUFFERED: '1'
       DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
       SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
@@ -58,9 +63,13 @@ base:
       NVSHMEM_REMOTE_TRANSPORT: none
       SGLANG_DG_CACHE_DIR: /deepgemm_cache
       FLASHINFER_WORKSPACE_BASE: /flashinfer_cache
-      SGLANG_SIMULATE_ACC_LEN: '2.5'
+      SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK: '2048'
+      SGLANG_SIMULATE_ACC_LEN: '2.99'
+      SGLANG_SIMULATE_ACC_METHOD: match-expected
+      SGLANG_SIMULATE_ACC_TOKEN_MODE: real-draft-token
     decode_environment:
       TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+      SGLANG_TIMEOUT_KEEP_ALIVE: '900'
       PYTHONUNBUFFERED: '1'
       DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
       SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
@@ -84,7 +93,8 @@ base:
       NVSHMEM_REMOTE_TRANSPORT: none
       SGLANG_DG_CACHE_DIR: /deepgemm_cache
       FLASHINFER_WORKSPACE_BASE: /flashinfer_cache
-      SGLANG_SIMULATE_ACC_LEN: '2.5'
+      SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK: '2048'
+      SGLANG_SIMULATE_ACC_LEN: '2.99'
       SGLANG_SIMULATE_ACC_METHOD: match-expected
       SGLANG_SIMULATE_ACC_TOKEN_MODE: real-draft-token
     sglang_config:
@@ -96,33 +106,41 @@ base:
         disaggregation-mode: prefill
         disaggregation-transfer-backend: nixl
         tensor-parallel-size: 4
-        data-parallel-size: 4
-        expert-parallel-size: 4
-        enable-dp-attention: true
-        enable-dp-lm-head: true
+        attn-cp-size: 1
+        enable-prefill-cp: false
+        enable-dsa-cache-layer-split: false
+        data-parallel-size: 1
+        expert-parallel-size: 1
+        enable-dp-attention: false
+        enable-dp-lm-head: false
         load-balance-method: total_tokens
-        chunked-prefill-size: 65536
-        max-prefill-tokens: 16384
-        max-running-requests: 16
-        cuda-graph-max-bs: 16
+        chunked-prefill-size: 32768
+        max-prefill-tokens: 8192
+        max-total-tokens: 1048576
+        max-running-requests: 64
+        cuda-graph-max-bs: 64
         disable-cuda-graph: true
         nsa-prefill-backend: trtllm
         nsa-decode-backend: trtllm
-        moe-runner-backend: flashinfer_cutlass
-        fp4-gemm-backend: flashinfer_cutlass
+        bf16-gemm-backend: cutedsl
+        moe-runner-backend: flashinfer_trtllm
+        fp4-gemm-backend: flashinfer_trtllm
+        disable-shared-experts-fusion: true
         enable-flashinfer-allreduce-fusion: true
         weight-loader-prefetch-checkpoints: true
         model-loader-extra-config: '{"enable_multithread_load": true}'
-        mem-fraction-static: 0.8
+        mem-fraction-static: 0.83
         context-length: 1048576
         enable-hierarchical-cache: true
         hicache-write-policy: write_back
         hicache-size: 135
         hicache-io-backend: direct
+        hicache-mem-layout: page_first_direct
         speculative-algorithm: EAGLE
-        speculative-num-steps: 1
+        speculative-num-steps: 3
         speculative-eagle-topk: 1
-        speculative-num-draft-tokens: 2
+        speculative-num-draft-tokens: 4
+        watchdog-timeout: 1800
         enable-metrics: true
         enable-cache-report: true
       decode:
@@ -134,22 +152,23 @@ base:
         disaggregation-transfer-backend: nixl
         disable-radix-cache: true
         speculative-algorithm: EAGLE
-        speculative-num-steps: 2
+        speculative-num-steps: 3
         speculative-eagle-topk: 1
-        speculative-num-draft-tokens: 3
+        speculative-num-draft-tokens: 4
         tensor-parallel-size: 4
         data-parallel-size: 1
         expert-parallel-size: 1
         enable-dp-attention: false
         enable-dp-lm-head: false
-        max-running-requests: 16
-        cuda-graph-max-bs: 16
+        max-running-requests: 64
+        cuda-graph-max-bs: 64
         chunked-prefill-size: 64
         context-length: 1048576
         nsa-prefill-backend: trtllm
         nsa-decode-backend: trtllm
+        bf16-gemm-backend: cutedsl
         moe-runner-backend: flashinfer_trtllm
-        fp4-gemm-backend: flashinfer_cutlass
+        fp4-gemm-backend: flashinfer_trtllm
         skip-tokenizer-init: true
         stream-interval: 30
         enable-flashinfer-allreduce-fusion: true
@@ -157,6 +176,7 @@ base:
         model-loader-extra-config: '{"enable_multithread_load": true}'
         mem-fraction-static: 0.9
         disaggregation-decode-extra-slots: 0
+        watchdog-timeout: 1800
         enable-metrics: true
         enable-cache-report: true
   health_check:
@@ -171,6 +191,9 @@ base:
       PORT: '8000'
       IS_MULTINODE: 'true'
       AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+      AIPERF_HTTP_TCP_USER_TIMEOUT: '900000'
+      AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+      AIPERF_REQUIRED_SERVER_METRIC_PREFIX: 'sglang:'
       AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
       HF_HUB_CACHE: /hf_hub_cache
   infra:
@@ -183,46 +206,11 @@ base:
     mem: '0'
     container-remap-root: ''
 
-zip_override_mtp_agentx_hightpt:
-  name: [agentx-2p1d-dep16]
-  backend:
-    sglang_config:
-      decode:
-        cuda-graph-max-bs: 144
-        data-parallel-size: 16
-        deepep-config: /configs/deepep_config.json
-        deepep-mode: low_latency
-        enable-dp-attention: true
-        enable-dp-lm-head: true
-        ep-dispatch-algorithm: static
-        ep-num-redundant-experts: 0
-        expert-parallel-size: 16
-        max-running-requests: 144
-        mem-fraction-static: 0.85
-        moe-a2a-backend: deepep
-        moe-dense-tp-size: 1
-        moe-runner-backend: flashinfer_cutedsl
-        speculative-moe-a2a-backend: deepep
-        speculative-moe-runner-backend: deep_gemm
-        tensor-parallel-size: 16
-      prefill:
-        data-parallel-size: 8
-        expert-parallel-size: 8
-        max-prefill-tokens: 8192
-        tensor-parallel-size: 8
+zip_override_mtp_agentx_frontier:
+  name: [agentx-1p1d-tp4-hicache]
   resources:
-    decode_nodes: 4
+    decode_nodes: 1
     decode_workers: 1
-    gpus_per_decode: 16
-    gpus_per_prefill: 8
-    prefill_nodes: 4
-    prefill_workers: 2
-
-zip_override_mtp_agentx_lowlat:
-  name: [agentx-1p2d-tp4, agentx-1p4d-tp4, agentx-1p6d-tp4]
-  resources:
-    decode_nodes: [2, 4, 6]
-    decode_workers: [2, 4, 6]
     gpus_per_decode: 4
     gpus_per_prefill: 4
     prefill_nodes: 1

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml
@@ -1,0 +1,229 @@
+base:
+  name: gb200-fp4-glm5.2-agentx
+  model:
+    path: glm-5.2-fp4
+    container: dynamo-sglang
+    precision: fp4
+  identity:
+    model:
+      repo: nvidia/GLM-5.2-NVFP4
+      revision: aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa
+    container:
+      image: lmsysorg/sglang:v0.5.17-cu130
+    frameworks:
+      dynamo: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
+      sglang: 0.5.17
+  resources:
+    gpu_type: gb200
+    gpus_per_node: 4
+  frontend:
+    type: dynamo
+    nginx_session_affinity: true
+    nginx_session_affinity_header: X-Dynamo-Session-ID
+    enable_multiple_frontends: true
+    env:
+      PIP_BREAK_SYSTEM_PACKAGES: '1'
+    args:
+      router-mode: kv
+      active-decode-blocks-threshold: None
+      active-prefill-tokens-threshold: None
+      active-prefill-tokens-threshold-frac: None
+      router-session-affinity-ttl-secs: 3600
+  dynamo:
+    hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
+    install: true
+  backend:
+    type: sglang
+    prefill_environment:
+      TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+      PYTHONUNBUFFERED: '1'
+      DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
+      SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
+      SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
+      SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
+      MC_TE_METRIC: 'true'
+      MC_FORCE_MNNVL: '1'
+      NCCL_MNNVL_ENABLE: '1'
+      NCCL_CUMEM_ENABLE: '1'
+      SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
+      SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: '0'
+      SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: '1'
+      SGLANG_ENABLE_THINKING: '1'
+      SGLANG_ENABLE_UNIFIED_RADIX_TREE: '1'
+      SGLANG_HICACHE_DEBUG_LOG: '1'
+      SGLANG_HICACHE_DEBUG_SAMPLE_RATE: '16384'
+      SGLANG_REASONING_EFFORT: max
+      PIP_BREAK_SYSTEM_PACKAGES: '1'
+      UCX_TLS: ib,cuda_copy,cuda_ipc,sm,self
+      NVSHMEM_REMOTE_TRANSPORT: none
+      SGLANG_DG_CACHE_DIR: /deepgemm_cache
+      FLASHINFER_WORKSPACE_BASE: /flashinfer_cache
+      SGLANG_SIMULATE_ACC_LEN: '2.5'
+    decode_environment:
+      TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
+      PYTHONUNBUFFERED: '1'
+      DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
+      SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
+      SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
+      SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
+      MC_TE_METRIC: 'true'
+      MC_FORCE_MNNVL: '1'
+      NCCL_MNNVL_ENABLE: '1'
+      NCCL_CUMEM_ENABLE: '1'
+      SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
+      SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: '0'
+      SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: '1'
+      SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK: '512'
+      SGLANG_MOE_NVFP4_DISPATCH: '1'
+      SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE: '1'
+      SGLANG_ENABLE_THINKING: '1'
+      SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION: '8'
+      SGLANG_REASONING_EFFORT: max
+      PIP_BREAK_SYSTEM_PACKAGES: '1'
+      UCX_TLS: ib,cuda_copy,cuda_ipc,sm,self
+      NVSHMEM_REMOTE_TRANSPORT: none
+      SGLANG_DG_CACHE_DIR: /deepgemm_cache
+      FLASHINFER_WORKSPACE_BASE: /flashinfer_cache
+      SGLANG_SIMULATE_ACC_LEN: '2.5'
+      SGLANG_SIMULATE_ACC_METHOD: match-expected
+      SGLANG_SIMULATE_ACC_TOKEN_MODE: real-draft-token
+    sglang_config:
+      prefill:
+        served-model-name: nvidia/GLM-5.2-NVFP4
+        trust-remote-code: true
+        quantization: modelopt_fp4
+        kv-cache-dtype: fp8_e4m3
+        disaggregation-mode: prefill
+        disaggregation-transfer-backend: nixl
+        tensor-parallel-size: 4
+        data-parallel-size: 4
+        expert-parallel-size: 4
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        load-balance-method: total_tokens
+        chunked-prefill-size: 65536
+        max-prefill-tokens: 16384
+        max-running-requests: 16
+        cuda-graph-max-bs: 16
+        disable-cuda-graph: true
+        nsa-prefill-backend: trtllm
+        nsa-decode-backend: trtllm
+        moe-runner-backend: flashinfer_cutlass
+        fp4-gemm-backend: flashinfer_cutlass
+        enable-flashinfer-allreduce-fusion: true
+        weight-loader-prefetch-checkpoints: true
+        model-loader-extra-config: '{"enable_multithread_load": true}'
+        mem-fraction-static: 0.8
+        context-length: 1048576
+        enable-hierarchical-cache: true
+        hicache-write-policy: write_back
+        hicache-size: 135
+        hicache-io-backend: direct
+        speculative-algorithm: EAGLE
+        speculative-num-steps: 1
+        speculative-eagle-topk: 1
+        speculative-num-draft-tokens: 2
+        enable-metrics: true
+        enable-cache-report: true
+      decode:
+        served-model-name: nvidia/GLM-5.2-NVFP4
+        trust-remote-code: true
+        quantization: modelopt_fp4
+        kv-cache-dtype: fp8_e4m3
+        disaggregation-mode: decode
+        disaggregation-transfer-backend: nixl
+        disable-radix-cache: true
+        speculative-algorithm: EAGLE
+        speculative-num-steps: 2
+        speculative-eagle-topk: 1
+        speculative-num-draft-tokens: 3
+        tensor-parallel-size: 4
+        data-parallel-size: 1
+        expert-parallel-size: 1
+        enable-dp-attention: false
+        enable-dp-lm-head: false
+        max-running-requests: 16
+        cuda-graph-max-bs: 16
+        chunked-prefill-size: 64
+        context-length: 1048576
+        nsa-prefill-backend: trtllm
+        nsa-decode-backend: trtllm
+        moe-runner-backend: flashinfer_trtllm
+        fp4-gemm-backend: flashinfer_cutlass
+        skip-tokenizer-init: true
+        stream-interval: 30
+        enable-flashinfer-allreduce-fusion: true
+        weight-loader-prefetch-checkpoints: true
+        model-loader-extra-config: '{"enable_multithread_load": true}'
+        mem-fraction-static: 0.9
+        disaggregation-decode-extra-slots: 0
+        enable-metrics: true
+        enable-cache-report: true
+  health_check:
+    max_attempts: 1440
+    interval_seconds: 10
+  benchmark:
+    type: custom
+    command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+    env:
+      INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+      RESULT_DIR: /logs/agentic
+      PORT: '8000'
+      IS_MULTINODE: 'true'
+      AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+      AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+      HF_HUB_CACHE: /hf_hub_cache
+  infra:
+    etcd_nats_dedicated_node: false
+    nats_max_payload_mb: 64
+  sbatch_directives:
+    mem: '0'
+    cpus-per-task: '144'
+  srun_options:
+    mem: '0'
+    container-remap-root: ''
+
+zip_override_mtp_agentx_hightpt:
+  name: [agentx-2p1d-dep16]
+  backend:
+    sglang_config:
+      decode:
+        cuda-graph-max-bs: 144
+        data-parallel-size: 16
+        deepep-config: /configs/deepep_config.json
+        deepep-mode: low_latency
+        enable-dp-attention: true
+        enable-dp-lm-head: true
+        ep-dispatch-algorithm: static
+        ep-num-redundant-experts: 0
+        expert-parallel-size: 16
+        max-running-requests: 144
+        mem-fraction-static: 0.85
+        moe-a2a-backend: deepep
+        moe-dense-tp-size: 1
+        moe-runner-backend: flashinfer_cutedsl
+        speculative-moe-a2a-backend: deepep
+        speculative-moe-runner-backend: deep_gemm
+        tensor-parallel-size: 16
+      prefill:
+        data-parallel-size: 8
+        expert-parallel-size: 8
+        max-prefill-tokens: 8192
+        tensor-parallel-size: 8
+  resources:
+    decode_nodes: 4
+    decode_workers: 1
+    gpus_per_decode: 16
+    gpus_per_prefill: 8
+    prefill_nodes: 4
+    prefill_workers: 2
+
+zip_override_mtp_agentx_lowlat:
+  name: [agentx-1p2d-tp4, agentx-1p4d-tp4, agentx-1p6d-tp4]
+  resources:
+    decode_nodes: [2, 4, 6]
+    decode_workers: [2, 4, 6]
+    gpus_per_decode: 4
+    gpus_per_prefill: 4
+    prefill_nodes: 1
+    prefill_workers: 1

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8053,69 +8053,21 @@ glm5.2-fp4-gb200-dynamo-sglang-agentic-disagg:
     - dram-utilization: 0.80
       search-space:
       - spec-decoding: mtp
-        conc-list: [32, 48]
+        conc-list: [10, 12]
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         prefill:
           num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[0]"
-        decode:
-          num-worker: 2
           tp: 4
           ep: 1
           dp-attn: false
-      - spec-decoding: mtp
-        conc-list: [48]
-        kv-offloading: dram
-        kv-offload-backend: { name: hicache }
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
           additional-settings:
-          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[1]"
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_frontier[0]"
         decode:
-          num-worker: 4
+          num-worker: 1
           tp: 4
           ep: 1
           dp-attn: false
-      - spec-decoding: mtp
-        conc-list: [45]
-        kv-offloading: dram
-        kv-offload-backend: { name: hicache }
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[2]"
-        decode:
-          num-worker: 6
-          tp: 4
-          ep: 1
-          dp-attn: false
-      - spec-decoding: mtp
-        conc-list: [96, 128, 160, 192]
-        kv-offloading: dram
-        kv-offload-backend: { name: hicache }
-        prefill:
-          num-worker: 2
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_hightpt[0]"
-        decode:
-          num-worker: 1
-          tp: 16
-          ep: 16
-          dp-attn: true
 
 qwen3.5-fp8-gb200-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8006,6 +8006,117 @@ glm5.2-fp4-b200-sglang-agentic-mtp:
       search-space:
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16] }
 
+glm5.2-fp4-gb200-dynamo-sglang-agentic-agg:
+  image: lmsysorg/sglang:v0.5.17-cu130
+  model: nvidia/GLM-5.2-NVFP4
+  model-prefix: glm5.2
+  runner: cluster:gb200-nv
+  precision: fp4
+  framework: dynamo-sglang
+  router: { name: dynamo-router, version: "71eb001e17fa73c742f0afe1a6ed96836cb135fd" }
+  multinode: true
+  disagg: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - spec-decoding: mtp
+        conc-list: [1, 2, 4, 8, 12, 16]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml"
+        decode:
+          num-worker: 0
+          tp: 8
+          ep: 1
+          dp-attn: false
+
+glm5.2-fp4-gb200-dynamo-sglang-agentic-disagg:
+  image: lmsysorg/sglang:v0.5.17-cu130
+  model: nvidia/GLM-5.2-NVFP4
+  model-prefix: glm5.2
+  runner: cluster:gb200-nv
+  precision: fp4
+  framework: dynamo-sglang
+  router: { name: dynamo-router, version: "71eb001e17fa73c742f0afe1a6ed96836cb135fd" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - spec-decoding: mtp
+        conc-list: [32, 48]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[0]"
+        decode:
+          num-worker: 2
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - spec-decoding: mtp
+        conc-list: [48]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[1]"
+        decode:
+          num-worker: 4
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - spec-decoding: mtp
+        conc-list: [45]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_lowlat[2]"
+        decode:
+          num-worker: 6
+          tp: 4
+          ep: 1
+          dp-attn: false
+      - spec-decoding: mtp
+        conc-list: [96, 128, 160, 192]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 2
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx.yaml:zip_override_mtp_agentx_hightpt[0]"
+        decode:
+          num-worker: 1
+          tp: 16
+          ep: 16
+          dp-attn: true
+
 qwen3.5-fp8-gb200-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5991,3 +5991,13 @@
     - "Add the tuned GB200 MiniMax-M3 FP4 AgentX frontier with EAGLE3, the B200 TP4 baseline, DEP4/DEP8, SimpleCPU offload, and KV-routed P/D."
     - "Use full-decode-only CUDA graphs for TP4 stability."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2609
+
+- config-keys:
+    - glm5.2-fp4-gb200-dynamo-sglang-agentic-agg
+    - glm5.2-fp4-gb200-dynamo-sglang-agentic-disagg
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add GB200 GLM-5.2 FP4 Dynamo-SGLang AgentX with EAGLE MTP, HiCache DRAM offload, and KV-aware correlation-ID affinity."
+    - "Measure the comparable TP8 curve plus 1P2D, 1P4D, 1P6D, and 2P1D DEP disaggregated topologies with every logical SGLang metrics endpoint."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2620

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5999,5 +5999,5 @@
     - agentic-coding
   description:
     - "Add GB200 GLM-5.2 FP4 Dynamo-SGLang AgentX with EAGLE MTP, HiCache DRAM offload, and KV-aware correlation-ID affinity."
-    - "Measure the comparable TP8 curve plus 1P2D, 1P4D, 1P6D, and 2P1D DEP disaggregated topologies with every logical SGLang metrics endpoint."
+    - "Measure the TP8 aggregate curve and tuned 1P1D TP4 HiCache c10/c12 disaggregated frontier with every logical SGLang metrics endpoint."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2620

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -181,6 +181,9 @@ if [[ $FRAMEWORK == "dynamo-sglang" ]]; then
     elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp4" ]]; then
         export MODEL_PATH="/mnt/lustre01/models/Qwen3.5-397B-A17B-NVFP4-V2"
         export SRT_SLURM_MODEL_PREFIX="qwen3.5-fp4"
+    elif [[ $MODEL_PREFIX == "glm5.2" && $PRECISION == "fp4" ]]; then
+        export MODEL_PATH="/mnt/lustre01/users-public/sa-shared/models/GLM-5.2-NVFP4"
+        export SRT_SLURM_MODEL_PREFIX="glm-5.2-fp4"
     elif [[ $MODEL_PREFIX == "glm5.1" && $PRECISION == "fp4" ]]; then
         # SRT_SLURM_MODEL_PREFIX matches the model.path alias ("glm-5-fp4")
         # in our GLM-5.1 sglang recipes.
@@ -266,7 +269,7 @@ NGINX_IMAGE="nginx:1.27.4"
 
 uses_watchtower_shared_fs() {
     case "$MODEL_PREFIX" in
-        minimaxm2.5|minimaxm3|kimik2.5|kimik3|qwen3.5) return 0 ;;
+        minimaxm2.5|minimaxm3|kimik2.5|kimik3|qwen3.5|glm5.2) return 0 ;;
     esac
     # dsv4 multinode runs only under dynamo-vllm on watchtower, which likewise
     # needs the srt-slurm workspace/outputs on a compute-visible shared FS
@@ -394,9 +397,19 @@ if [ -d "$SRT_REPO_DIR" ]; then
     rm -rf "$SRT_REPO_DIR"
 fi
 
-# MiniMax-M3 FP4 AgentX uses v1.0.50 for complete logical-worker metrics
-# discovery across aggregate, DP-attention, and disaggregated topologies.
-if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "minimaxm3" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-vllm" ]]; then
+# GLM-5.2 and MiniMax-M3 AgentX use v1.0.50 for complete logical-worker
+# metrics discovery across aggregate, DP-attention, and disaggregated topologies.
+if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "glm5.2" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-sglang" ]]; then
+    git clone --branch v1.0.50 --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
+    cd "$SRT_REPO_DIR"
+    test "$(git rev-parse HEAD)" = "e4019633c9e2bc25f38c44b81edf52bb0504d937" || {
+        echo "Error: NVIDIA/srt-slurm v1.0.50 resolved to an unexpected commit" >&2
+        exit 1
+    }
+    mkdir -p recipes/sglang/glm5.2/gb200-fp4/agentic
+    cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic" \
+        recipes/sglang/glm5.2/gb200-fp4/agentic
+elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "minimaxm3" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-vllm" ]]; then
     git clone --branch v1.0.50 --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
     test "$(git rev-parse HEAD)" = "e4019633c9e2bc25f38c44b81edf52bb0504d937" || {

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -587,6 +587,13 @@ if [[ "$IS_AGENTIC" == "1" ]]; then
     DEFAULT_MOUNTS_BLOCK="default_mounts:
   ${AIPERF_MMAP_CACHE_HOST_PATH}: /aiperf_mmap_cache
   ${HF_HUB_CACHE_HOST_PATH}: /hf_hub_cache"
+    if uses_watchtower_shared_fs && [[ "$MODEL_PREFIX" == "glm5.2" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-sglang" ]]; then
+        DYNAMO_WHEELS_CACHE_HOST_PATH="${SHARED_BASE}/dynamo-wheels"
+        mkdir -p "$DYNAMO_WHEELS_CACHE_HOST_PATH"
+        chmod 777 "$DYNAMO_WHEELS_CACHE_HOST_PATH" 2>/dev/null || true
+        DEFAULT_MOUNTS_BLOCK+="
+  ${DYNAMO_WHEELS_CACHE_HOST_PATH}: /configs/dynamo-wheels"
+    fi
 fi
 
 echo "Creating srtslurm.yaml configuration..."


### PR DESCRIPTION
## Summary
- Adds GB200 GLM-5.2 NVFP4 AgentX on stable SGLang v0.5.17 with EAGLE MTP, HiCache DRAM offload, and KV-aware Dynamo routing.
- Measures the comparable aggregate TP8 curve at C1/C2/C4/C8/C12/C16.
- Adds the directly tuned 1P1D TP4/TP4 HiCache disaggregated frontier at C10/C12.
- Passes every logical SGLang metrics URL to AIPerf, including both prefill and decode endpoints.

## Direct tuning evidence
- 1P1D TP4/TP4 C10: Slurm 23720, 434/434 successful, zero errors; normalized interactivity 67.23 tok/s/user and normalized throughput 8,155.59 tok/s/GPU.
- 1P1D TP4/TP4 C12: Slurm 23706, 391/391 successful, zero errors; normalized interactivity 55.32 tok/s/user and normalized throughput 8,380.91 tok/s/GPU.
- Both runs used correlation-ID affinity, KV routing/events, 3/3 reachable metrics endpoints, and validated the required sglang: metric prefix.

## Validation
- 251 matrix, validation, and changelog tests pass.
- Bash syntax, YAML parsing, diff checks, and perf-changelog validation pass.
- The generated official matrix contains exactly eight throughput jobs.
- Aggregate and disaggregated recipes pass NVIDIA/srt-slurm v1.0.50 dry-run validation.