### PR TITLE
feat(minimaxm3): add GB300 aggregate AgentX canary / 新增 GB300 聚合式 AgentX 验证点

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-agentic.yaml
@@ -1,0 +1,120 @@
+name: "minimax-m3-vllm-agg-gb300-tp2-c24-fp4-agentic"
+# GB300 aggregate translation of the current InferenceX B300 TP2/C24
+# max-throughput point. One TP2 worker serves both prefill and decode behind
+# Dynamo. SimpleCPU-lazy is capped at 400 GiB total (200 GiB per rank).
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 2
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 2
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN","rejection_sample_method":"synthetic","synthetic_acceptance_length":2.78}'
+      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":429496729600,"cpu_bytes_to_use_per_rank":214748364800,"lazy_offload":true}}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "72"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-eval-agentic.yaml
@@ -1,0 +1,119 @@
+name: "minimax-m3-vllm-agg-gb300-tp2-c24-fp4-eval-agentic"
+# Real-verification twin of agg-tp2-c24-agentic.yaml. Topology, memory, and
+# runtime settings are identical; only synthetic EAGLE acceptance is removed.
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 2
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 2
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
+      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":429496729600,"cpu_bytes_to_use_per_rank":214748364800,"lazy_offload":true}}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "72"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-agentic.yaml
@@ -1,0 +1,117 @@
+name: "minimax-m3-vllm-agg-gb300-tp4-c1-fp4-agentic"
+# GB300 aggregate translation of the B300 TP4/C1 latency point. One
+# GPU-resident TP4 worker serves both prefill and decode behind Dynamo.
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN","rejection_sample_method":"synthetic","synthetic_acceptance_length":2.78}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-eval-agentic.yaml
@@ -1,0 +1,117 @@
+name: "minimax-m3-vllm-agg-gb300-tp4-c1-fp4-eval-agentic"
+# Real-verification twin of agg-tp4-c1-agentic.yaml. Synthetic EAGLE
+# acceptance is intentionally omitted; all other runtime settings match.
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-agentic.yaml
@@ -1,0 +1,119 @@
+name: "minimax-m3-vllm-agg-gb300-tp4-c30-vllm-simple-fp4-agentic"
+# GB300 aggregate translation of the B300 TP4/C30 throughput point. One TP4
+# worker serves both phases behind Dynamo and uses 700 GiB of SimpleCPU-lazy.
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN","rejection_sample_method":"synthetic","synthetic_acceptance_length":2.78}'
+      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":751619276800,"cpu_bytes_to_use_per_rank":187904819200,"lazy_offload":true}}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-eval-agentic.yaml
@@ -1,0 +1,119 @@
+name: "minimax-m3-vllm-agg-gb300-tp4-c30-vllm-simple-fp4-eval-agentic"
+# Real-verification twin of the TP4/C30 SimpleCPU-lazy throughput recipe.
+# Synthetic EAGLE acceptance is omitted; topology and memory are identical.
+
+model:
+  path: "nvidia/MiniMax-M3-NVFP4"
+  container: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "nvidia/MiniMax-M3-NVFP4"
+  container:
+    image: "vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9"
+  frameworks:
+    dynamo: "1.4.0.dev20260730"
+
+dynamo:
+  version: "1.4.0.dev20260730"
+  install: true
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+environment:
+  PYTHONHASHSEED: "0"
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "least-loaded"
+    router-session-affinity-ttl-secs: 14400
+  env:
+    DYN_TOKENIZER: "fastokens"
+    DYN_TOKENIZER_CACHE_BYTES: "8589934592"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+
+backend:
+  type: vllm
+  connector: null
+  aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    DYN_TCP_CONNECT_TIMEOUT: "120"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+    VLLM_FLOAT32_MATMUL_PRECISION: "high"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_USE_NCCL_SYMM_MEM: "0"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+  vllm_config:
+    aggregated:
+      served-model-name: "nvidia/MiniMax-M3-NVFP4"
+      tensor-parallel-size: 4
+      pipeline-parallel-size: 1
+      trust-remote-code: true
+      enable-prefix-caching: true
+      kv-cache-dtype: "fp8"
+      block-size: 128
+      gpu-memory-utilization: 0.9
+      max-model-len: 1048576
+      language-model-only: true
+      no-enable-flashinfer-autotune: true
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
+      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":751619276800,"cpu_bytes_to_use_per_rank":187904819200,"lazy_offload":true}}'
+      max-cudagraph-capture-size: 512
+      max-num-batched-tokens: 16384
+      stream-interval: 20
+      reasoning-parser: "minimax_m3"
+      dyn-tool-call-parser: "minimax_m3"
+      dyn-reasoning-parser: "minimax_m3"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: "bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh"
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: "14400"
+    AIPERF_EXTRA_INPUTS: "thinking:true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "vllm:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    AIPERF_SERVER_METRICS_COLLECTION_INTERVAL: "1.0"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7438,6 +7438,69 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
         decode: { num-worker: 0, tp: 8, ep: 8, dp-attn: true }
 
+minimaxm3-fp4-gb300-dynamo-vllm-agentic-agg-mtp:
+  image: vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9
+  model: nvidia/MiniMax-M3-NVFP4
+  model-prefix: minimaxm3
+  runner: cluster:gb300-nv
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.4.0.dev20260730" }
+  multinode: true
+  disagg: false
+  scenarios:
+    agentic-coding:
+    # 0.887 resolves the two-GPU worker's proportional GB300 host-DRAM
+    # budget to 400 GB. The TP2/C24 recipe enforces 400 GiB total and
+    # 200 GiB per rank for SimpleCPU-lazy.
+    - dram-utilization: 0.887
+      search-space:
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: vllm-simple }
+        conc-list: [24]
+        prefill:
+          num-worker: 1
+          tp: 2
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-agentic.yaml"
+          - "EVAL_CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp2-c24-eval-agentic.yaml"
+        # The aggregate worker performs both phases. Keep the decode worker
+        # count at zero so result processing counts two GPUs only once.
+        decode: { num-worker: 0, tp: 2, ep: 1, dp-attn: false }
+    # 0.777 resolves a full four-GPU GB300 node to 700 GB. The TP4/C30
+    # recipe enforces 700 GiB total and 175 GiB per rank; resident TP4
+    # points receive a zero host-DRAM budget.
+    - dram-utilization: 0.777
+      search-space:
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [1, 5, 10, 15, 20]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-agentic.yaml"
+          - "EVAL_CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c1-eval-agentic.yaml"
+        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: vllm-simple }
+        conc-list: [30]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-agentic.yaml"
+          - "EVAL_CONFIG_FILE=recipes/vllm/minimax-m3/agentic/gb300-fp4/agg-tp4-c30-vllm-simple-eval-agentic.yaml"
+        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
+
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6103,3 +6103,12 @@
     - "Use a 270 GB/rank target HiCache pool for the GLM-5.2 B200 TP8 c12 and c16 AgentX points to avoid the host-cache capacity cliff."
     - "Keep the existing ratio-0.75 pool for c1, c4, and c8 while retaining the SGLang EAGLE MTP and golden synthetic acceptance setup."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2652
+
+- config-keys:
+    - minimaxm3-fp4-gb300-dynamo-vllm-agentic-agg-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add MiniMax-M3 NVFP4 GB300 aggregate AgentX submission via the Dynamo frontend and a vLLM aggregated worker."
+    - "Cover TP2 C24 and TP4 C1/C5/C10/C15/C20/C30, with SimpleCPU-lazy KV offload at TP2 C24 (400 GiB) and TP4 C30 (700 GiB); other TP4 points stay GPU-resident."
+  pr-link: XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6111,4 +6111,4 @@
   description:
     - "Add MiniMax-M3 NVFP4 GB300 aggregate AgentX submission via the Dynamo frontend and a vLLM aggregated worker."
     - "Cover TP2 C24 and TP4 C1/C5/C10/C15/C20/C30, with SimpleCPU-lazy KV offload at TP2 C24 (400 GiB) and TP4 C30 (700 GiB); other TP4 points stay GPU-resident."
-  pr-link: XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2664

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -80,6 +80,9 @@ elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp4" ]]; then
 elif [[ $MODEL_PREFIX == "minimaxm2.5" && $PRECISION == "fp8" ]]; then
     export MODEL_PATH=/data/models/MiniMax-M2.5
     export SRT_SLURM_MODEL_PREFIX="minimax-m2.5-fp8"
+elif [[ $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp4" ]]; then
+    export MODEL_PATH=/scratch/models/MiniMax-M3-NVFP4
+    export SRT_SLURM_MODEL_PREFIX="nvidia/MiniMax-M3-NVFP4"
 elif [[ $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp8" ]]; then
     export MODEL_PATH=/data/models/MiniMax-M3-MXFP8
     export SRT_SLURM_MODEL_PREFIX="minimax-m3-mxfp8"
@@ -97,7 +100,7 @@ elif [[ $MODEL_PREFIX == "qwen3.5" && $PRECISION == "fp8" ]]; then
     export MODEL_PATH=/scratch/models/Qwen3.5-397B-A17B-FP8
     export SRT_SLURM_MODEL_PREFIX="qwen3.5-fp8"
 else
-    echo "Unsupported model: $MODEL_PREFIX-$PRECISION. Supported models are: dsr1-fp4, dsr1-fp8, dsv4-fp4, glm5-fp4, glm5-fp8, glm5.2-fp4, minimaxm2.5-fp4, minimaxm2.5-fp8, kimik2.5-fp4, qwen3.5-fp4, qwen3.5-fp8"
+    echo "Unsupported model: $MODEL_PREFIX-$PRECISION. Supported models are: dsr1-fp4, dsr1-fp8, dsv4-fp4, glm5-fp4, glm5-fp8, glm5.2-fp4, minimaxm2.5-fp4, minimaxm2.5-fp8, minimaxm3-fp4, minimaxm3-fp8, kimik2.5-fp4, qwen3.5-fp4, qwen3.5-fp8"
     exit 1
 fi
 
@@ -181,6 +184,14 @@ fi
 
 export EVAL_ONLY="${EVAL_ONLY:-false}"
 
+# Agentic eval jobs use a real-verification recipe instead of the throughput
+# recipe's synthetic EAGLE acceptance model. Keep throughput and eval topology
+# identical; only speculative-token verification differs.
+if [[ "$EVAL_ONLY" == "true" && -n "${EVAL_CONFIG_FILE:-}" ]]; then
+    CONFIG_FILE="$EVAL_CONFIG_FILE"
+    echo "EVAL_ONLY=true: selecting real-verification recipe $CONFIG_FILE"
+fi
+
 export ISL="$ISL"
 export OSL="$OSL"
 
@@ -257,6 +268,9 @@ elif [[ "$IS_AGENTIC" == "1" ]]; then
     mkdir -p recipes/vllm/deepseek-v4/agentic || exit 1
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic" \
         recipes/vllm/deepseek-v4/agentic || exit 1
+    mkdir -p recipes/vllm/minimax-m3/agentic || exit 1
+    cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic" \
+        recipes/vllm/minimax-m3/agentic || exit 1
 elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv4" ]]; then
     git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"


### PR DESCRIPTION
## Description

- Config: `minimaxm3-fp4-gb300-dynamo-vllm-agentic-agg-mtp`
- Image: `vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9`

## 中文摘要

- 配置：`minimaxm3-fp4-gb300-dynamo-vllm-agentic-agg-mtp`
- 镜像：`vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9`

## Type of Change

- [x] New feature
- [x] Configuration change

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.
