### PR TITLE
Fix agentic eval for KV-offload entries (pass backend name, not object)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -453,7 +453,7 @@ jobs:
             dp-attn: ${{ matrix.config.dp-attn }}
             conc: ${{ matrix.config.conc }}
             kv-offloading: ${{ matrix.config.kv-offloading }}
-            kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+            kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
             total-cpu-dram-gb: ${{ matrix.config.total-cpu-dram-gb }}
             duration: ${{ inputs.agentx-fast && '1200' || (inputs.duration-override != '' && inputs.duration-override || matrix.config.duration) }}
             agentx-fast: ${{ inputs.agentx-fast }}


### PR DESCRIPTION
## Summary
The single-node agentic eval matrix caller `test-sweep-agentic-evals` passed the **object** `matrix.config.kv-offload-backend` (`{name, version}`) into the **string**-typed `kv-offload-backend` input of `benchmark-tmpl.yml`. When the agentic eval selector lands on a KV-offload arm (e.g. **Kimi-K3 `conc-10` `dram`+`lmcache`**), that type mismatch makes the reusable-workflow call invalid, so the **`agentic eval` job is never instantiated** (it shows as neither running nor skipped — it's simply absent).

The benchmark caller `test-sweep-agentic` already does this correctly by extracting `.name`. This aligns the eval caller with it.

```diff
- kv-offload-backend: ${{ matrix.config.kv-offload-backend }}
+ kv-offload-backend: ${{ matrix.config['kv-offload-backend'].name }}
```

### Evidence
- DSv4 agentic eval candidate = `conc-48, kv-offloading: none` → job **created** ✅
- Kimi-K3 agentic eval candidate = `conc-10, kv-offloading: dram, kv-offload-backend: {lmcache, 0.4.5}` → job **absent** ❌
- Both `get-jobs` produce exactly one agentic-eval candidate; the only difference is the offload object, and the offload benchmark jobs run fine because their caller extracts `.name` (e2e-tests.yml:415).

## Test plan
- [ ] Re-run a full sweep for a Kimi-K3 MI355X ATOM recipe with a `dram`+`lmcache` agentic arm and confirm the `agentic eval /` job is now created and runs.
- [ ] Confirm existing `kv-offloading: none` agentic evals (e.g. DSv4) are unaffected (`.name` on an absent object resolves to empty, matching the benchmark caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)