### PR TITLE
[AMD][MI35X] Sweep TP2/EP1 instead of TP2/EP2 on the Qwen3.5 MXFP4 MI355X AgentX arm

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -372,7 +372,7 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
+      - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32] }
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
 
 qwen3.5-fp4-mi355x-sglang-disagg:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6251,3 +6251,12 @@
   description:
     - "Refresh with lower stream interval to collect correct client metrics"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2686
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Replace the TP2/EP2 arm with TP2/EP1 so the 2-GPU point matches qwen3.5-fp4-b200-sglang-agentic-mtp."
+    - "Extend the TP2 concurrency list to 1, 4, 8, 12, 16, 20, 24, 28, and 32."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2693

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6259,4 +6259,4 @@
   description:
     - "Replace the TP2/EP2 arm with TP2/EP1 so the 2-GPU point matches qwen3.5-fp4-b200-sglang-agentic-mtp."
     - "Extend the TP2 concurrency list to 1, 4, 8, 12, 16, 20, 24, 28, and 32."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2693
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2694


### PR DESCRIPTION
## Motivation

The 2-GPU point of `qwen3.5-fp4-mi355x-sglang-agentic-mtp` is TP2/EP2, while its B200 counterpart `qwen3.5-fp4-b200-sglang-agentic-mtp` sweeps TP2/EP1. Those are different partitionings, so the 2-GPU columns of the two fleets are not comparable and the MI355X point does not answer the question the B200 point answers.

The current TP2 arm also stops at concurrency 20, which is short of where the arm is likely to saturate, so the shape of the 2-GPU curve near its knee is unmeasured.

## Modifications

In `configs/amd-master.yaml`, change the 2-GPU arm of `qwen3.5-fp4-mi355x-sglang-agentic-mtp` from `tp: 2, ep: 2` to `tp: 2, ep: 1`, and extend its concurrency list from `1, 4, 8, 12, 16, 20` to `1, 4, 8, 12, 16, 20, 24, 28, 32`.

Nothing else changes. The TP4/EP1 arm keeps its concurrency list, the image is untouched, KV stays GPU-resident on both arms (`kv-offloading: none`), and `benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh` is not modified.

The sweep grows from 16 to 19 points.

## Accuracy Tests

No accuracy-affecting logic changes in this repo — the change is limited to the expert-parallel size and the concurrency list of one benchmark arm. The AgentX eval rows continue to run real target-model verification.

## Benchmarking

Repo validation was run locally:

- `python -m pytest utils/matrix_logic/ -q` → 232 passed.
- `python utils/matrix_logic/generate_sweep_configs.py full-sweep --config-files configs/amd-master.yaml --model-prefix qwen3.5 --precision fp4 --scenario-type agentic-coding` → 19 configs: TP2/EP1 at concurrency 1, 4, 8, 12, 16, 20, 24, 28, 32 and TP4/EP1 at concurrency 1, 4, 8, 12, 16, 20, 24, 28, 32, 40. No TP2/EP2 points remain.

End-to-end MI355X AgentX numbers will come from the sweep triggered on this PR (`full-sweep-fail-fast`). Concurrency 24 through 32 at TP2 is exploratory: with GPU-resident KV only, the top of that range may run out of device KV pool, and if it does, the failing points mark the 2-GPU ceiling rather than a regression.

## Related

#2693 makes a larger change to the same arm: it also adds a HiCache host-DRAM KV tier and kvdram arms. This PR is the KV-neutral subset — TP2/EP1 and the concurrency list only.
