### PR TITLE
[codex] Remove legacy B200 topology labels

### DIFF
--- a/configs/deprecated/nvidia-1k1k-master.yaml
+++ b/configs/deprecated/nvidia-1k1k-master.yaml
@@ -5,7 +5,7 @@ dsr1-fp4-b200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post1" }
@@ -198,7 +198,7 @@ dsr1-fp8-b200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post2" }
@@ -4232,7 +4232,7 @@ dsr1-fp4-b200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-runtime
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }
@@ -4301,7 +4301,7 @@ dsr1-fp8-b200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-sglang
   kv-p2p-transfer: nixl
@@ -4373,7 +4373,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-sglang
   kv-p2p-transfer: nixl
@@ -4468,7 +4468,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
   image: "lmsysorg/sglang:v0.5.12.post1"
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "5b4bc1dd70965017a737c71b19db5a0aeaa88727" }

--- a/configs/deprecated/nvidia-kimik2.5-8k1k-master.yaml
+++ b/configs/deprecated/nvidia-kimik2.5-8k1k-master.yaml
@@ -96,7 +96,7 @@ kimik2.5-fp4-b200-dynamo-trt:
   image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21
   model: nvidia/Kimi-K2.5-NVFP4
   model-prefix: kimik2.5
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-trt
   router: { name: dynamo-router, version: "v1.3.0rc21" }

--- a/configs/deprecated/nvidia-minimaxm2.5-m2.7-master.yaml
+++ b/configs/deprecated/nvidia-minimaxm2.5-m2.7-master.yaml
@@ -542,7 +542,7 @@ minimaxm2.5-fp8-b200-dynamo-vllm:
   image: vllm/vllm-openai:v0.20.1
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-vllm
   multinode: true
@@ -929,7 +929,7 @@ minimaxm2.5-fp4-b200-dynamo-vllm:
   image: vllm/vllm-openai:v0.20.1
   model: nvidia/MiniMax-M2.5-NVFP4
   model-prefix: minimaxm2.5
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-vllm
   multinode: true

--- a/configs/deprecated/nvidia-minimaxm3-8k1k-master.yaml
+++ b/configs/deprecated/nvidia-minimaxm3-8k1k-master.yaml
@@ -43,7 +43,7 @@ minimaxm3-fp4-b200-dynamo-vllm:
   image: vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-vllm
   router: { name: dynamo-router, version: "1.3.0.dev20260710" }
@@ -424,7 +424,7 @@ minimaxm3-fp4-b200-dynamo-vllm-mtp:
   image: vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-vllm
   router: { name: dynamo-router, version: "1.3.0.dev20260710" }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2,7 +2,7 @@ dsr1-fp4-b200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post1" }
@@ -210,7 +210,7 @@ dsr1-fp8-b200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post2" }
@@ -3657,7 +3657,7 @@ dsr1-fp4-b200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-runtime
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }
@@ -3739,7 +3739,7 @@ dsr1-fp8-b200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-sglang
   kv-p2p-transfer: nixl
@@ -3862,7 +3862,7 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
   image: lmsysorg/sglang:v0.5.8.post1-cu130-amd64
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: dynamo-sglang
   kv-p2p-transfer: nixl
@@ -3992,7 +3992,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
   image: "lmsysorg/sglang:v0.5.12.post1"
   model: deepseek-r1-fp4
   model-prefix: dsr1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "5b4bc1dd70965017a737c71b19db5a0aeaa88727" }
@@ -4240,7 +4240,7 @@ dsv4-fp4-b200-dynamo-vllm:
   image: vllm/vllm-openai:v0.23.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp4
   framework: dynamo-vllm
   router: { name: dynamo-router, version: "1.2.0.dev20260426" }
@@ -9755,7 +9755,7 @@ glm5.1-fp8-b200-tilert:
   image: ghcr.io/tile-ai/tilert:0.1.5
   model: zai-org/GLM-5.1-FP8
   model-prefix: glm5.1
-  runner: b200-multinode
+  runner: cluster:b200-dgxc
   precision: fp8
   framework: tilert
   router: { name: tilert-pd-router, version: "0.1.5.post3" }

--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -74,10 +74,6 @@ labels:
     - b200-dgxc_07
     - b200-dgxc_08
     - b200-dgxc_09
-  b200-multinode:
-    - b200-dgxc-slurm_7
-    - b200-dgxc-slurm_8
-    - b200-dgxc-slurm_9
   b200-new:
     - b200-nscale-slurm_0
     - b200-nscale-slurm_1

--- a/experimental/operatorx/scripts/inferencex_testlist/dtypes.py
+++ b/experimental/operatorx/scripts/inferencex_testlist/dtypes.py
@@ -47,7 +47,7 @@ _FP16 = "fp16"
 
 
 def _runner_family(runner: str) -> str:
-    """Reduce a specific runner tag (e.g. "b200-dsv4", "b200-multinode") to a
+    """Reduce a specific runner tag (e.g. "b200-dsv4", "cluster:b200-dgxc") to a
     GPU family ("b200", "b300", "h200", "h100", "gb200", "gb300", "mi300x",
     "mi325x", "mi355x")."""
     r = runner.lower()

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -94,8 +94,8 @@ def _hardware_family(label: str) -> str:
 def scheduling_gpus_per_node(label: str, runner_data: dict) -> int:
     """Resolve GPUs per node for an abstract runner or worker hardware label.
 
-    Scheduling labels such as ``b200-multinode`` do not currently duplicate
-    the hardware facts stored under ``cluster:b200-dgxc``. Fall back to the
+    Legacy scheduling labels may not duplicate the hardware facts stored under
+    their canonical ``cluster:`` label. Fall back to the
     GPU family when the exact label has no hardware record, while rejecting
     ambiguous families that disagree about node shape.
     """

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -522,7 +522,7 @@ class TestMarkEvalEntries:
         matrix_values = [
             {
                 "model": "deepseek-ai/DeepSeek-R1-0528",
-                "runner": "b200-multinode",
+                "runner": "cluster:b200-dgxc",
                 "framework": "dynamo-trt",
                 "precision": "fp8",
                 "isl": 8192,
@@ -554,7 +554,7 @@ class TestMarkEvalEntries:
         matrix_values = [
             {
                 "model": "deepseek-ai/DeepSeek-R1-0528",
-                "runner": "b200-multinode",
+                "runner": "cluster:b200-dgxc",
                 "framework": "dynamo-trt",
                 "precision": "fp8",
                 "isl": 8192,
@@ -576,7 +576,7 @@ class TestMarkEvalEntries:
             },
             {
                 "model": "deepseek-ai/DeepSeek-R1-0528",
-                "runner": "b200-multinode",
+                "runner": "cluster:b200-dgxc",
                 "framework": "dynamo-trt",
                 "precision": "fp8",
                 "isl": 8192,

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -1303,7 +1303,7 @@ class TestMasterConfigEntries:
             "model-prefix": "dsr1",
             "precision": "fp4",
             "framework": "dynamo-trt",
-            "runner": "b200-multinode",
+            "runner": "b200",
             "multinode": True,
             "disagg": True,
             "kv-p2p-transfer": "nixl",

--- a/utils/test_ci_priority.py
+++ b/utils/test_ci_priority.py
@@ -30,7 +30,7 @@ def test_combined_high_value_signals_outrank_baseline_job():
     }
     high_value = {
         **baseline,
-        "runner": "b200-multinode",
+        "runner": "cluster:b200-dgxc",
         "framework": "sglang",
         "model-prefix": "dsv4",
         "precision": "fp4",


### PR DESCRIPTION
## Summary

- migrate active and deprecated B200 DGX Cloud master configs from the legacy `b200-multinode` label to `cluster:b200-dgxc`
- remove the obsolete `b200-multinode` runner group
- update tests and examples so the retired topology label is no longer referenced

The weighted lease scheduler now derives capacity from explicit node counts and leases runner slots within a canonical cluster pool. Static topology labels such as `b200-multinode`, `b200-disagg`, and `b200-multinode-p1` are no longer part of job placement.

The matching legacy labels have also been removed from the live B200 DGX Cloud runners. All 10 runners remain online and advertise `cluster:b200-dgxc`.

## Validation

- `python -m pytest utils/matrix_logic/test_validation.py utils/matrix_logic/test_generate_sweep_configs.py utils/test_ci_priority.py -q` (266 passed)
- generated the full current NVIDIA master successfully
- generated four affected deprecated NVIDIA masters successfully
- confirmed the fifth affected deprecated master still fails on an unrelated pre-existing GB300 `kv-p2p-transfer` validation error
- generated the B200 DGX Cloud subset and confirmed it exposes 1–7 node jobs, including eight 4-node rows
- confirmed no `b200-multinode`, `b200-disagg`, or `b200-multinode-p1` references remain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mislabeled runners would send multinode benchmarks to the wrong pool; scope is config and tests only, but it directly affects job placement for B200 disagg sweeps.
> 
> **Overview**
> Retires the legacy **`b200-multinode`** runner label across active and deprecated NVIDIA master configs, replacing it with **`cluster:b200-dgxc`** for B200 multinode/disagg entries (DeepSeek, Kimi, MiniMax, TileRT, etc.).
> 
> **`configs/runners.yaml`** drops the obsolete **`b200-multinode`** group (the three slurm-only runners); B200 DGX Cloud jobs are expected to target the canonical cluster label instead. Comments, sweep-generation docs, and tests (**`test_generate_sweep_configs`**, **`test_ci_priority`**, validation fixtures) are updated so multinode eval/CI examples and invalid-runner cases no longer reference the retired topology name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3d6b2c2828351e9a8a87cbfa33cb5b87e330a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->