### PR TITLE
[AMD][MI35X] 0821 deepseek-v4 sglang agentic benchmark

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_sglang_mtp.sh
@@ -73,6 +73,7 @@ export SGLANG_DSV4_REASONING_EFFORT=high
 export SGLANG_USE_ROCM700A=0
 export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton
 export AITER_BF16_FP8_MOE_BOUND=0
+export SGLANG_OPT_USE_AITER_BATCHED_GEMM=true
 
 # Unified radix tree: per-component (full-attn / SWA) cache management for
 # hybrid-attention models, plus proactive release of out-of-window SWA KV

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1727,7 +1727,7 @@ glm5.2-fp4-mi355x-atom-agentic-mtp:
 # collective under long-context prefill, so no DEP arm ships until that path is
 # validated. conc 16 appears on both arms to isolate the host KV tier's gain.
 dsv4-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260813
+  image: lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260821
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6287,4 +6287,13 @@
     - "Add concurrency 48 and 64 to the TP8/EP1 sweep, and 64 and 192 to the TP8/EP8 DP-attention sweep."
     - "Increase prefill mem_fraction_static from 0.72 to 0.85 and reduce HICACHE_RATIO from 4 to 3."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2643
-  
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Bump image to lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260821"
+    - "Enable SGLANG_OPT_USE_AITER_BATCHED_GEMM for mi355x sglang dsv4 agentic workload."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2705
+


### PR DESCRIPTION
Change:
- "Bump image to lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260821"
- "Enable SGLANG_OPT_USE_AITER_BATCHED_GEMM."