### PR TITLE
docs(golden_al): document ATOM's forced acceptance-length setting

### DIFF
--- a/golden_al_distribution/README.md
+++ b/golden_al_distribution/README.md
@@ -53,6 +53,23 @@ TensorRT-LLM supports it through [`TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS`](
 TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS=2.5
 ```
 
+ATOM supports it through `--spec-decode-acceptance-length`, which takes the golden AL directly:
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model MODEL \
+  --draft-model DRAFT_MODEL \
+  --method dspark \
+  --num-speculative-tokens 7 \
+  --spec-decode-acceptance-length 3.78
+```
+
+Acceptance length counts the target's guaranteed verification token, so the golden AL goes in unchanged — no off-by-one — matching vLLM's `synthetic_acceptance_length` and SGLang's `SGLANG_SIMULATE_ACC_LEN`. The value must fall in `[1, num_speculative_tokens + 1]`, and it resolves to the same minimum-variance per-position schedule vLLM derives, so the accepted-length *distribution* matches and not merely its mean. Accepted positions emit the real draft tokens, equivalent to SGLang's `real-draft-token`. The knob has an equivalent rate spelling, `--spec-decode-acceptance-rate`, which takes `(AL - 1) / num_speculative_tokens`; the two are mutually exclusive. Support landed in [ROCm/ATOM#1948](https://github.com/ROCm/ATOM/pull/1948).
+
+Read the realized value back from `average_tokens_per_forward` on the server's `/debug/mtp_stats`, or the `atom:mtp_average_tokens_per_forward` Prometheus metric. ATOM computes it as `1 + accepted draft tokens / verification steps`, the same formula used to collect the golden curves, so the two are directly comparable.
+
+**DSpark note:** ATOM rejects forced acceptance combined with the DSpark confidence scheduler (`--dspark-config '{"confidence_schedule": true}'`), which sizes each request's verify length at runtime and can cap acceptance below the requested length with no way to detect it. The golden DSpark curves were themselves collected without adaptive verification, so leaving it off is also the comparable configuration.
+
 This policy follows the same broad principle as MLPerf Inference: prescribe the workload rules needed for comparable system measurements. InferenceX is evaluating inference-system performance, not the ability to fine-tune a benchmark-specific speculative head.
 
 ## How a golden AL curve is collected
@@ -109,9 +126,13 @@ Before accepting an updated curve, reviewers should verify:
 | Model | Method | Golden YAML | Source run |
 | --- | --- | --- | --- |
 | DeepSeek V4 Pro | MTP | [`dsv4_mtp.yaml`](dsv4_mtp.yaml) | [27180633016](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27180633016) |
+| DeepSeek V4 Pro 0813 | DSpark (probabilistic draft) | [`dsv4-pro-0813-dspark.yaml`](dsv4-pro-0813-dspark.yaml) | [31742838308](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31742838308) |
 | Qwen3.5 397B-A17B | MTP | [`qwen3.5_mtp.yaml`](qwen3.5_mtp.yaml) | [27317114007](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27317114007) |
 | Kimi K2.5 | EAGLE3 | [`kimik2.5_eagle3.yaml`](kimik2.5_eagle3.yaml) | [28122195822](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28122195822) |
+| Kimi K3 | DSpark | [`kimik3_dspark.yaml`](kimik3_dspark.yaml) | [30304797750](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30304797750) |
+| Kimi K3 | DSpark (probabilistic draft, block verify) | [`kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml`](kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml) | [30316471205](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30316471205) |
 | MiniMax-M3 | EAGLE3 | [`minimaxm3_eagle3.yaml`](minimaxm3_eagle3.yaml) | [28061204145](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28061204145) |
+| MiniMax-M3 | EAGLE3 (GQA) | [`minimaxm3_eagle3_gqa.yaml`](minimaxm3_eagle3_gqa.yaml) | [29784780049](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29784780049) |
 | GLM-5.2 | MTP | [`glm5.2_mtp.yaml`](glm5.2_mtp.yaml) | [28058352479](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28058352479) |
 
 ## Primary references
@@ -122,6 +143,7 @@ Before accepting an updated curve, reviewers should verify:
 - [SPEED-Bench dataset and dataset card](https://huggingface.co/datasets/nvidia/SPEED-Bench)
 - [vLLM SPEED-Bench integration](https://github.com/vllm-project/vllm/pull/36029)
 - [vLLM synthetic acceptance support](https://github.com/vllm-project/vllm/pull/40662)
+- [ATOM forced acceptance-length support](https://github.com/ROCm/ATOM/pull/1948)
 - [InferenceX synthetic-acceptance tracking issue](https://github.com/SemiAnalysisAI/InferenceX/issues/1651)
 - [InferenceX SPEED-Bench workflow](../.github/workflows/speedbench-al.yml)
 - [InferenceX early reference-alignment PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1592)

--- a/golden_al_distribution/README_zh.md
+++ b/golden_al_distribution/README_zh.md
@@ -53,6 +53,23 @@ TensorRT-LLM 通过 [`TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS`](https://githu
 TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS=2.5
 ```
 
+ATOM 通过 `--spec-decode-acceptance-length` 支持该策略，该参数直接接受黄金 AL：
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model MODEL \
+  --draft-model DRAFT_MODEL \
+  --method dspark \
+  --num-speculative-tokens 7 \
+  --spec-decode-acceptance-length 3.78
+```
+
+接受长度包含目标模型保证产出的验证 token，因此黄金 AL 可以原样填入，**不存在差一问题**，与 vLLM 的 `synthetic_acceptance_length` 和 SGLang 的 `SGLANG_SIMULATE_ACC_LEN` 单位一致。取值范围为 `[1, num_speculative_tokens + 1]`，并会解析为与 vLLM 相同的最小方差逐位置概率表，因此匹配的是接受长度的**分布**，而不仅仅是均值。被接受的位置输出真实的草稿 token，等价于 SGLang 的 `real-draft-token`。该参数还有一种等价的接受率写法 `--spec-decode-acceptance-rate`，取值为 `(AL - 1) / num_speculative_tokens`；两者互斥。相关支持见 [ROCm/ATOM#1948](https://github.com/ROCm/ATOM/pull/1948)。
+
+实测值可从服务端 `/debug/mtp_stats` 的 `average_tokens_per_forward` 字段读取，或从 `atom:mtp_average_tokens_per_forward` Prometheus 指标读取。ATOM 按 `1 + 已接受草稿 token 数 / 验证步数` 计算，与黄金曲线的收集公式相同，可直接比较。
+
+**DSpark 注意事项：** ATOM 禁止将强制接受与 DSpark 置信度调度器（`--dspark-config '{"confidence_schedule": true}'`）同时使用——后者在运行时决定每个请求的验证长度，可能把接受长度压到目标值以下，且无法提前检测。黄金 DSpark 曲线本身也是在未开启自适应验证的条件下收集的，因此关闭它同样是可比较的配置。
+
 这一策略遵循与 MLPerf Inference 相同的广义原则：规定可比较系统测量所需的工作负载规则。InferenceX 评估的是推理系统性能，而不是微调特定基准推测头的能力。
 
 ## 黄金 AL 曲线如何收集
@@ -109,9 +126,13 @@ gh workflow run speedbench-al.yml \
 | 模型 | 方法 | 黄金 YAML | 源 run |
 | --- | --- | --- | --- |
 | DeepSeek V4 Pro | MTP | [`dsv4_mtp.yaml`](dsv4_mtp.yaml) | [27180633016](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27180633016) |
+| DeepSeek V4 Pro 0813 | DSpark（概率采样草稿） | [`dsv4-pro-0813-dspark.yaml`](dsv4-pro-0813-dspark.yaml) | [31742838308](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31742838308) |
 | Qwen3.5 397B-A17B | MTP | [`qwen3.5_mtp.yaml`](qwen3.5_mtp.yaml) | [27317114007](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27317114007) |
 | Kimi K2.5 | EAGLE3 | [`kimik2.5_eagle3.yaml`](kimik2.5_eagle3.yaml) | [28122195822](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28122195822) |
+| Kimi K3 | DSpark | [`kimik3_dspark.yaml`](kimik3_dspark.yaml) | [30304797750](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30304797750) |
+| Kimi K3 | DSpark（概率采样草稿 + 块验证） | [`kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml`](kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml) | [30316471205](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30316471205) |
 | MiniMax-M3 | EAGLE3 | [`minimaxm3_eagle3.yaml`](minimaxm3_eagle3.yaml) | [28061204145](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28061204145) |
+| MiniMax-M3 | EAGLE3（GQA） | [`minimaxm3_eagle3_gqa.yaml`](minimaxm3_eagle3_gqa.yaml) | [29784780049](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29784780049) |
 | GLM-5.2 | MTP | [`glm5.2_mtp.yaml`](glm5.2_mtp.yaml) | [28058352479](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28058352479) |
 
 ## 主要参考资料
@@ -122,6 +143,7 @@ gh workflow run speedbench-al.yml \
 - [SPEED-Bench 数据集和数据集卡](https://huggingface.co/datasets/nvidia/SPEED-Bench)
 - [vLLM SPEED-Bench 集成](https://github.com/vllm-project/vllm/pull/36029)
 - [vLLM 合成接受支持](https://github.com/vllm-project/vllm/pull/40662)
+- [ATOM 强制接受长度支持](https://github.com/ROCm/ATOM/pull/1948)
 - [InferenceX 合成接受跟踪 issue](https://github.com/SemiAnalysisAI/InferenceX/issues/1651)
 - [InferenceX SPEED-Bench 工作流](../.github/workflows/speedbench-al.yml)
 - [InferenceX 早期参考值对齐 PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1592)


### PR DESCRIPTION
## Summary

The AgentX fairness section documents synthetic-acceptance settings for vLLM, SGLang, and TensorRT-LLM, but not ATOM, so an ATOM submission had no documented way to replay a committed golden AL. This adds that paragraph.

ATOM takes the value directly:

```bash
python -m atom.entrypoints.openai_server \
  --model MODEL --draft-model DRAFT_MODEL \
  --method dspark --num-speculative-tokens 7 \
  --spec-decode-acceptance-length 3.78
```

Three properties worth calling out, all verified against this directory's `kimik3_dspark.yaml`:

- **Same unit, no off-by-one.** Acceptance length counts the target's guaranteed verification token, matching vLLM's `synthetic_acceptance_length` and SGLang's `SGLANG_SIMULATE_ACC_LEN`, so a golden AL is pasted in unchanged (unlike the TensorRT-LLM variable, which needs `AL - 1`).
- **Same distribution, not just the same mean.** The value resolves to the minimum-variance per-position schedule vLLM's `_acceptance_length_to_rates` derives — at AL 3.78 over 7 draft slots, `[1.0, 1.0, 0.78, 0, 0, 0, 0]`. Accepted positions emit the real draft tokens, equivalent to SGLang's `real-draft-token`.
- **Same AL formula.** ATOM reports `average_tokens_per_forward` as `1 + accepted draft tokens / verification steps`, identical to the collection formula in this README, so measured and golden values are directly comparable.

**DSpark caveat.** ATOM rejects forced acceptance combined with the DSpark confidence scheduler, which sizes each request's verify length at runtime and can cap acceptance below the requested length with no way to detect it. The collectors under `benchmarks/single_node/speedbench/` do not pass `enable_adaptive_verification`, so the golden DSpark curves were measured on the full fixed block — leaving the scheduler off is therefore also the comparable configuration.

Support landed in [ROCm/ATOM#1948](https://github.com/ROCm/ATOM/pull/1948).

### Drive-by: golden-curve table refresh

The "Current golden curves" table listed 5 entries while the directory now holds 9. Added the missing rows, with source runs taken from the first line of each YAML:

| Model | Method | Golden YAML | Source run |
| --- | --- | --- | --- |
| DeepSeek V4 Pro 0813 | DSpark (probabilistic draft) | `dsv4-pro-0813-dspark.yaml` | 31742838308 |
| Kimi K3 | DSpark | `kimik3_dspark.yaml` | 30304797750 |
| Kimi K3 | DSpark (probabilistic draft, block verify) | `kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml` | 30316471205 |
| MiniMax-M3 | EAGLE3 (GQA) | `minimaxm3_eagle3_gqa.yaml` | 29784780049 |

Happy to split this into its own PR if you would rather keep the change scoped to the ATOM paragraph.

