### PR TITLE
[codex] Clean up namespaced Slurm jobs on cancellation

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -347,11 +347,13 @@ jobs:
       - name: Slurm cleanup (pre-run)
         run: &slurm-cleanup |
           if command -v squeue >/dev/null 2>&1; then
-            echo "[Slurm] Cleaning up jobs named: ${{ runner.name }} ..."
-            scancel --user="$USER" --name="${{ runner.name }}" || true
-            while [ -n "$(squeue --user="$USER" --name='${{ runner.name }}' --noheader --format='%i')" ]; do
-              squeue --user="$USER" --name="${{ runner.name }}"
-              sleep 5
+            for job_name in "${{ runner.name }}" "inferencex-${{ runner.name }}"; do
+              echo "[Slurm] Cleaning up jobs named: $job_name ..."
+              scancel --user="$USER" --name="$job_name" || true
+              while [ -n "$(squeue --user="$USER" --name="$job_name" --noheader --format='%i')" ]; do
+                squeue --user="$USER" --name="$job_name"
+                sleep 5
+              done
             done
           fi
 


### PR DESCRIPTION
## Summary
- cancel both physical runner-name and `inferencex-`-namespaced Slurm jobs in the reusable multi-node cleanup
- wait for each matching allocation to leave the queue before continuing
- preserve the existing launcher trap as the fast path while making workflow cleanup a reliable fallback

## Validation
- parsed `.github/workflows/benchmark-multinode-tmpl.yml` with PyYAML
- `git diff --check`
- `actionlint .github/workflows/benchmark-multinode-tmpl.yml` (only pre-existing informational ShellCheck findings outside this change)
- reproduced with canceled GB200 run 33013627186: GitHub completed while Slurm job 24197 remained under the namespaced job name

No performance changelog entry is needed because this only corrects cancellation cleanup and does not change benchmark execution or results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only cancellation cleanup; no change to benchmark execution, recipes, or result processing.
> 
> **Overview**
> The reusable **multi-node benchmark** workflow’s shared Slurm cleanup step now targets **both** the physical runner name and the **`inferencex-`**-prefixed job name launchers use (e.g. GB200), instead of only `${{ runner.name }}`.
> 
> For each name it **`scancel`s** matching user jobs and **polls `squeue`** until the queue is empty, so pre-run and post-run cleanup can clear leftover allocations when a GitHub job is canceled while Slurm still holds the namespaced job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de6087d69df0ace9f89cb48a2898b955534e2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->