### PR TITLE
[AMD] Refresh DeepSeek-R1 MI355X SGLang image / [AMD] 更新 DeepSeek-R1 MI355X SGLang 镜像

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -769,7 +769,7 @@ dsr1-fp4-mi355x-sglang-disagg:
           - "DECODE_MTP_SIZE=0"
 
 dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
+  image: lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260820
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
   runner: mi355x-disagg

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6251,3 +6251,10 @@
   description:
     - "Refresh with lower stream interval to collect correct client metrics"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2686
+
+- config-keys:
+    - dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp
+  description:
+    - "Bump the SGLang ROCm image from v0.5.12.post1-rocm720-mi35x-20260529 to v0.5.17-rocm720-mi35x-20260820."
+    - "Pick up AITER d9e5ef7, including the stage-2 masked-reduce and persistent-MLA synchronization fixes for the DeepSeek-R1 MI355X accuracy corruption tracked in sgl-project/sglang#27194."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6257,4 +6257,4 @@
   description:
     - "Bump the SGLang ROCm image from v0.5.12.post1-rocm720-mi35x-20260529 to v0.5.17-rocm720-mi35x-20260820."
     - "Pick up AITER d9e5ef7, including the stage-2 masked-reduce and persistent-MLA synchronization fixes for the DeepSeek-R1 MI355X accuracy corruption tracked in sgl-project/sglang#27194."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2691


### PR DESCRIPTION
## Summary

- Bump `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` from `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529` to `lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260820`.
- Pick up AITER `d9e5ef7`, which contains the stage-2 masked-reduce fix from ROCm/aiter#3377 and the persistent-MLA synchronization fix from `cdd6628`.
- Address the DeepSeek-R1 MI355X TP8/EP8 DP-attention MTP accuracy corruption tracked in sgl-project/sglang#27194.
- Supersede closed PR #2435 with a current-main replacement.

## Validation

- `git diff --check`
- Parsed `configs/amd-master.yaml`, `configs/runners.yaml`, and `perf-changelog.yaml` with PyYAML.
- Generated the exact config key with `generate_sweep_configs.py test-config`; all emitted points use the new image and preserve the existing topology/search space.
- Verified the Docker Hub tag and image digest.
- Verified the image-pinned AITER commit descends from both required upstream fixes.

## 中文说明

- 将 `dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp` 的镜像从 `lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529` 升级到 `lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260820`。
- 新镜像固定使用 AITER `d9e5ef7`，其中包含 ROCm/aiter#3377 的第二阶段 masked-reduce 修复，以及 `cdd6628` 的 persistent-MLA 同步修复。
- 修复 sgl-project/sglang#27194 跟踪的 DeepSeek-R1 MI355X TP8/EP8、DP-attention、MTP 准确率损坏问题。
- 本 PR 基于当前 `main` 替代已关闭的 #2435。

## 验证

- `git diff --check`
- 使用 PyYAML 成功解析 `configs/amd-master.yaml`、`configs/runners.yaml` 和 `perf-changelog.yaml`。
- 使用 `generate_sweep_configs.py test-config` 生成目标配置；所有生成点均使用新镜像，并保留原有拓扑和搜索空间。
- 已验证 Docker Hub 标签与镜像摘要。
- 已确认镜像固定的 AITER commit 包含上述两个上游修复。