### PR TITLE
Require exact node demand for priority jobs

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -9,7 +9,7 @@ on:
       node-count:
         description: "Total Slurm nodes required by this benchmark"
         required: true
-        type: string
+        type: number
       priority:
         description: "Higher-is-sooner CI priority score"
         required: true
@@ -292,7 +292,7 @@ jobs:
       ${{ fromJSON(
         vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
         (
-          vars.NODE_SLOT_SCHEDULER_ENABLED == 'true' && inputs.node-count != '' &&
+          vars.NODE_SLOT_SCHEDULER_ENABLED == 'true' &&
           (
             inputs.skip-queue-pr != '' &&
             format(

--- a/.github/workflows/collectivex-sweep.yml
+++ b/.github/workflows/collectivex-sweep.yml
@@ -114,15 +114,29 @@ jobs:
     runs-on: >-
       ${{ fromJSON(
         vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
-        format(
-          '["self-hosted",{0},{1},{2}]',
-          toJSON(matrix.sku),
-          toJSON(format(
-            'ci-job-{0}-{1}',
-            needs.setup.outputs.priority,
-            matrix.queue-token
-          )),
-          toJSON(format('ci-attempt-{0}', github.run_attempt))
+        (
+          vars.NODE_SLOT_SCHEDULER_ENABLED == 'true' &&
+          format(
+            '["self-hosted",{0},{1},{2},{3}]',
+            toJSON(matrix.sku),
+            toJSON(format('nodes:{0}', matrix.nodes)),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              needs.setup.outputs.priority,
+              matrix.queue-token
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          ) ||
+          format(
+            '["self-hosted",{0},{1},{2}]',
+            toJSON(matrix.sku),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              needs.setup.outputs.priority,
+              matrix.queue-token
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          )
         ) ||
         format('[{0}]', toJSON(matrix.sku))
       ) }}

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -97,6 +97,19 @@ jobs:
 
           filt = data[:1]
 
+          for entry in filt:
+            node_count = entry.get('node-count', 1)
+            if isinstance(node_count, bool) or not isinstance(node_count, int) or node_count != 1:
+              print(
+                'Profile supports only validated single-node matrix entries; '
+                f'got node-count={node_count!r}.',
+                file=sys.stderr,
+              )
+              with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                f.write("filtered=[]\ncount=0\n")
+              raise SystemExit(1)
+            entry['node-count'] = node_count
+
           out = json.dumps(filt)
           print(out)
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
@@ -121,15 +134,29 @@ jobs:
     runs-on: >-
       ${{ fromJSON(
         vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
-        format(
-          '["self-hosted",{0},{1},{2}]',
-          toJSON(matrix.config.runner),
-          toJSON(format(
-            'ci-job-{0}-{1}',
-            matrix.config.priority,
-            matrix.config['queue-token']
-          )),
-          toJSON(format('ci-attempt-{0}', github.run_attempt))
+        (
+          vars.NODE_SLOT_SCHEDULER_ENABLED == 'true' &&
+          format(
+            '["self-hosted",{0},{1},{2},{3}]',
+            toJSON(matrix.config.runner),
+            toJSON(format('nodes:{0}', matrix.config['node-count'])),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              matrix.config.priority,
+              matrix.config['queue-token']
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          ) ||
+          format(
+            '["self-hosted",{0},{1},{2}]',
+            toJSON(matrix.config.runner),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              matrix.config.priority,
+              matrix.config['queue-token']
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          )
         ) ||
         format('[{0}]', toJSON(matrix.config.runner))
       ) }}

--- a/.github/workflows/speedbench-al.yml
+++ b/.github/workflows/speedbench-al.yml
@@ -139,15 +139,29 @@ jobs:
     runs-on: >-
       ${{ fromJSON(
         vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
-        format(
-          '["self-hosted",{0},{1},{2}]',
-          toJSON(inputs.runner),
-          toJSON(format(
-            'ci-job-{0}-{1}',
-            needs.setup.outputs.priority,
-            needs.setup.outputs.queue-token
-          )),
-          toJSON(format('ci-attempt-{0}', github.run_attempt))
+        (
+          vars.NODE_SLOT_SCHEDULER_ENABLED == 'true' &&
+          format(
+            '["self-hosted",{0},{1},{2},{3}]',
+            toJSON(inputs.runner),
+            toJSON('nodes:1'),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              needs.setup.outputs.priority,
+              needs.setup.outputs.queue-token
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          ) ||
+          format(
+            '["self-hosted",{0},{1},{2}]',
+            toJSON(inputs.runner),
+            toJSON(format(
+              'ci-job-{0}-{1}',
+              needs.setup.outputs.priority,
+              needs.setup.outputs.queue-token
+            )),
+            toJSON(format('ci-attempt-{0}', github.run_attempt))
+          )
         ) ||
         format('[{0}]', toJSON(inputs.runner))
       ) }}

--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -21,6 +21,7 @@ on:
       - "benchmarks/multi_node/amd_utils/job.slurm"
       - "utils/ci_priority.py"
       - "utils/test_ci_priority.py"
+      - "utils/test_node_demand_contract.py"
       - "utils/find_reusable_sweep_run.py"
       - "utils/test_find_reusable_sweep_run.py"
       - "utils/process_changelog.py"
@@ -80,6 +81,7 @@ jobs:
             utils/test_validate_reusable_sweep_artifacts.py \
             utils/changelog_gate_tests/test_run_sweep_gating.py \
             utils/test_ci_priority.py \
+            utils/test_node_demand_contract.py \
             utils/test_process_changelog.py \
             utils/test_collect_eval_results.py \
             utils/evals/test_batched_eval.py \

--- a/docs/ci-procedures.md
+++ b/docs/ci-procedures.md
@@ -131,6 +131,14 @@ jq -r '
 
 Confirm the intended image, model, hardware/cluster label, single- versus multi-node topology, input/output lengths, concurrency, TP/EP, decoding mode, and eval flags. Empty output is not a successful preflight.
 
+Every generated multi-node row must contain a strict positive integer
+`node-count`. When node-slot scheduling is enabled, the reusable workflow
+publishes that value as the `nodes:N` request label; missing or invalid demand
+fails matrix validation instead of silently entering the one-node queue.
+Direct priority-scheduled workflows that do not use the master-config generator
+must publish their own exact demand (for example, CollectiveX uses each shard's
+generated `nodes` value).
+
 Eval switches are exact:
 
 - Default: throughput entries plus the selected default fixed-sequence eval subset.

--- a/experimental/CollectiveX/tests/test_matrix.py
+++ b/experimental/CollectiveX/tests/test_matrix.py
@@ -45,6 +45,20 @@ def cells(document, project=("sku", "ep"), **filters):
 
 
 class MatrixTests(unittest.TestCase):
+    def test_every_shard_has_an_exact_positive_node_request(self):
+        document = matrix(backend="all")
+        self.assertTrue(document["include"])
+        for shard in document["include"]:
+            with self.subTest(shard=shard["id"]):
+                self.assertIs(type(shard["nodes"]), int)
+                self.assertGreater(shard["nodes"], 0)
+                self.assertTrue(shard["id"].endswith(f"-n{shard['nodes']}"))
+                self.assertTrue(shard["cases"])
+                self.assertEqual(
+                    {case["nodes"] for case in shard["cases"]},
+                    {shard["nodes"]},
+                )
+
     def test_sku_and_ep_filters_only_remove_cases(self):
         # Subtractive with ONE deliberate exception: naming an off-path precision explicitly
         # opts its rows back in (see OFF_PATH_PRECISIONS), so the fp8 subset is compared

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -219,7 +219,7 @@ def add_multinode_node_count(
         raise ValueError(
             f"{Fields.NUM_NODES.value} is not valid for disaggregated entries"
         )
-    elif runner_data:
+    else:
         entry[Fields.NODE_COUNT.value] = multinode_node_count(
             entry[Fields.PREFILL.value],
             entry[Fields.DECODE.value],

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -48,6 +48,18 @@ def test_disaggregated_multinode_node_count_rejects_num_nodes():
         add_multinode_node_count(entry, {}, num_nodes=3)
 
 
+def test_disaggregated_multinode_node_count_requires_hardware_inventory():
+    entry = {
+        "runner": "cluster:unknown",
+        "disagg": True,
+        "prefill": {"num-worker": 1, "tp": 8},
+        "decode": {"num-worker": 1, "tp": 8},
+    }
+
+    with pytest.raises(ValueError, match="Cannot resolve gpus-per-node"):
+        add_multinode_node_count(entry, {}, num_nodes=None)
+
+
 def test_aggregated_worker_expands_to_legacy_matrix_pair():
     benchmark = {
         "worker": {
@@ -2411,7 +2423,9 @@ class TestGenerateTestConfigSweep:
         with pytest.raises(ValueError, match="exceeds gpus-per-node"):
             generate_test_config_sweep(args, config, runner_config)
 
-    def test_multinode_agentic_groups_concurrencies_per_search_entry(self):
+    def test_multinode_agentic_groups_concurrencies_per_search_entry(
+        self, sample_runner_config
+    ):
         """One server allocation should run exactly one concurrency (one task per conc)."""
         config = {
             "dsv4-agentic-2p1d": {
@@ -2447,7 +2461,7 @@ class TestGenerateTestConfigSweep:
             runner_node_filter=None,
         )
 
-        result = generate_test_config_sweep(args, config)
+        result = generate_test_config_sweep(args, config, sample_runner_config)
 
         assert len(result) == 5
         assert [entry["conc"] for entry in result] == [[16], [32], [64], [128], [256]]
@@ -2464,6 +2478,7 @@ class TestGenerateTestConfigSweep:
         assert result[0]["decode"]["pp"] == 2
         assert result[0]["decode"]["dcp-size"] == 2
         assert result[0]["decode"]["pcp-size"] == 1
+        assert {entry["node-count"] for entry in result} == {9}
 
     def test_multinode_agentic_preserves_kv_offload_fields(self, sample_runner_config):
         config = {

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -71,6 +71,7 @@ def valid_multinode_matrix_entry():
         "framework": "dynamo-trt",
         "spec-decoding": "none",
         "runner": "gb200",
+        "node-count": 6,
         "isl": 1024,
         "osl": 1024,
         "prefill": {
@@ -644,6 +645,21 @@ class TestMultiNodeMatrixEntry:
         """Conc must be a list for multinode."""
         valid_multinode_matrix_entry["conc"] = 2150  # Single int, not list
         with pytest.raises(Exception):
+            MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
+
+    def test_node_count_is_required(self, valid_multinode_matrix_entry):
+        """A multinode row cannot silently degrade to a one-node request."""
+        del valid_multinode_matrix_entry["node-count"]
+        with pytest.raises(Exception, match="node-count"):
+            MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
+
+    @pytest.mark.parametrize("node_count", [0, -1, True, "2"])
+    def test_node_count_is_a_strict_positive_integer(
+        self, valid_multinode_matrix_entry, node_count
+    ):
+        """Invalid node requests fail before reaching the reusable workflow."""
+        valid_multinode_matrix_entry["node-count"] = node_count
+        with pytest.raises(Exception, match="node-count"):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     def test_missing_prefill(self, valid_multinode_matrix_entry):
@@ -1518,6 +1534,7 @@ MULTINODE_AGENTIC_EVAL_ROW = {
     "image": "lmsysorg/sglang-rocm:v0.5.15", "model": "deepseek-ai/DeepSeek-V4-Pro",
     "model-prefix": "dsv4", "precision": "fp4", "framework": "sglang-disagg",
     "spec-decoding": "none", "runner": "cluster:mi355x-amds",
+    "node-count": 2,
     "prefill": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
     "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
     "conc": [32], "kv-offloading": "dram",
@@ -1592,6 +1609,12 @@ class TestMultiNodeAgenticMatrixEntry:
         assert entry.run_eval is True
         assert entry.eval_only is True
         assert entry.eval_conc == 32
+
+    def test_node_count_is_required(self):
+        row = dict(MULTINODE_AGENTIC_EVAL_ROW)
+        del row["node-count"]
+        with pytest.raises(Exception, match="node-count"):
+            MultiNodeAgenticMatrixEntry(**row)
 
     def test_validate_agentic_matrix_entry_dispatches_on_prefill_key(self):
         """The dispatcher in validate_agentic_matrix_entry() picks

--- a/utils/matrix_logic/validation.py
+++ b/utils/matrix_logic/validation.py
@@ -259,9 +259,7 @@ class MultiNodeMatrixEntry(BaseModel):
         alias=Fields.SPEC_DECODING.value
     )
     runner: str
-    node_count: Optional[int] = Field(
-        default=None, alias=Fields.NODE_COUNT.value, gt=0, strict=True
-    )
+    node_count: int = Field(alias=Fields.NODE_COUNT.value, gt=0, strict=True)
     isl: int
     osl: int
     prefill: WorkerConfig
@@ -363,9 +361,7 @@ class MultiNodeAgenticMatrixEntry(BaseModel):
         alias=Fields.SPEC_DECODING.value
     )
     runner: str
-    node_count: Optional[int] = Field(
-        default=None, alias=Fields.NODE_COUNT.value, gt=0, strict=True
-    )
+    node_count: int = Field(alias=Fields.NODE_COUNT.value, gt=0, strict=True)
     prefill: WorkerConfig
     decode: WorkerConfig
     conc: list[int]

--- a/utils/test_node_demand_contract.py
+++ b/utils/test_node_demand_contract.py
@@ -1,0 +1,49 @@
+"""Static contracts for priority-scheduled workflow node demand."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def test_every_priority_scheduled_gpu_workflow_emits_node_demand() -> None:
+    expected_node_expression = {
+        "benchmark-tmpl.yml": "toJSON('nodes:1')",
+        "benchmark-multinode-tmpl.yml": (
+            "toJSON(format('nodes:{0}', inputs.node-count))"
+        ),
+        "collectivex-sweep.yml": "toJSON(format('nodes:{0}', matrix.nodes))",
+        "profile.yml": (
+            "toJSON(format('nodes:{0}', matrix.config['node-count']))"
+        ),
+        "speedbench-al.yml": "toJSON('nodes:1')",
+    }
+
+    priority_workflows = {
+        path.name
+        for path in WORKFLOWS.glob("*.yml")
+        if "ci-job-" in path.read_text(encoding="utf-8")
+    }
+    assert priority_workflows == set(expected_node_expression)
+
+    for name, expression in expected_node_expression.items():
+        contents = workflow(name)
+        assert "vars.NODE_SLOT_SCHEDULER_ENABLED == 'true'" in contents
+        assert expression in contents
+
+
+def test_multinode_workflow_never_suppresses_an_empty_node_request() -> None:
+    contents = workflow("benchmark-multinode-tmpl.yml")
+
+    node_input = contents.split("      node-count:", 1)[1].split(
+        "      priority:", 1
+    )[0]
+    assert "required: true" in node_input
+    assert "type: number" in node_input
+    assert "inputs.node-count != ''" not in contents
+    assert "inputs.node-count == ''" not in contents

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -1139,6 +1139,7 @@ def test_eval_rows_split_into_multinode_fixed_and_agentic_buckets(
         "image": "lmsysorg/sglang-rocm:v0.5.15", "model": "deepseek-ai/DeepSeek-V4-Pro",
         "model-prefix": "dsv4", "precision": "fp4", "framework": "sglang-disagg",
         "spec-decoding": "none", "runner": "cluster:mi355x-amds",
+        "node-count": 2,
         "prefill": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
         "decode": {"num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False},
         "disagg": True, "kv-p2p-transfer": "mori",


### PR DESCRIPTION
## Summary

- require a strict positive node-count for every generated multi-node row
- emit exact nodes:N labels for CollectiveX shards
- emit nodes:1 for Profile and SpeedBench and reject unsupported multi-node Profile rows
- require the reusable multi-node workflow input instead of suppressing empty demand
- fail generation when hardware inventory cannot prove node demand
- add static workflow contracts and matrix regressions

## Why

Live GB300 jobs were admitted as nodes:1 while requesting 3, 9, 12, or 14 Slurm nodes. The controller cannot enforce capacity safely unless every workflow publishes its exact demand. Old workflow reruns retain their original workflow definition, so validation must use a fresh dispatch at this branch SHA.

## Verification

- 304 focused tests passed
- NVIDIA: 1,329 rows generated; all 604 multi-node rows have valid positive node-count
- AMD: 473 rows generated; all 48 multi-node rows have valid positive node-count
- CollectiveX: all 88 shards match topology (52 one-node, 24 two-node, 12 four-node)
- changed workflows pass actionlint with shellcheck disabled; CollectiveX retains one pre-existing empty-choice warning also present on main
- YAML parsing and diff checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI scheduling labels and matrix validation for all multi-node sweeps; misconfigured rows or workflows will fail dispatch instead of silently under-requesting nodes, but incorrect demand could still block or mis-schedule jobs until caught by tests.
> 
> **Overview**
> Fixes multi-node GPU jobs being queued as **`nodes:1`** when they need many Slurm nodes by making **exact node demand** mandatory end-to-end.
> 
> **Matrix generation and validation** now require every multi-node row to carry a strict positive integer **`node-count`** (Pydantic no longer allows omission). **`add_multinode_node_count`** always computes demand from topology/recipes when not overridden, and fails if hardware inventory cannot resolve **`gpus-per-node`**. Profile rejects any generated entry whose **`node-count` ≠ 1**.
> 
> **Workflows** that use the priority scheduler add a **`nodes:N`** runner label when **`NODE_SLOT_SCHEDULER_ENABLED`** is on: multi-node template uses **`inputs.node-count`** (typed **`number`**, required—empty checks removed); CollectiveX uses **`matrix.nodes`**; Profile uses **`matrix.config['node-count']`**; SpeedBench AL hard-codes **`nodes:1`**.
> 
> **Guardrails**: new **`utils/test_node_demand_contract.py`** (wired into changelog-gate CI) asserts each priority GPU workflow emits the expected node expression; CollectiveX matrix tests assert every shard has consistent positive **`nodes`**; docs describe the **`node-count`** preflight rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b4d218b47bd7acbb9bc693e1a241d3953e7194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->