### PR TITLE
[codex] Sync H100 runner capacity with Slurm / 同步 H100 运行器与 Slurm 容量

### DIFF
--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -15,9 +15,6 @@ labels:
     - h100-dgxc-slurm_10
     - h100-dgxc-slurm_11
     - h100-dgxc-slurm_12
-    - h100-dgxc-slurm_13
-    - h100-dgxc-slurm_14
-    - h100-dgxc-slurm_15
     - h100-dgxc-slurm_16
     - h100-dgxc-slurm_17
     - h100-dgxc-slurm_18
@@ -203,9 +200,6 @@ labels:
     - h100-dgxc-slurm_10
     - h100-dgxc-slurm_11
     - h100-dgxc-slurm_12
-    - h100-dgxc-slurm_13
-    - h100-dgxc-slurm_14
-    - h100-dgxc-slurm_15
     - h100-dgxc-slurm_16
     - h100-dgxc-slurm_17
     - h100-dgxc-slurm_18


### PR DESCRIPTION
## Summary

- Remove `h100-dgxc-slurm_13`, `_14`, and `_15` from the generic `h100` and `cluster:h100-dgxc` runner inventories.
- Preserve `_16` through `_19`, which carry the specialized multinode and disaggregated-serving labels.
- Match the checked-in inventory to the live H100 Slurm partition and GitHub Actions runner pool: 17 nodes and 17 runners.

The three idle runner registrations were also removed from the live GitHub Actions runner registry before opening this PR.

## Why

The provider permanently reduced the original 20-node H100 allocation. The live Slurm partition now exposes 17 nodes, while GitHub still advertised 20 runner capacity tokens, allowing the weighted scheduler to over-admit by three nodes.

## Validation

- Verified `hpc-gpu-1` reports 17 Slurm nodes.
- Verified GitHub reports 17 online, idle `cluster:h100-dgxc` runners after the sync.
- `python -m pytest utils/matrix_logic/test_validation.py utils/matrix_logic/test_generate_sweep_configs.py -q` — 232 passed
- `git diff --check`

## 中文说明

- 从通用 `h100` 和 `cluster:h100-dgxc` 运行器清单中移除 `h100-dgxc-slurm_13`、`_14` 和 `_15`。
- 保留带有多节点和分离式推理专用标签的 `_16` 至 `_19`。
- 使仓库中的运行器清单与实时 H100 Slurm 分区和 GitHub Actions 运行器池保持一致：17 个节点、17 个运行器。

创建本 PR 前，已从 GitHub Actions 实时运行器注册表中删除这三个空闲运行器。

## 原因

云服务商永久缩减了原有的 20 节点 H100 配额。实时 Slurm 分区目前提供 17 个节点，但 GitHub 仍发布 20 个运行器容量令牌，导致加权调度器可能超额准入三个节点。

## 验证

- 已确认 `hpc-gpu-1` 报告 17 个 Slurm 节点。
- 同步后已确认 GitHub 报告 17 个在线且空闲的 `cluster:h100-dgxc` 运行器。
- `python -m pytest utils/matrix_logic/test_validation.py utils/matrix_logic/test_generate_sweep_configs.py -q` — 232 项测试通过
- `git diff --check`
