### PR TITLE
[Klaud Cold] docs: add AgentX, GLM5.3, and Kimi K3 2.8T to README news / 在 README 新闻中添加 AgentX、GLM5.3 与 Kimi K3 2.8T

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Meta, Mi
 
 ## News
 
+- **[2026/08]** 🔥 **AgentX: World's First Fully Open Source Apache 2.0 Realistic 1Mil+ Long Context, Multi Turn Benchmark Live** [dashboard](https://inferencex.semianalysis.com/agentx)
 - **[2026/08]** 🔥 GLM5.3: continuous agentic benchmarks live too [dashboard](https://inferencex.semianalysis.com/)
 - **[2026/07]** 🔥 Kimi K3 2.8T: continuous benchmarks live since Day 0
 - **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Meta, Mi
 
 ## News
 
+- **[2026/08]** 🔥 GLM5.3: continuous agentic benchmarks live too [dashboard](https://inferencex.semianalysis.com/)
 - **[2026/07]** 🔥 Kimi K3 2.8T: continuous benchmarks live since Day 0
 - **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Trusted by Operators of Trillion Dollar Token Factories such as OpenAI, Meta, Mi
 
 ## News
 
+- **[2026/07]** 🔥 Kimi K3 2.8T: continuous benchmarks live since Day 0
 - **[2026/06]** 🔥 MiniMax M3: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T: continuous benchmarks live since Day 0 [article](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance), [dashboard](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
 - **[2026/03]** 🔥 Qwen3.5 397B: continuous benchmarks live since Day 0 [dashboard](https://inferencex.semianalysis.com/)

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,6 +16,7 @@
 
 ## 新闻
 
+- **[2026/08]** 🔥 GLM5.3：同样已上线持续 Agentic 基准测试 [仪表盘](https://inferencex.semianalysis.com/)
 - **[2026/07]** 🔥 Kimi K3 2.8T：自 Day 0 起持续进行基准测试
 - **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试 [文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,6 +16,7 @@
 
 ## 新闻
 
+- **[2026/07]** 🔥 Kimi K3 2.8T：自 Day 0 起持续进行基准测试
 - **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)
 - **[2026/04]** 🔥 DeepSeek V4 Pro 1.6T：自 Day 0 起持续进行基准测试 [文章](https://newsletter.semianalysis.com/p/deepseekv4-16t-day-0-to-day-43-performance)，[仪表盘](https://inferencex.semianalysis.com/inference?preset=dsv4-launch)
 - **[2026/03]** 🔥 Qwen3.5 397B：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/)

--- a/README_zh.md
+++ b/README_zh.md
@@ -16,6 +16,7 @@
 
 ## 新闻
 
+- **[2026/08]** 🔥 **AgentX：全球首个完全开源、采用 Apache 2.0 许可的真实百万级长上下文多轮基准测试上线** [仪表盘](https://inferencex.semianalysis.com/agentx)
 - **[2026/08]** 🔥 GLM5.3：同样已上线持续 Agentic 基准测试 [仪表盘](https://inferencex.semianalysis.com/)
 - **[2026/07]** 🔥 Kimi K3 2.8T：自 Day 0 起持续进行基准测试
 - **[2026/06]** 🔥 MiniMax M3：自 Day 0 起持续进行基准测试 [仪表盘](https://inferencex.semianalysis.com/inference?preset=minimax-m3-launch)


### PR DESCRIPTION
Adds three entries to the top of the News list in both READMEs.

```
- **[2026/08]** 🔥 **AgentX: World's First Fully Open Source Apache 2.0 Realistic 1Mil+ Long Context, Multi Turn Benchmark Live** [dashboard](https://inferencex.semianalysis.com/agentx)
- **[2026/08]** 🔥 GLM5.3: continuous agentic benchmarks live too [dashboard](https://inferencex.semianalysis.com/)
- **[2026/07]** 🔥 Kimi K3 2.8T: continuous benchmarks live since Day 0
```

- `README.md` — English entries
- `README_zh.md` — Chinese entries, matching the existing `自 Day 0 起持续进行基准测试` / `仪表盘` phrasing

The GLM5.3 line points at the top-level dashboard, the same URL the Qwen3.5 397B and Kimi K2.5 entries use; say the word if it should point at `/agentx` instead. If there is a launch preset (`?preset=…`) for GLM5.3 or Kimi K3, pass it along and I'll swap it in.

Docs only — no config or recipe changes, so every commit carries `[skip-sweep]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)