### PR TITLE
[Klaud Cold] docs: deprecate DeepSeek-V4-Pro Single-turn 8k1k on 2026-09-08, keep AgentX / 弃用 DeepSeek-V4-Pro 单轮 8k1k（2026-09-08），保留 AgentX

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -42,6 +42,18 @@ Speculative-decoding A/B retirements apply to each pair below. The spec-decode a
 
 **Enacted on 2026-08-07** in [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527): 17 `kimik2.5` config keys were removed from the active master configs and archived under [`configs/deprecated/`](configs/deprecated/) as `nvidia-kimik2.5-8k1k-master.yaml` (10) and `amd-kimik2.5-8k1k-master.yaml` (7), and their 12 benchmark scripts were moved to the sibling `deprecated/` directories. `kimik2.5` now has **no active configuration in any master config** and is fully retired. The same PR archived `kimik2.5-int4-h100-vllm`, an agentic-coding key that #2493 left behind in `nvidia-master.yaml` after moving its script to `benchmarks/single_node/agentic/deprecated/`. It is now in `nvidia-kimik2.5-agentic-master.yaml` with its siblings. The SPEED-Bench acceptance-length script `benchmarks/single_node/speedbench/kimik2.5_fp4_b300_vllm.sh` is intentionally kept. Speedbench is driven by `speedbench-al.yml`, not the master configs, matching how #2493 treated MiniMax-M3.
 
+### Tuesday, September 8, 2026
+
+**Tuesday, September 8, 2026** is the last day for the **Single-turn 8k1k** scenario on **DeepSeek-V4-Pro 1.6T** (`dsv4`). The scenario is deprecated for this model after that date. **Agentic coding is unaffected and stays active for `dsv4`**, including its MTP and DSpark arms. The model is not retired: agentic coding becomes its only scenario, and it continues to run and publish.
+
+| Model | Deprecated | Remains |
+|---|---|---|
+| DeepSeek-V4-Pro 1.6T (`dsv4`) | Single-turn 8k1k | Agentic coding, including the MTP and DSpark arms |
+
+Rationale: `dsv4` carries the largest single-turn footprint in the repository. 45 active config keys use the 8k1k scenario, 32 in `configs/nvidia-master.yaml` and 13 in `configs/amd-master.yaml`, spanning H200, B200, B300, GB200, GB300, MI300X, MI325X, and MI355X across vLLM, SGLang, TensorRT-LLM, ATOM, Dynamo, and llm-d. That is a large share of every full sweep. AgentX trace replay is the scenario AI labs and the ML community ask about, and DeepSeek-V4-Pro's 19 agentic config keys are the part of `dsv4` that feeds the published North Star Pareto frontier. Retiring the fixed-sequence-length arm frees cluster hours for AgentX and for new frontier models such as Qwen3.8 2.4T without reducing what we publish for this model. Single-turn 8k1k stays active for the other models that still list it.
+
+**Status: not yet enacted.** All 45 8k1k config keys still run. On enactment they are removed from the active master configs and archived under [`configs/deprecated/`](configs/deprecated/), with their benchmark scripts moved to the sibling `deprecated/` directories, matching how [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493) and [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527) were carried out. The SPEED-Bench acceptance-length scripts for `dsv4` are intentionally kept. Speedbench is driven by `speedbench-al.yml`, not the master configs.
+
 ## Scenarios
 
 | Scenario | ISL/OSL | Status |
@@ -141,7 +153,7 @@ Other offloading tiers, including NVMe KV cache offloading, are outside the init
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | Agentic coding (DSpark only) | Agentic coding non-DSpark arm (deprecated from day 0) |
 | GLM-5.2 | `glm5.2` | 2026-07-18 ([#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)) | Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | |
 | MiniMax-M3 | `minimaxm3` | 2026-06-12 ([#1724](https://github.com/SemiAnalysisAI/InferenceX/pull/1724)) | Agentic coding | Single-turn 1k1k, Single-turn 8k1k (removed 2026-08-04, [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)) |
-| DeepSeek-V4-Pro | `dsv4` | 2026-04-24 ([#1130](https://github.com/SemiAnalysisAI/InferenceX/pull/1130)) | Single-turn 8k1k, Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | Single-turn 1k1k |
+| DeepSeek-V4-Pro | `dsv4` | 2026-04-24 ([#1130](https://github.com/SemiAnalysisAI/InferenceX/pull/1130)) | Single-turn 8k1k (last day 2026-09-08, see [Deprecation Notice](#deprecation-notice)), Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | Single-turn 1k1k |
 | GLM-5 / GLM-5.1 | `glm5`, `glm5.1` | 2026-03-06 ([#762](https://github.com/SemiAnalysisAI/InferenceX/pull/762)), with GLM-5.1 added 2026-04-21 ([#1098](https://github.com/SemiAnalysisAI/InferenceX/pull/1098)) | None (retired 2026-07-18, [#2276](https://github.com/SemiAnalysisAI/InferenceX/pull/2276)) | Single-turn 1k1k, Single-turn 1k8k (GLM-5 only), Single-turn 8k1k |
 | MiniMax-M2.5/2.7 | `minimaxm2.5` | 2026-02-18 ([#755](https://github.com/SemiAnalysisAI/InferenceX/pull/755)) | None (retired 2026-06-20, [#1874](https://github.com/SemiAnalysisAI/InferenceX/pull/1874)) | Single-turn 1k1k, Single-turn 1k8k, Single-turn 8k1k |
 | Kimi-K2.5/2.6/2.7-Code | `kimik2.5` | 2026-02-17 ([#734](https://github.com/SemiAnalysisAI/InferenceX/pull/734)) | None (fully retired 2026-08-07, [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527)) | Single-turn 1k1k, Single-turn 1k8k, Agentic coding (removed 2026-08-04, [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)), Single-turn 8k1k (removed 2026-08-07, [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527)) |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -42,6 +42,18 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 
 **已于 2026-08-07 执行**（[#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527)）：从启用的主配置中移除 17 个 `kimik2.5` 配置项，归档至 [`configs/deprecated/`](configs/deprecated/)，分别为 `nvidia-kimik2.5-8k1k-master.yaml`（10 个）与 `amd-kimik2.5-8k1k-master.yaml`（7 个）。对应的 12 个基准测试脚本移入同级 `deprecated/` 目录。此后 `kimik2.5` 在所有主配置中**均无启用配置**，正式完全退役。同一 PR 还归档了 `kimik2.5-int4-h100-vllm`。#2493 将其脚本移入 `benchmarks/single_node/agentic/deprecated/` 时，该智能体编码配置项被遗留在 `nvidia-master.yaml` 中，现已与同类项一并归入 `nvidia-kimik2.5-agentic-master.yaml`。SPEED-Bench 接受长度脚本 `benchmarks/single_node/speedbench/kimik2.5_fp4_b300_vllm.sh` 予以保留。Speedbench 由 `speedbench-al.yml` 驱动，不经过主配置，与 #2493 处理 MiniMax-M3 的方式一致。
 
+### 2026 年 9 月 8 日（星期二）
+
+**2026 年 9 月 8 日（星期二）**为 **DeepSeek-V4-Pro 1.6T**（`dsv4`）**单轮 8k1k** 场景的最后运行日，此后该场景对该模型弃用。**智能体编码不受影响，`dsv4` 的该场景继续启用**，其 MTP 与 DSpark 分支均予保留。该模型不会退役：智能体编码将成为其唯一场景，并继续运行与发布。
+
+| 模型 | 弃用内容 | 保留内容 |
+|---|---|---|
+| DeepSeek-V4-Pro 1.6T（`dsv4`） | 单轮 8k1k | 智能体编码，含 MTP 与 DSpark 分支 |
+
+原因：`dsv4` 是本仓库中单轮场景占用最大的模型。当前有 45 个启用的配置项使用 8k1k 场景（`configs/nvidia-master.yaml` 32 个，`configs/amd-master.yaml` 13 个），覆盖 H200、B200、B300、GB200、GB300、MI300X、MI325X 与 MI355X，涉及 vLLM、SGLang、TensorRT-LLM、ATOM、Dynamo 与 llm-d，在每一轮完整 sweep 中占比可观。AgentX 轨迹回放才是 AI 实验室与 ML 社区真正关注的场景，而 DeepSeek-V4-Pro 的 19 个智能体编码配置项正是 `dsv4` 中支撑已发布北极星（North Star）帕累托前沿的部分。下线固定序列长度分支可为 AgentX 以及 Qwen3.8 2.4T 等新前沿模型腾出集群机时，同时不减少该模型对外发布的内容。对于仍列有该场景的其他模型，单轮 8k1k 保持启用。
+
+**状态：尚未执行。** 全部 45 个 8k1k 配置项仍在运行。执行时将从启用的主配置中移除并归档至 [`configs/deprecated/`](configs/deprecated/)，对应基准测试脚本移入同级 `deprecated/` 目录，与 [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493) 和 [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527) 的做法一致。`dsv4` 的 SPEED-Bench 接受长度脚本予以保留。Speedbench 由 `speedbench-al.yml` 驱动，不经过主配置。
+
 ## 场景
 
 | 场景 | ISL/OSL | 状态 |


### PR DESCRIPTION
## Summary / 摘要

Announces **Tuesday, September 8, 2026** (two weeks out) as the last day for the **Single-turn 8k1k** scenario on **DeepSeek-V4-Pro 1.6T** (`dsv4`). **Agentic coding / AgentX stays active for `dsv4`**, including the MTP and DSpark arms, so the model is **not** retired — agentic coding simply becomes its only scenario.

宣布 **2026 年 9 月 8 日（星期二）**（即两周后）为 **DeepSeek-V4-Pro 1.6T**（`dsv4`）**单轮 8k1k** 场景的最后运行日。**智能体编码 / AgentX 对 `dsv4` 继续启用**，含 MTP 与 DSpark 分支，因此该模型**不会**退役，智能体编码将成为其唯一场景。

## Changes / 改动

- `MODELS.md`: new `### Tuesday, September 8, 2026` section in the Deprecation Notice with the deprecated/remains table, rationale, and a **Status: not yet enacted** note; `dsv4` row of the model support matrix now flags the pending last day.
- `MODELS_zh.md`: synchronized Chinese mirror.

- `MODELS.md`：在弃用公告中新增 `### 2026 年 9 月 8 日（星期二）` 小节，包含弃用/保留对照表、原因说明，以及**状态：尚未执行**的说明；模型支持矩阵的 `dsv4` 行标注该最后运行日。
- `MODELS_zh.md`：同步中文镜像。

## Rationale / 原因

`dsv4` has the largest single-turn footprint in the repo: **45 active config keys** use 8k1k (32 in `configs/nvidia-master.yaml`, 13 in `configs/amd-master.yaml`) across H200, B200, B300, GB200, GB300, MI300X, MI325X, MI355X and vLLM, SGLang, TensorRT-LLM, ATOM, Dynamo, llm-d. Its **19 agentic config keys** are the part that feeds the published North Star Pareto frontier. Retiring the fixed-sequence-length arm frees cluster hours for AgentX and new frontier models without reducing what we publish for this model.

`dsv4` 是仓库中单轮场景占用最大的模型：**45 个启用配置项**使用 8k1k（`configs/nvidia-master.yaml` 32 个，`configs/amd-master.yaml` 13 个），覆盖 H200、B200、B300、GB200、GB300、MI300X、MI325X、MI355X 及 vLLM、SGLang、TensorRT-LLM、ATOM、Dynamo、llm-d。其**19 个智能体编码配置项**才是支撑已发布北极星帕累托前沿的部分。下线固定序列长度分支可为 AgentX 与新前沿模型腾出集群机时，同时不减少该模型对外发布的内容。

## Scope / 范围

Docs only. No config, recipe, or script changes — nothing is removed in this PR; enactment (archiving to `configs/deprecated/`) is a follow-up after the last day. No `perf-changelog.yaml` entry required.

仅文档改动。不涉及配置、配方或脚本；本 PR 不移除任何内容，实际执行（归档至 `configs/deprecated/`）将在最后运行日之后由后续 PR 完成。无需新增 `perf-changelog.yaml` 条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy announcement; no configs, recipes, or benchmark scripts are modified.
> 
> **Overview**
> Documents **Tuesday, September 8, 2026** as the last day for **Single-turn 8k1k** on **DeepSeek-V4-Pro 1.6T** (`dsv4`). **Agentic coding / AgentX stays active** (including MTP and DSpark); the model is not retired—only the fixed-sequence-length arm is scheduled to go away.
> 
> Adds a new **Deprecation Notice** subsection in `MODELS.md` and `MODELS_zh.md` with a deprecated/remains table, rationale (45 active 8k1k keys vs. 19 agentic keys on the North Star frontier), and **Status: not yet enacted** with follow-up steps aligned to #2493/#2527 (archive master configs and scripts; keep SPEED-Bench AL scripts). Updates the `dsv4` row in the English **model support matrix** to flag the pending last day.
> 
> **No runtime changes in this PR**—configs and benchmarks still run until a later enactment PR after the cutoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1232e2a6914d9f5652a04fbef56d2dbc06520957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->