### PR TITLE
Fix agentic eval speculative decoding / 修复 AgentX 评测的推测解码传递

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -460,7 +460,7 @@ jobs:
             isl: '0'
             osl: '0'
             max-model-len: '0'
-            spec-decoding: 'none'
+            spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ 'false' }}
             run-eval: true
             eval-only: true

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -58,16 +58,6 @@ def test_recipe_fingerprint_reaches_all_e2e_benchmark_jobs():
     assert workflow.count("recipe-fingerprint: ${{ matrix.config") == 8
 
 
-def test_e2e_agentic_eval_preserves_spec_decoding():
-    workflow = (Path(__file__).parents[1] / ".github/workflows/e2e-tests.yml").read_text()
-    agentic_eval_job = workflow.split("test-sweep-agentic-evals:", 1)[1].split(
-        "test-sweep-multi-node-agentic:", 1
-    )[0]
-
-    assert "spec-decoding: ${{ matrix.config.spec-decoding }}" in agentic_eval_job
-    assert "spec-decoding: 'none'" not in agentic_eval_job
-
-
 def test_recipe_fingerprint_disambiguates_result_and_artifact_names():
     repo_root = Path(__file__).parents[1]
     for template_name in ("benchmark-tmpl.yml", "benchmark-multinode-tmpl.yml"):

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -58,6 +58,16 @@ def test_recipe_fingerprint_reaches_all_e2e_benchmark_jobs():
     assert workflow.count("recipe-fingerprint: ${{ matrix.config") == 8
 
 
+def test_e2e_agentic_eval_preserves_spec_decoding():
+    workflow = (Path(__file__).parents[1] / ".github/workflows/e2e-tests.yml").read_text()
+    agentic_eval_job = workflow.split("test-sweep-agentic-evals:", 1)[1].split(
+        "test-sweep-multi-node-agentic:", 1
+    )[0]
+
+    assert "spec-decoding: ${{ matrix.config.spec-decoding }}" in agentic_eval_job
+    assert "spec-decoding: 'none'" not in agentic_eval_job
+
+
 def test_recipe_fingerprint_disambiguates_result_and_artifact_names():
     repo_root = Path(__file__).parents[1]
     for template_name in ("benchmark-tmpl.yml", "benchmark-multinode-tmpl.yml"):


### PR DESCRIPTION
## Summary / 摘要

English:
- Preserve `matrix.config.spec-decoding` when dispatching single-node agentic eval jobs from `e2e-tests.yml`.

中文：
- 从 `e2e-tests.yml` 分发单节点 AgentX 评测任务时，保留 `matrix.config.spec-decoding`。

## Root cause / 根因

English: The direct and trusted-external E2E path hardcoded `spec-decoding: none` only for the agentic eval job. The matrix still identified the recipe as MTP, but the launcher received `SPEC_DECODING=none` and selected the non-MTP script. This caused [run 32318818381](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32318818381) to fail before server startup.

中文：直接 E2E 和受信任外部 PR 的路径仅在 AgentX 评测任务中硬编码了 `spec-decoding: none`。矩阵仍将该配方标识为 MTP，但启动器收到 `SPEC_DECODING=none` 后选择了非 MTP 脚本，导致 [运行 32318818381](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32318818381) 在服务启动前失败。

## Validation / 验证

- `actionlint .github/workflows/e2e-tests.yml`
- YAML parse and `git diff --check`