### PR TITLE
[AMD][AgentX] Add DeepSeek-V4-Pro FP4 MI355X ATOM MTP / 新增 DeepSeek-V4-Pro ATOM MTP

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -112,9 +112,9 @@ ATOM_CMD=(
     --index-cache-dtype fp8
     --enable-prefix-caching
     --gpu-memory-utilization 0.9
-    --max-num-batched-tokens 8192
-    --attn-prefill-chunk-size 8192
-    --state-checkpoint-interval-tokens 8192
+    --max-num-batched-tokens 16384
+    --attn-prefill-chunk-size 16384
+    --state-checkpoint-interval-tokens 32768
     --level 3
     --cudagraph-mode FULL
     "${SPEC_ARGS[@]}"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -103,7 +103,7 @@ ATOM_CMD=(
     --server-port "$PORT"
     --tensor-parallel-size "$TP"
     --kv-cache-dtype fp8
-    --index-cache-dtype fp8
+    --index-cache-dtype fp4
     --enable-prefix-caching
     --gpu-memory-utilization 0.9
     --max-num-batched-tokens 16384

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -112,9 +112,9 @@ ATOM_CMD=(
     --index-cache-dtype fp8
     --enable-prefix-caching
     --gpu-memory-utilization 0.9
-    --max-num-batched-tokens 16384
-    --attn-prefill-chunk-size 16384
-    --state-checkpoint-interval-tokens 32768
+    --max-num-batched-tokens 8192
+    --attn-prefill-chunk-size 8192
+    --state-checkpoint-interval-tokens 8192
     --level 3
     --cudagraph-mode FULL
     "${SPEC_ARGS[@]}"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -82,12 +82,6 @@ trap 'exit 143' TERM
 # request bursts produced by subagent fan-out.
 MAX_NUM_SEQS=$((2 * CONC))
 
-# Saturation arms carry a larger in-flight working set than the 30-minute
-# default warmup drain allows.
-if [ "$CONC" -ge 32 ]; then
-    export AGENTIC_WARMUP_GRACE_PERIOD=3600
-fi
-
 # golden_al_distribution/dsv4_mtp.yaml: thinking_on, 3 draft tokens -> AL 2.49
 # acceptance rate = (2.49 - 1) / 3 = 0.4966666667.
 NUM_SPEC_TOKENS=3
@@ -114,7 +108,7 @@ ATOM_CMD=(
     --gpu-memory-utilization 0.9
     --max-num-batched-tokens 16384
     --attn-prefill-chunk-size 16384
-    --state-checkpoint-interval-tokens 32768
+    --state-checkpoint-interval-tokens 8192
     --level 3
     --cudagraph-mode FULL
     "${SPEC_ARGS[@]}"

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -82,6 +82,12 @@ trap 'exit 143' TERM
 # request bursts produced by subagent fan-out.
 MAX_NUM_SEQS=$((2 * CONC))
 
+# Saturation arms carry a larger in-flight working set than the 30-minute
+# default warmup drain allows.
+if [ "$CONC" -ge 32 ]; then
+    export AGENTIC_WARMUP_GRACE_PERIOD=3600
+fi
+
 # golden_al_distribution/dsv4_mtp.yaml: thinking_on, 3 draft tokens -> AL 2.49
 # acceptance rate = (2.49 - 1) / 3 = 0.4966666667.
 NUM_SPEC_TOKENS=3

--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# Agentic trace replay benchmark for DeepSeek-V4-Pro FP4 on MI355X using
+# ATOM MTP. Throughput runs use the committed golden synthetic acceptance;
+# eval-only runs use the model's real MTP acceptance.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [ "$TP" -ne 8 ] || [ "$EP_SIZE" -ne 1 ] || [ "$DP_ATTENTION" != "false" ]; then
+    echo "This recipe requires TP=8, EP_SIZE=1, and DP_ATTENTION=false" >&2
+    exit 1
+fi
+require_agentic_kv_offload_none
+
+if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+rocm-smi || true
+amd-smi || true
+
+resolve_trace_source
+install_agentic_deps
+
+# ATOM runtime settings validated with the DeepSeek-V4-Pro AgentX baseline.
+export AITER_BF16_FP8_MOE_BOUND=0
+export AITER_LOG_LEVEL=WARNING
+export ATOM_MOE_GU_ITLV=1
+export ATOM_DISABLE_MMAP=true
+export ATOM_DEBUG_PREFIX_HITS=1
+export ATOM_PROFILER_MORE=0
+export ATOM_PROFILER_TIMEOUT=1200
+
+# AgentX/AIPerf network, failure, warmup, and trace-gap settings from the
+# validated one-hour baseline.
+export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
+export AIPERF_FAILED_REQUEST_THRESHOLD=0.10
+export AIPERF_LIVE_FAILED_REQUEST_THRESHOLD=0.10
+export AIPERF_TRACE_IDLE_GAP_CAP_SECONDS=300
+export AIPERF_WARMUP_REQUESTS_PER_LANE=10
+export AIPERF_BENCHMARK_GRACE_PERIOD=30
+
+# Require ATOM Prometheus metrics in every official result.
+export AIPERF_SERVER_METRICS_URLS="http://localhost:${PORT}/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="atom:"
+
+wait_for_amd_gpu_clean
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+SERVER_PID=""
+cleanup_atom_server() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "ATOM server" 60
+    exit "$exit_code"
+}
+trap cleanup_atom_server EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# AgentX concurrency counts session trees. Keep 2x scheduler headroom for the
+# request bursts produced by subagent fan-out.
+MAX_NUM_SEQS=$((2 * CONC))
+
+# golden_al_distribution/dsv4_mtp.yaml: thinking_on, 3 draft tokens -> AL 2.49
+# acceptance rate = (2.49 - 1) / 3 = 0.4966666667.
+NUM_SPEC_TOKENS=3
+SPEC_ACCEPTANCE_RATE=0.4966666667
+SPEC_ARGS=(
+    --method mtp
+    --num-speculative-tokens "$NUM_SPEC_TOKENS"
+)
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    SPEC_ARGS+=(--spec-decode-acceptance-rate "$SPEC_ACCEPTANCE_RATE")
+fi
+
+echo "Starting ATOM server with MAX_NUM_SEQS=$MAX_NUM_SEQS NUM_SPEC_TOKENS=$NUM_SPEC_TOKENS SPEC_ACCEPTANCE_RATE=$SPEC_ACCEPTANCE_RATE EVAL_ONLY=${EVAL_ONLY:-false}"
+ATOM_CMD=(
+    python3 -u -m atom.entrypoints.openai_server
+    --model "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --server-port "$PORT"
+    --tensor-parallel-size "$TP"
+    --kv-cache-dtype fp8
+    --index-cache-dtype fp8
+    --enable-prefix-caching
+    --gpu-memory-utilization 0.9
+    --max-num-batched-tokens 16384
+    --attn-prefill-chunk-size 16384
+    --state-checkpoint-interval-tokens 32768
+    --level 3
+    --cudagraph-mode FULL
+    "${SPEC_ARGS[@]}"
+    --max-num-seqs "$MAX_NUM_SEQS"
+)
+write_command "$RESULT_DIR/server_command.txt" "${ATOM_CMD[@]}"
+"${ATOM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    # AgentX DSv4 traces already carry fully formed chat payloads; do not apply
+    # AIPerf's generic chat template on top of them.
+    build_replay_cmd "$RESULT_DIR"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1284,6 +1284,22 @@ dsv4-fp4-mi355x-vllm-agentic-mtp:
       # while MTP creates two. Restore these points after the upstream hybrid
       # KV recovery fix lands: https://github.com/vllm-project/vllm/pull/45497
 
+# DeepSeek-V4-Pro FP4 AgentX on one MI355X node using ATOM MTP. Throughput
+# uses the thinking_on golden AL 2.49 for three draft tokens; eval uses real
+# MTP acceptance. max-num-seqs is set to 2x concurrency by the recipe.
+dsv4-fp4-mi355x-atom-agentic-mtp:
+  image: rocm/atom-dev:nightly_202608181633
+  model: deepseek-ai/DeepSeek-V4-Pro
+  model-prefix: dsv4
+  runner: cluster:mi355x-amds
+  precision: fp4
+  framework: atom
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 48] }
+
 dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-v2

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1288,7 +1288,7 @@ dsv4-fp4-mi355x-vllm-agentic-mtp:
 # uses the thinking_on golden AL 2.49 for three draft tokens; eval uses real
 # MTP acceptance. max-num-seqs is set to 2x concurrency by the recipe.
 dsv4-fp4-mi355x-atom-agentic-mtp:
-  image: rocm/atom-dev:nightly_202608181633
+  image: rocm/atom-dev:nightly_202608201032
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1298,8 +1298,7 @@ dsv4-fp4-mi355x-atom-agentic-mtp:
   scenarios:
     agentic-coding:
     - search-space:
-      #- { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 48] }
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 48] }
 
 dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1298,7 +1298,8 @@ dsv4-fp4-mi355x-atom-agentic-mtp:
   scenarios:
     agentic-coding:
     - search-space:
-      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 48] }
+      #- { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 48] }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, spec-decoding: mtp, conc-list: [48] }
 
 dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6204,13 +6204,6 @@
     - "Add DeepSeek-V4-Pro FP4 ATOM MTP AgentX on one 8x MI355X node at concurrency 1, 2, 4, 8, 16, 32, and 48, with no KV offload and max-num-seqs set to twice concurrency."
     - "Use rocm/atom-dev:nightly_202608181633 (digest sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f), FP8 KV/index caches, prefix caching, 32K state checkpoints, 16K batching/prefill chunks, and FULL cudagraph mode."
     - "Use three-token MTP with the committed DeepSeek-V4 thinking-mode golden AL 2.49 (synthetic acceptance rate 0.4966666667) for throughput, while eval-only runs measure real MTP acceptance."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2668
-
-- config-keys:
-    - dsv4-fp4-mi355x-atom-agentic-mtp
-  scenario-type:
-    - agentic-coding
-  description:
     - "Increase the AgentX warmup grace period from the 1800-second default to 3600 seconds at concurrency 32 and 48, matching the DeepSeek-V4-Pro SGLang saturation recipe so in-flight warmup requests can drain and reused long prefixes are fully primed before profiling."
     - "Keep concurrency 1 through 16 at the default 1800 seconds; the profiling duration remains 3600 seconds for every concurrency arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2668

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6180,4 +6180,4 @@
     - "Add DeepSeek-V4-Pro FP4 ATOM MTP AgentX on one 8x MI355X node at concurrency 1, 2, 4, 8, 16, 32, and 48, with no KV offload and max-num-seqs set to twice concurrency."
     - "Use rocm/atom-dev:nightly_202608181633 (digest sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f), FP8 KV/index caches, prefix caching, 32K state checkpoints, 16K batching/prefill chunks, and FULL cudagraph mode."
     - "Use three-token MTP with the committed DeepSeek-V4 thinking-mode golden AL 2.49 (synthetic acceptance rate 0.4966666667) for throughput, while eval-only runs measure real MTP acceptance."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2668

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6205,3 +6205,12 @@
     - "Use rocm/atom-dev:nightly_202608181633 (digest sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f), FP8 KV/index caches, prefix caching, 32K state checkpoints, 16K batching/prefill chunks, and FULL cudagraph mode."
     - "Use three-token MTP with the committed DeepSeek-V4 thinking-mode golden AL 2.49 (synthetic acceptance rate 0.4966666667) for throughput, while eval-only runs measure real MTP acceptance."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2668
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Increase the AgentX warmup grace period from the 1800-second default to 3600 seconds at concurrency 32 and 48, matching the DeepSeek-V4-Pro SGLang saturation recipe so in-flight warmup requests can drain and reused long prefixes are fully primed before profiling."
+    - "Keep concurrency 1 through 16 at the default 1800 seconds; the profiling duration remains 3600 seconds for every concurrency arm."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2668

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6171,3 +6171,13 @@
     - "Use AITER INT4 quick-reduce, ptpc_fp8 online quantization excluding embeddings, lm_head, gates, and experts, an FP8 KV cache, and three-token MTP with golden synthetic acceptance length 2.99 for benchmark runs."
     - "Set max-num-seqs to twice the concurrency, select CUDA graph capture sizes by concurrency, and cap max-num-batched-tokens at 16384."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2576
+
+- config-keys:
+    - dsv4-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add DeepSeek-V4-Pro FP4 ATOM MTP AgentX on one 8x MI355X node at concurrency 1, 2, 4, 8, 16, 32, and 48, with no KV offload and max-num-seqs set to twice concurrency."
+    - "Use rocm/atom-dev:nightly_202608181633 (digest sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f), FP8 KV/index caches, prefix caching, 32K state checkpoints, 16K batching/prefill chunks, and FULL cudagraph mode."
+    - "Use three-token MTP with the committed DeepSeek-V4 thinking-mode golden AL 2.49 (synthetic acceptance rate 0.4966666667) for throughput, while eval-only runs measure real MTP acceptance."
+  pr-link: TBD


### PR DESCRIPTION
## English

### Summary

- Add `dsv4-fp4-mi355x-atom-agentic-mtp` for DeepSeek-V4-Pro FP4 on one 8x MI355X node with ATOM, TP8, no KV offload, and AgentX concurrency `[1, 2, 4, 8, 16, 32, 48]`.
- Set `max-num-seqs = 2 * concurrency`, FP8 KV/index caches, prefix caching, 32K state checkpoints, 16K batched-token/prefill-chunk limits, compilation level 3, and FULL cudagraph mode.
- Use three-token MTP. Throughput runs use the committed `thinking_on` golden AL 2.49 (`--spec-decode-acceptance-rate 0.4966666667`); eval-only runs omit synthetic acceptance and use real MTP acceptance.
- Pin `rocm/atom-dev:nightly_202608181633` (manifest digest `sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f`).
- Keep native DeepSeek-V4 AgentX chat payload handling. The trace payloads are already fully formed, so the recipe does not apply AIPerf's generic chat template a second time.

This refresh supersedes the stale #2346 submission: it uses the current AgentX/AIPerf harness, a current ATOM image, complete server/runtime settings from the validated baseline, and the now-supported golden synthetic acceptance path. It does not modify or close #2346.

This recipe does not patch or check out ATOM at runtime. It is independent of ROCm/ATOM#1937 and does not use changes from that PR.

### Validation

- `bash -n benchmarks/single_node/agentic/dsv4_fp4_mi355x_atom_mtp.sh`
- YAML parsing for `configs/amd-master.yaml`, `configs/runners.yaml`, and `perf-changelog.yaml`
- Exact-key `test-config` matrix generation: 7 intended AgentX entries only
- Filtered `full-sweep` generation for `dsv4` / `atom` / `fp4` / `cluster:mi355x-amds`
- Launcher route resolves to the new executable benchmark script
- Docker manifest digest and the required ATOM CLI flags verified
- `git diff --check`

GPU sweep/eval will run under `full-sweep-fail-fast` after the changelog PR URL is backfilled.

## 中文

### 概要

- 新增 `dsv4-fp4-mi355x-atom-agentic-mtp`：在单节点 8x MI355X 上用 ATOM 运行 DeepSeek-V4-Pro FP4，采用 TP8、无 KV offload，AgentX 并发为 `[1, 2, 4, 8, 16, 32, 48]`。
- 设置 `max-num-seqs = 2 * concurrency`，启用 FP8 KV/index cache、prefix caching、32K state checkpoint、16K batched-token/prefill-chunk 上限、编译 level 3 和 FULL cudagraph。
- 使用 3 token MTP。吞吐测试采用仓库中 `thinking_on` 的 golden AL 2.49（`--spec-decode-acceptance-rate 0.4966666667`）；eval-only 不注入 synthetic acceptance，使用模型真实的 MTP acceptance。
- 固定镜像 `rocm/atom-dev:nightly_202608181633`（manifest digest：`sha256:fdc5650f2b6d13c22f1f1b3873ee6dc61278e6b0b90dc24d0f6c55810895032f`）。
- 保留 DeepSeek-V4 AgentX 原生 chat payload 处理。trace 中已经是完整 chat payload，因此不再二次套用 AIPerf 的通用 chat template。

这个 PR 是对陈旧 #2346 的更新替代：使用当前 AgentX/AIPerf harness、当前 ATOM 镜像、实测基线中的完整 server/runtime 参数，以及 ATOM 现已支持的 golden synthetic acceptance 路径。本 PR 不修改或关闭 #2346。

本 recipe 不会在运行时 patch 或 checkout ATOM；它与 ROCm/ATOM#1937 无关，也不使用该 PR 的改动。

### 验证

- benchmark 脚本通过 `bash -n`
- `configs/amd-master.yaml`、`configs/runners.yaml` 和 `perf-changelog.yaml` 均通过 YAML 解析
- exact-key `test-config` 只生成预期的 7 个 AgentX 点
- `dsv4` / `atom` / `fp4` / `cluster:mi355x-amds` 的过滤 `full-sweep` 生成通过
- launcher 路由到新建的可执行 benchmark 脚本
- 已核对 Docker manifest digest 和所需 ATOM CLI 参数
- `git diff --check` 通过

回填 changelog 中的真实 PR URL 后，将添加 `full-sweep-fail-fast` 运行 GPU sweep/eval。
