### PR TITLE
[codex] Remove legacy segmented runner labels

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/RECIPES.md
+++ b/benchmarks/multi_node/srt-slurm-recipes/RECIPES.md
@@ -26,7 +26,7 @@ dsr1-fp8-h200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8-cu130-runtime
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h200-multinode-slurm
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-sglang
   multinode: true

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -273,7 +273,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   image: lmsysorg/sglang:v0.5.16-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -381,7 +381,7 @@ qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -478,7 +478,7 @@ dsr1-fp8-mi355x-sglang-disagg:
   image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -553,7 +553,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
   image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -672,7 +672,7 @@ dsr1-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -803,7 +803,7 @@ dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -973,7 +973,7 @@ dsv4-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.14-rocm720-mi35x-20260701
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -1056,7 +1056,7 @@ dsv4-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.15-rocm720-mi35x-20260713
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -1335,7 +1335,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }

--- a/configs/deprecated/amd-1k1k-master.yaml
+++ b/configs/deprecated/amd-1k1k-master.yaml
@@ -278,7 +278,7 @@ qwen3.5-fp8-mi355x-sglang-disagg:
   image: lmsysorg/sglang:v0.5.14-rocm720-mi35x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -358,7 +358,7 @@ qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -436,7 +436,7 @@ glm5-fp8-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -616,7 +616,7 @@ dsr1-fp8-mi355x-sglang-disagg:
   image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -710,7 +710,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
   image: rocm/sgl-dev:sglang-0.5.9-rocm720-mi35x-mori-0227-2
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -804,7 +804,7 @@ kimik2.5-fp4-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:v0.24.0
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: vllm-disagg
   router: { name: vllm-router, version: "0.1.14" }
@@ -838,7 +838,7 @@ dsr1-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -950,7 +950,7 @@ dsr1-fp4-mi355x-sglang-disagg-1k1k-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260529
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -1223,7 +1223,7 @@ dsr1-fp4-mi355x-sglang-disagg-mtp:
   image: lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x-20260519
   model: amd/DeepSeek-R1-0528-MXFP4-v2
   model-prefix: dsr1
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -1491,7 +1491,7 @@ minimaxm3-fp8-mi355x-atom-disagg:
   image: rocm/atom-dev:nightly_202607011530
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: atom-disagg
   router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
@@ -1525,7 +1525,7 @@ minimaxm3-fp4-mi355x-atom-disagg:
   image: rocm/atom-dev:nightly_202607011530
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: atom-disagg
   router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
@@ -1632,7 +1632,7 @@ minimaxm3-fp8-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: vllm-disagg
   router: { name: vllm-router, version: "0.1.14" }

--- a/configs/deprecated/amd-glm5-glm5.1-master.yaml
+++ b/configs/deprecated/amd-glm5-glm5.1-master.yaml
@@ -38,7 +38,7 @@ glm5-fp8-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: zai-org/GLM-5-FP8
   model-prefix: glm5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: sglang-disagg
   router: { name: sglang-router, version: "0.3.2" }
@@ -157,4 +157,3 @@ glm5-fp8-mi325x-sglang-mtp:
 # to preserve main behavior; PR-branch modifications to those recipes are NOT
 # brought in here.
 # ============================================================================
-

--- a/configs/deprecated/amd-kimik2.5-8k1k-master.yaml
+++ b/configs/deprecated/amd-kimik2.5-8k1k-master.yaml
@@ -86,7 +86,7 @@ kimik2.5-fp4-mi355x-atom-disagg:
   image: rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atomesh_202607121715
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: atom-disagg
   kv-p2p-transfer: mooncake
@@ -139,7 +139,7 @@ kimik2.5-fp4-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: amd/Kimi-K2.5-MXFP4
   model-prefix: kimik2.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: vllm-disagg
   router: { name: vllm-router, version: "0.1.14" }

--- a/configs/deprecated/amd-minimaxm2.5-m2.7-master.yaml
+++ b/configs/deprecated/amd-minimaxm2.5-m2.7-master.yaml
@@ -152,7 +152,7 @@ minimaxm2.5-fp8-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-a6682d1d259cca69a9ae737ea5608fbbe7520031
   model: MiniMaxAI/MiniMax-M2.5
   model-prefix: minimaxm2.5
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: vllm-disagg
   multinode: true

--- a/configs/deprecated/amd-minimaxm3-8k1k-master.yaml
+++ b/configs/deprecated/amd-minimaxm3-8k1k-master.yaml
@@ -48,7 +48,7 @@ minimaxm3-fp4-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-2dfaae752b4db0d43cfc0715c780e33be030d0f1
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: vllm-disagg
   router: { name: vllm-router, version: "0.1.14" }
@@ -186,7 +186,7 @@ minimaxm3-fp8-mi355x-atom-disagg:
   image: rocm/atom-dev:nightly_202607011530
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: atom-disagg
   router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
@@ -237,7 +237,7 @@ minimaxm3-fp4-mi355x-atom-disagg:
   image: rocm/atom-dev:nightly_202607011530
   model: amd/MiniMax-M3-MXFP4
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp4
   framework: atom-disagg
   router: { name: atomesh, version: "04b120d3040e0dd1a6915e88a3a3c1f588e6684a" }
@@ -388,7 +388,7 @@ minimaxm3-fp8-mi355x-vllm-disagg:
   image: vllm/vllm-openai-rocm:nightly-2afa3f7e950264bb179d030c23a1ed1f46558fd9
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
-  runner: mi355x-disagg
+  runner: cluster:mi355x-amds
   precision: fp8
   framework: vllm-disagg
   router: { name: vllm-router, version: "0.1.14" }

--- a/configs/deprecated/nvidia-1k1k-master.yaml
+++ b/configs/deprecated/nvidia-1k1k-master.yaml
@@ -2355,7 +2355,7 @@ dsr1-fp8-h200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h200-multinode
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post1" }
@@ -2634,7 +2634,7 @@ dsr1-fp8-h100-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h100-multinode
+  runner: cluster:h100-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post3" }
@@ -2933,7 +2933,7 @@ dsr1-fp8-h100-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h100-multinode
+  runner: cluster:h100-dgxc
   precision: fp8
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }
@@ -4126,7 +4126,7 @@ dsr1-fp8-h200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h200-multinode
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1843,7 +1843,7 @@ dsr1-fp8-h200-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post1
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h200-multinode
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post1" }
@@ -2123,7 +2123,7 @@ dsr1-fp8-h100-dynamo-trt:
   image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:0.8.1.post3
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h100-multinode
+  runner: cluster:h100-dgxc
   precision: fp8
   framework: dynamo-trt
   router: { name: dynamo-router, version: "0.8.1.post3" }
@@ -2304,7 +2304,7 @@ dsr1-fp8-h100-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h100-multinode
+  runner: cluster:h100-dgxc
   precision: fp8
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }
@@ -3491,7 +3491,7 @@ dsr1-fp8-h200-dynamo-sglang:
   image: lmsysorg/sglang:v0.5.8.post1-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
-  runner: h200-multinode
+  runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-sglang
   router: { name: dynamo-router, version: "0.8.0" }

--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -22,11 +22,6 @@ labels:
     - h100-dgxc-slurm_17
     - h100-dgxc-slurm_18
     - h100-dgxc-slurm_19
-  h100-multinode:
-    - h100-dgxc-slurm_16
-    - h100-dgxc-slurm_17
-    - h100-dgxc-slurm_18
-    - h100-dgxc-slurm_19
   h200:
     - h200-cw_00
     - h200-cw_01
@@ -41,10 +36,6 @@ labels:
     - h200-dgxc-slurm_8
     - h200-dgxc-slurm_9
     - h200-dgxc-slurm_10
-    - h200-dgxc-slurm_11
-    - h200-dgxc-slurm_12
-    - h200-dgxc-slurm_13
-  h200-multinode:
     - h200-dgxc-slurm_11
     - h200-dgxc-slurm_12
     - h200-dgxc-slurm_13
@@ -104,10 +95,6 @@ labels:
     - mi300x-amds_06
     - mi300x-amds_07
     - mi300x-amds_08
-  mi300x-disagg:
-    - mi300x-amds_06
-    - mi300x-amds_07
-    - mi300x-amds_08
   mi325x:
     - mi325x-amds_00
     - mi325x-amds_01
@@ -115,14 +102,6 @@ labels:
     - mi325x-amds_03
     - mi325x-amds_04
     - mi325x-amds_05
-    - mi325x-amds_06
-    - mi325x-amds_07
-    - mi325x-amds_08
-  mi325x-disagg:
-    - mi325x-amds_00
-    - mi325x-amds_01
-    - mi325x-amds_02
-    - mi325x-amds_03
     - mi325x-amds_06
     - mi325x-amds_07
     - mi325x-amds_08
@@ -136,16 +115,6 @@ labels:
     - mi355x-amds_06
     - mi355x-amds_07
     - mi355x-amds_08
-  mi355x-disagg:
-    - mi355x-amds_06
-    - mi355x-amds_07
-    - mi355x-amds_08
-    - mi355x-amds_12
-    - mi355x-amds_14
-    - mi355x-amds_16
-    - mi355x-amds_17
-    - mi355x-amds_18
-    - mi355x-amds_19
   gb200:
     - gb200-nv_0
     - gb200-nv_1
@@ -163,12 +132,6 @@ labels:
     - b300-nv_10
     - b300-nv_11
     - b300-nv_12
-    - b300-nv_13
-    - b300-nv_14
-    - b300-nv_15
-    - b300-nv_16
-    - b300-nv_17
-  b300-p1:
     - b300-nv_13
     - b300-nv_14
     - b300-nv_15

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -610,7 +610,7 @@ class TestMarkEvalEntries:
         def entry(prefill_workers, decode_workers, conc):
             return {
                 "model": "deepseek-ai/DeepSeek-R1-0528",
-                "runner": "mi355x-disagg",
+                "runner": "cluster:mi355x-amds",
                 "framework": "vllm-disagg",
                 "precision": "fp8",
                 "isl": 8192,
@@ -647,7 +647,7 @@ class TestMarkEvalEntries:
         """Split concurrency rows for one parallelism should produce one eval job."""
         base_entry = {
             "model": "deepseek-ai/DeepSeek-R1-0528",
-            "runner": "mi355x-disagg",
+            "runner": "cluster:mi355x-amds",
             "framework": "sglang-disagg",
             "precision": "fp4",
             "isl": 8192,


### PR DESCRIPTION
## Summary

- route H100, H200, and MI355X multinode configurations through physical `cluster:*` labels
- remove obsolete `*-multinode`, `*-disagg`, and `*-p1` pools from the runner catalog
- update deprecated configs, documentation, and matrix fixtures so old scheduling labels are no longer requested

Disaggregation and multinode behavior continue to come from explicit configuration node counts; runner labels now identify physical clusters rather than allocation shapes.

## Validation

- 248 matrix and validation tests passed
- full NVIDIA master generation: 1,329 rows
- full AMD master generation: 473 rows
- no remaining config or fixture requests for the removed runner labels

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how benchmark jobs are scheduled cluster-wide; mis-mapped labels could send multinode disagg sweeps to the wrong pool, though validation and full master generation reportedly passed.
> 
> **Overview**
> Replaces **segmented scheduling labels** (`h100-multinode`, `h200-multinode`, `mi355x-disagg`, and related `*-disagg` / `b300-p1` pools) with **physical cluster labels** such as `cluster:h100-dgxc`, `cluster:h200-dgxc`, and `cluster:mi355x-amds` across active and deprecated master YAML, the srtslurm recipe doc example, and matrix test fixtures.
> 
> `configs/runners.yaml` drops the old subset runner pools so the catalog only lists full hardware clusters; **multinode and disaggregated layouts stay defined by each recipe’s `multinode` / `disagg` flags and prefill/decode worker counts**, not by runner name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9daa636d2e5996a78a361e52956ad2b654c95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->