### PR TITLE
[nv] dsv4 b200 tp8 agentic full_and_piecewise cudagraphs

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b200_vllm_mtp.sh
@@ -257,14 +257,24 @@ if [ "${EVAL_ONLY:-false}" = "true" ]; then
 else
     SPEC_CONFIG="{\"method\": \"mtp\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_length\": 2.49}"
 fi
-CUDA_GRAPH_CAPTURE_SIZES=""
+CAPTURE_SIZE_LIST=()
 for ((num_seqs = 1; num_seqs <= MAX_NUM_SEQS; num_seqs++)); do
-    if [ -n "$CUDA_GRAPH_CAPTURE_SIZES" ]; then
-        CUDA_GRAPH_CAPTURE_SIZES+=","
-    fi
-    CUDA_GRAPH_CAPTURE_SIZES+="$((num_seqs * TOKENS_PER_SEQ))"
+    CAPTURE_SIZE_LIST+=("$((num_seqs * TOKENS_PER_SEQ))")
 done
-COMPILATION_CONFIG="{\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CUDA_GRAPH_CAPTURE_SIZES}],\"mode\":0}"
+# TP additionally captures piecewise graphs for the mixed prefill/decode batches,
+# on top of the full graphs for the uniform decode batches above. Piecewise
+# capture requires the compiled graph, so no "mode":0 on that path. The DEP arm
+# keeps decode-only capture. The decode multiples and the piecewise sizes overlap
+# once MAX_NUM_SEQS*(1+N) passes 100, so sort and de-duplicate.
+if [ "$DP_ATTENTION" != "true" ]; then
+    CAPTURE_SIZE_LIST+=(100 200 300 400 500)
+fi
+CUDA_GRAPH_CAPTURE_SIZES=$(printf '%s\n' "${CAPTURE_SIZE_LIST[@]}" | sort -n -u | paste -sd, -)
+if [ "$DP_ATTENTION" != "true" ]; then
+    COMPILATION_CONFIG="{\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"cudagraph_capture_sizes\":[${CUDA_GRAPH_CAPTURE_SIZES}]}"
+else
+    COMPILATION_CONFIG="{\"cudagraph_mode\":\"FULL_DECODE_ONLY\",\"cudagraph_capture_sizes\":[${CUDA_GRAPH_CAPTURE_SIZES}],\"mode\":0}"
+fi
 
 echo "Starting vllm server..."
 export TORCH_CUDA_ARCH_LIST="10.0"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -974,7 +974,7 @@ dsv4-fp4-b200-vllm-agentic-mtp:
     - dram-utilization: 0.95
       search-space:
       # TP8 SimpleCPU + MTP
-      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, spec-decoding: mtp, conc-list: [1, 4, 8, 16, 24] }
+      - { tp: 8, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, spec-decoding: mtp, conc-list: [1, 4, 8, 14] }
       # DEP8 SimpleCPU + MTP
       - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, spec-decoding: mtp, conc-list: [32, 64, 96, 128, 160, 196], router: { name: vllm-router, version: "0.1.14" } }
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6350,3 +6350,11 @@
     - "Use the concurrency-1 aggregated Pareto point and disable TensorRT-LLM performance-metrics responses for all seven points."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2657
   
+
+- config-keys:
+    - dsv4-fp4-b200-vllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Serve the TP8 arm with FULL_AND_PIECEWISE cudagraphs, capturing the mixed prefill/decode batches as well as the uniform decode batches. The DEP8 arm is unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2707


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark recipe and published concurrency points only; no product, auth, or data-path code.
> 
> **Overview**
> Tunes the B200 DSv4 vLLM agentic MTP recipe so **TP8** captures mixed prefill/decode batches with `FULL_AND_PIECEWISE` CUDA graphs (sizes 100–500 plus the existing decode multiples), while **DEP8** stays on `FULL_DECODE_ONLY` with `mode:0`.
> 
> Also replaces the published TP8 concurrency sweep `[1, 4, 8, 16, 24]` with `[1, 4, 8, 14]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1f60b9f1a4ca7705aab274fe370885fc328736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->