### PR TITLE
Capture TensorRT-LLM AgentX server metrics

### DIFF
--- a/benchmarks/multi_node/agentic_srt.sh
+++ b/benchmarks/multi_node/agentic_srt.sh
@@ -90,6 +90,8 @@ while time.monotonic() < deadline:
             worker_metrics = fetch_metrics(worker_url)
             worker_active += metric_sum(worker_metrics, "vllm:num_requests_running")
             worker_active += metric_sum(worker_metrics, "vllm:num_requests_waiting")
+            worker_active += metric_sum(worker_metrics, "trtllm_num_requests_running")
+            worker_active += metric_sum(worker_metrics, "trtllm_num_requests_waiting")
         print(
             f"Agentic drain status: frontend_active={frontend_active:g} "
             f"worker_running_or_waiting={worker_active:g}",

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-1p1d-dep1-tep2-c44-b8-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-1p1d-dep1-tep2-c44-b8-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 2
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -111,7 +112,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 1
@@ -177,7 +178,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -211,6 +212,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-1p7d-dep4-tep8-c7-b1-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-1p7d-dep4-tep8-c7-b1-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 8
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -109,7 +110,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 4
@@ -174,7 +175,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -208,6 +209,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-2p2d-dep1-tep2-c52-b4-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-2p2d-dep1-tep2-c52-b4-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 2
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -111,7 +112,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 1
@@ -176,7 +177,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -210,6 +211,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-2p3d-tep2-tep8-c96-b128-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-2p3d-tep2-tep8-c96-b128-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 8
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -109,7 +110,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 2
@@ -191,7 +192,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -225,6 +226,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-3p1d-dep4-dep16-c565-b8-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-3p1d-dep4-dep16-c565-b8-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 16
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -109,7 +110,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 4
@@ -175,7 +176,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -209,6 +210,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-3p2d-dep4-dep4-c704-b32-mtp-kvoffload.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-3p2d-dep4-dep4-c704-b32-mtp-kvoffload.yaml
@@ -32,6 +32,7 @@ resources:
   gpus_per_decode: 4
 backend:
   type: trtllm
+  publish_events_and_metrics: true
   prefill_environment:
     CUDA_SCALE_LAUNCH_QUEUES: 4x
     MIMALLOC_ARENA_RESERVE: '0'
@@ -109,7 +110,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: MAX_UTILIZATION
       tensor_parallel_size: 4
@@ -178,7 +179,7 @@ backend:
         - cuda_core
       pipeline_parallel_size: 1
       print_iter_log: true
-      return_perf_metrics: false
+      return_perf_metrics: true
       scheduler_config:
         capacity_scheduler_policy: GUARANTEED_NO_EVICT
       speculative_config:
@@ -212,6 +213,7 @@ benchmark:
     IS_MULTINODE: 'true'
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_
     AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
     HF_HUB_CACHE: /hf_hub_cache
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6563,3 +6563,11 @@
     - "Filter AgentX traces at the same 202,752-token context limit used by both TileRT roles so oversized Weka trajectories are excluded before replay."
     - "Pin SemiAnalysisAI/srt-slurm PR #10 commit d1e6c97b3baf3e87103b6d83189544c3c7d61c38, stacked on the AMD/native-router PR #7 and base runtime PR #1, including explicit native HTTP dependencies, GLM-5.1-compatible Transformers v5 router tokenization, incomplete-snapshot recovery, backend-declared conversion GPU resources, pre-container NVIDIA driver-hook activation, and lossless Slurm container-environment exports."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2750
+
+- config-keys:
+    - qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg
+  scenario-type:
+    - agentic-coding
+  description:
+    - "collect metrics refresh"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2625

--- a/utils/agentic/aggregation/backends/__init__.py
+++ b/utils/agentic/aggregation/backends/__init__.py
@@ -8,9 +8,11 @@ from .atom import AtomBackend
 from .base import ServerMetricsBackend
 from .dynamo_vllm import DynamoVllmBackend
 from .sglang import SglangBackend
+from .trtllm import TrtllmBackend
 from .vllm import VllmBackend
 
 BACKENDS: tuple[ServerMetricsBackend, ...] = (
+    TrtllmBackend(),
     DynamoVllmBackend(),
     AtomBackend(),
     SglangBackend(),

--- a/utils/agentic/aggregation/backends/trtllm.py
+++ b/utils/agentic/aggregation/backends/trtllm.py
@@ -1,0 +1,244 @@
+"""TensorRT-LLM server metric adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..aggregation_common import (
+    gauge_stat,
+    label_value,
+    normalize_fraction,
+    rate,
+    sum_stat,
+)
+from .base import ServerMetricsBackend, counter_int
+
+
+class TrtllmBackend(ServerMetricsBackend):
+    name = "trtllm"
+
+    def matches(self, metrics: dict[str, dict[str, Any]], framework: str) -> bool:
+        metric_names = set(metrics)
+        return any(name.startswith("trtllm_") for name in metric_names) or (
+            not metrics
+            and framework.lower() in ("trtllm", "dynamo-trt", "dynamo-trtllm")
+        )
+
+    def populate(
+        self,
+        metrics: dict[str, dict[str, Any]],
+        flat: dict[str, Any],
+        nested: dict[str, Any],
+    ) -> None:
+        prompt_total = _first_counter_total(
+            metrics,
+            ["dynamo_frontend_input_sequence_tokens", "trtllm_prompt_tokens_total"],
+        )
+        generation_total = _first_counter_total(
+            metrics,
+            ["dynamo_frontend_output_tokens", "trtllm_generation_tokens_total"],
+        )
+        cached_tokens = sum_stat(
+            metrics,
+            "trtllm_prompt_cached_tokens_total",
+            preferred_keys=("total", "sum", "max", "avg"),
+        )
+
+        flat["total_prompt_tokens"] = counter_int(prompt_total)
+        flat["total_generation_tokens"] = counter_int(generation_total)
+        flat["server_gpu_cache_hit_rate"] = normalize_fraction(
+            gauge_stat(
+                metrics,
+                "trtllm_kv_cache_hit_rate",
+                preferred_keys=("avg", "max", "total"),
+                combine="avg",
+            )
+        )
+        if flat["server_gpu_cache_hit_rate"] is None:
+            flat["server_gpu_cache_hit_rate"] = rate(cached_tokens, prompt_total)
+        flat["server_overall_cache_hit_rate"] = flat["server_gpu_cache_hit_rate"]
+
+        flat["gpu_kv_cache_usage_pct"] = normalize_fraction(
+            gauge_stat(
+                metrics,
+                "trtllm_kv_cache_utilization",
+                preferred_keys=("max", "avg", "total"),
+                combine="max",
+            )
+        )
+        flat["cpu_kv_cache_usage_pct"] = normalize_fraction(
+            gauge_stat(
+                metrics,
+                "trtllm_kv_cache_host_utilization",
+                preferred_keys=("max", "avg", "total"),
+                combine="max",
+            )
+        )
+        flat["kv_offload_bytes_gpu_to_cpu"] = sum_stat(
+            metrics,
+            "trtllm_kv_cache_offload_bytes_total",
+            preferred_keys=("total", "sum", "max", "avg"),
+        )
+        flat["kv_offload_bytes_cpu_to_gpu"] = sum_stat(
+            metrics,
+            "trtllm_kv_cache_onboard_bytes_total",
+            preferred_keys=("total", "sum", "max", "avg"),
+        )
+
+        computed_tokens = None
+        if prompt_total is not None and cached_tokens is not None:
+            computed_tokens = max(prompt_total - cached_tokens, 0.0)
+
+        nested["cache"].update(
+            {
+                "gpu_cache_hit_rate": flat["server_gpu_cache_hit_rate"],
+                "overall_cache_hit_rate": flat["server_overall_cache_hit_rate"],
+                "cached_tokens_by_source": {"device": cached_tokens}
+                if cached_tokens is not None
+                else {},
+            }
+        )
+        nested["kv_cache"].update(
+            {
+                "gpu_usage_pct": flat["gpu_kv_cache_usage_pct"],
+                "cpu_usage_pct": flat["cpu_kv_cache_usage_pct"],
+            }
+        )
+        nested["kv_offload"].update(
+            {
+                "bytes_gpu_to_cpu": flat["kv_offload_bytes_gpu_to_cpu"],
+                "bytes_cpu_to_gpu": flat["kv_offload_bytes_cpu_to_gpu"],
+            }
+        )
+        nested["tokens"].update(
+            {
+                "prompt_total": flat["total_prompt_tokens"],
+                "generation_total": flat["total_generation_tokens"],
+                "prompt_by_source": {
+                    "gpu_cache_hit": cached_tokens,
+                    "cpu_or_external_cache_hit": None,
+                    "computed": computed_tokens,
+                    "raw": {"device": cached_tokens}
+                    if cached_tokens is not None
+                    else {},
+                },
+            }
+        )
+        nested["sources"] = _trtllm_sources(metrics)
+
+    def gpu_kv_capacity_tokens(
+        self,
+        metrics: dict[str, dict[str, Any]],
+        server_log_paths: list[Path],
+    ) -> int | None:
+        del server_log_paths
+        max_blocks = sum_stat(
+            metrics,
+            "trtllm_kv_cache_max_blocks",
+            preferred_keys=("max", "avg", "total", "sum"),
+        )
+        tokens_per_block = gauge_stat(
+            metrics,
+            "trtllm_kv_cache_tokens_per_block",
+            preferred_keys=("max", "avg", "total"),
+            combine="max",
+        )
+        if max_blocks is None or tokens_per_block is None:
+            return None
+        return counter_int(max_blocks * tokens_per_block)
+
+
+def _first_counter_total(
+    metrics: dict[str, dict[str, Any]],
+    metric_names: list[str],
+) -> float | None:
+    for metric_name in metric_names:
+        value = sum_stat(
+            metrics,
+            metric_name,
+            preferred_keys=("total", "sum", "max", "avg"),
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _trtllm_sources(metrics: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    endpoints: set[str] = set()
+    roles: dict[str, str] = {}
+    for entry in metrics.values():
+        if not isinstance(entry, dict):
+            continue
+        series_list = entry.get("series")
+        if not isinstance(series_list, list):
+            continue
+        for series in series_list:
+            if not isinstance(series, dict) or not series.get("endpoint_url"):
+                continue
+            endpoint = str(series["endpoint_url"])
+            endpoints.add(endpoint)
+            mode = label_value(series, "disaggregation_mode") or label_value(
+                series, "dynamo_component"
+            )
+            if mode:
+                roles[endpoint] = _normalize_role(mode)
+
+    sources: list[dict[str, Any]] = []
+    for endpoint in sorted(endpoints):
+        series_filter = lambda series, endpoint=endpoint: str(
+            series.get("endpoint_url", "")
+        ) == endpoint
+        prompt_tokens = sum_stat(
+            metrics,
+            "trtllm_prompt_tokens_total",
+            series_filter=series_filter,
+        )
+        generation_tokens = sum_stat(
+            metrics,
+            "trtllm_generation_tokens_total",
+            series_filter=series_filter,
+        )
+        cached_tokens = sum_stat(
+            metrics,
+            "trtllm_prompt_cached_tokens_total",
+            series_filter=series_filter,
+        )
+        hit_rate = normalize_fraction(
+            gauge_stat(
+                metrics,
+                "trtllm_kv_cache_hit_rate",
+                combine="avg",
+                series_filter=series_filter,
+            )
+        )
+        if hit_rate is None:
+            hit_rate = rate(cached_tokens, prompt_tokens)
+        sources.append(
+            {
+                "id": f"{roles.get(endpoint, 'worker')}|{endpoint}",
+                "role": roles.get(endpoint, "worker"),
+                "prompt_tokens": prompt_tokens,
+                "generation_tokens": generation_tokens,
+                "prefix_cache_hit_rate": hit_rate,
+                "gpu_kv_cache_usage_pct": normalize_fraction(
+                    gauge_stat(
+                        metrics,
+                        "trtllm_kv_cache_utilization",
+                        series_filter=series_filter,
+                    )
+                ),
+            }
+        )
+    return sources
+
+
+def _normalize_role(mode: str) -> str:
+    lowered = mode.lower()
+    if lowered in ("prefill", "context", "ctx"):
+        return "prefill"
+    if lowered in ("decode", "generation", "gen", "backend"):
+        return "decode"
+    if lowered in ("aggregated", "prefill_and_decode", "agg"):
+        return "combined"
+    return lowered

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -1322,6 +1322,133 @@ def test_processor_normalizes_sglang_server_metrics(tmp_path: Path):
     assert agg["server_metrics"]["tokens"]["prompt_by_source"]["computed"] == 500.0
 
 
+def test_processor_normalizes_trtllm_server_metrics(tmp_path: Path):
+    result_dir = _write_fixture(tmp_path)
+    artifact = result_dir / "aiperf_artifacts"
+    prefill_url = "http://10.0.0.1:7500/metrics"
+    decode_url = "http://10.0.0.2:7501/metrics"
+    server_metrics = {
+        "metrics": {
+            "dynamo_frontend_input_sequence_tokens": {
+                "type": "counter",
+                "series": [{"stats": {"total": 1000.0}}],
+            },
+            "dynamo_frontend_output_tokens": {
+                "type": "counter",
+                "series": [{"stats": {"total": 200.0}}],
+            },
+            "trtllm_prompt_tokens_total": {
+                "type": "counter",
+                "series": [
+                    {
+                        "endpoint_url": prefill_url,
+                        "labels": {"dynamo_component": "prefill"},
+                        "stats": {"total": 600.0},
+                    },
+                    {
+                        "endpoint_url": decode_url,
+                        "labels": {"dynamo_component": "backend"},
+                        "stats": {"total": 400.0},
+                    },
+                ],
+            },
+            "trtllm_generation_tokens_total": {
+                "type": "counter",
+                "series": [
+                    {
+                        "endpoint_url": decode_url,
+                        "labels": {"dynamo_component": "backend"},
+                        "stats": {"total": 200.0},
+                    }
+                ],
+            },
+            "trtllm_prompt_cached_tokens_total": {
+                "type": "counter",
+                "series": [
+                    {"endpoint_url": prefill_url, "stats": {"total": 200.0}},
+                    {"endpoint_url": decode_url, "stats": {"total": 300.0}},
+                ],
+            },
+            "trtllm_kv_cache_hit_rate": {
+                "type": "gauge",
+                "series": [
+                    {"endpoint_url": prefill_url, "stats": {"avg": 0.4}},
+                    {"endpoint_url": decode_url, "stats": {"avg": 0.6}},
+                ],
+            },
+            "trtllm_kv_cache_utilization": {
+                "type": "gauge",
+                "series": [
+                    {"endpoint_url": prefill_url, "stats": {"max": 0.7}},
+                    {"endpoint_url": decode_url, "stats": {"max": 0.8}},
+                ],
+            },
+            "trtllm_kv_cache_host_utilization": {
+                "type": "gauge",
+                "series": [{"endpoint_url": prefill_url, "stats": {"max": 0.25}}],
+            },
+            "trtllm_kv_cache_offload_bytes_total": {
+                "type": "counter",
+                "series": [
+                    {
+                        "endpoint_url": prefill_url,
+                        "labels": {"disaggregation_mode": "prefill"},
+                        "stats": {"total": 4096.0},
+                    }
+                ],
+            },
+            "trtllm_kv_cache_onboard_bytes_total": {
+                "type": "counter",
+                "series": [
+                    {
+                        "endpoint_url": decode_url,
+                        "labels": {"disaggregation_mode": "decode"},
+                        "stats": {"total": 2048.0},
+                    }
+                ],
+            },
+            "trtllm_kv_cache_max_blocks": {
+                "type": "gauge",
+                "series": [
+                    {"endpoint_url": prefill_url, "stats": {"max": 100.0}},
+                    {"endpoint_url": decode_url, "stats": {"max": 200.0}},
+                ],
+            },
+            "trtllm_kv_cache_tokens_per_block": {
+                "type": "gauge",
+                "series": [
+                    {"endpoint_url": prefill_url, "stats": {"max": 64.0}},
+                    {"endpoint_url": decode_url, "stats": {"max": 64.0}},
+                ],
+            },
+        }
+    }
+    with open(artifact / "server_metrics_export.json", "w") as f:
+        json.dump(server_metrics, f)
+
+    agg = _run_processor(
+        result_dir,
+        tmp_path / "out",
+        env_overrides={"FRAMEWORK": "dynamo-trt", "IS_MULTINODE": "true"},
+    )
+
+    assert agg["server_metrics"]["adapter"] == "trtllm"
+    _assert_stable_server_metrics_schema(agg)
+    assert agg["server_metrics"]["tokens"]["prompt_total"] == 1000
+    assert agg["server_metrics"]["tokens"]["generation_total"] == 200
+    assert agg["server_metrics"]["cache"]["gpu_cache_hit_rate"] == pytest.approx(0.5)
+    assert agg["server_metrics"]["cache"]["overall_cache_hit_rate"] == pytest.approx(0.5)
+    assert agg["server_metrics"]["kv_cache"]["gpu_usage_pct"] == pytest.approx(0.8)
+    assert agg["server_metrics"]["kv_cache"]["cpu_usage_pct"] == pytest.approx(0.25)
+    assert agg["server_metrics"]["kv_cache"]["gpu_total_tokens"] == 19_200
+    assert agg["server_metrics"]["kv_offload"]["bytes_gpu_to_cpu"] == 4096
+    assert agg["server_metrics"]["kv_offload"]["bytes_cpu_to_gpu"] == 2048
+    assert {source["role"] for source in agg["server_metrics"]["sources"]} == {
+        "prefill",
+        "decode",
+    }
+
+
 def test_processor_normalizes_dynamo_server_metrics(tmp_path: Path):
     result_dir = _write_fixture(tmp_path)
     artifact = result_dir / "aiperf_artifacts"


### PR DESCRIPTION
## Summary

Follow-up to #2612.

- Enable TensorRT-LLM native Prometheus publication and per-request performance metrics on every logical prefill/decode worker.
- Require non-empty `trtllm_` server-metric exports while retaining srt-slurm v1.0.50’s one-list endpoint injection for disaggregated topologies.
- Add the TensorRT-LLM AgentX adapter for token totals, cache hit rate, GPU/host KV utilization and capacity, offload traffic, and per-endpoint P/D sources.
- Include TensorRT-LLM queue gauges in post-profile drain validation.

Upstream metric surface: NVIDIA/TensorRT-LLM#12545.

## Validation

- 37 aggregation tests passed.
- All 6 recipes pass srt-slurm v1.0.50 schema loading with metrics enabled and required prefix `trtllm_`.
- Full-sweep generation returns the intended 6 disaggregated AgentX points.
- Shell syntax, Ruff, and diff checks pass.
- Live GB300 inspection confirmed the existing #2612 deployment passes all logical `/metrics` endpoints but emits zero `trtllm_` series while `publish_events_and_metrics` is disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark recipes, metrics aggregation, and drain polling; they do not alter inference serving logic beyond enabling metric publication in configs.
> 
> **Overview**
> **Enables end-to-end TensorRT-LLM Prometheus metrics for GB300 disaggregated AgentX benchmarks** and folds them into the existing agentic aggregation schema.
> 
> Six Qwen3.5 FP4 `agentx` srt-slurm recipes now turn on **`publish_events_and_metrics`**, set **`return_perf_metrics: true`** on prefill/decode workers, and require non-empty exports via **`AIPERF_REQUIRED_SERVER_METRIC_PREFIX: trtllm_`**. Post-profile drain in **`agentic_srt.sh`** also counts **`trtllm_num_requests_running`** / **`trtllm_num_requests_waiting`** so idle detection works for TRT-LLM workers, not only vLLM.
> 
> A new **`TrtllmBackend`** adapter (registered ahead of other backends) maps `trtllm_*` and Dynamo frontend token counters into normalized cache/KV/offload/token fields, GPU KV capacity, and per-endpoint prefill/decode **sources**. Coverage is backed by a processor test and a perf-changelog entry for **`qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5713868d043b64afdf5fb99a8b8a28cfde2696eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->