### PR TITLE
[Klaud Cold] qwen3.8next-fp8-mi355x-sglang-agentic: Qwen3.8-Flash-Next FP8 SGLang AgentX on MI355X / MI355X 上 Qwen3.8-Flash-Next FP8 SGLang AgentX 配方

### DIFF
--- a/benchmarks/single_node/agentic/qwen3.8next_bf16_mi355x_sglang.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_bf16_mi355x_sglang.sh
@@ -2,9 +2,31 @@
 set -euo pipefail
 set -x
 
-# AgentX trace replay for Qwen3.5-397B-A17B MXFP4 on MI355X with SGLang
-# native EAGLE MTP. Throughput uses the committed golden synthetic
-# acceptance length; evaluation retains real target-model verification.
+# AgentX trace replay for Qwen3.8-Flash-Next BF16 on MI355X with SGLang.
+# Day-zero recipe; SGLang is the plan-of-record engine for this model
+# (MODELS.md).
+#
+# Two deliberate differences from the NVIDIA arms:
+#
+#   * No speculative decoding. The MI355X SGLang path for this model does not
+#     drive MTP yet, so this arm runs the target model alone and carries no
+#     synthetic-acceptance pin. Add MTP and the golden AL once ROCm supports
+#     it. Until then this arm is not directly comparable to the spec-decode
+#     NVIDIA arms on the published frontier.
+#
+#   * BF16, not FP8 or FP4. NVFP4 is greyed out for MI355X in the cookbook and
+#     there is no AMD FP4 checkpoint. FP8 does not load either: this image's
+#     model code classifies model.layers.N.ple.ple_embedding.ngram_embedding
+#     as an unquantized module and asserts its weight_scale is 1.0, while the
+#     FP8 checkpoint genuinely quantizes it and ships a real scale:
+#       AssertionError: Expected 1.0, got 0.00019931793212890625 in skipped
+#       model.layers.1.ple.ple_embedding.ngram_embedding.weight_scale
+#       qwen4_exp.py:2039 in load_weights
+#     The checkpoint's modules_to_not_convert lists ple.conv1d, ple.key_proj
+#     and ple.value_proj but not the ngram embedding, so the skip set is being
+#     matched too broadly on the .ple. prefix. No serve flag changes that. The
+#     BF16 checkpoint (335.3 GiB, no quantization_config at all) has no scales
+#     to mis-handle. Revert to FP8 once a fixed ROCm image ships.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 

--- a/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 set -x
 
-# AgentX trace replay for Qwen3.8-Flash-Next BF16 on MI355X with SGLang.
+# AgentX trace replay for Qwen3.8-Flash-Next FP8 on MI355X with SGLang.
 # Day-zero recipe; SGLang is the plan-of-record engine for this model
 # (MODELS.md).
 #
@@ -14,19 +14,28 @@ set -x
 #     it. Until then this arm is not directly comparable to the spec-decode
 #     NVIDIA arms on the published frontier.
 #
-#   * BF16, not FP8 or FP4. NVFP4 is greyed out for MI355X in the cookbook and
-#     there is no AMD FP4 checkpoint. FP8 does not load either: this image's
-#     model code classifies model.layers.N.ple.ple_embedding.ngram_embedding
-#     as an unquantized module and asserts its weight_scale is 1.0, while the
-#     FP8 checkpoint genuinely quantizes it and ships a real scale:
-#       AssertionError: Expected 1.0, got 0.00019931793212890625 in skipped
-#       model.layers.1.ple.ple_embedding.ngram_embedding.weight_scale
-#       qwen4_exp.py:2039 in load_weights
-#     The checkpoint's modules_to_not_convert lists ple.conv1d, ple.key_proj
-#     and ple.value_proj but not the ngram embedding, so the skip set is being
-#     matched too broadly on the .ple. prefix. No serve flag changes that. The
-#     BF16 checkpoint (335.3 GiB, no quantization_config at all) has no scales
-#     to mis-handle. Revert to FP8 once a fixed ROCm image ships.
+#   * FP8, not FP4. NVFP4 is greyed out for MI355X in the SGLang cookbook and
+#     there is no AMD FP4 checkpoint for this model.
+#
+# KNOWN BLOCKER, upstream, not in this recipe: on the current
+# lmsysorg/sglang-rocm:qwen38flashnext image the server aborts while loading
+# weights with
+#   AssertionError: Expected 1.0, got 0.00019931793212890625 in skipped
+#   model.layers.1.ple.ple_embedding.ngram_embedding.weight_scale
+#   qwen4_exp.py:2039 in load_weights
+# The model registers no parameter for the PLE ngram embedding, so load_weights
+# takes the "skipped" branch, which assumes any orphaned _scale must be a no-op
+# and asserts it is 1.0. The checkpoint really does quantize that embedding:
+# its 128 shard_N.weight tensors are F8_E4M3 with a single BF16 weight_scale of
+# ~1.99e-4, and modules_to_not_convert lists ple.conv1d, ple.key_proj and
+# ple.value_proj but not the ngram embedding.
+#
+# Suppressing the assert is NOT a fix: the shards would load as raw FP8 with
+# the scale never applied, leaving that embedding wrong by ~5000x with no error
+# reported. The CUDA image carries a different SGLang build and loads the same
+# checkpoint, so this is specific to the ROCm build. It clears when that image
+# implements the quantized PLE ngram embedding; the recipe below is otherwise
+# the cookbook's verified balanced command and needs no further change.
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
 

--- a/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
@@ -100,23 +100,24 @@ SGLANG_CMD=(
     --host 0.0.0.0
     --port "$PORT"
     --trust-remote-code
-    "${PARALLEL_ARGS[@]}"
+    # Verified flags from the SGLang cookbook playground for this model on
+    # MI355X / FP8 / balanced / single node. Low-latency and high-throughput
+    # are not offered for this part, and NVFP4 is greyed out, so balanced FP8
+    # at TP8 is the whole of the verified AMD surface today.
+    --tp-size "$TP"
     --attention-backend aiter
-    --mem-fraction-static 0.80
-    --model-loader-extra-config '{"enable_multithread_load": true}'
+    --page-size 32
+    --kv-cache-dtype auto
+    --chunked-prefill-size 16384
     --watchdog-timeout 1200
-    --page-size 16
-    --kv-cache-dtype fp8_e4m3
-    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --mem-fraction-static 0.9
+    --model-loader-extra-config '{"enable_multithread_load": true}'
     --max-running-requests "$MAX_RUNNING_REQUESTS"
-    --max-prefill-tokens 32768
-    --chunked-prefill-size 32768
-    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
     --stream-interval 50
+    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
     "${TOKENIZER_ARGS[@]}"
     --tokenizer-path "$MODEL"
-    --reasoning-parser qwen3
-    --tool-call-parser qwen3_coder
     --enable-metrics
     --enable-cache-report
     "${CACHE_ARGS[@]}"

--- a/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
+++ b/benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# AgentX trace replay for Qwen3.5-397B-A17B MXFP4 on MI355X with SGLang
+# native EAGLE MTP. Throughput uses the committed golden synthetic
+# acceptance length; evaluation retains real target-model verification.
+
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+export EVAL_FRAMEWORK="lm-eval"
+
+check_env_vars \
+    MODEL TP CONC EP_SIZE KV_OFFLOADING \
+    TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+
+SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-30}
+
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
+fi
+
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+rocm-smi || true
+amd-smi || true
+
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126_256k
+resolve_trace_source
+install_agentic_deps
+
+export AIPERF_SERVER_METRICS_URLS="http://localhost:${PORT}/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="sglang:"
+
+SERVER_LOG="$RESULT_DIR/server.log"
+mkdir -p "$RESULT_DIR"
+
+SERVER_PID=""
+cleanup_agentic_services() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    set +e
+    stop_background_process_tree "$SERVER_PID" "SGLang server" 60
+    exit "$exit_code"
+}
+trap cleanup_agentic_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+CACHE_ARGS=()
+if require_agentic_kv_offload_backend hicache; then
+    HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
+    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through}"
+    HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-direct}"
+    HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
+    echo "HiCache CPU tier: ratio=$HICACHE_RATIO, write_policy=$HICACHE_WRITE_POLICY, io_backend=$HICACHE_IO_BACKEND, mem_layout=$HICACHE_MEM_LAYOUT, dram_budget=${TOTAL_CPU_DRAM_GB} GB, tp=$TP"
+    CACHE_ARGS=(
+        --enable-hierarchical-cache
+        --hicache-ratio "$HICACHE_RATIO"
+        --hicache-write-policy "$HICACHE_WRITE_POLICY"
+        --hicache-io-backend "$HICACHE_IO_BACKEND"
+        --hicache-mem-layout "$HICACHE_MEM_LAYOUT"
+    )
+fi
+
+PARALLEL_ARGS=(
+    --tp "$TP"
+    --dp 1
+    --ep-size "$EP_SIZE"
+)
+
+TOKENIZER_ARGS=()
+if [ "$TP" -ge 4 ]; then
+    TOKENIZER_ARGS=(--tokenizer-worker-num 6)
+fi
+
+MAX_RUNNING_REQUESTS=$((2 * CONC))
+CUDA_GRAPH_MAX_BS="$CONC"
+[ "$CUDA_GRAPH_MAX_BS" -gt 64 ] && CUDA_GRAPH_MAX_BS=64
+
+export PYTHONNOUSERSITE=1
+export SGLANG_USE_AITER=1
+export SGLANG_USE_AITER_UNIFIED_ATTN=1
+export AITER_FLYDSL_FORCE=1
+export SGLANG_MAMBA_SSM_DTYPE=bfloat16
+export SGLANG_TIMEOUT_KEEP_ALIVE=1800
+
+
+SGLANG_CMD=(
+    python3 -m sglang.launch_server
+    --model-path "$MODEL_PATH"
+    --served-model-name "$MODEL"
+    --host 0.0.0.0
+    --port "$PORT"
+    --trust-remote-code
+    "${PARALLEL_ARGS[@]}"
+    --attention-backend aiter
+    --mem-fraction-static 0.80
+    --model-loader-extra-config '{"enable_multithread_load": true}'
+    --watchdog-timeout 1200
+    --page-size 16
+    --kv-cache-dtype fp8_e4m3
+    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --max-running-requests "$MAX_RUNNING_REQUESTS"
+    --max-prefill-tokens 32768
+    --chunked-prefill-size 32768
+    --scheduler-recv-interval "$SCHEDULER_RECV_INTERVAL"
+    --stream-interval 50
+    "${TOKENIZER_ARGS[@]}"
+    --tokenizer-path "$MODEL"
+    --reasoning-parser qwen3
+    --tool-call-parser qwen3_coder
+    --enable-metrics
+    --enable-cache-report
+    "${CACHE_ARGS[@]}"
+)
+
+printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/sglang_command.txt"
+"${SGLANG_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [ "${EVAL_ONLY:-false}" = "true" ]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    REPLAY_CMD+=" --apply-chat-template"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -377,6 +377,24 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 64] }
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [20, 24, 28, 32] }
 
+
+# Qwen3.8-Flash-Next FP8 AgentX on MI355X via SGLang, without speculative
+# decoding: the MI355X SGLang path for this model does not drive MTP yet, so
+# this arm runs the target model alone and carries no synthetic-acceptance pin.
+# FP8 because there is no AMD FP4 checkpoint for this model yet.
+qwen3.8next-fp8-mi355x-sglang-agentic:
+  image: lmsysorg/sglang-rocm:qwen38flashnext
+  model: Qwen/Qwen3.8-Flash-Next-FP8
+  model-prefix: qwen3.8next
+  runner: cluster:mi355x-amds
+  precision: fp8
+  framework: sglang
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.8
+      search-space:
+      - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
 qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: amd/Qwen3.5-397B-A17B-MXFP4

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -381,16 +381,17 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
 # Qwen3.8-Flash-Next FP8 AgentX on MI355X via SGLang, without speculative
 # decoding: the MI355X SGLang path for this model does not drive MTP yet, so
 # this arm runs the target model alone and carries no synthetic-acceptance pin.
-# BF16 at TP8. NVFP4 is greyed out for MI355X and there is no AMD FP4
-# checkpoint; FP8 does not load on this image either, because its model code
-# asserts a 1.0 weight_scale on the PLE ngram embedding that the FP8 checkpoint
-# genuinely quantizes. BF16 has no scales at all. Revert to FP8 once fixed.
-qwen3.8next-bf16-mi355x-sglang-agentic:
+# FP8 at TP8 per the cookbook's verified balanced single-node command; NVFP4
+# is greyed out for MI355X and there is no AMD FP4 checkpoint for this model.
+# Blocked upstream: the current ROCm image asserts a 1.0 weight_scale on the
+# PLE ngram embedding that this checkpoint genuinely quantizes to F8_E4M3.
+# See the script header; suppressing the assert would corrupt the embedding.
+qwen3.8next-fp8-mi355x-sglang-agentic:
   image: lmsysorg/sglang-rocm:qwen38flashnext
-  model: Qwen/Qwen3.8-Flash-Next
+  model: Qwen/Qwen3.8-Flash-Next-FP8
   model-prefix: qwen3.8next
   runner: cluster:mi355x-amds
-  precision: bf16
+  precision: fp8
   framework: sglang
   multinode: false
   scenarios:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -381,14 +381,16 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
 # Qwen3.8-Flash-Next FP8 AgentX on MI355X via SGLang, without speculative
 # decoding: the MI355X SGLang path for this model does not drive MTP yet, so
 # this arm runs the target model alone and carries no synthetic-acceptance pin.
-# FP8 at TP8 per the cookbook's verified balanced single-node command; NVFP4
-# is greyed out for MI355X and there is no AMD FP4 checkpoint for this model.
-qwen3.8next-fp8-mi355x-sglang-agentic:
+# BF16 at TP8. NVFP4 is greyed out for MI355X and there is no AMD FP4
+# checkpoint; FP8 does not load on this image either, because its model code
+# asserts a 1.0 weight_scale on the PLE ngram embedding that the FP8 checkpoint
+# genuinely quantizes. BF16 has no scales at all. Revert to FP8 once fixed.
+qwen3.8next-bf16-mi355x-sglang-agentic:
   image: lmsysorg/sglang-rocm:qwen38flashnext
-  model: Qwen/Qwen3.8-Flash-Next-FP8
+  model: Qwen/Qwen3.8-Flash-Next
   model-prefix: qwen3.8next
   runner: cluster:mi355x-amds
-  precision: fp8
+  precision: bf16
   framework: sglang
   multinode: false
   scenarios:

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -381,7 +381,8 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
 # Qwen3.8-Flash-Next FP8 AgentX on MI355X via SGLang, without speculative
 # decoding: the MI355X SGLang path for this model does not drive MTP yet, so
 # this arm runs the target model alone and carries no synthetic-acceptance pin.
-# FP8 because there is no AMD FP4 checkpoint for this model yet.
+# FP8 at TP8 per the cookbook's verified balanced single-node command; NVFP4
+# is greyed out for MI355X and there is no AMD FP4 checkpoint for this model.
 qwen3.8next-fp8-mi355x-sglang-agentic:
   image: lmsysorg/sglang-rocm:qwen38flashnext
   model: Qwen/Qwen3.8-Flash-Next-FP8
@@ -394,7 +395,7 @@ qwen3.8next-fp8-mi355x-sglang-agentic:
     agentic-coding:
     - dram-utilization: 0.8
       search-space:
-      - { tp: 4, ep: 1, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
+      - { tp: 8, ep: 1, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
 qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523
   model: amd/Qwen3.5-397B-A17B-MXFP4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6491,13 +6491,13 @@
     - "Route only enabled recipes through the immutable producer fork and preserve non-power launcher revisions."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2688
 - config-keys:
-    - qwen3.8next-bf16-mi355x-sglang-agentic
+    - qwen3.8next-fp8-mi355x-sglang-agentic
   scenario-type:
     - agentic-coding
   description:
-    - "Add the day-zero Qwen3.8-Flash-Next BF16 AgentX recipe on MI355X with SGLang at TP8 and concurrency 1/4/8/12/16."
+    - "Add the day-zero Qwen3.8-Flash-Next FP8 AgentX recipe on MI355X with SGLang at TP8 and concurrency 1/4/8/12/16."
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
-    - "Serve the BF16 checkpoint: NVFP4 is unavailable for MI355X, no AMD FP4 checkpoint exists, and the FP8 checkpoint does not load on this image because its model code asserts a 1.0 weight scale on a PLE embedding the checkpoint genuinely quantizes."
+    - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet and NVFP4 is unavailable for MI355X."
     - "Correct the serve flags to the SGLang cookbook's verified balanced single-node command for this model: TP8 rather than TP4, page size 32, automatic KV cache dtype, chunked prefill 16384, memory fraction 0.9, and multithreaded model loading."
     - "Mount the repository away from the container path this image keeps its python packages under, so the bind mount stops hiding the SGLang and aiter trees the image puts on PYTHONPATH, and point the shared library's workspace variable at the new mount."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6499,4 +6499,5 @@
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
     - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet and NVFP4 is unavailable for MI355X."
     - "Correct the serve flags to the SGLang cookbook's verified balanced single-node command for this model: TP8 rather than TP4, page size 32, automatic KV cache dtype, chunked prefill 16384, memory fraction 0.9, and multithreaded model loading."
+    - "Mount the repository away from the container path this image keeps its python packages under, so the bind mount stops hiding the SGLang and aiter trees the image puts on PYTHONPATH."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6499,5 +6499,5 @@
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
     - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet and NVFP4 is unavailable for MI355X."
     - "Correct the serve flags to the SGLang cookbook's verified balanced single-node command for this model: TP8 rather than TP4, page size 32, automatic KV cache dtype, chunked prefill 16384, memory fraction 0.9, and multithreaded model loading."
-    - "Mount the repository away from the container path this image keeps its python packages under, so the bind mount stops hiding the SGLang and aiter trees the image puts on PYTHONPATH."
+    - "Mount the repository away from the container path this image keeps its python packages under, so the bind mount stops hiding the SGLang and aiter trees the image puts on PYTHONPATH, and point the shared library's workspace variable at the new mount."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6490,3 +6490,12 @@
     - "Required lanes promote exporter startup timeouts, launch failures, and endpoint resolution failures to blocking validation failures, so a recipe cannot publish a result whose power collection never started."
     - "Route only enabled recipes through the immutable producer fork and preserve non-power launcher revisions."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2688
+- config-keys:
+    - qwen3.8next-fp8-mi355x-sglang-agentic
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add the day-zero Qwen3.8-Flash-Next FP8 AgentX recipe on MI355X with SGLang at TP4 and concurrency 1/4/8/12/16."
+    - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
+    - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6498,4 +6498,4 @@
     - "Add the day-zero Qwen3.8-Flash-Next FP8 AgentX recipe on MI355X with SGLang at TP4 and concurrency 1/4/8/12/16."
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
     - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6497,5 +6497,6 @@
   description:
     - "Add the day-zero Qwen3.8-Flash-Next FP8 AgentX recipe on MI355X with SGLang at TP4 and concurrency 1/4/8/12/16."
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
-    - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet."
+    - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet and NVFP4 is unavailable for MI355X."
+    - "Correct the serve flags to the SGLang cookbook's verified balanced single-node command for this model: TP8 rather than TP4, page size 32, automatic KV cache dtype, chunked prefill 16384, memory fraction 0.9, and multithreaded model loading."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6491,13 +6491,13 @@
     - "Route only enabled recipes through the immutable producer fork and preserve non-power launcher revisions."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2688
 - config-keys:
-    - qwen3.8next-fp8-mi355x-sglang-agentic
+    - qwen3.8next-bf16-mi355x-sglang-agentic
   scenario-type:
     - agentic-coding
   description:
-    - "Add the day-zero Qwen3.8-Flash-Next FP8 AgentX recipe on MI355X with SGLang at TP4 and concurrency 1/4/8/12/16."
+    - "Add the day-zero Qwen3.8-Flash-Next BF16 AgentX recipe on MI355X with SGLang at TP8 and concurrency 1/4/8/12/16."
     - "Run without speculative decoding because the MI355X SGLang path for this model does not drive MTP yet, so this arm carries no synthetic-acceptance pin."
-    - "Serve the FP8 checkpoint because no AMD FP4 checkpoint exists for this model yet and NVFP4 is unavailable for MI355X."
+    - "Serve the BF16 checkpoint: NVFP4 is unavailable for MI355X, no AMD FP4 checkpoint exists, and the FP8 checkpoint does not load on this image because its model code asserts a 1.0 weight scale on a PLE embedding the checkpoint genuinely quantizes."
     - "Correct the serve flags to the SGLang cookbook's verified balanced single-node command for this model: TP8 rather than TP4, page size 32, automatic KV cache dtype, chunked prefill 16384, memory fraction 0.9, and multithreaded model loading."
     - "Mount the repository away from the container path this image keeps its python packages under, so the bind mount stops hiding the SGLang and aiter trees the image puts on PYTHONPATH, and point the shared library's workspace variable at the new mount."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2754

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -325,6 +325,11 @@ else
     if [[ "$IMAGE" == *qwen38flashnext* ]]; then
         WS_MOUNT_DIR="/inferencex"
         export RESULT_DIR="${RESULT_DIR/#\/workspace//inferencex}"
+        # benchmark_lib.sh resolves AGENTIC_DIR, AIPERF_DIR and every `cd` into
+        # the repo through this variable, which defaults to /workspace. Move it
+        # with the mount or install_agentic_deps looks for the requirements
+        # file at /workspace/utils/... inside the image and fails.
+        export INFMAX_CONTAINER_WORKSPACE="$WS_MOUNT_DIR"
         echo "Image ships packages under /workspace; mounting the repo at $WS_MOUNT_DIR (RESULT_DIR=$RESULT_DIR)"
     fi
 

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -313,12 +313,27 @@ else
         BENCHMARK_SCRIPT="$SCRIPT_FALLBACK"
     fi
 
+    # Some bring-up images ship their python packages under /workspace and put
+    # them on PYTHONPATH, e.g. the qwen38flashnext ROCm image sets
+    #   PYTHONPATH=/workspace/sglang-qwen-next/python:/workspace/aiter-pr4882
+    # and has no pip-installed sglang at all. Bind mounting the repo over
+    # /workspace masks those trees, and the server dies with
+    # "No module named 'sglang'". Mount the repo elsewhere for such images and
+    # move RESULT_DIR with it; the host side of the mount is unchanged, so the
+    # workflow's artifact staging still finds everything under GITHUB_WORKSPACE.
+    WS_MOUNT_DIR="/workspace"
+    if [[ "$IMAGE" == *qwen38flashnext* ]]; then
+        WS_MOUNT_DIR="/inferencex"
+        export RESULT_DIR="${RESULT_DIR/#\/workspace//inferencex}"
+        echo "Image ships packages under /workspace; mounting the repo at $WS_MOUNT_DIR (RESULT_DIR=$RESULT_DIR)"
+    fi
+
     srun --jobid=$JOB_ID \
         --container-image=$SQUASH_FILE \
-        --container-mounts=$GITHUB_WORKSPACE:/workspace/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$AIPERF_MMAP_CACHE_HOST_PATH:/aiperf_mmap_cache \
+        --container-mounts=$GITHUB_WORKSPACE:$WS_MOUNT_DIR/,$HF_HUB_CACHE_MOUNT:$HF_HUB_CACHE,$AIPERF_MMAP_CACHE_HOST_PATH:/aiperf_mmap_cache \
         $SLRUM_HOME_MOUNT \
         --container-writable \
-        --container-workdir=/workspace/ \
+        --container-workdir=$WS_MOUNT_DIR/ \
         --container-remap-root \
         --no-container-entrypoint --export=ALL,AIPERF_DATASET_MMAP_CACHE_DIR=/aiperf_mmap_cache \
         bash "$BENCHMARK_SCRIPT"


### PR DESCRIPTION
## Summary / 摘要

**Qwen3.8-Flash-Next AgentX recipe on MI355X, served by SGLang.** SGLang is this model's plan-of-record engine per `MODELS.md`. This is the AMD arm of the four-chip set and the only one without speculative decoding.

MI355X 上的 **Qwen3.8-Flash-Next AgentX 配方，由 SGLang 提供服务**。按 `MODELS.md`，SGLang 是该模型的 PoR 引擎。本 PR 是四芯片系列中的 AMD 分支，也是唯一不启用投机解码的一个。

## Config key / 配置项

`qwen3.8next-fp8-mi355x-sglang-agentic` — `Qwen/Qwen3.8-Flash-Next-FP8`, `lmsysorg/sglang-rocm:qwen38flashnext`, `cluster:mi355x-amds`, TP8/EP1, conc `[1, 4, 8, 12, 16]`, no KV offloading.

## Two deliberate differences from the NVIDIA arms / 与 NVIDIA 分支的两点差异

- **No speculative decoding.** The MI355X SGLang path for this model does not drive MTP yet, so this arm runs the target model alone. The key therefore has no `-mtp` suffix, the search space carries no `spec-decoding`, and the script has **no** `--speculative-*` flags and **no** `SGLANG_SIMULATE_ACC_*` pin — it is the one Qwen3.8-Flash-Next AgentX arm without a synthetic-acceptance target. Add MTP and the golden AL once the ROCm path supports it. Note this makes the arm not directly comparable to the spec-decode NVIDIA arms on the published frontier.
- **FP8, not FP4.** NVFP4 is greyed out for MI355X in the cookbook and there is no AMD FP4 checkpoint for this model.

## ⚠️ Blocked upstream / 上游阻塞

**This arm cannot pass on the current ROCm image.** The server aborts in `load_weights`:

```
AssertionError: Expected 1.0, got 0.00019931793212890625 in skipped
model.layers.1.ple.ple_embedding.ngram_embedding.weight_scale
  qwen4_exp.py:2039 in load_weights
```

The model registers no parameter for the PLE ngram embedding, so the loader takes its "skipped" branch, which assumes any orphaned `_scale` is a no-op and asserts it is 1.0. Reading the checkpoint directly says otherwise: that embedding is **128 `shard_N.weight` tensors of dtype `F8_E4M3`** with one BF16 `weight_scale` of ≈1.99e-4, and `modules_to_not_convert` lists `ple.conv1d`, `ple.key_proj`, `ple.value_proj` — **not** the ngram embedding. The tensor really is quantized; the model just cannot consume it yet.

**Suppressing the assert is not a fix.** The shards would load as raw FP8 with the scale never applied, leaving that embedding wrong by ~5000× with no error reported. That is silent corruption, so it is deliberately not done.

The CUDA image carries a different SGLang build and loads the same checkpoint fine, so this is specific to the ROCm build, and `lmsysorg/sglang-rocm:qwen38flashnext` has not been rebuilt since 2026-08-26. Everything else here is the cookbook's verified balanced command; **this PR is ready to pass the moment a fixed ROCm image ships**, with no further recipe change.

**本分支在当前 ROCm 镜像上无法通过。** 模型未为 PLE ngram embedding 注册参数，加载器走「skipped」分支并断言 `_scale` 为 1.0；而权重中该 embedding 实为 128 个 `F8_E4M3` 的 `shard_N.weight` 加一个 ≈1.99e-4 的 BF16 `weight_scale`，`modules_to_not_convert` 并未包含它。屏蔽该断言不是修复：分片会以原始 FP8 加载且从不施加 scale，使该 embedding 偏差约 5000 倍且不报错，属静默数值破坏，故刻意不做。CUDA 镜像使用另一套 SGLang 构建可正常加载，问题仅限 ROCm 构建，该标签自 2026-08-26 未重建。其余部分即 cookbook 验证命令，**待修复镜像发布后本 PR 无需再改即可通过**。

- **不启用投机解码**：MI355X 上该模型的 SGLang 路径尚不支持 MTP，故仅运行目标模型。配置项因此不带 `-mtp` 后缀，搜索空间不含 `spec-decoding`，脚本中**没有** `--speculative-*` 参数，也**没有** `SGLANG_SIMULATE_ACC_*` 锁定——这是 Qwen3.8-Flash-Next 各 AgentX 分支中唯一没有合成接受目标的一个。待 ROCm 路径支持后再补上 MTP 与黄金 AL。需注意，这使该分支在已发布前沿上与启用投机解码的 NVIDIA 分支不具备直接可比性。
- **使用 FP8 而非 FP4**：该模型目前没有 AMD FP4 权重，故使用 `Qwen/Qwen3.8-Flash-Next-FP8`（172.8 GiB）。Qwen3.5 的 MI355X 同类配方使用 `amd/Qwen3.5-397B-A17B-MXFP4`，此处无对应权重。

## Recipe decisions / 配方要点

- **TP4/EP1.** 172.8 GiB is about 43 GiB per rank on MI355X's 288 GB, leaving ample room for the 256k-capped agentic traces.
- **Image.** `lmsysorg/sglang-rocm:qwen38flashnext`, the ROCm model bring-up tag published 2026-08-26 (verified on Docker Hub).
- **Serve flags** are carried from `qwen3.5_fp4_mi355x_sglang_mtp.sh` minus the speculative block: `aiter` attention backend, `SGLANG_USE_AITER`/`SGLANG_USE_AITER_UNIFIED_ATTN`/`AITER_FLYDSL_FORCE`, page size 16, `fp8_e4m3` KV cache, bf16 Mamba SSM, 32768 prefill/chunked-prefill.
- No launcher change needed: `runners/launch_mi355x-amds.sh` resolves `agentic/<prefix>_<precision>_mi355x_<framework>.sh` with an empty spec suffix when `SPEC_DECODING` is not `mtp` — verified against the generated matrix (`exp-name qwen3.8next_tp4_conc1_kvnone`, `spec-decoding: none`).

- **TP4/EP1**：MI355X 288 GB 下每卡权重约 43 GiB，为 256k 上限的智能体轨迹留出充足显存。
- **镜像**：`lmsysorg/sglang-rocm:qwen38flashnext`（2026-08-26 发布的 ROCm 模型适配标签，已核实）。
- **服务参数**沿用 `qwen3.5_fp4_mi355x_sglang_mtp.sh` 并去掉投机解码部分。
- 无需改动 launcher：`SPEC_DECODING` 非 `mtp` 时后缀为空，已按生成矩阵核实脚本名可解析。

## Files / 改动文件

- `benchmarks/single_node/agentic/qwen3.8next_fp8_mi355x_sglang.sh` (new)
- `configs/amd-master.yaml` — new entry after the Qwen3.5 MI355X SGLang sibling
- `perf-changelog.yaml` — appended entry

Part of a four-PR set, one per chip: B200 (#2751), B300 (#2752), H200 (#2753), MI355X (this).

本 PR 属于按芯片划分的四个 PR 之一：B200（#2751）、B300（#2752）、H200（#2753）、MI355X（本 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark scripts, AMD config, changelog, and a container mount workaround for one bring-up image; no auth, data, or serving core logic changes.
> 
> **Overview**
> Adds the **day-zero AgentX** recipe for **Qwen3.8-Flash-Next FP8** on **MI355X** using **SGLang** (`qwen3.8next-fp8-mi355x-sglang-agentic`): new agentic benchmark script, `amd-master.yaml` entry at **TP8/EP1** with conc **1/4/8/12/16**, no KV offloading, and a **perf-changelog** note.
> 
> Unlike the NVIDIA arms, this AMD path **omits speculative decoding** (no MTP / synthetic-acceptance pin) because the MI355X SGLang stack for this model does not drive MTP yet. It targets the **FP8** checkpoint because there is no AMD FP4 weight and NVFP4 is unavailable on MI355X. Serve flags follow the **SGLang cookbook balanced single-node** recipe (e.g. **TP8**, page size **32**, **auto** KV dtype, chunked prefill **16384**, mem fraction **0.9**, multithreaded load).
> 
> **`launch_mi355x-amds.sh`** now mounts the repo at **`/inferencex`** (not `/workspace`) for **`qwen38flashnext`** images so the bind mount does not hide the image’s **sglang/aiter** trees on `PYTHONPATH`; **`RESULT_DIR`** and **`INFMAX_CONTAINER_WORKSPACE`** move with that mount.
> 
> The script header documents an **upstream ROCm image blocker**: loading **`Qwen/Qwen3.8-Flash-Next-FP8`** can abort on a **PLE ngram embedding `weight_scale`** assert until the image correctly loads that quantized tensor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b02f48a1e9f73abe7153ebf4f3f7ddbb6b72be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


