### PR TITLE
[AgentX] Fix B300 SimpleCPU cache sizing / 修正 B300 SimpleCPU 缓存容量

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_b300_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b300_vllm_mtp.sh
@@ -142,7 +142,7 @@ case "$KV_OFFLOAD_BACKEND" in
   "kv_connector": "SimpleCPUOffloadConnector",
   "kv_role": "kv_both",
   "kv_connector_extra_config": {
-    "cpu_bytes_to_use": ${CPU_BYTES_PER_RANK},
+    "cpu_bytes_to_use_per_rank": ${CPU_BYTES_PER_RANK},
     "enable_cross_layers_blocks": "true",
     "lazy_offload": ${SIMPLE_LAZY_OFFLOAD}
   }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5991,3 +5991,11 @@
     - "Add the tuned GB200 MiniMax-M3 FP4 AgentX frontier with EAGLE3, the B200 TP4 baseline, DEP4/DEP8, SimpleCPU offload, and KV-routed P/D."
     - "Use full-decode-only CUDA graphs for TP4 stability."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2609
+
+- config-keys:
+    - dsv4-fp4-b300-vllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Pass the pre-divided B300 SimpleCPU host-memory budget through cpu_bytes_to_use_per_rank."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2622


### PR DESCRIPTION
## Summary / 摘要

- The B300 launcher already divides total host DRAM by GPU count, but passed that per-rank value through the server-wide `cpu_bytes_to_use` key. Use `cpu_bytes_to_use_per_rank` so vLLM does not divide the budget again.
- Keep the committed concurrency grid unchanged. Initial runtime validation is limited to DEP8 concurrency `[256, 384, 512, 576]` to compare KV-cache hit rate.

- B300 启动脚本已按 GPU 数量划分主机内存，却通过服务级的 `cpu_bytes_to_use` 传递该 per-rank 值。改用 `cpu_bytes_to_use_per_rank`，避免 vLLM 再次划分缓存预算。
- 不修改已提交的并发配置。首次运行时验证仅测试 DEP8 并发 `[256, 384, 512, 576]`，用于比较 KV 缓存命中率。

## Validation / 验证

- Bash syntax, YAML parsing, and `git diff --check` passed.
- Exact matrix generation produced four DEP8 SimpleCPU points at concurrency `256, 384, 512, 576`.
- Runtime benchmark is pending a manual `e2e-tests.yml` dispatch with:

```text
test-config --config-files configs/nvidia-master.yaml --config-keys dsv4-fp4-b300-vllm-agentic-mtp --scenario-type agentic-coding --conc 256 384 512 576 --no-evals
```

- Bash 语法、YAML 解析与 `git diff --check` 已通过。
- 精确矩阵生成得到四个 DEP8 SimpleCPU 测试点，并发为 `256, 384, 512, 576`。
- 运行时基准测试等待通过 `e2e-tests.yml` 手动触发。