### PR TITLE
fix(config): annotate GLM-5.2 TRT AgentX native KV offload

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9110,10 +9110,12 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    - dram-utilization: 0.15239
+      search-space:
       - spec-decoding: mtp
         conc-list: [30]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 1
           tp: 4
@@ -9129,7 +9131,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: false
       - spec-decoding: mtp
         conc-list: [20]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 1
           tp: 4
@@ -9145,7 +9148,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: false
       - spec-decoding: mtp
         conc-list: [60]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 3
           tp: 4
@@ -9161,7 +9165,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: false
       - spec-decoding: mtp
         conc-list: [152]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 5
           tp: 4
@@ -9177,7 +9182,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [259]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 8
           tp: 4
@@ -9193,7 +9199,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [227]
-        kv-offloading: none
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc22.post1" }
         prefill:
           num-worker: 6
           tp: 4


### PR DESCRIPTION
## Summary

- correct the six disaggregated GLM-5.2 TensorRT-LLM AgentX points added by #2657 from no offload to DRAM KV offload
- record the native backend version from the TensorRT-LLM image
- set the generated CPU DRAM budget to 137 GB, matching the recipes pinned to a 128 GiB host cache
- leave the aggregate point unchanged because its recipe does not enable a host cache

## Scope

This changes master-config metadata only. It does not modify benchmark recipes or runtime behavior, so there is no performance changelog entry.

## Validation

- generated both GLM-5.2 TensorRT-LLM AgentX config keys successfully
- confirmed all six disaggregated points emit kv-offloading=dram, native@1.3.0rc22.post1, and total-cpu-dram-gb=137
- confirmed the aggregate point remains kv-offloading=none with total-cpu-dram-gb=0
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change in nvidia-master.yaml; no recipe, runtime, or auth/data-path changes.
> 
> **Overview**
> Corrects master-config metadata for the six disaggregated GLM-5.2 TensorRT-LLM AgentX points so they record **DRAM KV offload** instead of none.
> 
> Each point now uses `kv-offloading: dram` with native backend `1.3.0rc22.post1`, and `dram-utilization: 0.15239` so generated CPU DRAM budget is 137 GB (128 GiB host cache). The aggregate (no host cache) point is unchanged. Recipes and runtime are not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225829c152246b4875b479fbaaa18d0b954c0ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->