### PR TITLE
fix: fold DP_SIZE into single-node num_gpus for per-GPU throughput

### DIFF
--- a/utils/process_result.py
+++ b/utils/process_result.py
@@ -249,9 +249,10 @@ else:
     pp = int(os.environ.get('PP_SIZE', '1'))
     dcp_size = int(os.environ.get('DCP_SIZE', '1'))
     pcp_size = int(os.environ.get('PCP_SIZE', '1'))
-    if pp <= 0 or dcp_size <= 0 or pcp_size <= 0:
-        raise ValueError("PP_SIZE, DCP_SIZE, and PCP_SIZE must be positive integers.")
-    num_gpus = tp_size * pp * pcp_size
+    dp_size = int(os.environ.get('DP_SIZE', '1'))
+    if pp <= 0 or dcp_size <= 0 or pcp_size <= 0 or dp_size <= 0:
+        raise ValueError("PP_SIZE, DCP_SIZE, PCP_SIZE, and DP_SIZE must be positive integers.")
+    num_gpus = tp_size * pp * pcp_size * dp_size
 
     single_node_data = {
         'is_multinode': False,
@@ -259,6 +260,7 @@ else:
         'pp': pp,
         'dcp_size': dcp_size,
         'pcp_size': pcp_size,
+        'dp_size': dp_size,
         'ep': ep_size,
         'dp_attention': dp_attention,
         'tput_per_gpu': float(bmk_result['total_token_throughput']) / num_gpus,

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -459,6 +459,59 @@ class TestCalculations:
         assert output_data["output_tput_per_gpu"] == pytest.approx(6000.0 / 16)
         assert output_data["input_tput_per_gpu"] == pytest.approx(2000.0 / 16)
 
+    def test_throughput_per_gpu_single_node_default_dp_size(self, tmp_path, single_node_env_vars):
+        """DP_SIZE defaults to 1 when unset, so existing single-node configs are unaffected."""
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 8,
+            "total_token_throughput": 8000.0,
+            "output_throughput": 6000.0,
+        }
+
+        result = run_script(tmp_path, single_node_env_vars, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        output_data = json.loads(result.stdout)
+        assert output_data["dp_size"] == 1
+        assert output_data["tput_per_gpu"] == pytest.approx(8000.0 / 8)
+
+    def test_throughput_per_gpu_single_node_with_dp_size(self, tmp_path, single_node_env_vars):
+        """DP_SIZE multiplies the GPU denominator, e.g. --tensor-parallel-size 1
+        --data-parallel-size 2 running two full-model replicas on 2 GPUs."""
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 8,
+            "total_token_throughput": 8000.0,
+            "output_throughput": 6000.0,
+        }
+
+        env = single_node_env_vars.copy()
+        env.update({"TP": "1", "DP_SIZE": "2"})
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+        output_data = json.loads(result.stdout)
+        assert output_data["dp_size"] == 2
+        assert output_data["tput_per_gpu"] == pytest.approx(8000.0 / 2)
+        assert output_data["output_tput_per_gpu"] == pytest.approx(6000.0 / 2)
+        assert output_data["input_tput_per_gpu"] == pytest.approx(2000.0 / 2)
+
+    def test_invalid_dp_size_raises_error(self, tmp_path, single_node_env_vars):
+        benchmark_result = {
+            "model_id": "test-model",
+            "max_concurrency": 8,
+            "total_token_throughput": 8000.0,
+            "output_throughput": 6000.0,
+        }
+
+        env = single_node_env_vars.copy()
+        env.update({"DP_SIZE": "0"})
+
+        result = run_script(tmp_path, env, benchmark_result)
+        assert result.returncode != 0
+        assert "DP_SIZE" in result.stderr
+
     def test_throughput_per_gpu_multinode(self, tmp_path, multinode_env_vars):
         """Test throughput per GPU calculation for multinode."""
         benchmark_result = {


### PR DESCRIPTION
## Summary

Fixes #2714.

`process_result.py`'s single-node branch computes:

```python
num_gpus = tp_size * pp * pcp_size
```

with no data-parallel term. Any single-node config running
`--tensor-parallel-size 1 --data-parallel-size N` (N full-model
replicas on N GPUs) without also exporting that as `TP`/`PP`/`PCP_SIZE`
divides `total_token_throughput` by 1 instead of N, inflating
`tput_per_gpu` / `output_tput_per_gpu` / `input_tput_per_gpu` by a
factor of N.

## Fix

Read an optional `DP_SIZE` env var (defaults to `"1"`, so every
existing single-node config is unaffected) and fold it into
`num_gpus = tp_size * pp * pcp_size * dp_size`. Also record `dp_size`
in the output JSON alongside the existing `pp`/`dcp_size`/`pcp_size`
fields, for parity with how the other parallelism dimensions are
surfaced.

## Test plan

- Added `test_throughput_per_gpu_single_node_default_dp_size` —
  confirms `DP_SIZE` unset behaves exactly as before (`dp_size == 1`).
- Added `test_throughput_per_gpu_single_node_with_dp_size` — confirms
  `DP_SIZE=2` halves `tput_per_gpu`/`output_tput_per_gpu`/`input_tput_per_gpu`.
- Added `test_invalid_dp_size_raises_error` — `DP_SIZE=0` fails loud,
  matching the existing `PP_SIZE`/`DCP_SIZE`/`PCP_SIZE` validation.
- `python -m pytest utils/test_process_result.py` — 53 passed (50
  existing + 3 new), no regressions.

Recipes that run internal `--data-parallel-size N` today keep N as a
script-local constant not exported to `process_result.py`; wiring
`DP_SIZE=N` through for those recipes is a separate follow-up once
this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow result-aggregation math change with a default of 1, so existing runs are unchanged unless DP_SIZE is set. Does not touch auth, serving, or recipe wiring.
> 
> **Overview**
> Fixes inflated single-node `tput_per_gpu` (and related per-GPU metrics) when data-parallel replicas are used without encoding that width in `TP`/`PP`/`PCP_SIZE`.
> 
> The single-node path now reads optional `DP_SIZE` (default `1`), multiplies it into `num_gpus`, validates it as a positive integer, and emits `dp_size` in the aggregated JSON. Existing configs that omit the env var keep the previous denominator. Recipes still need to export `DP_SIZE` for this to take effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07cfda8e595d14ed10dca80841a63e87dc38633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->