### PR TITLE
docs: swap planned Qwen3.8 2.4T for Qwen3.8-Flash-Next on SGLang | 文档：将计划中的 Qwen3.8 2.4T 替换为 SGLang 上的 Qwen3.8-Flash-Next

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -150,7 +150,7 @@ Other offloading tiers, including NVMe KV cache offloading, are outside the init
 
 | Model architecture class | Prefix | Date added | Active scenarios | Deprecated scenarios |
 |---|---|---|---|---|
-| Qwen3.8-Flash-Next | `qwen3.8next` | TBD | Agentic coding | |
+| Qwen3.8-Flash-Next | `qwen3.8next` | 2026-08-26 ([#2742](https://github.com/SemiAnalysisAI/InferenceX/pull/2742)) | Agentic coding | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | Agentic coding (DSpark only) | Agentic coding non-DSpark arm (deprecated from day 0) |
 | GLM-5.2 | `glm5.2` | 2026-07-18 ([#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)) | Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | |
 | MiniMax-M3 | `minimaxm3` | 2026-06-12 ([#1724](https://github.com/SemiAnalysisAI/InferenceX/pull/1724)) | Agentic coding | Single-turn 1k1k, Single-turn 8k1k (removed 2026-08-04, [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)) |

--- a/MODELS.md
+++ b/MODELS.md
@@ -50,7 +50,7 @@ Speculative-decoding A/B retirements apply to each pair below. The spec-decode a
 |---|---|---|
 | DeepSeek-V4-Pro 1.6T (`dsv4`) | Single-turn 8k1k | Agentic coding, including the MTP and DSpark arms |
 
-Rationale: `dsv4` carries the largest single-turn footprint in the repository. 45 active config keys use the 8k1k scenario, 32 in `configs/nvidia-master.yaml` and 13 in `configs/amd-master.yaml`, spanning H200, B200, B300, GB200, GB300, MI300X, MI325X, and MI355X across vLLM, SGLang, TensorRT-LLM, ATOM, Dynamo, and llm-d. That is a large share of every full sweep. AgentX trace replay is the scenario AI labs and the ML community ask about, and DeepSeek-V4-Pro's 19 agentic config keys are the part of `dsv4` that feeds the published North Star Pareto frontier. Retiring the fixed-sequence-length arm frees cluster hours for AgentX and for new frontier models such as Qwen3.8 2.4T without reducing what we publish for this model. Single-turn 8k1k stays active for the other models that still list it.
+Rationale: `dsv4` carries the largest single-turn footprint in the repository. 45 active config keys use the 8k1k scenario, 32 in `configs/nvidia-master.yaml` and 13 in `configs/amd-master.yaml`, spanning H200, B200, B300, GB200, GB300, MI300X, MI325X, and MI355X across vLLM, SGLang, TensorRT-LLM, ATOM, Dynamo, and llm-d. That is a large share of every full sweep. AgentX trace replay is the scenario AI labs and the ML community ask about, and DeepSeek-V4-Pro's 19 agentic config keys are the part of `dsv4` that feeds the published North Star Pareto frontier. Retiring the fixed-sequence-length arm frees cluster hours for AgentX and for new frontier models such as Qwen3.8-Flash-Next without reducing what we publish for this model. Single-turn 8k1k stays active for the other models that still list it.
 
 **Status: not yet enacted.** All 45 8k1k config keys still run. On enactment they are removed from the active master configs and archived under [`configs/deprecated/`](configs/deprecated/), with their benchmark scripts moved to the sibling `deprecated/` directories, matching how [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493) and [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527) were carried out. The SPEED-Bench acceptance-length scripts for `dsv4` are intentionally kept. Speedbench is driven by `speedbench-al.yml`, not the master configs.
 
@@ -125,6 +125,7 @@ The table also records both the agreed plan-of-record (PoR) draft-model mapping 
 | MiniMax-M3 (`minimaxm3`) | native/upstream vLLM engine | `Inferact/MiniMax-M3-EAGLE3` and/or `Inferact/MiniMax-M3-EAGLE3-GQA` | None | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 | GLM-5.2 (`glm5.2`) | native/upstream SGLang engine | native MTP | None | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 | Qwen3.5-397B-A17B (`qwen3.5`) | native/upstream SGLang engine | native MTP | None | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
+| Qwen3.8-Flash-Next (`qwen3.8next`) | native/upstream SGLang engine | TBD (pending model release) | None | Additional non-vLLM/SGLang engines under the ordering guideline and exceptions above |
 
 ### KV cache offloading policy
 
@@ -149,7 +150,7 @@ Other offloading tiers, including NVMe KV cache offloading, are outside the init
 
 | Model architecture class | Prefix | Date added | Active scenarios | Deprecated scenarios |
 |---|---|---|---|---|
-| Qwen3.8 2.4T | `qwen3.8` | TBD | Agentic coding | |
+| Qwen3.8-Flash-Next | `qwen3.8next` | TBD | Agentic coding | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | Agentic coding (DSpark only) | Agentic coding non-DSpark arm (deprecated from day 0) |
 | GLM-5.2 | `glm5.2` | 2026-07-18 ([#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)) | Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | |
 | MiniMax-M3 | `minimaxm3` | 2026-06-12 ([#1724](https://github.com/SemiAnalysisAI/InferenceX/pull/1724)) | Agentic coding | Single-turn 1k1k, Single-turn 8k1k (removed 2026-08-04, [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)) |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -150,7 +150,7 @@ InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和
 
 | 模型架构类别 | 前缀 | 加入日期 | 启用场景 | 已弃用场景 |
 |---|---|---|---|---|
-| Qwen3.8-Flash-Next | `qwen3.8next` | 待定 | 智能体编码 | |
+| Qwen3.8-Flash-Next | `qwen3.8next` | 2026-08-26（[#2742](https://github.com/SemiAnalysisAI/InferenceX/pull/2742)） | 智能体编码 | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | 智能体编码（仅 DSpark） | 智能体编码非 DSpark 分支（自第 0 天起弃用） |
 | GLM-5.2 | `glm5.2` | 2026-07-18（[#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)） | 智能体编码（非 MTP 分支仍在运行，「仅 MTP」转换仍待执行，见弃用公告） | |
 | MiniMax-M3 | `minimaxm3` | 2026-06-12（[#1724](https://github.com/SemiAnalysisAI/InferenceX/pull/1724)） | 智能体编码 | 单轮 1k1k、单轮 8k1k（2026-08-04 移除，[#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)） |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -50,7 +50,7 @@ InferenceX-e2e 运行在数量固定且有限的 GPU 资源池上，并由一支
 |---|---|---|
 | DeepSeek-V4-Pro 1.6T（`dsv4`） | 单轮 8k1k | 智能体编码，含 MTP 与 DSpark 分支 |
 
-原因：`dsv4` 是本仓库中单轮场景占用最大的模型。当前有 45 个启用的配置项使用 8k1k 场景（`configs/nvidia-master.yaml` 32 个，`configs/amd-master.yaml` 13 个），覆盖 H200、B200、B300、GB200、GB300、MI300X、MI325X 与 MI355X，涉及 vLLM、SGLang、TensorRT-LLM、ATOM、Dynamo 与 llm-d，在每一轮完整 sweep 中占比可观。AgentX 轨迹回放才是 AI 实验室与 ML 社区真正关注的场景，而 DeepSeek-V4-Pro 的 19 个智能体编码配置项正是 `dsv4` 中支撑已发布北极星（North Star）帕累托前沿的部分。下线固定序列长度分支可为 AgentX 以及 Qwen3.8 2.4T 等新前沿模型腾出集群机时，同时不减少该模型对外发布的内容。对于仍列有该场景的其他模型，单轮 8k1k 保持启用。
+原因：`dsv4` 是本仓库中单轮场景占用最大的模型。当前有 45 个启用的配置项使用 8k1k 场景（`configs/nvidia-master.yaml` 32 个，`configs/amd-master.yaml` 13 个），覆盖 H200、B200、B300、GB200、GB300、MI300X、MI325X 与 MI355X，涉及 vLLM、SGLang、TensorRT-LLM、ATOM、Dynamo 与 llm-d，在每一轮完整 sweep 中占比可观。AgentX 轨迹回放才是 AI 实验室与 ML 社区真正关注的场景，而 DeepSeek-V4-Pro 的 19 个智能体编码配置项正是 `dsv4` 中支撑已发布北极星（North Star）帕累托前沿的部分。下线固定序列长度分支可为 AgentX 以及 Qwen3.8-Flash-Next 等新前沿模型腾出集群机时，同时不减少该模型对外发布的内容。对于仍列有该场景的其他模型，单轮 8k1k 保持启用。
 
 **状态：尚未执行。** 全部 45 个 8k1k 配置项仍在运行。执行时将从启用的主配置中移除并归档至 [`configs/deprecated/`](configs/deprecated/)，对应基准测试脚本移入同级 `deprecated/` 目录，与 [#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493) 和 [#2527](https://github.com/SemiAnalysisAI/InferenceX/pull/2527) 的做法一致。`dsv4` 的 SPEED-Bench 接受长度脚本予以保留。Speedbench 由 `speedbench-al.yml` 驱动，不经过主配置。
 
@@ -125,6 +125,7 @@ InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和
 | MiniMax-M3（`minimaxm3`） | 原生/上游 vLLM 引擎 | `Inferact/MiniMax-M3-EAGLE3` 和/或 `Inferact/MiniMax-M3-EAGLE3-GQA` | 无 | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 | GLM-5.2（`glm5.2`） | 原生/上游 SGLang 引擎 | 原生 MTP | 无 | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 | Qwen3.5-397B-A17B（`qwen3.5`） | 原生/上游 SGLang 引擎 | 原生 MTP | 无 | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
+| Qwen3.8-Flash-Next（`qwen3.8next`） | 原生/上游 SGLang 引擎 | 待定（等待模型发布） | 无 | 按照上述提交顺序指南及例外处理的其他非 vLLM/SGLang 引擎 |
 
 ### KV 缓存卸载策略
 
@@ -149,7 +150,7 @@ InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和
 
 | 模型架构类别 | 前缀 | 加入日期 | 启用场景 | 已弃用场景 |
 |---|---|---|---|---|
-| Qwen3.8 2.4T | `qwen3.8` | 待定 | 智能体编码 | |
+| Qwen3.8-Flash-Next | `qwen3.8next` | 待定 | 智能体编码 | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | 智能体编码（仅 DSpark） | 智能体编码非 DSpark 分支（自第 0 天起弃用） |
 | GLM-5.2 | `glm5.2` | 2026-07-18（[#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)） | 智能体编码（非 MTP 分支仍在运行，「仅 MTP」转换仍待执行，见弃用公告） | |
 | MiniMax-M3 | `minimaxm3` | 2026-06-12（[#1724](https://github.com/SemiAnalysisAI/InferenceX/pull/1724)） | 智能体编码 | 单轮 1k1k、单轮 8k1k（2026-08-04 移除，[#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)） |


### PR DESCRIPTION
## Description

Swap the planned Qwen3.8 lane to **Qwen3.8-Flash-Next** on SGLang, per Oren's request in #ext-amd-sw-engineering-semianalysis.

Qwen3.8-Flash-Next is the first open-weight release of the architecture that will underpin Qwen4, so benchmarking it exercises more new frontier architecture than the previously planned Qwen3.8 2.4T:

- **Hybrid Attention with QSA** — Gated DeltaNet + Qwen Sparse Attention operating at the micro-block level, cutting long-context latency (critical for agentic workloads)
- **Gated Residual** — widened residual streams with element-wise read gates and per-branch scalar write gates
- **N-gram Embedding** — +51B embedding parameters that are offload-friendly for memory-constrained accelerators (125B main model, ~6B active per token)

References: [Qwen blog](https://qwen.ai/blog?id=qwen3.8-flash-next) · [Qwen/Qwen3.8-Flash-Next on Hugging Face](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)

Changes (mirrored in `MODELS.md` and `MODELS_zh.md`):

- Model support matrix: `Qwen3.8 2.4T` / `qwen3.8` → `Qwen3.8-Flash-Next` / `qwen3.8next` (date still TBD, Agentic coding)
- Engine submission policy table: new row mapping Qwen3.8-Flash-Next to the native/upstream **SGLang** engine; draft-model PoR is TBD pending model release
- DSv4 deprecation rationale: "new frontier models such as Qwen3.8 2.4T" → "Qwen3.8-Flash-Next"

Note: the proposed canonical prefix `qwen3.8next` follows the existing no-dash convention (`qwen3.5`, `glm5.2`, `minimaxm3`); no configs reference `qwen3.8` yet, so this is a docs-only rename. Happy to adjust the prefix if maintainers prefer keeping `qwen3.8`.

## 说明

按 Oren 的要求，将原计划的 Qwen3.8 SGLang 基准测试通道替换为 **Qwen3.8-Flash-Next**（Qwen4 架构预览版）。变更同步更新了 `MODELS.md` 与 `MODELS_zh.md`：模型支持矩阵行、引擎提交策略表（映射到原生/上游 SGLang 引擎）以及 DSv4 弃用公告中的提法。

## Related Issue

N/A

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have tested my changes locally (docs-only; verified both tables render)
- [x] I have updated documentation if necessary (bilingual: `MODELS.md` + `MODELS_zh.md` in the same PR)
- [ ] ~~perf-changelog entry~~ — N/A, docs-only change with no benchmark-performance effect and no recipe addition/modification
- [ ] ~~/reuse-sweep-run~~ — N/A, no sweep needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to bilingual model policy tables with no runtime, config, or benchmark behavior changes.
> 
> **Overview**
> Updates **`MODELS.md`** and **`MODELS_zh.md`** so the planned Qwen lane is **Qwen3.8-Flash-Next** (`qwen3.8next`) on the native/upstream **SGLang** engine, replacing the placeholder **Qwen3.8 2.4T** (`qwen3.8`).
> 
> The **model support matrix** row now names Flash-Next, sets prefix `qwen3.8next`, records add date **2026-08-26** ([#2742](https://github.com/SemiAnalysisAI/InferenceX/pull/2742)), and keeps **Agentic coding** as the only active scenario. The **engine submission policy** table gains a matching row with draft-model PoR **TBD (pending model release)**. The **DeepSeek-V4-Pro 8k1k deprecation** rationale now cites **Qwen3.8-Flash-Next** as the example of a new frontier model that will consume freed cluster hours.
> 
> No configs or benchmarks change; this is documentation alignment ahead of future onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f47a78b862af2789e5ddacce289ffcdbc127adcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->