### PR TITLE
[Klaud Cold] minimaxm3-fp4-mi355x-atom-agentic-mtp: day-zero MiniMax-M3 MXFP4 ATOM AgentX recipe on MI355X / MI355X 上 MiniMax-M3 MXFP4 ATOM AgentX 首发配方

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -eo pipefail
+set -x
+
+# Agentic trace replay benchmark for MiniMax-M3 MXFP4 on MI355X using ATOM
+# with EAGLE3 speculative decoding. Throughput runs pin acceptance to the
+# committed golden curve; eval-only runs use the drafter's real acceptance.
+#
+# Required env vars:
+#   MODEL, MODEL_PATH, TP, CONC, KV_OFFLOADING, KV_OFFLOAD_BACKEND,
+#   TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION, EP_SIZE, DP_ATTENTION
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+
+echo "MODEL=$MODEL TP=$TP CONC=$CONC KV_OFFLOADING=$KV_OFFLOADING TOTAL_CPU_DRAM_GB=$TOTAL_CPU_DRAM_GB RESULT_DIR=$RESULT_DIR DURATION=$DURATION EP_SIZE=$EP_SIZE DP_ATTENTION=$DP_ATTENTION"
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+# The AITER page-16 sparse-attention path wants exactly one KV head per
+# tensor-parallel rank. MiniMax-M3 has four KV heads, so this recipe is TP4.
+if [ "$TP" -ne 4 ] || [ "$EP_SIZE" -ne 1 ] || [ "$DP_ATTENTION" != "false" ]; then
+    echo "This recipe requires TP=4, EP_SIZE=1, and DP_ATTENTION=false" >&2
+    exit 1
+fi
+require_agentic_kv_offload_none
+
+# ROCR/HIP visibility
+if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+DRAFT_MODEL="Inferact/MiniMax-M3-EAGLE3"
+NUM_SPEC_TOKENS=3
+# golden_al_distribution/minimaxm3_eagle3.yaml:
+# minimax-m3.thinking_on[3]
+SPEC_DECODE_AL=2.83
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+hf download "$DRAFT_MODEL"
+
+rocm-smi || true
+amd-smi || true
+
+resolve_trace_source
+install_agentic_deps
+
+# Require the ATOM Prometheus stream in every official result. AIPerf
+# deduplicates this endpoint against its automatic localhost discovery.
+export AIPERF_SERVER_METRICS_URLS="http://localhost:${PORT}/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="atom:"
+
+# VRAM space check
+wait_for_amd_gpu_clean
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+SERVER_PID=""
+cleanup_atom_server() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "ATOM server" 60
+    exit "$exit_code"
+}
+trap cleanup_atom_server EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# ---- ATOM env ---------------------------------------------------------------
+echo "Starting atom server..."
+export PYTHONNOUSERSITE=1
+
+# Without this the aiter kernel logs flood the server log for the whole replay.
+export AITER_LOG_LEVEL="${AITER_LOG_LEVEL:-WARNING}"
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+# MiniMax-M3 sparse attention runs on the Triton path under ATOM, matching the
+# TRITON_ATTN backend the vLLM MI355X recipe pins.
+export ATOM_FORCE_ATTN_TRITON=1
+
+# CUDA/HIPGRAPH settings
+case "$CONC" in
+  1)  CUDAGRAPH_CAPTURE_SIZES='[1,2]' ;;
+  4)  CUDAGRAPH_CAPTURE_SIZES='[1,2,4,8]' ;;
+  8)  CUDAGRAPH_CAPTURE_SIZES='[1,2,4,8,12,16]' ;;
+  12) CUDAGRAPH_CAPTURE_SIZES='[1,2,4,8,12,16,20,24]' ;;
+  16) CUDAGRAPH_CAPTURE_SIZES='[1,2,4,8,12,16,20,24,28,32]' ;;
+  *)
+    echo "Unsupported CONC=$CONC" >&2
+    exit 2
+    ;;
+esac
+
+# ---- Speculative ------------------------------------------------------------
+# Synthetic acceptance standardizes throughput against the committed golden
+# EAGLE3 curve. Accuracy evals must use real target verification.
+SPEC_ARGS=(
+    --method eagle3
+    --draft-model "$DRAFT_MODEL"
+    --num-speculative-tokens "$NUM_SPEC_TOKENS"
+)
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    SPEC_ARGS+=(--spec-decode-acceptance-length "$SPEC_DECODE_AL")
+fi
+echo "DRAFT_MODEL=$DRAFT_MODEL NUM_SPEC_TOKENS=$NUM_SPEC_TOKENS SPEC_DECODE_AL=$SPEC_DECODE_AL"
+
+# ---- LLM server -------------------------------------------------------------
+# AgentX concurrency counts session trees. Keep 2x scheduler headroom for the
+# request bursts produced by subagent fan-out.
+ATOM_CMD=(
+    python3 -u -m atom.entrypoints.openai_server
+    --model "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --server-port "$PORT"
+    --tensor-parallel-size "$TP"
+    --trust-remote-code
+    --block-size 128
+    --kv_cache_dtype fp8
+    --enable_prefix_caching
+    --gpu-memory-utilization 0.8
+    --max-num-batched-tokens 16384
+    --max-num-seqs "$((2 * CONC))"
+    --cudagraph-capture-sizes "$CUDAGRAPH_CAPTURE_SIZES"
+    --online_quant_config '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","vision_tower","multi_modal_projector","patch_merge_mlp","*block_sparse_moe"]}'
+    "${SPEC_ARGS[@]}"
+)
+write_command "$RESULT_DIR/server_command.txt" "${ATOM_CMD[@]}"
+"${ATOM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ---- Run benchmark ----------------------------------------------------------
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --apply-chat-template"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1679,6 +1679,23 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
       - { tp: 2, kv-offloading: none, conc-list: [1, 2, 5], spec-decoding: mtp }
       - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.3" }, conc-list: [32, 40], spec-decoding: mtp }
 
+# MiniMax-M3 MXFP4 agentic-coding benchmark on MI355X via ATOM with EAGLE3
+# speculative decoding. TP4 matches the vLLM sibling: MiniMax-M3 has four KV
+# heads, so one KV head per rank keeps the AITER sparse-attention fast path.
+# No KV offloading in this first ATOM AgentX bring-up.
+minimaxm3-fp4-mi355x-atom-agentic-mtp:
+  image: rocm/atom-dev:nightly_202608251555
+  model: amd/MiniMax-M3-MXFP4
+  model-prefix: minimaxm3
+  runner: cluster:mi355x-amds
+  precision: fp4
+  framework: atom
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - { tp: 4, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 4, 8, 12, 16], spec-decoding: mtp }
+
 # GLM-5.2 FP4 agentic-coding benchmark on MI355X via SGLang with MTP speculative
 # decoding. Two arms: (1) TP4/EP4 with HiCache KV offloading to DRAM, concurrency
 # sweep [1, 2, 4, 8, 10, 12, 16]; (2) TP8/EP8 without KV offloading for low-latency

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6475,4 +6475,4 @@
     - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM, EAGLE3 speculative decoding, and TP4 at concurrency 1/4/8/12/16."
     - "Pin throughput runs to the committed golden EAGLE3 acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
     - "Keep ATOM prefix caching enabled for the trace-replay workload instead of the disabled setting the retired single-turn 8k1k recipe used."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2733

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6467,3 +6467,12 @@
     - "Reduce the concurrency-1536 disaggregated topology from six to five DEP8 prefill workers while retaining one DEP16 decode worker."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2644
   
+- config-keys:
+    - minimaxm3-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM, EAGLE3 speculative decoding, and TP4 at concurrency 1/4/8/12/16."
+    - "Pin throughput runs to the committed golden EAGLE3 acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
+    - "Keep ATOM prefix caching enabled for the trace-replay workload instead of the disabled setting the retired single-turn 8k1k recipe used."
+  pr-link: TBD


### PR DESCRIPTION
## Summary / 摘要

Day-zero **MiniMax-M3 MXFP4 AgentX recipe on MI355X served by ATOM** with EAGLE3 speculative decoding. `minimaxm3` currently has no ATOM coverage in AgentX — the vLLM MI355X arm is the only MI355X entry — so this adds the ATOM arm.

在 MI355X 上新增由 **ATOM** 服务的 **MiniMax-M3 MXFP4 AgentX 配方**，采用 EAGLE3 投机解码。`minimaxm3` 目前在 AgentX 中没有 ATOM 覆盖（MI355X 上仅有 vLLM 分支），本 PR 补上 ATOM 分支。

## Config key / 配置项

`minimaxm3-fp4-mi355x-atom-agentic-mtp` — `amd/MiniMax-M3-MXFP4`, `rocm/atom-dev:nightly_202608251555` (latest ATOM nightly, verified on Docker Hub), `cluster:mi355x-amds`, TP4, conc `[1, 4, 8, 12, 16]`, no KV offloading.

## Recipe decisions / 配方要点

- **TP4.** MiniMax-M3 has four KV heads, so TP4 gives exactly one KV head per rank and keeps the AITER sparse-attention fast path — the same reason the vLLM MI355X sibling runs TP4.
- **EAGLE3, 3 draft tokens**, drafter `Inferact/MiniMax-M3-EAGLE3` (the PoR draft the retired ATOM MI355X recipe used). Throughput runs pin `--spec-decode-acceptance-length 2.83` from `golden_al_distribution/minimaxm3_eagle3.yaml` (`thinking_on[3]`); eval-only runs drop the pin and use real target verification.
- **Prefix caching enabled.** The retired single-turn 8k1k ATOM recipe passed `--no-enable_prefix_caching`; that is deliberately **not** carried over — trace replay is exactly the workload prefix caching pays for.
- **No `--hf-overrides` index-cache block.** The vLLM arm sets `{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}`; this ATOM recipe deliberately does not.
- No launcher change needed: `runners/launch_mi355x-amds.sh` already resolves `<prefix>_<precision>_mi355x_<framework><_mtp>.sh` under `agentic/`, and already routes `amd/MiniMax-M3*` weights to the NFS HF cache.

- **TP4**：MiniMax-M3 有 4 个 KV head，TP4 使每个 rank 恰好一个 KV head，可走 AITER 稀疏注意力快速路径，与 vLLM MI355X 同类配方一致。
- **EAGLE3、3 个草稿 token**，草稿模型 `Inferact/MiniMax-M3-EAGLE3`。吞吐运行按 `golden_al_distribution/minimaxm3_eagle3.yaml`（`thinking_on[3]`）锁定 `--spec-decode-acceptance-length 2.83`；仅评测运行取消锁定，使用真实目标验证。
- **启用前缀缓存**：已退役的单轮 8k1k ATOM 配方使用 `--no-enable_prefix_caching`，此处刻意不沿用——轨迹回放正是前缀缓存最有价值的负载。
- **不添加 `--hf-overrides` 索引缓存参数**：vLLM 分支设置了 `{"text_config": {"use_index_cache": true, "index_topk_freq": 4}}`，本 ATOM 配方刻意不设置。
- 无需改动 launcher：`runners/launch_mi355x-amds.sh` 已能解析 `agentic/` 下的脚本名，并已将 `amd/MiniMax-M3*` 权重指向 NFS HF 缓存。

## Files / 改动文件

- `benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh` (new)
- `configs/amd-master.yaml` — new entry after the vLLM MI355X sibling
- `perf-changelog.yaml` — appended entry

## Note / 说明

A sibling PR builds the **same config key** from the upstream [ROCm/ATOM Qwen3.5 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md) shape instead. The two are **mutually exclusive candidates** — merge whichever sweeps green, not both.

另有一个同类 PR 按上游 [ROCm/ATOM Qwen3.5 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md) 的形态实现**同一配置项**。两者**互斥**，只应合并全量 sweep 通过的那一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and YAML config only; no changes to application runtime, auth, or shared orchestration logic beyond registering a new sweep recipe.
> 
> **Overview**
> Adds **day-zero AgentX coverage** for `amd/MiniMax-M3-MXFP4` on MI355X served by **ATOM** (alongside the existing vLLM arm), via new config key `minimaxm3-fp4-mi355x-atom-agentic-mtp` and benchmark script `minimaxm3_fp4_mi355x_atom_mtp.sh`.
> 
> The recipe runs **TP4 / EP1 / no DP-attention / no KV offload**, sweeps concurrency **1, 4, 8, 12, 16**, and uses **EAGLE3** with drafter `Inferact/MiniMax-M3-EAGLE3` and three draft tokens. **Throughput** runs pin `--spec-decode-acceptance-length` to **2.83** from the committed golden curve; **`EVAL_ONLY`** drops the pin for real target verification. The ATOM server enables **prefix caching**, PTPC FP8 online quant, Triton sparse attention (`ATOM_FORCE_ATTN_TRITON`), and required `atom:` Prometheus metrics for AIPerf.
> 
> `perf-changelog.yaml` documents the new matrix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28edf0994765a633b5bf18baec92c4380d69661f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->