### PR TITLE
Refresh GB200 Qwen3.5 AgentX Pareto / 刷新 GB200 Qwen3.5 AgentX Pareto 配置

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp-hicache.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp-hicache.yaml
@@ -1,24 +1,12 @@
-name: qwen35-gb200-sglang-agentic-mtp-agg-tp4
+name: qwen35-gb200-sglang-agentic-mtp-agg-tp2ep2-hicache
 
-model:
-  path: qwen3.5-fp4
-  container: lmsysorg/sglang:nightly-dev-20260818-c0b6474b
-  precision: fp4
-
+model: { path: qwen3.5-fp4, container: lmsysorg/sglang:nightly-dev-20260818-c0b6474b, precision: fp4 }
 identity:
   model: { repo: nvidia/Qwen3.5-397B-A17B-NVFP4-V2 }
   container: { image: lmsysorg/sglang:nightly-dev-20260818-c0b6474b }
-
 slurm: { time_limit: "8:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
-
-resources:
-  gpu_type: gb200
-  gpus_per_node: 4
-  agg_nodes: 1
-  agg_workers: 1
-  gpus_per_agg: 4
-
+resources: { gpu_type: gb200, gpus_per_node: 4, agg_nodes: 1, agg_workers: 1, gpus_per_agg: 2 }
 infra: { nats_max_payload_mb: 8 }
 frontend:
   type: sglang
@@ -41,43 +29,58 @@ backend:
       served-model-name: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
       model-path: /model/
       trust-remote-code: true
-      tensor-parallel-size: 4
+      tensor-parallel-size: 2
+      pipeline-parallel-size: 1
       data-parallel-size: 1
-      expert-parallel-size: 1
-      enable-symm-mem: true
+      expert-parallel-size: 2
+      enable-dp-attention: false
+      enable-dp-lm-head: false
+      enable-symm-mem: false
       quantization: modelopt_fp4
       fp4-gemm-backend: flashinfer_cutlass
       kv-cache-dtype: fp8_e4m3
       mamba-ssm-dtype: bfloat16
-      mamba-scheduler-strategy: extra_buffer
-      mamba-track-interval: 8192
+      mamba-radix-cache-strategy: extra_buffer_lazy
+      mamba-track-interval: 1048576
       attention-backend: trtllm_mha
+      linear-attn-prefill-backend: flashinfer
       linear-attn-decode-backend: flashinfer
       moe-runner-backend: flashinfer_trtllm
+      speculative-moe-runner-backend: flashinfer_trtllm
       speculative-algorithm: NEXTN
       speculative-num-steps: 3
       speculative-eagle-topk: 1
       speculative-num-draft-tokens: 4
+      enable-linear-replayssm-spec: true
+      linear-replayssm-cache-len: 8
       cuda-graph-max-bs: 64
       max-running-requests: 80
       max-prefill-tokens: 16384
       chunked-prefill-size: 16384
-      mem-fraction-static: 0.80
-      max-mamba-cache-size: 360
+      mem-fraction-static: 0.88
+      # extra_buffer_lazy uses four physical Mamba state slots per running request.
+      # C40 remains healthy while C48 reaches the device-KV capacity cliff.
+      max-mamba-cache-size: 320
       allow-auto-truncate: true
       stream-interval: 50
       scheduler-recv-interval: 10
       tokenizer-worker-num: 6
+      page-size: 64
+      enable-hierarchical-cache: true
+      hicache-ratio: 2.5
+      hicache-io-backend: direct
+      hicache-mem-layout: page_first_direct
+      hicache-write-policy: write_through_selective
       mamba-max-states-per-path: 1
       weight-loader-prefetch-checkpoints: true
       weight-loader-prefetch-num-threads: 4
       weight-loader-drop-cache-after-load: true
+      watchdog-timeout: 1000000
       enable-metrics: true
       enable-cache-report: true
 
 sbatch_directives: { mem: "0", cpus-per-task: "144" }
 srun_options: { mem: "0", container-remap-root: "" }
-
 benchmark:
   type: custom
   command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
@@ -86,7 +89,7 @@ benchmark:
     RESULT_DIR: /logs/agentic
     PORT: "8000"
     IS_MULTINODE: "false"
-    TP: "4"
+    TP: "2"
     AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
     AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
     WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126_256k

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp.yaml
@@ -1,9 +1,9 @@
 name: qwen35-gb200-sglang-agentic-mtp-agg-tp2ep2
 
-model: { path: qwen3.5-fp4, container: dynamo-sglang, precision: fp4 }
+model: { path: qwen3.5-fp4, container: lmsysorg/sglang:nightly-dev-20260818-c0b6474b, precision: fp4 }
 identity:
   model: { repo: nvidia/Qwen3.5-397B-A17B-NVFP4-V2 }
-  container: { image: lmsysorg/sglang:v0.5.17-cu130 }
+  container: { image: lmsysorg/sglang:nightly-dev-20260818-c0b6474b }
 slurm: { time_limit: "8:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
 resources: { gpu_type: gb200, gpus_per_node: 4, agg_nodes: 1, agg_workers: 1, gpus_per_agg: 2 }
@@ -32,30 +32,39 @@ backend:
       tensor-parallel-size: 2
       data-parallel-size: 1
       expert-parallel-size: 2
-      enable-symm-mem: true
+      enable-dp-attention: false
+      enable-dp-lm-head: false
+      enable-symm-mem: false
       quantization: modelopt_fp4
       fp4-gemm-backend: flashinfer_cutlass
       kv-cache-dtype: fp8_e4m3
       mamba-ssm-dtype: bfloat16
-      mamba-scheduler-strategy: extra_buffer
-      mamba-track-interval: 8192
+      mamba-radix-cache-strategy: extra_buffer_lazy
+      mamba-track-interval: 1048576
       attention-backend: trtllm_mha
+      linear-attn-prefill-backend: flashinfer
       linear-attn-decode-backend: flashinfer
       moe-runner-backend: flashinfer_trtllm
+      speculative-moe-runner-backend: flashinfer_trtllm
       speculative-algorithm: NEXTN
       speculative-num-steps: 3
       speculative-eagle-topk: 1
       speculative-num-draft-tokens: 4
+      enable-linear-replayssm-spec: true
+      linear-replayssm-cache-len: 8
       cuda-graph-max-bs: 64
-      max-running-requests: 40
+      max-running-requests: 80
       max-prefill-tokens: 16384
       chunked-prefill-size: 16384
       mem-fraction-static: 0.85
-      max-mamba-cache-size: 200
+      max-mamba-cache-size: 320
       allow-auto-truncate: true
       stream-interval: 50
       scheduler-recv-interval: 10
       mamba-max-states-per-path: 1
+      weight-loader-prefetch-checkpoints: true
+      weight-loader-prefetch-num-threads: 4
+      weight-loader-drop-cache-after-load: true
       enable-metrics: true
       enable-cache-report: true
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7222,7 +7222,7 @@ qwen3.5-fp4-b200-sglang-agentic-mtp:
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 18, 20, 22, 24, 28, 32] }
 
 qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.17-cu130
+  image: lmsysorg/sglang:nightly-dev-20260818-c0b6474b
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
   model-prefix: qwen3.5
   runner: cluster:gb200-nv
@@ -7232,13 +7232,13 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
   disagg: false
   scenarios:
     agentic-coding:
-    - dram-utilization: 0.70
+    - dram-utilization: 0.90
       search-space:
-      # Measured Pareto points from the complete fast sweep. TP4 covers the
-      # low-latency branch; HiCache extends the high-throughput branch.
+      # TP4 covers the low-latency branch. TP4 HiCache is omitted because the
+      # half-GPU TP2/EP2 branch already dominates that operating range.
       - spec-decoding: mtp
         kv-offloading: none
-        conc-list: [1, 4, 8, 12, 16, 20, 32, 40]
+        conc-list: [1, 2, 4, 8, 12, 20, 24]
         prefill:
           num-worker: 1
           tp: 4
@@ -7249,25 +7249,11 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp4-mtp.yaml"
         decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
-      - spec-decoding: mtp
-        kv-offloading: dram
-        kv-offload-backend: { name: hicache }
-        conc-list: [48, 56, 64, 72]
-        prefill:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
-          - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp4-mtp-hicache.yaml"
-        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
-      # TP2/EP2 supplies the middle of the measured frontier with half the
-      # GPU count of TP4.
+      # TP2/EP2 probes the middle and high-throughput frontier with half the
+      # GPU count of TP4; the HiCache arm extends beyond the old C24 ceiling.
       - spec-decoding: mtp
         kv-offloading: none
-        conc-list: [4, 8, 16, 20, 24]
+        conc-list: [4, 8, 12, 20]
         prefill:
           num-worker: 1
           tp: 2
@@ -7277,6 +7263,20 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp.yaml"
+        decode: { num-worker: 0, tp: 2, ep: 2, dp-attn: false }
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        conc-list: [22, 24, 28, 32, 40]
+        prefill:
+          num-worker: 1
+          tp: 2
+          ep: 2
+          dp-attn: false
+          additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
+          - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp-hicache.yaml"
         decode: { num-worker: 0, tp: 2, ep: 2, dp-attn: false }
 
 minimaxm3-fp4-b300-vllm-agentic-mtp:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6086,3 +6086,13 @@
     - "Use TP8/EP1 concurrency 2 through 24, published FlashInfer 0.6.17 CUDA 13 wheels, and golden MTP acceptance length 3.39."
     - "Use the lmsysorg/sglang:nightly-dev-cu13-20260815-a5ba081f image."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2592
+
+- config-keys:
+    - qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Refresh GB200 Qwen3.5 NVFP4-V2 AgentX on lmsysorg/sglang:nightly-dev-20260818-c0b6474b without engine patches."
+    - "Add a TP2/EP2 HiCache branch and update the resident recipes with extra_buffer_lazy, ReplaySSM speculative verification, and checkpoint page-cache release."
+    - "Select TP4 C1/C2/C4/C8/C12/C20/C24, TP2/EP2 resident C4/C8/C12/C20, and TP2/EP2 HiCache C22/C24/C28/C32/C40 with golden synthetic acceptance length 3.39."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6095,4 +6095,4 @@
     - "Refresh GB200 Qwen3.5 NVFP4-V2 AgentX on lmsysorg/sglang:nightly-dev-20260818-c0b6474b without engine patches."
     - "Add a TP2/EP2 HiCache branch and update the resident recipes with extra_buffer_lazy, ReplaySSM speculative verification, and checkpoint page-cache release."
     - "Select TP4 C1/C2/C4/C8/C12/C20/C24, TP2/EP2 resident C4/C8/C12/C20, and TP2/EP2 HiCache C22/C24/C28/C32/C40 with golden synthetic acceptance length 3.39."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2660


### PR DESCRIPTION
## Description

Refresh the GB200 Qwen3.5 NVFP4-V2 AgentX configuration on `lmsysorg/sglang:nightly-dev-20260818-c0b6474b`.

- Add a TP2/EP2 HiCache recipe using CPU DRAM KV offload.
- Update the TP4 and TP2/EP2 resident recipes with `extra_buffer_lazy`, ReplaySSM speculative verification, and checkpoint page-cache release.
- Select 16 Pareto points: TP4 C1/C2/C4/C8/C12/C20/C24, TP2/EP2 resident C4/C8/C12/C20, and TP2/EP2 HiCache C22/C24/C28/C32/C40.
- Pin simulated acceptance to the committed Qwen3.5 thinking-on golden AL of 3.39; the launcher injector disables it for `EVAL_ONLY` runs.
- Keep the existing public `cluster:gb200-nv` launcher and routing unchanged.

Local validation completed:

- Exact-key schema and matrix generation produced all 16 intended benchmark points and three eval selections.
- Master/recipe image, topology, offload, and synthetic-AL parity were checked.
- Committed-ref changelog processing, YAML parsing, Bash syntax, and `git diff --check` passed.

Recipe requirement: N/A — this is a multi-node `dynamo-sglang` submission with in-repository srt-slurm recipes.

## 中文说明

刷新 GB200 Qwen3.5 NVFP4-V2 AgentX 配置，使用 `lmsysorg/sglang:nightly-dev-20260818-c0b6474b` 镜像。

- 新增使用 CPU DRAM KV 卸载的 TP2/EP2 HiCache 配方。
- 更新 TP4 与 TP2/EP2 常驻配方，启用 `extra_buffer_lazy`、ReplaySSM 推测验证和检查点页缓存释放。
- 选择 16 个 Pareto 配置点：TP4 C1/C2/C4/C8/C12/C20/C24、TP2/EP2 常驻 C4/C8/C12/C20，以及 TP2/EP2 HiCache C22/C24/C28/C32/C40。
- 将模拟接受长度固定为已提交的 Qwen3.5 thinking-on 黄金 AL 3.39；启动器注入逻辑会在 `EVAL_ONLY` 运行中禁用该设置。
- 保持现有公开 `cluster:gb200-nv` 启动器与路由不变。

已完成本地验证：

- 精确配置键的 schema 与矩阵生成产生了预期的 16 个基准测试点和 3 个评测选择。
- 已核对主配置与配方的镜像、拓扑、卸载和模拟 AL 一致性。
- 已通过基于提交引用的变更日志处理、YAML 解析、Bash 语法和 `git diff --check` 检查。

配方要求：不适用——这是使用仓库内 srt-slurm 配方的多节点 `dynamo-sglang` 提交。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.
