### PR TITLE
fix(config): annotate DSV4 TRT AgentX native KV offload

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8193,8 +8193,11 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    - dram-utilization: 0.21429
+      search-space:
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [4]
         prefill:
           num-worker: 1
@@ -8210,6 +8213,8 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           ep: 8
           dp-attn: false
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [24]
         prefill:
           num-worker: 1
@@ -8225,6 +8230,8 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           ep: 4
           dp-attn: false
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [388]
         prefill:
           num-worker: 1
@@ -8240,6 +8247,8 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           ep: 32
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [736]
         prefill:
           num-worker: 2
@@ -8255,6 +8264,8 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           ep: 32
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [1152]
         prefill:
           num-worker: 3
@@ -8270,6 +8281,8 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           ep: 16
           dp-attn: true
       - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [2626]
         prefill:
           num-worker: 5


### PR DESCRIPTION
## Summary

- mark the six DeepSeek-V4 TensorRT-LLM AgentX points added by #2690 as DRAM KV offload
- record the native backend version from the TensorRT-LLM image
- set the generated CPU DRAM budget to 193 GB, matching the recipes pinned to a 180 GiB host cache

## Scope

This changes master-config metadata only. It does not modify benchmark recipes or runtime behavior, so there is no performance changelog entry.

## Validation

- generated dsv4-fp4-gb300-dynamo-trt-agentx successfully
- confirmed all six points emit kv-offloading=dram, native@1.3.0rc24, and total-cpu-dram-gb=193
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Master-config metadata only; no recipe, runtime, or benchmark-path changes.
> 
> **Overview**
> Marks the six DeepSeek-V4 TensorRT-LLM AgentX search points as **DRAM KV offload** with the native backend (`native@1.3.0rc24`) and sets `dram-utilization` so generated CPU DRAM budget is 193 GB.
> 
> Metadata-only change in `nvidia-master.yaml`; recipes and runtime behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6404c1b4dfd2832367e1bcc239650161538acf16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->