### PR TITLE
[CI] Repair stale runner git state before checkout / checkout 前自愈 runner 陈旧 git 状态

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -336,13 +336,17 @@ jobs:
           # dirs behind in the persistent self-hosted workspace, and both make
           # actions/checkout fail before any benchmark starts. The runner
           # executes one job at a time, so any lock found here is stale by
-          # definition; a submodule git dir whose HEAD no longer resolves is
-          # dropped together with its worktree so checkout re-clones it.
+          # definition. Grouping dirs (e.g. .git/modules/utils) hold only
+          # nested module dirs, so any dir carrying top-level files is a
+          # module git dir — a truncated clone may lack HEAD entirely, and a
+          # git dir whose HEAD does not resolve to a commit is dropped
+          # together with its worktree so checkout re-clones it.
           repo_dir="${{ github.workspace }}"
           if [ -d "${repo_dir}/.git" ]; then
             find "${repo_dir}/.git" -name index.lock -type f -delete || true
             for gitdir in "${repo_dir}"/.git/modules/* "${repo_dir}"/.git/modules/*/*; do
-              [ -f "${gitdir}/HEAD" ] || continue
+              [ -d "${gitdir}" ] || continue
+              [ -n "$(find "${gitdir}" -maxdepth 1 -type f -print -quit)" ] || continue
               if ! git --git-dir="${gitdir}" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1; then
                 rel="${gitdir##*/.git/modules/}"
                 echo "[git-repair] Removing corrupt submodule state: ${rel}"

--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -330,6 +330,27 @@ jobs:
             done
           fi
 
+      - name: Repair stale git state (pre-run)
+        run: |
+          # Interrupted runs leave index.lock files and corrupt submodule git
+          # dirs behind in the persistent self-hosted workspace, and both make
+          # actions/checkout fail before any benchmark starts. The runner
+          # executes one job at a time, so any lock found here is stale by
+          # definition; a submodule git dir whose HEAD no longer resolves is
+          # dropped together with its worktree so checkout re-clones it.
+          repo_dir="${{ github.workspace }}"
+          if [ -d "${repo_dir}/.git" ]; then
+            find "${repo_dir}/.git" -name index.lock -type f -delete || true
+            for gitdir in "${repo_dir}"/.git/modules/* "${repo_dir}"/.git/modules/*/*; do
+              [ -f "${gitdir}/HEAD" ] || continue
+              if ! git --git-dir="${gitdir}" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1; then
+                rel="${gitdir##*/.git/modules/}"
+                echo "[git-repair] Removing corrupt submodule state: ${rel}"
+                rm -rf "${gitdir}" "${repo_dir:?}/${rel}"
+              fi
+            done
+          fi
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.REPO_PAT }}

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -269,13 +269,17 @@ jobs:
           # dirs behind in the persistent self-hosted workspace, and both make
           # actions/checkout fail before any benchmark starts. The runner
           # executes one job at a time, so any lock found here is stale by
-          # definition; a submodule git dir whose HEAD no longer resolves is
-          # dropped together with its worktree so checkout re-clones it.
+          # definition. Grouping dirs (e.g. .git/modules/utils) hold only
+          # nested module dirs, so any dir carrying top-level files is a
+          # module git dir — a truncated clone may lack HEAD entirely, and a
+          # git dir whose HEAD does not resolve to a commit is dropped
+          # together with its worktree so checkout re-clones it.
           repo_dir="${{ github.workspace }}"
           if [ -d "${repo_dir}/.git" ]; then
             find "${repo_dir}/.git" -name index.lock -type f -delete || true
             for gitdir in "${repo_dir}"/.git/modules/* "${repo_dir}"/.git/modules/*/*; do
-              [ -f "${gitdir}/HEAD" ] || continue
+              [ -d "${gitdir}" ] || continue
+              [ -n "$(find "${gitdir}" -maxdepth 1 -type f -print -quit)" ] || continue
               if ! git --git-dir="${gitdir}" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1; then
                 rel="${gitdir##*/.git/modules/}"
                 echo "[git-repair] Removing corrupt submodule state: ${rel}"

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -263,6 +263,27 @@ jobs:
             done
           fi
 
+      - name: Repair stale git state (pre-run)
+        run: |
+          # Interrupted runs leave index.lock files and corrupt submodule git
+          # dirs behind in the persistent self-hosted workspace, and both make
+          # actions/checkout fail before any benchmark starts. The runner
+          # executes one job at a time, so any lock found here is stale by
+          # definition; a submodule git dir whose HEAD no longer resolves is
+          # dropped together with its worktree so checkout re-clones it.
+          repo_dir="${{ github.workspace }}"
+          if [ -d "${repo_dir}/.git" ]; then
+            find "${repo_dir}/.git" -name index.lock -type f -delete || true
+            for gitdir in "${repo_dir}"/.git/modules/* "${repo_dir}"/.git/modules/*/*; do
+              [ -f "${gitdir}/HEAD" ] || continue
+              if ! git --git-dir="${gitdir}" rev-parse --verify 'HEAD^{commit}' >/dev/null 2>&1; then
+                rel="${gitdir##*/.git/modules/}"
+                echo "[git-repair] Removing corrupt submodule state: ${rel}"
+                rm -rf "${gitdir}" "${repo_dir:?}/${rel}"
+              fi
+            done
+          fi
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.REPO_PAT }}


### PR DESCRIPTION
## Problem

Today's GB300 and B200-nscale sweeps died at `actions/checkout` before any benchmark started:

- `gb300-nv_07/_13/_14`: `fatal: Unable to create '.git/modules/utils/aiperf/index.lock': File exists.` — stale lock left by an interrupted run (run 32767730083, reproduced on both attempts).
- `b200-nscale-slurm_03/_06`: `fatal: Unable to find current revision in submodule path 'utils/aiperf'` — corrupt cached submodule git dir (run 32767921727).

Both are persistent-workspace pollution on self-hosted runners; `clean: true` on checkout does not touch `.git/modules` or lock files, so every job that lands on an affected runner fails until someone cleans the box by hand. The pollution source recurs: any cancel storm (e.g. fail-fast) that interrupts git mid-submodule-checkout can mint new stale locks across the fleet.

## Fix

Add a "Repair stale git state (pre-run)" step before checkout in `benchmark-tmpl.yml` and `benchmark-multinode-tmpl.yml`:

- delete any `index.lock` under `.git` (the runner executes one job at a time, so a lock present at job start is stale by definition);
- for each submodule git dir whose `HEAD` no longer resolves to a commit, remove the git dir and its worktree so checkout re-clones it.

No-op on healthy workspaces; no benchmark behavior change.

## 中文说明

### 问题

GB300 与 B200-nscale 的 sweep 在 `actions/checkout` 阶段即失败：gb300-nv_07/_13/_14 上是 `utils/aiperf` submodule 的陈旧 `index.lock`；b200-nscale-slurm_03/_06 上是损坏的 submodule git 缓存。checkout 的 `clean: true` 清理不到 `.git/modules` 与锁文件，落到这些 runner 的 job 全部失败。任何中断 git 写入的 cancel（如 fail-fast）都会重新制造此类污染。

### 修复

在两个 benchmark template 的 checkout 前增加 "Repair stale git state" step：删除 `.git` 下的 `index.lock`（runner 单 job 运行，开工时的锁必然陈旧）；HEAD 无法解析为 commit 的 submodule git 目录连同其 worktree 一并移除，交由 checkout 重新 clone。健康 workspace 上完全 no-op，不改变任何 benchmark 行为。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pre-checkout cleanup on self-hosted runners; submodule removal is gated on invalid HEAD and assumes one job per runner for lock deletion.
> 
> **Overview**
> Self-hosted benchmark jobs were failing at **`actions/checkout`** when interrupted runs left **`index.lock`** files or broken **`utils/aiperf`** submodule metadata in the persistent workspace—**`clean: true`** does not clear `.git/modules` or those locks.
> 
> Both **`benchmark-tmpl.yml`** and **`benchmark-multinode-tmpl.yml`** now run **Repair stale git state (pre-run)** immediately after Slurm/resource cleanup and **before** checkout. The step deletes all **`index.lock`** files under `.git` and, for submodule git directories whose **`HEAD`** cannot resolve to a commit, removes the git dir and matching worktree so checkout can re-clone. Healthy workspaces are unchanged; benchmark logic is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1780b520d4ac316e05c61a341458f510989840d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->