### PR TITLE
[NVIDIA][B200][AgentX] Add Qwen3.8-Flash-Next NVFP4 SGLang MTP / 添加 Qwen3.8-Flash-Next NVFP4 SGLang MTP 配置

### DIFF
--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# AgentX trace replay for Qwen3.8-Flash-Next NVFP4 on B200 with SGLang
+# native NEXTN MTP. Day-zero recipe; SGLang is the plan-of-record engine for
+# this model (MODELS.md). Throughput uses the golden synthetic AL; evals retain
+# real target-model verification.
+#
+# The checkpoint is RadixArk/Qwen3.8-Flash-Next-NVFP4 (126 GiB,
+# quantization_config.quant_method = modelopt), so --quantization modelopt_fp4
+# matches the same flag the Qwen3.5 NVFP4 sibling uses. The model ships native
+# MTP modules (kept unquantized by the checkpoint's ignore list), so NEXTN
+# needs no external drafter.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+# Use the lightweight GSM8K eval instead of the AgentX SWE-bench default.
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+
+SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-10}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+nvidia-smi
+
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126_256k
+resolve_trace_source
+install_agentic_deps
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+CACHE_ARGS=()
+if require_agentic_kv_offload_backend hicache; then
+    REQUESTED_HICACHE_TOTAL_GB="${HICACHE_TOTAL_CPU_DRAM_GB:-$TOTAL_CPU_DRAM_GB}"
+    if [ "$REQUESTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: requested HiCache pool ${REQUESTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    TOTAL_CPU_DRAM_GB="$REQUESTED_HICACHE_TOTAL_GB"
+    # SGLang applies --hicache-size independently to Qwen's target KV and
+    # Mamba pools. Native NEXTN also creates a draft KV pool with the same
+    # slot count; its one attention layer adds 1/15 of the target KV bytes.
+    # Reserve 1 GB/rank for page alignment and enforce H * 31/15 per rank.
+    HICACHE_ALIGNMENT_RESERVE_GB=$TP
+    HICACHE_USABLE_TOTAL_GB=$((TOTAL_CPU_DRAM_GB - HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$HICACHE_USABLE_TOTAL_GB" -lt 1 ]; then
+        echo "Error: insufficient DRAM after HiCache alignment reserve" >&2
+        exit 1
+    fi
+    MAX_HICACHE_SIZE_GB=$((HICACHE_USABLE_TOTAL_GB * 15 / TP / 31))
+    HICACHE_SIZE_GB="${HICACHE_SIZE_GB:-$MAX_HICACHE_SIZE_GB}"
+    if [ "$HICACHE_SIZE_GB" -lt 1 ] || [ "$HICACHE_SIZE_GB" -gt "$MAX_HICACHE_SIZE_GB" ]; then
+        echo "Error: HICACHE_SIZE_GB=$HICACHE_SIZE_GB outside 1..$MAX_HICACHE_SIZE_GB" >&2
+        exit 1
+    fi
+    PROJECTED_HICACHE_TOTAL_GB=$(((HICACHE_SIZE_GB * TP * 31 + 14) / 15 + HICACHE_ALIGNMENT_RESERVE_GB))
+    if [ "$PROJECTED_HICACHE_TOTAL_GB" -gt "$TOTAL_CPU_DRAM_GB" ]; then
+        echo "Error: projected HiCache use ${PROJECTED_HICACHE_TOTAL_GB} GB exceeds configured capacity ${TOTAL_CPU_DRAM_GB} GB" >&2
+        exit 1
+    fi
+    echo "HiCache CPU pools: ${HICACHE_SIZE_GB} GB target + Mamba + 1/15 draft per rank across TP=${TP}; projected node total ${PROJECTED_HICACHE_TOTAL_GB} GB <= ${TOTAL_CPU_DRAM_GB} GB"
+    CACHE_ARGS=(
+        --page-size 64
+        --enable-hierarchical-cache
+        --hicache-size "$HICACHE_SIZE_GB"
+        --hicache-io-backend kernel
+        --hicache-mem-layout page_first
+        --hicache-write-policy write_through_selective
+    )
+fi
+
+PARALLEL_ARGS=(
+    --tp "$TP"
+    --dp 1
+    --ep-size "$EP_SIZE"
+)
+
+# TP4 needs parallel tokenization to keep 256k AgentX warmups below the client
+# request timeout. Keep TP2 on SGLang's single-worker default: multi-tokenizer
+# startup races with the TP2 HiCache shared-memory initialization path.
+TOKENIZER_ARGS=()
+if [ "$TP" -ge 4 ]; then
+    TOKENIZER_ARGS=(--tokenizer-worker-num 6)
+fi
+
+# AgentX concurrency counts live session trees rather than individual HTTP
+# requests. Leave room for subagent fan-out and avoid spending HBM on graphs
+# above the batch sizes that remain useful for this long-context workload.
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+CUDA_GRAPH_MAX_BS="$CONC"
+[ "$CUDA_GRAPH_MAX_BS" -gt 64 ] && CUDA_GRAPH_MAX_BS=64
+
+export TORCH_CUDA_ARCH_LIST="10.0"
+export PYTHONNOUSERSITE=1
+export NCCL_NVLS_ENABLE=1
+export SGL_ENABLE_JIT_DEEPGEMM=false
+export SGLANG_ENABLE_FLASHINFER_GEMM=true
+# Keep server-side connections alive beyond AIPerf's 300-second client pool
+# timeout so bursty AgentX trajectories cannot reuse a closing idle socket.
+export SGLANG_TIMEOUT_KEEP_ALIVE=1800
+
+if [ "${EVAL_ONLY:-false}" != "true" ]; then
+    # Qwen3.8-Flash-Next acceptance length, SPEED-Bench coding.
+    # --speculative-num-steps 3 with 4 draft tokens is 3 speculative
+    # tokens per verification step, i.e. the MTP=3 cell -> AL 3.24.
+    # Measured thinking=off in speedbench-al run 33031708148; the
+    # thinking=on collection is still in flight, so this is an
+    # interim value and is not yet a committed golden_al_distribution
+    # curve. Refresh once qwen3.8next_mtp.yaml lands.
+    export SGLANG_SIMULATE_ACC_LEN=3.24
+    export SGLANG_SIMULATE_ACC_METHOD=match-expected
+    export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
+fi
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    "${PARALLEL_ARGS[@]}"
+    --enable-symm-mem
+    --quantization modelopt_fp4
+    --fp4-gemm-backend flashinfer_cutlass
+    --kv-cache-dtype fp8_e4m3
+    --mamba-ssm-dtype bfloat16
+    --attention-backend trtllm_mha
+    --moe-runner-backend flashinfer_trtllm
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --max-prefill-tokens 16384
+    --chunked-prefill-size 16384
+    --mem-fraction-static 0.80
+    --stream-interval 50
+    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    "${TOKENIZER_ARGS[@]}"
+    --tokenizer-path "$MODEL"
+    --reasoning-parser qwen3
+    --tool-call-parser qwen3_coder
+    --speculative-algorithm NEXTN
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --enable-metrics
+    --enable-cache-report
+    "${CACHE_ARGS[@]}"
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+capture_cache_metrics() {
+    {
+        echo "=== SGLang cache metrics snapshot $(date --iso-8601=seconds) ==="
+        curl -fsS "http://localhost:$PORT/metrics" 2>/dev/null \
+            | grep -E '^(sglang:(cache_hit_rate|cached_tokens_total|prompt_tokens_total|hicache_host_used_tokens|hicache_host_total_tokens|token_usage|num_requests_running|num_requests_waiting))' \
+            || true
+        echo "============================================================"
+    } >> "$SERVER_LOG"
+}
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+capture_cache_metrics
+trap capture_cache_metrics EXIT
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --server-metrics http://localhost:$PORT/metrics"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -12,6 +12,10 @@ set -x
 # matches the same flag the Qwen3.5 NVFP4 sibling uses. The model ships native
 # MTP modules (kept unquantized by the checkpoint's ignore list), so NEXTN
 # needs no external drafter.
+#
+# TP1: the cookbook's verified single-node command for this model is --tp 1 on
+# both Blackwell parts. 126 GiB of NVFP4 weights fit on one B200, so the
+# model is not sharded and every rank-crossing collective disappears.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 
@@ -116,14 +120,12 @@ export SGLANG_ENABLE_FLASHINFER_GEMM=true
 export SGLANG_TIMEOUT_KEEP_ALIVE=1800
 
 if [ "${EVAL_ONLY:-false}" != "true" ]; then
-    # Qwen3.8-Flash-Next acceptance length, SPEED-Bench coding.
-    # --speculative-num-steps 3 with 4 draft tokens is 3 speculative
-    # tokens per verification step, i.e. the MTP=3 cell -> AL 3.24.
-    # Measured thinking=off in speedbench-al run 33031708148; the
-    # thinking=on collection is still in flight, so this is an
-    # interim value and is not yet a committed golden_al_distribution
-    # curve. Refresh once qwen3.8next_mtp.yaml lands.
-    export SGLANG_SIMULATE_ACC_LEN=3.24
+    # golden_al_distribution/qwen3.8next_mtp.yaml:
+    # qwen3.8-flash-next-fp8.thinking_on[3] = 2.32.
+    # --speculative-num-steps 3 with 4 draft tokens is 3 speculative tokens
+    # per verification step, i.e. the MTP=3 cell. AgentX replays run with
+    # thinking on, so the thinking_on row is the right one.
+    export SGLANG_SIMULATE_ACC_LEN=2.32
     export SGLANG_SIMULATE_ACC_METHOD=match-expected
     export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
 fi
@@ -136,28 +138,27 @@ SGLANG_CMD=(
     --port "$PORT"
     --trust-remote-code
     "${PARALLEL_ARGS[@]}"
-    --enable-symm-mem
-    --quantization modelopt_fp4
-    --fp4-gemm-backend flashinfer_cutlass
-    --kv-cache-dtype fp8_e4m3
+    # Verified flags from the SGLang cookbook playground for this model on
+    # B200 / NVFP4 / single node. Quantization is read from the
+    # checkpoint, so no --quantization flag; the hybrid GDN linear-attention
+    # layers take their own backends rather than --attention-backend.
+    --linear-attn-prefill-backend flashinfer
+    --linear-attn-decode-backend flashinfer
     --mamba-ssm-dtype bfloat16
-    --attention-backend trtllm_mha
-    --moe-runner-backend flashinfer_trtllm
-    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --speculative-algorithm NEXTN
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --reasoning-parser auto
+    # NEXTN silently resets --max-running-requests to 48 when it is unset, so
+    # this must stay explicit and sized to the AgentX concurrency.
     --max-running-requests "$MAX_RUNNING_REQUESTS"
-    --max-prefill-tokens 16384
-    --chunked-prefill-size 16384
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
     --mem-fraction-static 0.80
     --stream-interval 50
     --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
     "${TOKENIZER_ARGS[@]}"
     --tokenizer-path "$MODEL"
-    --reasoning-parser qwen3
-    --tool-call-parser qwen3_coder
-    --speculative-algorithm NEXTN
-    --speculative-num-steps 3
-    --speculative-eagle-topk 1
-    --speculative-num-draft-tokens 4
     --enable-metrics
     --enable-cache-report
     "${CACHE_ARGS[@]}"

--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -32,10 +32,79 @@ if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
 fi
 
-if [[ -n "${MODEL_PATH:-}" ]]; then
-    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
-        hf download "$MODEL" --local-dir "$MODEL_PATH"
+# The B200 nscale launcher hands us a shared directory rather than a staged
+# checkpoint, and several matrix cells run against it at once, so "non-empty"
+# is not the same as "complete". A first cell whose download stalls leaves a
+# partial tree that every later cell accepts and serves: that is how this arm
+# produced a fully loaded server and gsm8k exact_match 0.0000, with 81 GB of
+# 126 GB on disk, 8 leftover .incomplete files and no index. Check the index
+# and every shard it names instead, and let hf download resume the rest --
+# it is incremental, so re-running it on a partial tree is cheap and correct.
+model_download_is_complete() {
+    local dir="$1"
+    local index="$dir/model.safetensors.index.json"
+    [[ -f "$index" ]] || return 1
+    if [[ -n "$(find "$dir" -name '*.incomplete' -print -quit 2>/dev/null)" ]]; then
+        return 1
     fi
+    python3 - "$dir" <<'PYEOF'
+import json, os, sys
+
+directory = sys.argv[1]
+index = os.path.join(directory, "model.safetensors.index.json")
+try:
+    shards = set(json.load(open(index))["weight_map"].values())
+except Exception:
+    sys.exit(1)
+missing = [s for s in sorted(shards) if not os.path.isfile(os.path.join(directory, s))]
+if missing:
+    print(f"checkpoint incomplete: {len(missing)}/{len(shards)} shards missing, "
+          f"first {missing[0]}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+download_model_once() {
+    # Serialize across the matrix cells sharing this directory. Without the
+    # lock the completeness check turns "one cell downloads" into "every cell
+    # downloads into the same tree at once", and hf download names its
+    # .incomplete files by content hash, so the concurrent writers collide on
+    # the same paths. The first holder downloads; the rest wake up, find the
+    # checkpoint complete and skip. flock matches what the launcher already
+    # does for squashfs imports.
+    local lock="${MODEL_PATH}.lock"
+    mkdir -p "$(dirname "$MODEL_PATH")"
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "WARNING: flock unavailable; downloading without the cross-cell lock" >&2
+        _download_model_if_needed
+        return
+    fi
+    exec 9>"$lock"
+    if ! flock -w 5400 9; then
+        echo "WARNING: timed out waiting for $lock; proceeding unlocked" >&2
+    fi
+    _download_model_if_needed
+    exec 9>&-
+}
+
+_download_model_if_needed() {
+    if model_download_is_complete "$MODEL_PATH"; then
+        echo "Checkpoint already complete at $MODEL_PATH"
+        return
+    fi
+    echo "Downloading $MODEL into $MODEL_PATH (absent or incomplete)"
+    # Xet stalled this transfer twice at exactly 81 GB, once from a login node
+    # and once from inside a job. The plain HTTPS path does not.
+    HF_HUB_DISABLE_XET=1 hf download "$MODEL" --local-dir "$MODEL_PATH"
+    if ! model_download_is_complete "$MODEL_PATH"; then
+        echo "Error: $MODEL_PATH is still incomplete after hf download" >&2
+        exit 1
+    fi
+}
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    download_model_once
 else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"

--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -144,14 +144,12 @@ SGLANG_CMD=(
     # layers take their own backends rather than --attention-backend.
     --linear-attn-prefill-backend flashinfer
     --linear-attn-decode-backend flashinfer
-    # float32, not the cookbook's bfloat16. With NEXTN enabled the GDN linear
-    # attention backend routes verification through flashinfer's
-    # gated_delta_rule_mtp, which asserts initial_state.dtype == torch.float32
-    # and aborts CUDA graph capture on a bf16 SSM state:
-    #   AssertionError: initial_state must be float32, got torch.bfloat16
-    #   flashinfer/gdn_decode.py:761, via gdn_backend.py target_verify
-    # Confirmed on the H200 arm; same backend, same kernel, same NEXTN here.
-    --mamba-ssm-dtype float32
+    # bfloat16 is mandatory on Blackwell: SGLang rejects the launch outright
+    # with "--linear-attn-decode-backend flashinfer on SM100+ requires
+    # --mamba-ssm-dtype bfloat16". Hopper wants the opposite -- flashinfer's
+    # gated_delta_rule_mtp verify kernel asserts a float32 state there -- so
+    # the H200 arm sets float32 and this one must not follow it.
+    --mamba-ssm-dtype bfloat16
     --speculative-algorithm NEXTN
     --speculative-num-steps 3
     --speculative-eagle-topk 1

--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -144,7 +144,14 @@ SGLANG_CMD=(
     # layers take their own backends rather than --attention-backend.
     --linear-attn-prefill-backend flashinfer
     --linear-attn-decode-backend flashinfer
-    --mamba-ssm-dtype bfloat16
+    # float32, not the cookbook's bfloat16. With NEXTN enabled the GDN linear
+    # attention backend routes verification through flashinfer's
+    # gated_delta_rule_mtp, which asserts initial_state.dtype == torch.float32
+    # and aborts CUDA graph capture on a bf16 SSM state:
+    #   AssertionError: initial_state must be float32, got torch.bfloat16
+    #   flashinfer/gdn_decode.py:761, via gdn_backend.py target_verify
+    # Confirmed on the H200 arm; same backend, same kernel, same NEXTN here.
+    --mamba-ssm-dtype float32
     --speculative-algorithm NEXTN
     --speculative-num-steps 3
     --speculative-eagle-topk 1

--- a/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp4_b200_sglang_mtp.sh
@@ -32,79 +32,10 @@ if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
 fi
 
-# The B200 nscale launcher hands us a shared directory rather than a staged
-# checkpoint, and several matrix cells run against it at once, so "non-empty"
-# is not the same as "complete". A first cell whose download stalls leaves a
-# partial tree that every later cell accepts and serves: that is how this arm
-# produced a fully loaded server and gsm8k exact_match 0.0000, with 81 GB of
-# 126 GB on disk, 8 leftover .incomplete files and no index. Check the index
-# and every shard it names instead, and let hf download resume the rest --
-# it is incremental, so re-running it on a partial tree is cheap and correct.
-model_download_is_complete() {
-    local dir="$1"
-    local index="$dir/model.safetensors.index.json"
-    [[ -f "$index" ]] || return 1
-    if [[ -n "$(find "$dir" -name '*.incomplete' -print -quit 2>/dev/null)" ]]; then
-        return 1
-    fi
-    python3 - "$dir" <<'PYEOF'
-import json, os, sys
-
-directory = sys.argv[1]
-index = os.path.join(directory, "model.safetensors.index.json")
-try:
-    shards = set(json.load(open(index))["weight_map"].values())
-except Exception:
-    sys.exit(1)
-missing = [s for s in sorted(shards) if not os.path.isfile(os.path.join(directory, s))]
-if missing:
-    print(f"checkpoint incomplete: {len(missing)}/{len(shards)} shards missing, "
-          f"first {missing[0]}", file=sys.stderr)
-    sys.exit(1)
-sys.exit(0)
-PYEOF
-}
-
-download_model_once() {
-    # Serialize across the matrix cells sharing this directory. Without the
-    # lock the completeness check turns "one cell downloads" into "every cell
-    # downloads into the same tree at once", and hf download names its
-    # .incomplete files by content hash, so the concurrent writers collide on
-    # the same paths. The first holder downloads; the rest wake up, find the
-    # checkpoint complete and skip. flock matches what the launcher already
-    # does for squashfs imports.
-    local lock="${MODEL_PATH}.lock"
-    mkdir -p "$(dirname "$MODEL_PATH")"
-    if ! command -v flock >/dev/null 2>&1; then
-        echo "WARNING: flock unavailable; downloading without the cross-cell lock" >&2
-        _download_model_if_needed
-        return
-    fi
-    exec 9>"$lock"
-    if ! flock -w 5400 9; then
-        echo "WARNING: timed out waiting for $lock; proceeding unlocked" >&2
-    fi
-    _download_model_if_needed
-    exec 9>&-
-}
-
-_download_model_if_needed() {
-    if model_download_is_complete "$MODEL_PATH"; then
-        echo "Checkpoint already complete at $MODEL_PATH"
-        return
-    fi
-    echo "Downloading $MODEL into $MODEL_PATH (absent or incomplete)"
-    # Xet stalled this transfer twice at exactly 81 GB, once from a login node
-    # and once from inside a job. The plain HTTPS path does not.
-    HF_HUB_DISABLE_XET=1 hf download "$MODEL" --local-dir "$MODEL_PATH"
-    if ! model_download_is_complete "$MODEL_PATH"; then
-        echo "Error: $MODEL_PATH is still incomplete after hf download" >&2
-        exit 1
-    fi
-}
-
 if [[ -n "${MODEL_PATH:-}" ]]; then
-    download_model_once
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
 else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7564,6 +7564,23 @@ qwen3.5-fp4-b200-sglang-agentic-mtp:
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 14] }
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 18, 20, 22, 24, 28, 32] }
 
+
+# Qwen3.8-Flash-Next NVFP4 AgentX on B200 via SGLang with native NEXTN MTP.
+# Day-zero recipe: SGLang is the plan-of-record engine for this model. TP4 at
+# 126 GiB of NVFP4 weights leaves ample HBM for the 256k-capped agentic traces.
+qwen3.8next-fp4-b200-sglang-agentic-mtp:
+  image: lmsysorg/sglang:qwen38flashnext
+  model: RadixArk/Qwen3.8-Flash-Next-NVFP4
+  model-prefix: qwen3.8next
+  runner: cluster:b200-nscale
+  precision: fp4
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.8
+      search-space:
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
 qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
   image: lmsysorg/sglang:nightly-dev-20260818-c0b6474b
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7566,8 +7566,9 @@ qwen3.5-fp4-b200-sglang-agentic-mtp:
 
 
 # Qwen3.8-Flash-Next NVFP4 AgentX on B200 via SGLang with native NEXTN MTP.
-# Day-zero recipe: SGLang is the plan-of-record engine for this model. TP4 at
-# 126 GiB of NVFP4 weights leaves ample HBM for the 256k-capped agentic traces.
+# Day-zero recipe: SGLang is the plan-of-record engine for this model. TP1 per
+# the cookbook's verified single-node command; 126 GiB of NVFP4 weights fit on
+# one B200, so the model is not sharded.
 qwen3.8next-fp4-b200-sglang-agentic-mtp:
   image: lmsysorg/sglang:qwen38flashnext
   model: RadixArk/Qwen3.8-Flash-Next-NVFP4
@@ -7580,7 +7581,7 @@ qwen3.8next-fp4-b200-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.8
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
+      - { tp: 1, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
 qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp:
   image: lmsysorg/sglang:nightly-dev-20260818-c0b6474b
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6922,4 +6922,5 @@
     - "Route the qwen3.8next fp4 prefix in the B200 nscale launcher, which previously rejected the prefix outright, and fetch the checkpoint from HuggingFace into a shared-storage cache instead of requiring it pre-staged under the models tree."
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
+    - "Use a float32 Mamba SSM state: flashinfer's gated_delta_rule_mtp verify kernel asserts float32 and aborts CUDA graph capture on the bfloat16 state the cookbook command specifies."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6923,5 +6923,5 @@
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
     - "Keep the bfloat16 Mamba SSM state the cookbook specifies: SGLang requires it on SM100 or newer whenever the flashinfer linear-attention decode backend is selected."
-    - "Treat the shared checkpoint directory as complete only when the index and every shard it names are present, take a cross-cell lock around the download, and disable Xet for it, after a stalled partial download was served as a finished model."
+    - "Download the checkpoint to node-local scratch rather than the shared home, and treat it as complete only when the index and every shard it names are present, after a stalled partial download was served as a finished model and a shared-home download hit a stale-handle error."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6910,3 +6910,13 @@
   description:
     - "Repin the image from vllm/vllm-openai-rocm:nightly-311b3513af33bc29b4acb2fde2e9313e5e9966a0 to the 2026-09-05 ROCm nightly (nightly-e962733e08d10f7ca65dac4df99e116460b8b174, digest sha256:511755968434e26da590c3398f1e8a6399be4416226d5779ce92fb0655811a9c). Docker Hub last pushed it at 2026-09-05T05:27:09Z and the tag commit is vllm-project/vllm@e962733e."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2841
+
+- config-keys:
+    - qwen3.8next-fp4-b200-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add the day-zero Qwen3.8-Flash-Next NVFP4 AgentX recipe on B200 with SGLang native NEXTN MTP at TP4 and concurrency 1/4/8/12/16."
+    - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
+    - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6920,4 +6920,6 @@
     - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
     - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
     - "Route the qwen3.8next fp4 prefix to its staged checkpoint in the B200 nscale launcher, which previously rejected the prefix outright."
+    - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
+    - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6922,5 +6922,5 @@
     - "Route the qwen3.8next fp4 prefix in the B200 nscale launcher, which previously rejected the prefix outright, and fetch the checkpoint from HuggingFace into a shared-storage cache instead of requiring it pre-staged under the models tree."
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
-    - "Use a float32 Mamba SSM state: flashinfer's gated_delta_rule_mtp verify kernel asserts float32 and aborts CUDA graph capture on the bfloat16 state the cookbook command specifies."
+    - "Keep the bfloat16 Mamba SSM state the cookbook specifies: SGLang requires it on SM100 or newer whenever the flashinfer linear-attention decode backend is selected."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6923,4 +6923,5 @@
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
     - "Keep the bfloat16 Mamba SSM state the cookbook specifies: SGLang requires it on SM100 or newer whenever the flashinfer linear-attention decode backend is selected."
+    - "Treat the shared checkpoint directory as complete only when the index and every shard it names are present, take a cross-cell lock around the download, and disable Xet for it, after a stalled partial download was served as a finished model."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6919,9 +6919,8 @@
     - "Add the day-zero Qwen3.8-Flash-Next NVFP4 AgentX recipe on B200 with SGLang native NEXTN MTP at TP4 and concurrency 1/4/8/12/16."
     - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
     - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
-    - "Route the qwen3.8next fp4 prefix in the B200 nscale launcher, which previously rejected the prefix outright, and fetch the checkpoint from HuggingFace into a shared-storage cache instead of requiring it pre-staged under the models tree."
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
     - "Keep the bfloat16 Mamba SSM state the cookbook specifies: SGLang requires it on SM100 or newer whenever the flashinfer linear-attention decode backend is selected."
-    - "Download the checkpoint to node-local scratch rather than the shared home, and treat it as complete only when the index and every shard it names are present, after a stalled partial download was served as a finished model and a shared-home download hit a stale-handle error."
+    - "Route the qwen3.8next fp4 prefix in the B200 nscale launcher to its staged checkpoint under the models tree; the launcher previously rejected the prefix outright."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6919,4 +6919,4 @@
     - "Add the day-zero Qwen3.8-Flash-Next NVFP4 AgentX recipe on B200 with SGLang native NEXTN MTP at TP4 and concurrency 1/4/8/12/16."
     - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
     - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6919,7 +6919,7 @@
     - "Add the day-zero Qwen3.8-Flash-Next NVFP4 AgentX recipe on B200 with SGLang native NEXTN MTP at TP4 and concurrency 1/4/8/12/16."
     - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
     - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
-    - "Route the qwen3.8next fp4 prefix to its staged checkpoint in the B200 nscale launcher, which previously rejected the prefix outright."
+    - "Route the qwen3.8next fp4 prefix in the B200 nscale launcher, which previously rejected the prefix outright, and fetch the checkpoint from HuggingFace into a shared-storage cache instead of requiring it pre-staged under the models tree."
     - "Correct the serve flags to the SGLang cookbook's verified single-node command for this model: TP1 rather than TP4, the flashinfer linear-attention prefill and decode backends, bfloat16 Mamba SSM, and checkpoint-derived quantization."
     - "Set the acceptance length to the committed golden thinking_on value of 2.32 at three speculative tokens, replacing the interim 3.24."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6919,4 +6919,5 @@
     - "Add the day-zero Qwen3.8-Flash-Next NVFP4 AgentX recipe on B200 with SGLang native NEXTN MTP at TP4 and concurrency 1/4/8/12/16."
     - "Serve RadixArk/Qwen3.8-Flash-Next-NVFP4 with modelopt_fp4 quantization, the trtllm_mha attention backend, and the flashinfer_trtllm MoE runner, following the Qwen3.5 NVFP4 B200 sibling."
     - "Pin throughput runs to an interim acceptance length of 3.24 measured at three speculative tokens; eval-only runs keep real target verification."
+    - "Route the qwen3.8next fp4 prefix to its staged checkpoint in the B200 nscale launcher, which previously rejected the prefix outright."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2751

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -82,6 +82,25 @@ elif [[ $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp4" ]]; then
 elif [[ $MODEL_PREFIX == "kimik3" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/scratch/models/Kimi-K3"
     export SRT_SLURM_MODEL_PREFIX="kimik3"
+elif [[ $MODEL_PREFIX == "qwen3.8next" && $PRECISION == "fp4" ]]; then
+    # Qwen3.8-Flash-Next NVFP4. Like the dsv4 branch, prefer an explicitly
+    # supplied MODEL_PATH, then a staged directory, so a differently named
+    # staging dir does not need a code change here. This launcher bind-mounts
+    # MODEL_PATH into the container and exports MODEL=$MODEL_PATH, so there is
+    # no hf-download fallback: the checkpoint must be staged on the cluster.
+    SELECTED_MODEL_PATH=""
+    if [[ -n "${MODEL_PATH:-}" && -d "${MODEL_PATH}" ]]; then
+        SELECTED_MODEL_PATH="$MODEL_PATH"
+    else
+        for candidate in /scratch/models/Qwen3.8-Flash-Next-NVFP4 /scratch/models/Qwen3.8-Flash-Next-FP8 /scratch/models/Qwen3.8-Flash-Next; do
+            if [[ -d "$candidate" ]]; then
+                SELECTED_MODEL_PATH="$candidate"
+                break
+            fi
+        done
+    fi
+    export MODEL_PATH="${SELECTED_MODEL_PATH:-/scratch/models/Qwen3.8-Flash-Next-NVFP4}"
+    export SRT_SLURM_MODEL_PREFIX="qwen3.8next-fp4"
 else
     echo "Unsupported model prefix/precision: $MODEL_PREFIX/$PRECISION"
     echo "Available models under /scratch/models:"

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -83,14 +83,18 @@ elif [[ $MODEL_PREFIX == "kimik3" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/scratch/models/Kimi-K3"
     export SRT_SLURM_MODEL_PREFIX="kimik3"
 elif [[ $MODEL_PREFIX == "qwen3.8next" && $PRECISION == "fp4" ]]; then
-    # Qwen3.8-Flash-Next NVFP4 is not pre-staged under /scratch/models, so this
-    # branch does not point at the staging tree. It hands the bench script a
-    # writable cache directory on the shared /scratch filesystem and lets the
-    # script's own `hf download --local-dir "$MODEL_PATH"` populate it on the
-    # first run; later runs find it already there. KEEP_HF_MODEL_ID keeps MODEL
-    # as the HuggingFace repo id further down, because `hf download` needs a
-    # repo id and every other branch here overwrites MODEL with the local path.
-    export MODEL_PATH="${MODEL_PATH:-/scratch/hf-models/Qwen3.8-Flash-Next-NVFP4}"
+    # Qwen3.8-Flash-Next NVFP4 is not staged on this cluster, so this branch
+    # does not point at the staging tree. Note /scratch is NOT the same
+    # filesystem on both sides: on the login node it is a symlink to NFS
+    # /data/scratch, while on a compute node it is node-local /dev/md0 xfs that
+    # holds the staged models and is not writable by the runner account. The
+    # home directory is the one path that is shared, writable and identical on
+    # both, so the checkpoint goes there and the bench script's own
+    # `hf download --local-dir "$MODEL_PATH"` populates it on the first run.
+    # KEEP_HF_MODEL_ID keeps MODEL as the HuggingFace repo id further down,
+    # because `hf download` needs a repo id and every other branch here
+    # overwrites MODEL with the local path.
+    export MODEL_PATH="${MODEL_PATH:-${HOME}/models/Qwen3.8-Flash-Next-NVFP4}"
     export KEEP_HF_MODEL_ID=1
     export SRT_SLURM_MODEL_PREFIX="qwen3.8next-fp4"
 else
@@ -590,6 +594,7 @@ else
         # mounted below and srun fails outright on a missing mount source.
         if ! mkdir -p "$MODEL_PATH"; then
             echo "Error: cannot create $MODEL_PATH on shared storage; the bind mount below would fail" >&2
+            echo "Note: compute-node /scratch is node-local and not writable here; use a path under \$HOME" >&2
             exit 1
         fi
     else

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -83,23 +83,23 @@ elif [[ $MODEL_PREFIX == "kimik3" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/scratch/models/Kimi-K3"
     export SRT_SLURM_MODEL_PREFIX="kimik3"
 elif [[ $MODEL_PREFIX == "qwen3.8next" && $PRECISION == "fp4" ]]; then
-    # Qwen3.8-Flash-Next NVFP4 is not staged on this cluster, so this branch
-    # does not point at the staging tree. The bench script's own
-    # `hf download --local-dir "$MODEL_PATH"` populates it instead, and
-    # KEEP_HF_MODEL_ID below keeps MODEL a HuggingFace repo id so that call has
-    # something valid to fetch.
-    #
-    # The target is node-local scratch, not the shared home. /tmp on a compute
-    # node is /dev/md0 with ~17 TB free; $HOME is NFSv4. Downloading 126 GiB to
-    # the shared home made every cell in the matrix write the same tree from a
-    # different node, and huggingface_hub failed reading a shard back with
-    #   OSError: [Errno 521] ... layer-00007-experts-0256-0383.safetensors
-    # a stale-handle class error. Node-local storage makes each node fetch its
-    # own copy -- about 2.5 minutes at the 861 MB/s these nodes sustain -- and
-    # removes cross-node sharing from the picture entirely. The directory is
-    # created with srun so it lands on the allocated node.
-    export MODEL_PATH="${MODEL_PATH:-/tmp/inferencex-models/Qwen3.8-Flash-Next-NVFP4}"
-    export KEEP_HF_MODEL_ID=1
+    # Staged on the compute nodes like every other model here, so this is the
+    # ordinary branch again: no hf download and no writable target needed.
+    # Verified on im-b200-c004: 126 GB, index present, 206/206 shards, no
+    # .incomplete leftovers. The candidate search mirrors the dsv4 branch so a
+    # differently named staging directory needs no code change.
+    SELECTED_MODEL_PATH=""
+    if [[ -n "${MODEL_PATH:-}" && -d "${MODEL_PATH}" ]]; then
+        SELECTED_MODEL_PATH="$MODEL_PATH"
+    else
+        for candidate in /scratch/models/Qwen3.8-Flash-Next-NVFP4 /scratch/models/Qwen3.8-Flash-Next; do
+            if [[ -d "$candidate" ]]; then
+                SELECTED_MODEL_PATH="$candidate"
+                break
+            fi
+        done
+    fi
+    export MODEL_PATH="${SELECTED_MODEL_PATH:-/scratch/models/Qwen3.8-Flash-Next-NVFP4}"
     export SRT_SLURM_MODEL_PREFIX="qwen3.8next-fp4"
 else
     echo "Unsupported model prefix/precision: $MODEL_PREFIX/$PRECISION"
@@ -592,20 +592,7 @@ else
     # Point the bench script at the resolved MODEL_PATH instead of
     # pulling from the HF hub cache. Bench scripts skip `hf download` when
     # MODEL is a local path.
-    if [[ "${KEEP_HF_MODEL_ID:-0}" == "1" ]]; then
-        # The bench script downloads into MODEL_PATH itself, so MODEL has to
-        # stay a HuggingFace repo id. Create the directory first: it is bind
-        # mounted below and srun fails outright on a missing mount source.
-        # Create it ON THE ALLOCATED NODE, because MODEL_PATH is node-local
-        # scratch: /tmp is /dev/md0 with ~17 TB free on these nodes, while the
-        # login node has an unrelated /tmp of its own.
-        if ! srun --jobid="$JOB_ID" mkdir -p "$MODEL_PATH"; then
-            echo "Error: cannot create $MODEL_PATH on the compute node; the bind mount below would fail" >&2
-            exit 1
-        fi
-    else
-        export MODEL="$MODEL_PATH"
-    fi
+    export MODEL="$MODEL_PATH"
 
     # Use flock to serialize concurrent imports to the same squash file
     # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -83,23 +83,15 @@ elif [[ $MODEL_PREFIX == "kimik3" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/scratch/models/Kimi-K3"
     export SRT_SLURM_MODEL_PREFIX="kimik3"
 elif [[ $MODEL_PREFIX == "qwen3.8next" && $PRECISION == "fp4" ]]; then
-    # Qwen3.8-Flash-Next NVFP4. Like the dsv4 branch, prefer an explicitly
-    # supplied MODEL_PATH, then a staged directory, so a differently named
-    # staging dir does not need a code change here. This launcher bind-mounts
-    # MODEL_PATH into the container and exports MODEL=$MODEL_PATH, so there is
-    # no hf-download fallback: the checkpoint must be staged on the cluster.
-    SELECTED_MODEL_PATH=""
-    if [[ -n "${MODEL_PATH:-}" && -d "${MODEL_PATH}" ]]; then
-        SELECTED_MODEL_PATH="$MODEL_PATH"
-    else
-        for candidate in /scratch/models/Qwen3.8-Flash-Next-NVFP4 /scratch/models/Qwen3.8-Flash-Next-FP8 /scratch/models/Qwen3.8-Flash-Next; do
-            if [[ -d "$candidate" ]]; then
-                SELECTED_MODEL_PATH="$candidate"
-                break
-            fi
-        done
-    fi
-    export MODEL_PATH="${SELECTED_MODEL_PATH:-/scratch/models/Qwen3.8-Flash-Next-NVFP4}"
+    # Qwen3.8-Flash-Next NVFP4 is not pre-staged under /scratch/models, so this
+    # branch does not point at the staging tree. It hands the bench script a
+    # writable cache directory on the shared /scratch filesystem and lets the
+    # script's own `hf download --local-dir "$MODEL_PATH"` populate it on the
+    # first run; later runs find it already there. KEEP_HF_MODEL_ID keeps MODEL
+    # as the HuggingFace repo id further down, because `hf download` needs a
+    # repo id and every other branch here overwrites MODEL with the local path.
+    export MODEL_PATH="${MODEL_PATH:-/scratch/hf-models/Qwen3.8-Flash-Next-NVFP4}"
+    export KEEP_HF_MODEL_ID=1
     export SRT_SLURM_MODEL_PREFIX="qwen3.8next-fp4"
 else
     echo "Unsupported model prefix/precision: $MODEL_PREFIX/$PRECISION"
@@ -592,7 +584,17 @@ else
     # Point the bench script at the resolved MODEL_PATH instead of
     # pulling from the HF hub cache. Bench scripts skip `hf download` when
     # MODEL is a local path.
-    export MODEL="$MODEL_PATH"
+    if [[ "${KEEP_HF_MODEL_ID:-0}" == "1" ]]; then
+        # The bench script downloads into MODEL_PATH itself, so MODEL has to
+        # stay a HuggingFace repo id. Create the directory first: it is bind
+        # mounted below and srun fails outright on a missing mount source.
+        if ! mkdir -p "$MODEL_PATH"; then
+            echo "Error: cannot create $MODEL_PATH on shared storage; the bind mount below would fail" >&2
+            exit 1
+        fi
+    else
+        export MODEL="$MODEL_PATH"
+    fi
 
     # Use flock to serialize concurrent imports to the same squash file
     # Override ENROOT_CACHE_PATH to avoid permission issues with system-wide cache on worker nodes

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -84,17 +84,21 @@ elif [[ $MODEL_PREFIX == "kimik3" && $PRECISION == "fp4" ]]; then
     export SRT_SLURM_MODEL_PREFIX="kimik3"
 elif [[ $MODEL_PREFIX == "qwen3.8next" && $PRECISION == "fp4" ]]; then
     # Qwen3.8-Flash-Next NVFP4 is not staged on this cluster, so this branch
-    # does not point at the staging tree. Note /scratch is NOT the same
-    # filesystem on both sides: on the login node it is a symlink to NFS
-    # /data/scratch, while on a compute node it is node-local /dev/md0 xfs that
-    # holds the staged models and is not writable by the runner account. The
-    # home directory is the one path that is shared, writable and identical on
-    # both, so the checkpoint goes there and the bench script's own
-    # `hf download --local-dir "$MODEL_PATH"` populates it on the first run.
-    # KEEP_HF_MODEL_ID keeps MODEL as the HuggingFace repo id further down,
-    # because `hf download` needs a repo id and every other branch here
-    # overwrites MODEL with the local path.
-    export MODEL_PATH="${MODEL_PATH:-${HOME}/models/Qwen3.8-Flash-Next-NVFP4}"
+    # does not point at the staging tree. The bench script's own
+    # `hf download --local-dir "$MODEL_PATH"` populates it instead, and
+    # KEEP_HF_MODEL_ID below keeps MODEL a HuggingFace repo id so that call has
+    # something valid to fetch.
+    #
+    # The target is node-local scratch, not the shared home. /tmp on a compute
+    # node is /dev/md0 with ~17 TB free; $HOME is NFSv4. Downloading 126 GiB to
+    # the shared home made every cell in the matrix write the same tree from a
+    # different node, and huggingface_hub failed reading a shard back with
+    #   OSError: [Errno 521] ... layer-00007-experts-0256-0383.safetensors
+    # a stale-handle class error. Node-local storage makes each node fetch its
+    # own copy -- about 2.5 minutes at the 861 MB/s these nodes sustain -- and
+    # removes cross-node sharing from the picture entirely. The directory is
+    # created with srun so it lands on the allocated node.
+    export MODEL_PATH="${MODEL_PATH:-/tmp/inferencex-models/Qwen3.8-Flash-Next-NVFP4}"
     export KEEP_HF_MODEL_ID=1
     export SRT_SLURM_MODEL_PREFIX="qwen3.8next-fp4"
 else
@@ -592,9 +596,11 @@ else
         # The bench script downloads into MODEL_PATH itself, so MODEL has to
         # stay a HuggingFace repo id. Create the directory first: it is bind
         # mounted below and srun fails outright on a missing mount source.
-        if ! mkdir -p "$MODEL_PATH"; then
-            echo "Error: cannot create $MODEL_PATH on shared storage; the bind mount below would fail" >&2
-            echo "Note: compute-node /scratch is node-local and not writable here; use a path under \$HOME" >&2
+        # Create it ON THE ALLOCATED NODE, because MODEL_PATH is node-local
+        # scratch: /tmp is /dev/md0 with ~17 TB free on these nodes, while the
+        # login node has an unrelated /tmp of its own.
+        if ! srun --jobid="$JOB_ID" mkdir -p "$MODEL_PATH"; then
+            echo "Error: cannot create $MODEL_PATH on the compute node; the bind mount below would fail" >&2
             exit 1
         fi
     else


### PR DESCRIPTION
## Description

Add a single-node Qwen3.8-Flash-Next NVFP4 AgentX configuration for B200 using SGLang native NEXTN MTP.

- Register `qwen3.8next-fp4-b200-sglang-agentic-mtp` at TP1/EP1 with concurrency 1, 4, 8, and 16.
- Use the merged SGLang cookbook recipe: https://github.com/sgl-project/sglang/pull/36496.
- Use the committed thinking-on MTP=3 synthetic acceptance length of 2.32 for benchmark replay; evaluation retains real target-model verification.
- Size maximum running requests and CUDA graph capture to twice concurrency. At concurrency 16, use `--mem-fraction-static 0.90` and a 160-slot Mamba cache.
- Route the B200 Nscale launcher to the staged Qwen3.8-Flash-Next NVFP4 checkpoint.

Validation passed for YAML and Bash syntax, exact-key matrix generation, 316 matrix tests, image availability, golden-AL matching, launcher routing, and public-boundary scans.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] I appended the new entry to the physical end of `perf-changelog.yaml` without editing historical entries
- [ ] An authorized maintainer has commented `/reuse-sweep-run` after a final green sweep, if applicable

<details>
<summary>中文</summary>

## 说明

在 B200 上新增单节点 Qwen3.8-Flash-Next NVFP4 AgentX 配置，使用 SGLang 原生 NEXTN MTP。

- 注册 `qwen3.8next-fp4-b200-sglang-agentic-mtp`，采用 TP1/EP1，并覆盖并发 1、4、8 和 16。
- 使用已合入的 SGLang cookbook 配方：https://github.com/sgl-project/sglang/pull/36496。
- 基准回放使用已提交的 thinking-on、MTP=3 黄金模拟接受长度 2.32；评测保留真实目标模型验证。
- 将最大运行请求数和 CUDA Graph 捕获上限设为并发数的两倍；并发 16 时使用 `--mem-fraction-static 0.90` 和 160 槽 Mamba 缓存。
- B200 Nscale 启动器路由到已预置的 Qwen3.8-Flash-Next NVFP4 权重。

已通过 YAML 与 Bash 语法检查、精确配置键矩阵生成、316 项矩阵测试、镜像检查、黄金接受长度校验、启动器路由检查和公开边界扫描。

## 关联 Issue

N/A

## 变更类型

新增功能；配置变更。

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and configuration wiring only; no changes to auth, data handling, or production serving paths.
> 
> **Overview**
> Adds a **single-node B200 AgentX** path for **Qwen3.8-Flash-Next NVFP4** using **SGLang native NEXTN MTP** at **TP1**, wired through a new benchmark script that follows the merged SGLang cookbook (flashinfer linear-attention backends, **bfloat16** Mamba state, checkpoint-derived quantization, NEXTN with 3 steps / 4 draft tokens).
> 
> Registers **`qwen3.8next-fp4-b200-sglang-agentic-mtp`** in the master matrix for **agentic-coding** at concurrencies **1, 4, 8, and 16** (GPU-resident KV only in the search space). Throughput replay uses the committed **thinking-on MTP=3 synthetic acceptance length 2.32**; eval mode keeps real verification and switches to **lm-eval GSM8K**. The script enforces a **complete staged NVFP4 checkpoint**, sizes **max-running-requests** and CUDA graphs to **2× concurrency** (with higher static memory and Mamba cache at conc 16), and optionally sizes **HiCache** when that backend is requested.
> 
> Updates the **B200 Nscale launcher** to default **`qwen3.8next` / fp4** to the staged checkpoint path, and records the change in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab015a0e59829c4301f6b328fbbb1d0fecee5a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->