### PR TITLE
Remove hung Qwen3.5 AgentX concurrency points

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7080,7 +7080,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 60, 64, 68, 72] }
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56] }
+      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [36, 44, 52] }
 
 qwen3.5-fp8-h200-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
@@ -7217,7 +7217,7 @@ qwen3.5-fp4-b200-sglang-agentic-mtp:
     - dram-utilization: 0.80
       search-space:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 56, 60, 62, 64] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 66, 68, 70, 72, 76] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [64, 66, 68, 70, 72] }
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 14] }
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 18, 20, 22, 24, 28, 32] }
 


### PR DESCRIPTION
## Summary

- remove the six hung B300 TP2/EP2 HiCache concurrency points: 32, 34, 38, 40, 48, and 56
- remove the hung B200 TP4/EP1 HiCache concurrency 76 point
- retain the healthy points in both search spaces

## Why

Production database inspection found these AgentX profiles stopped early while server telemetry continued without requests. The corresponding dashboard points are being purged in SemiAnalysisAI/InferenceX-app#761.

This updates the canonical sweep definitions so the bad points are not generated again.

## Sweep behavior

`perf-changelog.yaml` is intentionally unchanged. The head commit includes `[skip-sweep]` because this PR only removes known-bad search-space points and should not launch replacement performance runs.

## Checks

Not run, per request.
