### PR TITLE
config: make aggregate multinode topology explicit

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1407,52 +1407,39 @@ kimik3-fp4-h200-vllm-agentic:
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 10, 12]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 2
           tp: 16
           ep: 32
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-h200-tp16dp2ep32-latency-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 16
-          ep: 32
-          dp-attn: true
       # Balanced: TP8 x DP4 with EP32 across four H200 nodes.
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 4
           tp: 8
           ep: 32
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-h200-tp8dp4ep32-balanced-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 32
-          dp-attn: true
       # Throughput-oriented hybrid TP/DEP/EP with vLLM's host-DRAM KV tier.
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple }
         conc-list: [8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 4
           tp: 8
           ep: 32
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-h200-tp8dp4ep32-vllm-simple-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 32
-          dp-attn: true
-
 # NOTE: At the time of submission, https://docs.vllm.ai/projects/recipes/en/latest/moonshotai/Kimi-K2.5.html
 # does not have a B300-specific recipe, so this config reuses the existing
 # Kimi-K2.5 FP4 B200 vLLM recipe as-is until B300-specific tuning is available.
@@ -1643,21 +1630,14 @@ dsv4-fp8-h200-dynamo-sglang-agentic-agg:
         conc-list: [1, 2, 4, 8, 16]
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/deepseek-v4/agentic/agg-h200-tp8-mtp-kvoffload.yaml"
-        # The aggregated worker serves prefill and decode on the same GPUs.
-        # Keep decode at zero to avoid double-counting the TP8 allocation.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 # MTP variant of dsv4-fp8-h200-sglang. Mirrors the non-MTP recipe (same image,
 # runner pool, search space) and adds EAGLE speculative decoding via
 # --speculative-algorithm EAGLE with the (3,1,4) chain matching dsv4-fp4-b300-sglang-mtp.
@@ -6807,116 +6787,86 @@ qwen3.5-fp4-gb300-dynamo-sglang-agentic-agg:
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [1]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c1-mtp-hicache-jid2530006.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [24]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c24-mtp-hicache-jid2530012.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [32]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c32-mtp-hicache-jid2530013.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [40]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c40-mtp-hicache-jid2530015.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [48]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c48-mtp-hicache-jid2530017.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [52]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c52-mtp-hicache-jid2527406.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [64]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb300-fp4/agentic/agg-gb300-tp2-c64-mtp-hicache-jid2527410.yaml"
-        decode:
-          num-worker: 0
-          tp: 2
-          ep: 1
-          dp-attn: false
-
-
 # The seven disaggregated frontier points use six TP4 shapes plus one TP2
 # shape. Stable X-Dynamo-Session-ID affinity replaces the removed conv-aware
 # routing message path.
@@ -7376,7 +7326,8 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [1, 2, 4, 8, 12, 20, 24]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 1
@@ -7385,13 +7336,13 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp4-mtp.yaml"
-        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
       # TP2/EP2 probes the middle and high-throughput frontier with half the
       # GPU count of TP4; the HiCache arm extends beyond the old C24 ceiling.
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [4, 8, 12, 20]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 2
@@ -7400,12 +7351,12 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp.yaml"
-        decode: { num-worker: 0, tp: 2, ep: 2, dp-attn: false }
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
         conc-list: [22, 24, 28, 32, 40]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 2
           ep: 2
@@ -7414,7 +7365,6 @@ qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.39"
           - "CONFIG_FILE=recipes/sglang/qwen3.5/gb200-fp4/agentic/agg-gb200-tp2ep2-mtp-hicache.yaml"
-        decode: { num-worker: 0, tp: 2, ep: 2, dp-attn: false }
 
 minimaxm3-fp4-b300-vllm-agentic-mtp:
   image: vllm/vllm-openai:nightly-ac7509e2b1db40fec2f03dde1ed4e9dfdc2338c9
@@ -7623,7 +7573,8 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [1, 2, 5, 8, 10, 12, 15, 20]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 1
@@ -7632,12 +7583,12 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple }
         conc-list: [20, 30, 40]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 1
@@ -7646,11 +7597,11 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-        decode: { num-worker: 0, tp: 4, ep: 1, dp-attn: false }
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [4, 32]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 4
@@ -7659,12 +7610,12 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-        decode: { num-worker: 0, tp: 4, ep: 4, dp-attn: true }
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple }
         conc-list: [32, 40]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 4
@@ -7673,11 +7624,11 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-vllm-simple-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-        decode: { num-worker: 0, tp: 4, ep: 4, dp-attn: true }
       - spec-decoding: mtp
         kv-offloading: none
         conc-list: [48]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 8
@@ -7686,7 +7637,6 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep8-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-        decode: { num-worker: 0, tp: 8, ep: 8, dp-attn: true }
 
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
   image: vllm/vllm-openai:v0.27.1
@@ -7734,7 +7684,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp-agg:
       # comparison, then use the public vLLM GB200 DEP8 topology for throughput.
       - spec-decoding: mtp
         conc-list: [1, 2, 4, 6, 8]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -7743,14 +7694,10 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-mtp-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         conc-list: [8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 8
@@ -7759,12 +7706,6 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb200-dep8-mtp-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 8
-          dp-attn: true
-
 dsv4-fp4-gb200-dynamo-vllm-agentic-mtp-disagg:
   image: vllm/vllm-openai:nightly-3ee2df30337a301164c46ae444b76ee67e71c106
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -7831,7 +7772,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-agg:
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
         conc-list: [1]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -7840,16 +7782,10 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb300-tp8-mtp-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts eight GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         conc-list: [4]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -7858,16 +7794,10 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb300-tp8-mtp-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts eight GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         conc-list: [1, 2, 4, 6, 8]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 1
@@ -7876,14 +7806,6 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb300-tp4-mtp-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts four GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 4
-          ep: 1
-          dp-attn: false
-
 dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
   image: vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -8041,7 +7963,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg:
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
         conc-list: [1]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -8050,16 +7973,10 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts eight GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         conc-list: [4]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -8068,16 +7985,10 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts eight GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         conc-list: [8]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -8086,14 +7997,6 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c8-mtp2-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts eight GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
   image: vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -8206,52 +8109,40 @@ kimik3-fp4-gb200-dynamo-vllm-agentic:
       # https://recipes.vllm.ai/moonshotai/Kimi-K3?hardware=gb200&nodes=4&strategy=multi_node_tp
       - spec-decoding: mtp
         conc-list: [1, 2, 4, 8]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 16
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp16-latency-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 16
-          ep: 1
-          dp-attn: false
       # Balanced: multi_node_tep strategy, TEP16 across four GB200 nodes.
       # https://recipes.vllm.ai/moonshotai/Kimi-K3?hardware=gb200&nodes=4&strategy=multi_node_tep
       - spec-decoding: mtp
         conc-list: [8, 16, 24, 32]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 16
           ep: 16
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tep16-balanced-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 16
-          ep: 16
-          dp-attn: false
       # Throughput oriented: official multi_node_dep strategy, DEP16 across
       # four GB200 nodes (TP4 x DP4 = EP16, one local DP rank per node).
       # The recipe allows up to 3600s for full-context saturation warmup to drain.
       # https://recipes.vllm.ai/moonshotai/Kimi-K3?hardware=gb200&nodes=4&strategy=multi_node_dep
       - spec-decoding: mtp
         conc-list: [32, 64, 96, 128, 192, 256]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 4
           ep: 16
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-dep16-throughput-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 4
-          ep: 16
-          dp-attn: true
       # High-concurrency DEP16 with vLLM Simple CPU KV offloading. c384
       # exercises 384 of the 393 AgentX trajectories and remains below the
       # aggregate max-num-seqs capacity of 512 (128 per DP rank).
@@ -8259,19 +8150,14 @@ kimik3-fp4-gb200-dynamo-vllm-agentic:
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple, version: "13c59a3" }
         conc-list: [128, 192, 256, 384]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 4
           ep: 16
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-dep16-throughput-vllm-simple-offload-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 4
-          ep: 16
-          dp-attn: true
-
 # Kimi-K3 GB200 TP16/DCP16 profiles using Mooncake DRAM offload.
 kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-dcp16-agg:
   image: vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-75c2eef
@@ -8290,7 +8176,8 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-dcp16-agg:
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.12.post1" }
         conc-list: [1, 2, 4, 8, 16]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 16
           dcp-size: 16
@@ -8300,7 +8187,6 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-dcp16-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.36"
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-dcp16-dspark4-maxseq2-mooncake-agentic.yaml"
-        decode: { num-worker: 0, tp: 16, dcp-size: 16, ep: 1, dp-attn: false }
 
 kimik3-fp4-gb200-dynamo-vllm-agentic-mooncake-dcp16-agg:
   image: vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-75c2eef
@@ -8318,7 +8204,8 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-mooncake-dcp16-agg:
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.12.post1" }
         conc-list: [8, 40, 48]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 16
           dcp-size: 16
@@ -8326,7 +8213,6 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-mooncake-dcp16-agg:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-dcp16-nospec-mooncake-agentic.yaml"
-        decode: { num-worker: 0, tp: 16, dcp-size: 16, ep: 1, dp-attn: false }
 
 dsv4-fp4-gb300-dynamo-trt-agentx:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc24
@@ -8464,7 +8350,8 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [16]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -8475,18 +8362,12 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c16-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          dcp-size: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [32]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -8497,17 +8378,11 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c32-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          dcp-size: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [48]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -8516,17 +8391,11 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c48-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          dcp-size: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [72]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -8535,17 +8404,11 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c72-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          dcp-size: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [96]
-        prefill:
+        num-nodes: 4
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -8554,14 +8417,6 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c96-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          dcp-size: 8
-          ep: 1
-          dp-attn: false
-
 dsv4-fp4-gb300-dynamo-sglang-agentic-agg:
   image: lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -8577,7 +8432,8 @@ dsv4-fp4-gb300-dynamo-sglang-agentic-agg:
     - search-space:
       - spec-decoding: mtp
         conc-list: [1, 4]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -8586,15 +8442,11 @@ dsv4-fp4-gb300-dynamo-sglang-agentic-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/sglang/deepseek-v4/agentic/agg-gb300-tp8-mtp-lowlatency.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
     - search-space:
       - spec-decoding: mtp
         conc-list: [8]
-        prefill:
+        num-nodes: 1
+        worker:
           num-worker: 1
           tp: 4
           ep: 1
@@ -8603,12 +8455,6 @@ dsv4-fp4-gb300-dynamo-sglang-agentic-agg:
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.49"
           - "CONFIG_FILE=recipes/sglang/deepseek-v4/agentic/agg-gb300-tp4-mtp-lowlatency.yaml"
-        decode:
-          num-worker: 0
-          tp: 4
-          ep: 1
-          dp-attn: false
-
 dsv4-fp4-gb300-dynamo-sglang-agentic-disagg:
   image: lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729
   model: deepseek-ai/DeepSeek-V4-Pro
@@ -8921,19 +8767,14 @@ glm5.2-fp4-gb200-dynamo-sglang-agentic-agg:
         conc-list: [1, 2, 4, 8, 12, 16]
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/glm5.2-agentx-agg.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 glm5.2-fp4-gb200-dynamo-sglang-agentic-disagg:
   image: lmsysorg/sglang:v0.5.17-cu130
   model: nvidia/GLM-5.2-NVFP4
@@ -9064,55 +8905,42 @@ glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp-agg:
           name: hicache
         conc-list:
         - 2
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/agg-gb200-tp8-c2-mtp.yaml
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend:
           name: hicache
         conc-list:
         - 4
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/agg-gb200-tp8-c4-mtp.yaml
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend:
           name: hicache
         conc-list:
         - 8
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - CONFIG_FILE=recipes/sglang/glm5.2/gb200-fp4/agentic/agg-gb200-tp8-c8-mtp.yaml
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 glm5.2-fp4-gb300-dynamo-sglang-agentic-agg:
   image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
   model: nvidia/GLM-5.2-NVFP4
@@ -9132,21 +8960,14 @@ glm5.2-fp4-gb300-dynamo-sglang-agentic-agg:
         conc-list: [2, 4]
         kv-offloading: dram
         kv-offload-backend: { name: hicache }
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5.2/gb300-fp4/agentic/glm5.2-agentx-agg.yaml"
-        # Aggregated worker serves prefill and decode on the same GPUs.
-        # Keep decode at zero to avoid double-counting the TP8 allocation.
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 glm5.2-fp4-gb300-dynamo-sglang-agentic-disagg:
   image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
   model: nvidia/GLM-5.2-NVFP4
@@ -9265,7 +9086,8 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-agg-mtp:
       - spec-decoding: mtp
         conc-list: [1]
         kv-offloading: none
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           ep: 1
@@ -9273,12 +9095,6 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-agg-mtp:
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-agg-gb300-tp8-c1-b2-mtp8.yaml"
           - "SLURM_PARTITION=batch_3"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
-
 # GLM-5.2 NVFP4 TensorRT-LLM AgentX on GB300 with Dynamo disaggregated serving.
 # Six topology variants use NIXL KV transfer and MTP3/MTP5 decoding.
 glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
@@ -9590,7 +9406,8 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-agg:
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.12.post1" }
         conc-list: [1, 4]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           dcp-size: 8
@@ -9602,7 +9419,6 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-agg:
           # the B300 low-latency arm.
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb300-dcp8-dspark7-maxseq2-mooncake-agentic.yaml"
-        decode: { num-worker: 0, tp: 8, dcp-size: 8, ep: 1, dp-attn: false }
 
 # High-throughput aggregate p90-ITL Pareto points without speculative decoding
 # or a max-num-seqs override.
@@ -9622,7 +9438,8 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-mooncake-dcp8-agg:
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.12.post1" }
         conc-list: [48, 70, 74]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           dcp-size: 8
@@ -9630,7 +9447,6 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-mooncake-dcp8-agg:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb300-dcp8-nospec-mooncake-agentic.yaml"
-        decode: { num-worker: 0, tp: 8, dcp-size: 8, ep: 1, dp-attn: false }
 
 
 # Kimi-K3 MXFP4 B200 aggregated vLLM via Dynamo (TP8 x PP2, 2 nodes / 16
@@ -9661,7 +9477,8 @@ kimik3-fp4-b200-dynamo-vllm-agentic:
     - search-space:
       - spec-decoding: none
         conc-list: [1, 2, 4, 8, 16, 32]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9669,15 +9486,6 @@ kimik3-fp4-b200-dynamo-vllm-agentic:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-agentic.yaml"
-        # The aggregate worker also performs decode; keep the decode worker
-        # count at zero so result aggregation counts the 16 GPUs only once.
-        decode:
-          num-worker: 0
-          tp: 8
-          pp: 2
-          ep: 1
-          dp-attn: false
-
 # DSpark uses two node-local TP8 attention/dense groups and DP2 across nodes.
 # Expert parallel spans all 16 ranks, so the 896 experts remain EP16 while
 # FlashInfer fused collectives stay inside each B200 NVSwitch domain.
@@ -9698,7 +9506,8 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [1]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9708,16 +9517,12 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c1-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [2]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9727,16 +9532,12 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c2-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [4]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9746,16 +9547,12 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c4-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [8]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9765,16 +9562,12 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c8-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [16]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9784,16 +9577,12 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c16-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [32]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9803,15 +9592,11 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c32-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=3.84"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [48]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9819,15 +9604,11 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c48-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [72]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9835,15 +9616,11 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c72-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
       - kv-offloading: dram
         kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         conc-list: [96]
-        prefill:
+        num-nodes: 2
+        worker:
           num-worker: 1
           tp: 8
           pp: 2
@@ -9851,11 +9628,6 @@ kimik3-fp4-b200-dynamo-vllm-agentic-dspark:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-b200-tp8pp2-mooncake-c96-agentic.yaml"
-        decode:
-          num-worker: 0
-          tp: 8
-          ep: 1
-          dp-attn: false
 qwen3.5-fp8-gb300-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3
   model: Qwen/Qwen3.5-397B-A17B-FP8

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -149,14 +149,13 @@ def recipe_node_count(prefill: dict, decode: dict) -> int | None:
     if len(config_files) != 1:
         raise ValueError(f"Conflicting CONFIG_FILE settings: {sorted(config_files)}")
 
-    relative_path = config_files.pop().removeprefix("recipes/")
-    recipe_path = (
-        Path(__file__).resolve().parents[2]
-        / "benchmarks"
-        / "multi_node"
-        / "srt-slurm-recipes"
-        / relative_path
-    )
+    config_file = config_files.pop()
+    repo_root = Path(__file__).resolve().parents[2]
+    recipe_root = repo_root / "benchmarks" / "multi_node" / "srt-slurm-recipes"
+    if config_file.startswith("benchmarks/multi_node/srt-slurm-recipes/"):
+        recipe_path = repo_root / config_file
+    else:
+        recipe_path = recipe_root / config_file.removeprefix("recipes/")
     if not recipe_path.exists():
         # Some srt-slurm recipes live only in the runtime image. Their master
         # config topology remains the best available scheduling estimate.
@@ -248,6 +247,30 @@ def with_worker_parallelism_defaults(worker: dict) -> dict:
     }
 
 
+def multinode_worker_pair(benchmark: dict, disagg: bool) -> tuple[dict, dict]:
+    """Return the legacy prefill/decode matrix pair for a master entry."""
+    if disagg:
+        return (
+            with_worker_parallelism_defaults(benchmark[Fields.PREFILL.value]),
+            with_worker_parallelism_defaults(benchmark[Fields.DECODE.value]),
+        )
+
+    worker = with_worker_parallelism_defaults(benchmark[Fields.WORKER.value])
+    prefill = {Fields.NUM_WORKER.value: 1, **worker}
+    decode = {
+        Fields.NUM_WORKER.value: 0,
+        **{
+            key: value
+            for key, value in worker.items()
+            if key not in (
+                Fields.NUM_WORKER.value,
+                Fields.ADDITIONAL_SETTINGS.value,
+            )
+        },
+    }
+    return prefill, decode
+
+
 def worker_gpus_per_node(worker: dict, gpus_per_node: int) -> int:
     """Return GPUs a single worker replica occupies on one node.
 
@@ -309,7 +332,10 @@ def agentic_dram_offload_gb(
     utilization = Decimal(str(agentic_config[Fields.DRAM_UTILIZATION.value]))
     gpus_per_node = runner_gpus_per_node(runner, runner_data)
 
-    if Fields.PREFILL.value in benchmark:
+    if Fields.WORKER.value in benchmark:
+        gpu_count = worker_gpus_per_node(
+            benchmark[Fields.WORKER.value], gpus_per_node)
+    elif Fields.PREFILL.value in benchmark:
         gpu_count = worker_gpus_per_node(
             benchmark[Fields.PREFILL.value], gpus_per_node)
     else:
@@ -732,10 +758,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     # spec_decoding defaults to "none" if not specified
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
 
-                    prefill = with_worker_parallelism_defaults(
-                        bmk[Fields.PREFILL.value])
-                    decode = with_worker_parallelism_defaults(
-                        bmk[Fields.DECODE.value])
+                    prefill, decode = multinode_worker_pair(bmk, disagg)
 
                     # Get concurrency values (can be list or range)
                     conc_list = bmk.get(Fields.CONC_LIST.value)
@@ -941,10 +964,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
 
             for bmk in bmk_space:
                 if is_multinode:
-                    prefill = with_worker_parallelism_defaults(
-                        bmk[Fields.PREFILL.value])
-                    decode = with_worker_parallelism_defaults(
-                        bmk[Fields.DECODE.value])
+                    prefill, decode = multinode_worker_pair(bmk, disagg)
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
                     kv_offloading = bmk.get(Fields.KV_OFFLOADING.value, "none")
                     kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)
@@ -1130,10 +1150,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                 if is_multinode:
                     # Multinode config
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
-                    prefill = with_worker_parallelism_defaults(
-                        bmk[Fields.PREFILL.value])
-                    decode = with_worker_parallelism_defaults(
-                        bmk[Fields.DECODE.value])
+                    prefill, decode = multinode_worker_pair(bmk, disagg)
 
                     # Get concurrency values
                     if Fields.CONC_LIST.value in bmk:
@@ -1252,10 +1269,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
 
             for bmk in bmk_space:
                 if is_multinode:
-                    prefill = with_worker_parallelism_defaults(
-                        bmk[Fields.PREFILL.value])
-                    decode = with_worker_parallelism_defaults(
-                        bmk[Fields.DECODE.value])
+                    prefill, decode = multinode_worker_pair(bmk, disagg)
                     spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
                     kv_offloading = bmk.get(Fields.KV_OFFLOADING.value, "none")
                     kv_offload_backend = bmk.get(Fields.KV_OFFLOAD_BACKEND.value)

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -15,6 +15,7 @@ from generate_sweep_configs import (
     mark_all_eval_entries,
     mark_eval_entries,
     multinode_node_count,
+    multinode_worker_pair,
     seq_len_itos,
     seq_len_stoi,
     seq_len_to_str,
@@ -45,6 +46,41 @@ def test_disaggregated_multinode_node_count_rejects_num_nodes():
 
     with pytest.raises(ValueError, match="num-nodes.*disaggregated"):
         add_multinode_node_count(entry, {}, num_nodes=3)
+
+
+def test_aggregated_worker_expands_to_legacy_matrix_pair():
+    benchmark = {
+        "worker": {
+            "num-worker": 2,
+            "tp": 8,
+            "pp": 2,
+            "ep": 1,
+            "dp-attn": False,
+            "additional-settings": ["CONFIG_FILE=recipes/aggregate.yaml"],
+        }
+    }
+
+    prefill, decode = multinode_worker_pair(benchmark, disagg=False)
+
+    assert prefill == {
+        "num-worker": 2,
+        "tp": 8,
+        "pp": 2,
+        "dcp-size": 1,
+        "pcp-size": 1,
+        "ep": 1,
+        "dp-attn": False,
+        "additional-settings": ["CONFIG_FILE=recipes/aggregate.yaml"],
+    }
+    assert decode == {
+        "num-worker": 0,
+        "tp": 8,
+        "pp": 2,
+        "dcp-size": 1,
+        "pcp-size": 1,
+        "ep": 1,
+        "dp-attn": False,
+    }
 
 
 def test_multinode_node_count_uses_role_gpu_footprints(sample_runner_config):
@@ -100,6 +136,27 @@ def test_multinode_node_count_prefers_checked_in_recipe_resources(
     assert multinode_node_count(
         prefill, decode, "cluster:gb200-nv", sample_runner_config
     ) == 7
+
+
+def test_multinode_node_count_resolves_repo_relative_recipe_path(
+    sample_runner_config,
+):
+    prefill = {
+        "num-worker": 1,
+        "tp": 8,
+        "additional-settings": [
+            (
+                "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/"
+                "trtllm/glm5.2/gb300-fp4/agentic/"
+                "dynamo-agg-gb300-tp8-c1-b2-mtp8.yaml"
+            )
+        ],
+    }
+    decode = {"num-worker": 0, "tp": 8}
+
+    assert multinode_node_count(
+        prefill, decode, "cluster:gb300-nv", sample_runner_config
+    ) == 2
 
 
 # =============================================================================
@@ -1280,6 +1337,8 @@ class TestGenerateFullSweepMultiNode:
                 "framework": "dynamo-trt",
                 "runner": "h200",
                 "multinode": True,
+                "disagg": True,
+                "kv-p2p-transfer": "nixl",
                 "scenarios": {
                     "fixed-seq-len": [
 
@@ -1543,6 +1602,8 @@ class TestEdgeCases:
                 "framework": "dynamo-trt",
                 "runner": "gb200",
                 "multinode": True,
+                "disagg": True,
+                "kv-p2p-transfer": "nixl",
                 "scenarios": {
                     "fixed-seq-len": [
 
@@ -1661,6 +1722,8 @@ class TestEdgeCases:
                 "framework": "dynamo-trt",
                 "runner": "gb200",
                 "multinode": True,
+                "disagg": True,
+                "kv-p2p-transfer": "nixl",
                 "scenarios": {
                     "fixed-seq-len": [
 
@@ -1709,6 +1772,8 @@ class TestEdgeCases:
                 "framework": "dynamo-trt",
                 "runner": "gb200",
                 "multinode": True,
+                "disagg": True,
+                "kv-p2p-transfer": "nixl",
                 "scenarios": {
                     "fixed-seq-len": [
 

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -832,6 +832,23 @@ class TestSingleNodeSearchSpaceEntry:
 class TestMultiNodeSearchSpaceEntry:
     """Tests for MultiNodeSearchSpaceEntry model."""
 
+    def test_valid_aggregate_worker(self):
+        """An aggregate entry has one worker rather than serving roles."""
+        entry = MultiNodeSearchSpaceEntry(**{
+            "worker": {
+                "tp": 8,
+                "pp": 2,
+                "ep": 1,
+                "dp-attn": False,
+            },
+            "num-nodes": 2,
+            "conc-list": [1, 2, 4],
+        })
+        assert entry.worker.tp == 8
+        assert entry.worker.pp == 2
+        assert entry.prefill is None
+        assert entry.decode is None
+
     def test_valid_with_conc_list(self):
         """Valid multinode search space with list (like gb200 config)."""
         entry = MultiNodeSearchSpaceEntry(**{
@@ -978,6 +995,20 @@ class TestSeqLenConfigs:
 # Test MasterConfigEntry models
 # =============================================================================
 
+def make_aggregated_multinode_master_config(config, num_nodes=3):
+    """Convert the disaggregated fixture to one aggregate worker."""
+    config["disagg"] = False
+    search_entry = config[
+        "scenarios"
+    ]["fixed-seq-len"][0]["search-space"][0]
+    worker = search_entry.pop("prefill")
+    search_entry.pop("decode")
+    worker.pop("num-worker")
+    search_entry["worker"] = worker
+    search_entry["num-nodes"] = num_nodes
+    return search_entry
+
+
 class TestMasterConfigEntries:
     """Tests for master config entry models."""
 
@@ -1049,7 +1080,7 @@ class TestMasterConfigEntries:
         valid_multinode_master_config,
     ):
         """P2P transfer is not restricted to disaggregated multinode serving."""
-        valid_multinode_master_config["disagg"] = False
+        make_aggregated_multinode_master_config(valid_multinode_master_config)
 
         config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
@@ -1059,17 +1090,39 @@ class TestMasterConfigEntries:
         self,
         valid_multinode_master_config,
     ):
-        """Aggregated search-space entries may set their Slurm node count."""
-        valid_multinode_master_config["disagg"] = False
-        search_entry = valid_multinode_master_config[
-            "scenarios"
-        ]["fixed-seq-len"][0]["search-space"][0]
-        search_entry["num-nodes"] = 3
+        """Aggregated entries require one worker and a Slurm node count."""
+        make_aggregated_multinode_master_config(valid_multinode_master_config)
 
         config = MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
         validated_entry = config.scenarios.fixed_seq_len[0].search_space[0]
         assert validated_entry.num_nodes == 3
+        assert validated_entry.worker.tp == 4
+        assert validated_entry.prefill is None
+        assert validated_entry.decode is None
+
+    def test_aggregated_multinode_requires_num_nodes(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Every aggregate multi-node entry must declare its allocation."""
+        search_entry = make_aggregated_multinode_master_config(
+            valid_multinode_master_config
+        )
+        search_entry.pop("num-nodes")
+
+        with pytest.raises(Exception, match="disagg=false requires num-nodes"):
+            MultiNodeMasterConfigEntry(**valid_multinode_master_config)
+
+    def test_aggregated_multinode_rejects_prefill_decode(
+        self,
+        valid_multinode_master_config,
+    ):
+        """Aggregate master entries cannot model separate serving roles."""
+        valid_multinode_master_config["disagg"] = False
+
+        with pytest.raises(Exception, match="disagg=false requires one worker"):
+            MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_disaggregated_multinode_rejects_num_nodes(
         self,
@@ -1081,7 +1134,7 @@ class TestMasterConfigEntries:
         ]["fixed-seq-len"][0]["search-space"][0]
         search_entry["num-nodes"] = 3
 
-        with pytest.raises(Exception, match="num-nodes is only valid"):
+        with pytest.raises(Exception, match="disagg=true.*num-nodes"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     @pytest.mark.parametrize("num_nodes", [0, -1, True])
@@ -1091,11 +1144,10 @@ class TestMasterConfigEntries:
         num_nodes,
     ):
         """Explicit aggregate node counts must be strict positive integers."""
-        valid_multinode_master_config["disagg"] = False
-        search_entry = valid_multinode_master_config[
-            "scenarios"
-        ]["fixed-seq-len"][0]["search-space"][0]
-        search_entry["num-nodes"] = num_nodes
+        make_aggregated_multinode_master_config(
+            valid_multinode_master_config,
+            num_nodes=num_nodes,
+        )
 
         with pytest.raises(Exception, match="num-nodes"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -56,6 +56,7 @@ class Fields(Enum):
 
     # Multinode-specific fields (when MULTINODE = true)
     SPEC_DECODING = 'spec-decoding'
+    WORKER = 'worker'
     PREFILL = 'prefill'
     DECODE = 'decode'
     NUM_WORKER = 'num-worker'
@@ -204,7 +205,30 @@ class WorkerConfig(BaseModel):
     dp_attn: bool = Field(alias=Fields.DP_ATTN.value)
     hardware: Optional[str] = Field(default=None, min_length=1)
     additional_settings: Optional[List[str]] = Field(
-        default=[], alias=Fields.ADDITIONAL_SETTINGS.value)
+        default_factory=list, alias=Fields.ADDITIONAL_SETTINGS.value)
+
+    @model_validator(mode='after')
+    def validate_worker_topology(self):
+        return _validate_tp_context_topology(self)
+
+
+class AggregateWorkerConfig(BaseModel):
+    """Topology for the aggregate worker role serving prefill and decode."""
+    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+
+    num_worker: int = Field(
+        default=1, alias=Fields.NUM_WORKER.value, gt=0, strict=True)
+    tp: int
+    pp: int = Field(default=1, gt=0, strict=True)
+    dcp_size: int = Field(
+        default=1, alias=Fields.DCP_SIZE.value, gt=0, strict=True)
+    pcp_size: int = Field(
+        default=1, alias=Fields.PCP_SIZE.value, gt=0, strict=True)
+    ep: int
+    dp_attn: bool = Field(alias=Fields.DP_ATTN.value)
+    hardware: Optional[str] = Field(default=None, min_length=1)
+    additional_settings: Optional[List[str]] = Field(
+        default_factory=list, alias=Fields.ADDITIONAL_SETTINGS.value)
 
     @model_validator(mode='after')
     def validate_worker_topology(self):
@@ -546,8 +570,9 @@ class MultiNodeSearchSpaceEntry(BaseModel):
 
     spec_decoding: Literal["mtp", "draft_model", "none"] = Field(
         default="none", alias=Fields.SPEC_DECODING.value)
-    prefill: WorkerConfig
-    decode: WorkerConfig
+    worker: Optional[AggregateWorkerConfig] = None
+    prefill: Optional[WorkerConfig] = None
+    decode: Optional[WorkerConfig] = None
     num_nodes: Optional[int] = Field(
         default=None, alias=Fields.NUM_NODES.value, gt=0, strict=True)
     router: Optional[ComponentMetadata] = None
@@ -567,7 +592,21 @@ class MultiNodeSearchSpaceEntry(BaseModel):
 
     @model_validator(mode='after')
     def validate_worker_hardware_pair(self):
-        return _validate_worker_hardware_pair(self)
+        has_worker = self.worker is not None
+        has_any_disagg_worker = self.prefill is not None or self.decode is not None
+        has_complete_disagg_workers = (
+            self.prefill is not None and self.decode is not None
+        )
+        if has_worker == has_any_disagg_worker or (
+            has_any_disagg_worker and not has_complete_disagg_workers
+        ):
+            raise ValueError(
+                "Multinode search-space entries must specify either worker "
+                "or both prefill and decode"
+            )
+        if has_complete_disagg_workers:
+            _validate_worker_hardware_pair(self)
+        return self
 
 
 class SingleNodeSeqLenConfig(BaseModel):
@@ -604,6 +643,7 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
     dp_attn: Optional[bool] = Field(default=None, alias=Fields.DP_ATTN.value)
     spec_decoding: Literal["mtp", "draft_model", "none"] = Field(
         default="none", alias=Fields.SPEC_DECODING.value)
+    worker: Optional[AggregateWorkerConfig] = None
     prefill: Optional[WorkerConfig] = None
     decode: Optional[WorkerConfig] = None
     num_nodes: Optional[int] = Field(
@@ -633,14 +673,21 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
     @model_validator(mode='after')
     def validate_topology_fields(self):
         has_single_node = self.tp is not None
+        has_aggregate_worker = self.worker is not None
         has_any_multinode_field = self.prefill is not None or self.decode is not None
         has_complete_multinode = self.prefill is not None and self.decode is not None
-        if has_single_node:
-            valid = not has_any_multinode_field
-        else:
-            valid = has_complete_multinode
-        if not valid:
-            raise ValueError("Agentic search-space entries must specify either tp or both prefill and decode")
+        topology_count = sum((
+            has_single_node,
+            has_aggregate_worker,
+            has_complete_multinode,
+        ))
+        if topology_count != 1 or (
+            has_any_multinode_field and not has_complete_multinode
+        ):
+            raise ValueError(
+                "Agentic search-space entries must specify exactly one of tp, "
+                "worker, or both prefill and decode"
+            )
         if has_single_node:
             if self.kv_offloading is None:
                 raise ValueError(
@@ -648,7 +695,7 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
                     f"{Fields.KV_OFFLOADING.value}"
                 )
             _validate_tp_context_topology(self)
-        if has_complete_multinode:
+        if has_aggregate_worker or has_complete_multinode:
             explicitly_single_node_fields = {
                 "pp",
                 "dcp_size",
@@ -667,7 +714,8 @@ class AgenticCodingSearchSpaceEntry(BaseModel):
                     "Multinode agentic search-space entries cannot specify "
                     f"{field_names}"
                 )
-            _validate_worker_hardware_pair(self)
+            if has_complete_multinode:
+                _validate_worker_hardware_pair(self)
         return self
 
 class AgenticCodingConfig(BaseModel):
@@ -778,19 +826,51 @@ def _validate_component_metadata_scope(self: BaseModel) -> BaseModel:
     return self
 
 
-def _validate_num_nodes_scope(self: BaseModel) -> BaseModel:
-    """Allow explicit node counts only for aggregated multinode entries."""
+def _validate_multinode_entry_scope(self: BaseModel) -> BaseModel:
+    """Match each search-space topology to its master serving mode."""
     search_space_entries = _master_search_space_entries(self)
-    entries_with_num_nodes = [
-        entry for entry in search_space_entries
-        if getattr(entry, "num_nodes", None) is not None
-    ]
+    for entry in search_space_entries:
+        worker = getattr(entry, "worker", None)
+        prefill = getattr(entry, "prefill", None)
+        decode = getattr(entry, "decode", None)
+        num_nodes = getattr(entry, "num_nodes", None)
 
-    if (not self.multinode or self.disagg) and entries_with_num_nodes:
-        raise ValueError(
-            f"{Fields.NUM_NODES.value} is only valid when "
-            f"{Fields.MULTINODE.value}=true and {Fields.DISAGG.value}=false"
-        )
+        if not self.multinode:
+            if (
+                worker is not None
+                or prefill is not None
+                or decode is not None
+                or num_nodes is not None
+            ):
+                raise ValueError(
+                    "Single-node search-space entries must specify tp topology "
+                    "and cannot declare worker, prefill, decode, or num-nodes"
+                )
+            continue
+
+        if self.disagg:
+            if worker is not None or num_nodes is not None:
+                raise ValueError(
+                    f"{Fields.DISAGG.value}=true requires prefill and decode "
+                    f"and rejects {Fields.WORKER.value} and "
+                    f"{Fields.NUM_NODES.value}"
+                )
+            if prefill is None or decode is None:
+                raise ValueError(
+                    f"{Fields.DISAGG.value}=true requires prefill and decode"
+                )
+            continue
+
+        if worker is None or prefill is not None or decode is not None:
+            raise ValueError(
+                f"{Fields.DISAGG.value}=false requires one "
+                f"{Fields.WORKER.value} and rejects prefill and decode"
+            )
+        if num_nodes is None:
+            raise ValueError(
+                f"{Fields.DISAGG.value}=false requires "
+                f"{Fields.NUM_NODES.value} in every search-space entry"
+            )
     return self
 
 
@@ -819,8 +899,8 @@ class SingleNodeMasterConfigEntry(BaseModel):
         return _validate_component_metadata_scope(self)
 
     @model_validator(mode='after')
-    def validate_num_nodes_scope(self):
-        return _validate_num_nodes_scope(self)
+    def validate_multinode_entry_scope(self):
+        return _validate_multinode_entry_scope(self)
 
 
 class MultiNodeMasterConfigEntry(BaseModel):
@@ -851,8 +931,8 @@ class MultiNodeMasterConfigEntry(BaseModel):
         return _validate_component_metadata_scope(self)
 
     @model_validator(mode='after')
-    def validate_num_nodes_scope(self):
-        return _validate_num_nodes_scope(self)
+    def validate_multinode_entry_scope(self):
+        return _validate_multinode_entry_scope(self)
 
 
 def validate_master_config(master_configs: dict) -> List[dict]:

--- a/utils/runner_setup/RUNNER_SETUP.md
+++ b/utils/runner_setup/RUNNER_SETUP.md
@@ -213,11 +213,16 @@ must also remain enabled. If either variable is disabled, workflows omit
 subtracts `0.001` per additional node so otherwise equal work prefers smaller
 allocations without overriding the existing business-priority signals.
 
-Aggregated multi-node search-space entries can declare `num-nodes`; that value
-becomes the generated `node-count` directly. `num-nodes` is rejected for
-disaggregated entries because their independent prefill and decode allocations
-determine the total. During migration, entries without `num-nodes` derive
-`node-count` from, in precedence order:
+Aggregated multi-node search-space entries must declare one aggregate `worker`
+role and `num-nodes`; that value becomes the generated `node-count` directly.
+The worker may set `num-worker` when the aggregate engine uses multiple process
+replicas, otherwise it defaults to one. The generator expands this role into
+the legacy internal prefill/decode matrix shape expected by the launcher.
+Aggregate master entries cannot declare separate `prefill` or `decode` roles.
+
+Disaggregated entries must declare `prefill` and `decode`, and reject both
+`worker` and `num-nodes`. Their generated `node-count` is derived from, in
+precedence order:
 
 1. checked-in srt-slurm recipe `resources`;
 2. explicit `PREFILL_NODES` and `DECODE_NODES` settings; or


### PR DESCRIPTION
## Summary

- Recreates and expands #2479 on current `main` as the upper layer of the stack above #2740.
- Requires `multinode: true, disagg: false` entries to declare one aggregate `worker` role and an explicit `num-nodes`.
- Preserves `num-worker` for aggregate engines that use multiple process replicas.
- Requires `disagg: true` entries to use separate `prefill` and `decode` roles and rejects `worker` and `num-nodes` there.
- Migrates all 58 current aggregate search-space entries across 21 configurations.
- Translates the aggregate master shape back into the legacy internal prefill/decode matrix contract without changing the launcher interface.

## Validation

- `python -m pytest utils/matrix_logic/ utils/test_ci_priority.py -q` — 266 passed.
- Generated 1,329 NVIDIA rows and 473 AMD rows, identical row counts to the base PR.
- Verified all 58 aggregate `num-nodes` values against checked-in recipe resources with zero mismatches.
- Audited 253 multi-node master entries against 245 distinct checked-in recipes with zero node-count mismatches.
- Audited both master files: NVIDIA has 21 aggregate configs with all 58 search-space entries backfilled, while AMD has no aggregate configs requiring migration and all 38 entries across its 11 disaggregated configs retain the correct role-specific shape.
- Compared complete generation against #2740: all 1,802 rows and all 652 emitted multi-node `node-count` values are preserved; AMD output is unchanged.
- Generated output is unchanged except for nine aggregate Kimi K3 rows where the unused zero-worker decode shadow is normalized from PP1 to PP2; runtime behavior is unchanged because that shadow has `num-worker: 0`.
- Verified all 652 generated multi-node rows have a valid positive `node-count`.

Replaces #2479.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML and validation-only changes with backward-compatible matrix expansion; extensive tests report unchanged row counts and node-count values aside from normalized decode shadows.
> 
> **Overview**
> **Aggregated multinode** benchmark entries in `nvidia-master.yaml` now declare a single **`worker`** role plus explicit **`num-nodes`**, instead of modeling the same GPUs with **`prefill`** and a zero-worker **`decode`** shadow.
> 
> Validation and sweep generation enforce that split: **`disagg: false`** requires **`worker`** and **`num-nodes`** and rejects role-specific **`prefill`/`decode`**; **`disagg: true`** keeps **`prefill`/`decode`** and rejects **`worker`** and **`num-nodes`**. The generator still emits the legacy internal prefill/decode matrix via **`multinode_worker_pair`**, so the launcher contract stays the same.
> 
> **`generate_sweep_configs`** also resolves **`CONFIG_FILE`** paths that already start with **`benchmarks/multi_node/srt-slurm-recipes/`**, and aggregate agentic DRAM sizing can use the **`worker`** topology. **`RUNNER_SETUP.md`** documents the new master shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a08f131fbb95c63c5eb83ba198fbfc250ceceae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->