### PR TITLE
Refresh B200 MiniMax M3 TRT AgentX with stream interval 20

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_b200_trt_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_b200_trt_mtp.sh
@@ -134,7 +134,7 @@ enable_chunked_prefill: true
 enable_autotuner: true
 trust_remote_code: true
 reasoning_parser: minimax_m3
-stream_interval: 100
+stream_interval: 20
 print_iter_log: true
 num_postprocess_workers: 8
 enable_attention_dp: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6225,3 +6225,11 @@
     - "Add a TP2/EP2 HiCache branch and update the resident recipes with extra_buffer_lazy, ReplaySSM speculative verification, and checkpoint page-cache release."
     - "Select TP4 C1/C2/C4/C8/C12/C20/C24, TP2/EP2 resident C4/C8/C12/C20, and TP2/EP2 HiCache C22/C24/C28/C32/C40 with golden synthetic acceptance length 3.39."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2660
+
+- config-keys:
+    - minimaxm3-fp4-b200-trtllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Refresh with lower stream interval to collect correct client metrics"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2686


### PR DESCRIPTION
## Summary

- Lower the MiniMax M3 B200 TensorRT-LLM AgentX stream interval from 100 to 20.
- Refresh the affected AgentX sweep so client-side latency metrics use more frequent stream observations.

## Why

A stream interval of 100 can collapse short generations into a single content update. That makes client-observed inter-token latency and interactivity unrepresentative for those requests. A lower interval provides enough intermediate observations to measure the client experience more faithfully.

## Performance changelog

Refresh with lower stream interval to collect correct client metrics

## Validation

- `bash -n benchmarks/single_node/agentic/minimaxm3_fp4_b200_trt_mtp.sh`
- `git diff --check`