### PR TITLE
Fix AgentX KV offload metadata

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6699,9 +6699,12 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    - dram-utilization: 0.60953
+      search-space:
       # 1P1D: 1 prefill (TP1/EP1/dp-attn), 1 decode (TP2/EP2), conc=44
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [44]
         prefill:
           num-worker: 1
@@ -6715,8 +6718,12 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           tp: 2
           ep: 2
           dp-attn: false
+    - dram-utilization: 0.15239
+      search-space:
       # 1P7D: 1 prefill (TP4/EP4/dp-attn), 7 decode (TP8/EP8), conc=7
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [7]
         prefill:
           num-worker: 1
@@ -6730,8 +6737,12 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           tp: 8
           ep: 8
           dp-attn: false
+    - dram-utilization: 0.60953
+      search-space:
       # 2P2D: 2 prefill (TP1/EP1/dp-attn), 2 decode (TP2/EP2), conc=52
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [52]
         prefill:
           num-worker: 2
@@ -6745,8 +6756,12 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           tp: 2
           ep: 2
           dp-attn: false
+    - dram-utilization: 0.30477
+      search-space:
       # 2P3D: 2 prefill (TP2/EP2), 3 decode (TP8/EP8), conc=96
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [96]
         prefill:
           num-worker: 2
@@ -6760,8 +6775,12 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           tp: 8
           ep: 8
           dp-attn: false
+    - dram-utilization: 0.15239
+      search-space:
       # 3P1D: 3 prefill (TP4/EP4/dp-attn), 1 decode (TP16/EP16/dp-attn), conc=565
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [565]
         prefill:
           num-worker: 3
@@ -6777,6 +6796,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: true
       # 3P2D: 3 prefill (TP4/EP4/dp-attn), 2 decode (TP4/EP4/dp-attn), conc=704
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [704]
         prefill:
           num-worker: 3
@@ -7646,10 +7667,13 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    - dram-utilization: 0.19957
+      search-space:
       # Keep the checked-in recipes on real MTP verification. Throughput jobs
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [1152]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7667,6 +7691,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           ep: 12
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [1024]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7684,6 +7710,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           ep: 16
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [256]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7788,10 +7816,13 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    - dram-utilization: 0.15523
+      search-space:
       # Keep the checked-in recipes on real MTP verification. Throughput jobs
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [576]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7809,6 +7840,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           ep: 12
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [512]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7826,6 +7859,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           ep: 16
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [256]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
@@ -7843,6 +7878,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           ep: 8
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [128]
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:


### PR DESCRIPTION
## Summary

- annotate the three GB300 DSV4 Mooncake points with DRAM offload metadata
- annotate the four GB200 DSV4 Mooncake points with DRAM offload metadata
- annotate the six GB300 Qwen3.5 TensorRT-LLM points with native host-cache metadata
- size generated DRAM capacity to match the checked-in recipes: 180 GB, 140 GB, and 128 GiB respectively

## Scope

This changes master-config metadata only. It does not modify benchmark recipes or runtime behavior, so there is no performance changelog entry.

## Validation

- parsed `configs/nvidia-master.yaml`
- generated the three affected config keys successfully
- confirmed exactly 13 points emit `kv-offloading: dram`, the expected backend and version, and matching `total-cpu-dram-gb` values