### PR TITLE
Test AIPerf empty-content TTFT on MiniMax TRT

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_b300_trt_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_b300_trt_mtp.sh
@@ -173,5 +173,6 @@ if [ "${EVAL_ONLY}" = "true" ]; then
     run_eval --port "$PORT"
 else
     build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --allow-empty-content"
     run_agentic_replay_and_write_outputs "$RESULT_DIR"
 fi

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6215,3 +6215,12 @@
     - "Use NIXL KV transfer for disaggregated variants, prefill HiCache DRAM offload, native MTP with committed thinking-on golden acceptance lengths, and lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642."
     - "Leave DYN_ROUTER_TEMPERATURE unset across the recipe set."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2642
+
+- config-keys:
+    - minimaxm3-fp4-b300-trtllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Test AIPerf PR #42 empty-content TTFT handling on the MiniMax-M3 NVFP4 B300 TensorRT-LLM AgentX configuration."
+    - "Pin utils/aiperf to e8ece5d29bd0285af1ced36fbc4c670328b2d58c and enable --allow-empty-content for this recipe."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2682


### PR DESCRIPTION
## Summary

- Pin `utils/aiperf` to the exact head of SemiAnalysisAI/agentx-harness PR #42 (`e8ece5d29bd0285af1ced36fbc4c670328b2d58c`).
- Enable `--allow-empty-content` only for the MiniMax-M3 NVFP4 B300 TensorRT-LLM AgentX recipe.
- Use the existing TP8, concurrency-1 configuration to test whether the parser-suppressed first generation event establishes TTFT.

## Why

The existing MiniMax-M3 TRT-LLM configuration uses `stream_interval: 100`. Its first generated reasoning delimiter is suppressed by the reasoning parser, so current AIPerf waits for later non-empty content before recording TTFT. This PR tests AIPerf PR #42 against that concrete serving path.

## Validation

- `bash -n benchmarks/single_node/agentic/minimaxm3_fp4_b300_trt_mtp.sh`
- Focused AIPerf tests: `26 passed`
- Matrix generation selects exactly MiniMax-M3 TRT, B300, TP8, concurrency 1.
- A one-off AgentX fast run will be linked after dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark script and perf changelog only; no production serving or auth paths change.
> 
> **Overview**
> This wires **AIPerf empty-content TTFT handling** into the MiniMax-M3 NVFP4 B300 TensorRT-LLM AgentX benchmark: after `build_replay_cmd`, the replay path now appends **`--allow-empty-content`** before `run_agentic_replay_and_write_outputs` (throughput runs only; eval unchanged).
> 
> **`perf-changelog.yaml`** adds an **agentic-coding** entry for `minimaxm3-fp4-b300-trtllm-agentic-mtp` describing validation of AIPerf PR #42 on this recipe (including the aiperf pin and flag called out in the changelog text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9707fc6f32a223287f5b9896b57eafc01aabf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->