### PR TITLE
[Klaud Cold] minimaxm3-fp4-mi355x-atom-agentic-mtp: MiniMax-M3 MXFP4 ATOM AgentX on MI355X with the Inferact EAGLE3 drafter / MI355X 上采用 Inferact EAGLE3 草稿模型的 MiniMax-M3 MXFP4 ATOM AgentX 配方

### DIFF
--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
@@ -3,16 +3,22 @@ set -eo pipefail
 set -x
 
 # Agentic trace replay benchmark for MiniMax-M3 MXFP4 on MI355X using ATOM
-# with native MTP speculative decoding.
+# with EAGLE3 speculative decoding against the Inferact drafter.
 #
-# Serve shape follows the upstream ATOM recipe:
-#   https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md
-#     python -m atom.entrypoints.openai_server --model <model> \
-#       --kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3
-# Everything ATOM does not require is left at its default on purpose, so this
-# recipe stays the upstream-faithful arm. MiniMax-M3 ships native MTP modules
-# (config.json text_config.num_mtp_modules = 7), so no external drafter is
-# loaded.
+# The server flags are a port of the retired single-turn 8k1k MI355X ATOM
+# recipe (benchmarks/single_node/fixed_seq_len/deprecated/
+# minimaxm3_fp4_mi355x_atom_mtp.sh): same EAGLE3 drafter and draft length,
+# same ptpc_fp8 online quant exclusions, same Triton attention env, same
+# block size and memory fraction. The serve shape follows the upstream ATOM
+# recipe (https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md): TP4,
+# FP8 KV cache, three draft tokens, and ATOM defaults for everything the
+# recipe does not name.
+#
+# Two deliberate departures from the retired 8k1k script:
+#   * prefix caching stays ON. Trace replay is exactly the workload it pays
+#     for, so --no-enable_prefix_caching is not carried over.
+#   * --max-model-len is left at the model default. Agentic traces are long
+#     context and must not be clipped to the 8k1k scenario's 32768.
 #
 # Required env vars:
 #   MODEL, MODEL_PATH, TP, CONC, KV_OFFLOADING, KV_OFFLOAD_BACKEND,
@@ -31,7 +37,8 @@ if [[ -n "${SLURM_JOB_ID:-}" ]]; then
 fi
 
 # The upstream recipe is TP4, which is also what MiniMax-M3's four KV heads
-# want: one KV head per rank keeps the AITER sparse-attention fast path.
+# want: one KV head per rank keeps the AITER sparse-attention fast path. The
+# retired 8k1k MI355X ATOM recipe swept TP4 for the same reason.
 if [ "$TP" -ne 4 ] || [ "$EP_SIZE" -ne 1 ] || [ "$DP_ATTENTION" != "false" ]; then
     echo "This recipe requires TP=4, EP_SIZE=1, and DP_ATTENTION=false" >&2
     exit 1
@@ -43,10 +50,12 @@ if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
     export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
 fi
 
+# Drafter and draft length carried over from the retired 8k1k MI355X ATOM
+# recipe. MiniMax-M3's plan-of-record draft is the external Inferact EAGLE3
+# head, not the checkpoint's MTP modules.
+DRAFT_MODEL="Inferact/MiniMax-M3-EAGLE3"
 NUM_SPEC_TOKENS=3
-# golden_al_distribution/minimaxm3_eagle3.yaml: minimax-m3.thinking_on[3].
-# AgentX pins every submission for a model to one golden acceptance curve, so
-# the native-MTP arm targets the same acceptance length as the EAGLE3 arm.
+# golden_al_distribution/minimaxm3_eagle3.yaml: minimax-m3.thinking_on[3]
 SPEC_DECODE_AL=2.83
 
 if [[ -n "${MODEL_PATH:-}" ]]; then
@@ -57,6 +66,8 @@ else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"
 fi
+
+hf download "$DRAFT_MODEL"
 
 rocm-smi || true
 amd-smi || true
@@ -90,25 +101,32 @@ trap 'exit 143' TERM
 
 echo "Starting atom server..."
 export PYTHONNOUSERSITE=1
+
+# ---- ATOM env (from the retired 8k1k MI355X ATOM recipe) --------------------
+export AITER_QUICK_REDUCE_QUANTIZATION=INT4
+export ATOM_FORCE_ATTN_TRITON=1
 # Without this the aiter kernel logs flood the server log for the whole replay.
 export AITER_LOG_LEVEL="${AITER_LOG_LEVEL:-WARNING}"
 
+MEM_FRAC_STATIC=0.8
+MAX_NUM_BATCHED_TOKENS=32768
+
 # ---- Speculative ------------------------------------------------------------
 # Synthetic acceptance standardizes throughput against the committed golden
-# curve. Accuracy evals must use real target verification.
+# EAGLE3 curve. Accuracy evals must use real target verification.
 SPEC_ARGS=(
-    --method mtp
+    --method eagle3
+    --draft-model "$DRAFT_MODEL"
     --num-speculative-tokens "$NUM_SPEC_TOKENS"
 )
 if [ "${EVAL_ONLY:-false}" != "true" ]; then
     SPEC_ARGS+=(--spec-decode-acceptance-length "$SPEC_DECODE_AL")
 fi
-echo "NUM_SPEC_TOKENS=$NUM_SPEC_TOKENS SPEC_DECODE_AL=$SPEC_DECODE_AL"
+echo "DRAFT_MODEL=$DRAFT_MODEL NUM_SPEC_TOKENS=$NUM_SPEC_TOKENS SPEC_DECODE_AL=$SPEC_DECODE_AL"
 
 # ---- LLM server -------------------------------------------------------------
 # AgentX concurrency counts session trees. Keep 2x scheduler headroom for the
-# request bursts produced by subagent fan-out. Every other server knob is left
-# at the ATOM default, as the upstream recipe leaves it.
+# request bursts produced by subagent fan-out.
 ATOM_CMD=(
     python3 -u -m atom.entrypoints.openai_server
     --model "$MODEL_PATH"
@@ -117,8 +135,13 @@ ATOM_CMD=(
     --server-port "$PORT"
     --tensor-parallel-size "$TP"
     --trust-remote-code
+    --block-size 128
     --kv_cache_dtype fp8
+    --enable_prefix_caching
+    --gpu-memory-utilization "$MEM_FRAC_STATIC"
+    --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS"
     --max-num-seqs "$((2 * CONC))"
+    --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}'
     "${SPEC_ARGS[@]}"
 )
 write_command "$RESULT_DIR/server_command.txt" "${ATOM_CMD[@]}"

--- a/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
+++ b/benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -eo pipefail
+set -x
+
+# Agentic trace replay benchmark for MiniMax-M3 MXFP4 on MI355X using ATOM
+# with native MTP speculative decoding.
+#
+# Serve shape follows the upstream ATOM recipe:
+#   https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md
+#     python -m atom.entrypoints.openai_server --model <model> \
+#       --kv_cache_dtype fp8 -tp 4 --method mtp --num-speculative-tokens 3
+# Everything ATOM does not require is left at its default on purpose, so this
+# recipe stays the upstream-faithful arm. MiniMax-M3 ships native MTP modules
+# (config.json text_config.num_mtp_modules = 7), so no external drafter is
+# loaded.
+#
+# Required env vars:
+#   MODEL, MODEL_PATH, TP, CONC, KV_OFFLOADING, KV_OFFLOAD_BACKEND,
+#   TOTAL_CPU_DRAM_GB, RESULT_DIR, DURATION, EP_SIZE, DP_ATTENTION
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION EP_SIZE DP_ATTENTION
+
+echo "MODEL=$MODEL TP=$TP CONC=$CONC KV_OFFLOADING=$KV_OFFLOADING TOTAL_CPU_DRAM_GB=$TOTAL_CPU_DRAM_GB RESULT_DIR=$RESULT_DIR DURATION=$DURATION EP_SIZE=$EP_SIZE DP_ATTENTION=$DP_ATTENTION"
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+# The upstream recipe is TP4, which is also what MiniMax-M3's four KV heads
+# want: one KV head per rank keeps the AITER sparse-attention fast path.
+if [ "$TP" -ne 4 ] || [ "$EP_SIZE" -ne 1 ] || [ "$DP_ATTENTION" != "false" ]; then
+    echo "This recipe requires TP=4, EP_SIZE=1, and DP_ATTENTION=false" >&2
+    exit 1
+fi
+require_agentic_kv_offload_none
+
+# ROCR/HIP visibility
+if [[ -n "${ROCR_VISIBLE_DEVICES:-}" ]]; then
+    export HIP_VISIBLE_DEVICES="$ROCR_VISIBLE_DEVICES"
+fi
+
+NUM_SPEC_TOKENS=3
+# golden_al_distribution/minimaxm3_eagle3.yaml: minimax-m3.thinking_on[3].
+# AgentX pins every submission for a model to one golden acceptance curve, so
+# the native-MTP arm targets the same acceptance length as the EAGLE3 arm.
+SPEC_DECODE_AL=2.83
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+rocm-smi || true
+amd-smi || true
+
+resolve_trace_source
+install_agentic_deps
+
+# Require the ATOM Prometheus stream in every official result. AIPerf
+# deduplicates this endpoint against its automatic localhost discovery.
+export AIPERF_SERVER_METRICS_URLS="http://localhost:${PORT}/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="atom:"
+
+# VRAM space check
+wait_for_amd_gpu_clean
+
+# ---- Server config ----------------------------------------------------------
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+SERVER_PID=""
+cleanup_atom_server() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "ATOM server" 60
+    exit "$exit_code"
+}
+trap cleanup_atom_server EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+echo "Starting atom server..."
+export PYTHONNOUSERSITE=1
+# Without this the aiter kernel logs flood the server log for the whole replay.
+export AITER_LOG_LEVEL="${AITER_LOG_LEVEL:-WARNING}"
+
+# ---- Speculative ------------------------------------------------------------
+# Synthetic acceptance standardizes throughput against the committed golden
+# curve. Accuracy evals must use real target verification.
+SPEC_ARGS=(
+    --method mtp
+    --num-speculative-tokens "$NUM_SPEC_TOKENS"
+)
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    SPEC_ARGS+=(--spec-decode-acceptance-length "$SPEC_DECODE_AL")
+fi
+echo "NUM_SPEC_TOKENS=$NUM_SPEC_TOKENS SPEC_DECODE_AL=$SPEC_DECODE_AL"
+
+# ---- LLM server -------------------------------------------------------------
+# AgentX concurrency counts session trees. Keep 2x scheduler headroom for the
+# request bursts produced by subagent fan-out. Every other server knob is left
+# at the ATOM default, as the upstream recipe leaves it.
+ATOM_CMD=(
+    python3 -u -m atom.entrypoints.openai_server
+    --model "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --server-port "$PORT"
+    --tensor-parallel-size "$TP"
+    --trust-remote-code
+    --kv_cache_dtype fp8
+    --max-num-seqs "$((2 * CONC))"
+    "${SPEC_ARGS[@]}"
+)
+write_command "$RESULT_DIR/server_command.txt" "${ATOM_CMD[@]}"
+"${ATOM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+# ---- Run benchmark ----------------------------------------------------------
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --apply-chat-template"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1679,11 +1679,13 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
       - { tp: 2, kv-offloading: none, conc-list: [1, 2, 5], spec-decoding: mtp }
       - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.3" }, conc-list: [32, 40], spec-decoding: mtp }
 
-# MiniMax-M3 MXFP4 agentic-coding benchmark on MI355X via ATOM with native MTP.
-# Serve shape follows the upstream ATOM recipe
+# MiniMax-M3 MXFP4 agentic-coding benchmark on MI355X via ATOM with EAGLE3
+# speculative decoding against the Inferact drafter. Server flags are a port
+# of the retired single-turn 8k1k MI355X ATOM recipe; the serve shape follows
+# the upstream ATOM recipe
 # (https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md): TP4, FP8 KV
-# cache, MTP with three draft tokens, every other knob left at the ATOM
-# default. No KV offloading in this first ATOM AgentX bring-up.
+# cache, three draft tokens, ATOM defaults for everything it does not name.
+# No KV offloading in this first ATOM AgentX bring-up.
 minimaxm3-fp4-mi355x-atom-agentic-mtp:
   image: rocm/atom-dev:nightly_202608251555
   model: amd/MiniMax-M3-MXFP4

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1679,6 +1679,24 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
       - { tp: 2, kv-offloading: none, conc-list: [1, 2, 5], spec-decoding: mtp }
       - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.3" }, conc-list: [32, 40], spec-decoding: mtp }
 
+# MiniMax-M3 MXFP4 agentic-coding benchmark on MI355X via ATOM with native MTP.
+# Serve shape follows the upstream ATOM recipe
+# (https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md): TP4, FP8 KV
+# cache, MTP with three draft tokens, every other knob left at the ATOM
+# default. No KV offloading in this first ATOM AgentX bring-up.
+minimaxm3-fp4-mi355x-atom-agentic-mtp:
+  image: rocm/atom-dev:nightly_202608251555
+  model: amd/MiniMax-M3-MXFP4
+  model-prefix: minimaxm3
+  runner: cluster:mi355x-amds
+  precision: fp4
+  framework: atom
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - { tp: 4, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 4, 8, 12, 16], spec-decoding: mtp }
+
 # GLM-5.2 FP4 agentic-coding benchmark on MI355X via SGLang with MTP speculative
 # decoding. Two arms: (1) TP4/EP4 with HiCache KV offloading to DRAM, concurrency
 # sweep [1, 2, 4, 8, 10, 12, 16]; (2) TP8/EP8 without KV offloading for low-latency

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6472,7 +6472,9 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM native MTP at TP4 and concurrency 1/4/8/12/16."
-    - "Follow the upstream ATOM recipe serve shape: FP8 KV cache, three MTP draft tokens, and ATOM defaults for every other server knob."
-    - "Pin throughput runs to the committed golden acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
+    - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM, EAGLE3 speculative decoding against the Inferact drafter, TP4, and concurrency 1/4/8/12/16."
+    - "Port the server flags from the retired single-turn 8k1k MI355X ATOM recipe: same drafter and draft length, ptpc_fp8 online quant exclusions, Triton attention, block size 128, and memory fraction 0.8."
+    - "Follow the upstream ATOM recipe serve shape of TP4 with an FP8 KV cache and three draft tokens, leaving ATOM defaults for every knob the recipe does not name."
+    - "Keep prefix caching enabled and the model default max sequence length, unlike the retired 8k1k recipe."
+    - "Pin throughput runs to the committed golden EAGLE3 acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2734

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6467,3 +6467,12 @@
     - "Reduce the concurrency-1536 disaggregated topology from six to five DEP8 prefill workers while retaining one DEP16 decode worker."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2644
   
+- config-keys:
+    - minimaxm3-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM native MTP at TP4 and concurrency 1/4/8/12/16."
+    - "Follow the upstream ATOM recipe serve shape: FP8 KV cache, three MTP draft tokens, and ATOM defaults for every other server knob."
+    - "Pin throughput runs to the committed golden acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6475,4 +6475,4 @@
     - "Add a day-zero MiniMax-M3 MXFP4 AgentX recipe on MI355X with ATOM native MTP at TP4 and concurrency 1/4/8/12/16."
     - "Follow the upstream ATOM recipe serve shape: FP8 KV cache, three MTP draft tokens, and ATOM defaults for every other server knob."
     - "Pin throughput runs to the committed golden acceptance length of 2.83 at three draft tokens; eval-only runs keep real target verification."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2734


### PR DESCRIPTION
## Summary / 摘要

Day-zero **MiniMax-M3 MXFP4 AgentX recipe on MI355X served by ATOM**, with **EAGLE3 speculative decoding against the Inferact drafter**. The server flags are a port of the retired single-turn 8k1k MI355X ATOM recipe; the serve shape follows the upstream [ROCm/ATOM Qwen3.5 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md) — TP4, FP8 KV cache, three draft tokens, ATOM defaults for everything it does not name.

在 MI355X 上新增由 **ATOM** 服务的 **MiniMax-M3 MXFP4 AgentX 配方**，采用 **EAGLE3 投机解码，草稿模型为 Inferact 版本**。服务参数移植自已退役的单轮 8k1k MI355X ATOM 配方；服务形态遵循上游 [ROCm/ATOM Qwen3.5 recipe](https://github.com/ROCm/ATOM/blob/main/recipes/Qwen3.5.md)：TP4、FP8 KV 缓存、3 个草稿 token，其余未指明的参数保持 ATOM 默认。

## Config key / 配置项

`minimaxm3-fp4-mi355x-atom-agentic-mtp` — `amd/MiniMax-M3-MXFP4`, `rocm/atom-dev:nightly_202608251555` (latest ATOM nightly, verified on Docker Hub), `cluster:mi355x-amds`, TP4, conc `[1, 4, 8, 12, 16]`, no KV offloading.

## Speculative decoding / 投机解码

`--method eagle3 --draft-model Inferact/MiniMax-M3-EAGLE3 --num-speculative-tokens 3` — the drafter and draft length the retired 8k1k MI355X ATOM recipe used, and MiniMax-M3's plan-of-record draft per `MODELS.md`. The checkpoint's native MTP modules are **not** used. Throughput runs pin `--spec-decode-acceptance-length 2.83` from `golden_al_distribution/minimaxm3_eagle3.yaml` (`thinking_on[3]`); eval-only runs drop the pin and use real target verification.

`--method eagle3 --draft-model Inferact/MiniMax-M3-EAGLE3 --num-speculative-tokens 3`，即已退役 8k1k MI355X ATOM 配方所用的草稿模型与草稿长度，也是 `MODELS.md` 中 MiniMax-M3 的 PoR 草稿方案；不使用 checkpoint 自带的原生 MTP 模块。吞吐运行按 `golden_al_distribution/minimaxm3_eagle3.yaml` 的 `thinking_on[3]` 锁定 `--spec-decode-acceptance-length 2.83`，仅评测运行取消锁定并使用真实目标验证。

## Ported from the retired 8k1k MI355X ATOM recipe / 移植自已退役的 8k1k MI355X ATOM 配方

`ptpc_fp8` `online_quant_config` with the MiniMax-M3 exclusion list, `ATOM_FORCE_ATTN_TRITON=1`, `AITER_QUICK_REDUCE_QUANTIZATION=INT4`, `--block-size 128`, `--gpu-memory-utilization 0.8`, `--max-num-batched-tokens 32768`, `--kv_cache_dtype fp8`, `--trust-remote-code`.

Two deliberate departures / 两处刻意不同：

- **Prefix caching stays ON.** `--no-enable_prefix_caching` is not carried over — trace replay is exactly the workload prefix caching pays for.
- **`--max-model-len` left at the model default**, so agentic long-context traces are not clipped to the 8k1k scenario's 32768.
- No `--hf-overrides` index-cache block (the vLLM MI355X arm sets one; this recipe deliberately does not).

- **保持前缀缓存启用**：不沿用 `--no-enable_prefix_caching`——轨迹回放正是前缀缓存最有价值的负载。
- **`--max-model-len` 使用模型默认值**，避免长上下文智能体轨迹被裁剪到 8k1k 场景的 32768。
- 不添加 `--hf-overrides` 索引缓存参数（vLLM MI355X 分支有设置，本配方刻意不设）。

TP4 is both what the upstream recipe prescribes and what this model wants: MiniMax-M3 has four KV heads, so one KV head per rank keeps the AITER sparse-attention fast path. No launcher change needed — `runners/launch_mi355x-amds.sh` already resolves the `agentic/` ATOM `_mtp` script name and routes `amd/MiniMax-M3*` weights to the NFS HF cache.

## Files / 改动文件

- `benchmarks/single_node/agentic/minimaxm3_fp4_mi355x_atom_mtp.sh` (new)
- `configs/amd-master.yaml` — new entry after the vLLM MI355X sibling
- `perf-changelog.yaml` — appended entry

## Note / 说明

Sibling PR #2733 builds the **same config key** from the current InferenceX ATOM AgentX siblings instead (explicit cudagraph capture sizes, `--max-num-batched-tokens 16384`, no `ATOM_FORCE_ATTN_TRITON`). The two are **mutually exclusive candidates** — merge whichever sweeps green, not both.

同类 PR #2733 以当前 InferenceX 的 ATOM AgentX 配方为蓝本实现**同一配置项**（显式 cudagraph 尺寸、`--max-num-batched-tokens 16384`、不设 `ATOM_FORCE_ATTN_TRITON`）。两者**互斥**，只应合并全量 sweep 通过的那一个。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark scripts, cluster config, and changelog; no production inference or auth paths are modified.
> 
> **Overview**
> Adds a **day-zero AgentX recipe** for `amd/MiniMax-M3-MXFP4` on MI355X served by **ATOM** (`minimaxm3-fp4-mi355x-atom-agentic-mtp`), with a new launcher script that runs agentic trace replay against an ATOM OpenAI server.
> 
> The server setup **ports the retired single-turn 8k1k MI355X ATOM recipe**: Inferact **EAGLE3** drafter (`Inferact/MiniMax-M3-EAGLE3`), three speculative tokens, `ptpc_fp8` online quant exclusions, Triton attention env, block size 128, and 0.8 GPU memory fraction. It also follows the upstream ATOM serve shape (**TP4**, **FP8 KV cache**, three draft tokens). **Prefix caching stays enabled** and **max sequence length is not clipped** to the 8k1k 32768 cap.
> 
> Throughput runs pin **synthetic spec-decode acceptance length 2.83**; eval-only runs drop the pin. The config registers **TP4 / EP1 / no KV offload** with concurrency **1, 4, 8, 12, 16** on `cluster:mi355x-amds`, and `perf-changelog.yaml` documents the entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2eb156117c7ffca53552ba734dc16b5e36fbfac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->