### PR TITLE
Test realized Slurm launch-plan artifact upload

### DIFF
--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -398,15 +398,13 @@ if [ -d "$SRT_REPO_DIR" ]; then
     rm -rf "$SRT_REPO_DIR"
 fi
 
-# GLM-5.2 AgentX temporarily tracks SemiAnalysisAI/srt-slurm PR #4 so its
-# realized launch-plan artifacts can be validated end to end before merge.
-# MiniMax-M3 remains on v1.0.50 below.
+# GLM-5.2 and MiniMax-M3 AgentX use v1.0.50 for complete logical-worker
+# metrics discovery across aggregate, DP-attention, and disaggregated topologies.
 if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "glm5.2" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-sglang" ]]; then
-    git clone https://github.com/SemiAnalysisAI/srt-slurm.git "$SRT_REPO_DIR"
+    git clone --branch v1.0.50 --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
-    git checkout ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0 || exit 1
-    test "$(git rev-parse HEAD)" = "ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0" || {
-        echo "Error: SemiAnalysisAI/srt-slurm PR #4 resolved to an unexpected commit" >&2
+    test "$(git rev-parse HEAD)" = "e4019633c9e2bc25f38c44b81edf52bb0504d937" || {
+        echo "Error: NVIDIA/srt-slurm v1.0.50 resolved to an unexpected commit" >&2
         exit 1
     }
     mkdir -p recipes/sglang/glm5.2/gb200-fp4/agentic
@@ -618,10 +616,6 @@ cat > srtslurm.yaml <<EOF
 default_account: "${SLURM_ACCOUNT}"
 default_partition: "${SLURM_PARTITION}"
 default_time_limit: "6:00:00"
-
-# Persist exact realized srun commands under logs/launch-plan so the normal
-# multinode server-log artifact upload captures them.
-record_launch_plan: true
 
 # Resource defaults
 gpus_per_node: 4

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -398,13 +398,15 @@ if [ -d "$SRT_REPO_DIR" ]; then
     rm -rf "$SRT_REPO_DIR"
 fi
 
-# GLM-5.2 and MiniMax-M3 AgentX use v1.0.50 for complete logical-worker
-# metrics discovery across aggregate, DP-attention, and disaggregated topologies.
+# GLM-5.2 AgentX temporarily tracks SemiAnalysisAI/srt-slurm PR #4 so its
+# realized launch-plan artifacts can be validated end to end before merge.
+# MiniMax-M3 remains on v1.0.50 below.
 if [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "glm5.2" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "dynamo-sglang" ]]; then
-    git clone --branch v1.0.50 --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
+    git clone https://github.com/SemiAnalysisAI/srt-slurm.git "$SRT_REPO_DIR"
     cd "$SRT_REPO_DIR"
-    test "$(git rev-parse HEAD)" = "e4019633c9e2bc25f38c44b81edf52bb0504d937" || {
-        echo "Error: NVIDIA/srt-slurm v1.0.50 resolved to an unexpected commit" >&2
+    git checkout ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0 || exit 1
+    test "$(git rev-parse HEAD)" = "ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0" || {
+        echo "Error: SemiAnalysisAI/srt-slurm PR #4 resolved to an unexpected commit" >&2
         exit 1
     }
     mkdir -p recipes/sglang/glm5.2/gb200-fp4/agentic
@@ -616,6 +618,10 @@ cat > srtslurm.yaml <<EOF
 default_account: "${SLURM_ACCOUNT}"
 default_partition: "${SLURM_PARTITION}"
 default_time_limit: "6:00:00"
+
+# Persist exact realized srun commands under logs/launch-plan so the normal
+# multinode server-log artifact upload captures them.
+record_launch_plan: true
 
 # Resource defaults
 gpus_per_node: 4

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -7,10 +7,11 @@ SLURM_ACCOUNT="sa-shared"
 HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-/models/gharunners/hf-hub-cache}"
 AIPERF_MMAP_CACHE_HOST_PATH="${AIPERF_MMAP_CACHE_HOST_PATH:-/home/sa-shared/gharunners/ai-perf-cache}"
 
-# Temporarily track SemiAnalysisAI/srt-slurm PR #4 so its realized launch-plan
-# artifacts can be validated by the H200 AgentX hardware gate before merge.
-POWER_SRT_SLURM_URL="https://github.com/SemiAnalysisAI/srt-slurm.git"
-POWER_SRT_SLURM_PIN="ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0"
+# Immutable producer prerequisite for the GLM-5.2 AgentX lane. This fork is
+# intentionally long-lived; update the SHA only after reviewing a new fork
+# commit and re-running the H200 hardware gate.
+POWER_SRT_SLURM_URL="https://github.com/edwingao28/srt-slurm.git"
+POWER_SRT_SLURM_PIN="e5c837f06a362dc888dfea2ee588e9f19c298270"
 
 set -x
 
@@ -36,8 +37,17 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
         t && /^  provider: dcgm-power$/ { p = 1 }
         t && /^  enabled: true$/        { e = 1 }
         END { exit !(p && e) }
-    ' "$_RECIPE_SRC"; then
+' "$_RECIPE_SRC"; then
         USES_DCGM_POWER=1
+    fi
+
+    # PR #4 is based on the main srt-slurm lineage, which does not contain the
+    # separate dcgm-power fork's schema. This draft smoke intentionally omits
+    # power collection so it can exercise only the launch-plan upload contract.
+    LAUNCH_PLAN_SMOKE=0
+    if [[ "$IS_AGENTIC" == "1" && "$FRAMEWORK" == "dynamo-sglang" && "$MODEL_PREFIX" == "glm5.2" && "$PRECISION" == "fp8" ]]; then
+        LAUNCH_PLAN_SMOKE=1
+        USES_DCGM_POWER=0
     fi
 
     # Only explicitly reviewed H200 FP8 AgentX recipes may use dcgm-power.
@@ -110,7 +120,15 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
     if [[ $IS_AGENTIC == "1" && $FRAMEWORK == "dynamo-sglang" && (
         "$MODEL_PREFIX" == "glm5.2" || "$MODEL_PREFIX" == "dsv4"
     ) ]]; then
-        if [[ "$USES_DCGM_POWER" == "1" ]]; then
+        if [[ "$LAUNCH_PLAN_SMOKE" == "1" ]]; then
+            git clone https://github.com/SemiAnalysisAI/srt-slurm.git "$SRT_REPO_DIR"
+            cd "$SRT_REPO_DIR"
+            git checkout ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0 || exit 1
+            test "$(git rev-parse HEAD)" = "ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0" || {
+                echo "Error: SemiAnalysisAI/srt-slurm PR #4 resolved to an unexpected commit" >&2
+                exit 1
+            }
+        elif [[ "$USES_DCGM_POWER" == "1" ]]; then
             # The pinned fork carries the v1.0.44 AgentX lifecycle plus the formal
             # custom-benchmark dcgm-power contract used by the allowlisted recipes.
             git clone "$POWER_SRT_SLURM_URL" "$SRT_REPO_DIR"
@@ -298,6 +316,10 @@ EOF
     if [[ -f "$LOCAL_CONFIG_FILE" ]]; then
         mkdir -p "$(dirname "$CONFIG_PATH")"
         cp "$LOCAL_CONFIG_FILE" "$CONFIG_PATH"
+    fi
+
+    if [[ "$LAUNCH_PLAN_SMOKE" == "1" ]]; then
+        sed -i '/^telemetry:/,/^[^ ]/{ /^telemetry:/d; /^  /d; }' "$CONFIG_PATH"
     fi
 
     if [[ "$USES_DCGM_POWER" == "1" ]]; then

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -7,11 +7,10 @@ SLURM_ACCOUNT="sa-shared"
 HF_HUB_CACHE_MOUNT="${HF_HUB_CACHE_MOUNT:-/models/gharunners/hf-hub-cache}"
 AIPERF_MMAP_CACHE_HOST_PATH="${AIPERF_MMAP_CACHE_HOST_PATH:-/home/sa-shared/gharunners/ai-perf-cache}"
 
-# Immutable producer prerequisite for the GLM-5.2 AgentX lane. This fork is
-# intentionally long-lived; update the SHA only after reviewing a new fork
-# commit and re-running the H200 hardware gate.
-POWER_SRT_SLURM_URL="https://github.com/edwingao28/srt-slurm.git"
-POWER_SRT_SLURM_PIN="e5c837f06a362dc888dfea2ee588e9f19c298270"
+# Temporarily track SemiAnalysisAI/srt-slurm PR #4 so its realized launch-plan
+# artifacts can be validated by the H200 AgentX hardware gate before merge.
+POWER_SRT_SLURM_URL="https://github.com/SemiAnalysisAI/srt-slurm.git"
+POWER_SRT_SLURM_PIN="ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0"
 
 set -x
 
@@ -254,6 +253,9 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
 default_account: "${SLURM_ACCOUNT}"
 default_partition: "${SLURM_PARTITION}"
 default_time_limit: "4:00:00"
+# Persist exact realized srun commands under logs/launch-plan so the normal
+# multinode server-log artifact upload captures them.
+record_launch_plan: true
 # Resource defaults
 gpus_per_node: 8
 network_interface: ""


### PR DESCRIPTION
## Summary

- pin the H200 GLM-5.2 AgentX smoke path to SemiAnalysisAI/srt-slurm PR #4 at `ff57ec45f9fba76f58f0255c8f2a83c335c1bdc0`
- enable realized launch-plan recording in the generated H200 cluster configuration
- omit the recipe dcgm-power block for this smoke because PR #4 is based on the main srt-slurm lineage rather than the separate power-producer fork
- rely on the existing multinode server-log bundle and artifact upload path to preserve `logs/launch-plan`

Depends on https://github.com/SemiAnalysisAI/srt-slurm/pull/4.

## Validation

- [x] `bash -n runners/launch_h200-dgxc-slurm.sh`
- [x] `python3 -m pytest utils/matrix_logic/ -q` (232 passed)
- [x] generated one H200 GLM-5.2 2P2D AgentX configuration at concurrency 8
- [x] [bespoke AgentX target job](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32900919824/job/97974467790) completed successfully with a 180-second profile (14/14 profiled requests successful, 0 errors)
- [x] uploaded server-log artifact contains `launch-plan/manifest.json` and 11 realized `srun` scripts
- [x] all 11 scripts are executable, pass `bash -n`, and match the SHA-256 values in the manifest; no literal HF/GitHub/AWS token patterns were found
- [ ] `recipe.lock.yaml` is not present in the uploaded archive even though the manifest lists `../recipe.lock.yaml` under `related_artifacts`

The target job, artifact aggregation, and success-rate jobs all succeeded. GitHub still reports the parent workflow conclusion as failure despite every executed job succeeding; the other matrix jobs were intentionally skipped.

The initial GB200 dispatch was cancelled while queued after checking live fleet utilization. The first H200 attempt confirmed PR #4 lacks the separate dcgm-power schema and did not submit a Slurm job. The successful H200 run spent most of its 42-minute target-job time in GLM-5.2/DeepGEMM startup and default AgentX warmup; the measured profile itself was 181.8 seconds.

This PR remains intentionally draft. The missing lockfile should be resolved in srt-slurm PR #4 before that change is merged.
