### PR TITLE
CollectiveX: name Slurm allocations after the GHA runner (dash correlation)

### DIFF
--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -424,10 +424,24 @@ exec python3 bench/run_ep.py "$@"
 BASH
 }
 
+# Slurm job name for dashboard correlation. inferencex-dash's cluster collector
+# samples allocation names (sacct JobName) and the dashboard joins them against
+# the GHA job's runner_name — the production runners' convention
+# (--job-name="$RUNNER_NAME"). Fall back to a fixed label for hand-driven runs;
+# reject anything that is not a plain Slurm-safe token rather than quoting it.
+collx_slurm_job_name() {
+  local name="${RUNNER_NAME:-}"
+  [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || name="collectivex"
+  printf '%s' "$name"
+}
+
 # Allocate via salloc's stable grant message and assign JOB_ID in this shell.
 # Record it so workflow cleanup can release a launcher interrupted by Actions.
+# The job name is prepended so a caller-supplied --job-name still wins (salloc
+# takes the last occurrence).
 collx_salloc_jobid() {
   local log_label=scheduler-allocation log job_id root="${COLLX_JOB_ROOT:-}"
+  set -- --job-name="$(collx_slurm_job_name)" "$@"
   case "${COLLX_SALLOC_ATTEMPT:-1}" in
     1) ;;
     2|3) log_label+="-a${COLLX_SALLOC_ATTEMPT}" ;;

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -145,7 +145,6 @@ class ConfigTests(unittest.TestCase):
         self.assertIn(b"COLLX_SQUASH_DIR\0/home/sa-shared/containers\0", payload)
         self.assertIn(b"COLLX_RDMA_DEVICES\0", payload)
 
-
 class StageTests(unittest.TestCase):
     def test_create_copy_and_validate_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -145,33 +145,6 @@ class ConfigTests(unittest.TestCase):
         self.assertIn(b"COLLX_SQUASH_DIR\0/home/sa-shared/containers\0", payload)
         self.assertIn(b"COLLX_RDMA_DEVICES\0", payload)
 
-class SlurmJobNameTests(unittest.TestCase):
-    # inferencex-dash correlates cluster allocations with GHA jobs by Slurm job
-    # name == the runner_name (the production runners' --job-name="$RUNNER_NAME"
-    # convention), so collx_salloc_jobid must submit under that name and fall
-    # back to a fixed label rather than an unset or unsafe one.
-    @staticmethod
-    def _job_name(env_pairs: str) -> str:
-        completed = subprocess.run(
-            ["bash", "-c",
-             f"source runtime/common.sh 2>/dev/null; {env_pairs} collx_slurm_job_name"],
-            cwd=RUNTIME.parent, capture_output=True, text=True, check=True,
-        )
-        return completed.stdout
-
-    def test_runner_name_becomes_the_job_name(self) -> None:
-        self.assertEqual(self._job_name("RUNNER_NAME=mi355x-amds_03"), "mi355x-amds_03")
-
-    def test_unset_runner_name_falls_back(self) -> None:
-        self.assertEqual(self._job_name("RUNNER_NAME="), "collectivex")
-
-    def test_unsafe_runner_name_falls_back(self) -> None:
-        self.assertEqual(self._job_name("RUNNER_NAME='bad name;rm'"), "collectivex")
-
-    def test_salloc_submits_under_the_job_name(self) -> None:
-        common = (RUNTIME / "common.sh").read_text()
-        self.assertIn('set -- --job-name="$(collx_slurm_job_name)" "$@"', common)
-
 
 class StageTests(unittest.TestCase):
     def test_create_copy_and_validate_cleanup(self) -> None:

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -145,6 +145,34 @@ class ConfigTests(unittest.TestCase):
         self.assertIn(b"COLLX_SQUASH_DIR\0/home/sa-shared/containers\0", payload)
         self.assertIn(b"COLLX_RDMA_DEVICES\0", payload)
 
+class SlurmJobNameTests(unittest.TestCase):
+    # inferencex-dash correlates cluster allocations with GHA jobs by Slurm job
+    # name == the runner_name (the production runners' --job-name="$RUNNER_NAME"
+    # convention), so collx_salloc_jobid must submit under that name and fall
+    # back to a fixed label rather than an unset or unsafe one.
+    @staticmethod
+    def _job_name(env_pairs: str) -> str:
+        completed = subprocess.run(
+            ["bash", "-c",
+             f"source runtime/common.sh 2>/dev/null; {env_pairs} collx_slurm_job_name"],
+            cwd=RUNTIME.parent, capture_output=True, text=True, check=True,
+        )
+        return completed.stdout
+
+    def test_runner_name_becomes_the_job_name(self) -> None:
+        self.assertEqual(self._job_name("RUNNER_NAME=mi355x-amds_03"), "mi355x-amds_03")
+
+    def test_unset_runner_name_falls_back(self) -> None:
+        self.assertEqual(self._job_name("RUNNER_NAME="), "collectivex")
+
+    def test_unsafe_runner_name_falls_back(self) -> None:
+        self.assertEqual(self._job_name("RUNNER_NAME='bad name;rm'"), "collectivex")
+
+    def test_salloc_submits_under_the_job_name(self) -> None:
+        common = (RUNTIME / "common.sh").read_text()
+        self.assertIn('set -- --job-name="$(collx_slurm_job_name)" "$@"', common)
+
+
 class StageTests(unittest.TestCase):
     def test_create_copy_and_validate_cleanup(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
CollectiveX `salloc` calls carried no `--job-name`, so its allocations never correlated with GHA jobs on inferencex-dash (the cluster collector samples `sacct JobName`; the dashboard joins it against `ci_jobs.runner_name` — the `--job-name="$RUNNER_NAME"` convention every production runner launcher already follows).

One seam: `collx_salloc_jobid` now prepends `--job-name="$(collx_slurm_job_name)"` (caller-supplied `--job-name` would still win since salloc takes the last occurrence). `collx_slurm_job_name` uses `RUNNER_NAME` when it is a plain Slurm-safe token, else falls back to `collectivex` (hand-driven runs, unsafe names). Covers all three Slurm launchers (single-slurm, gb-nv, mi-amds); mi-tw is Docker and out of scope. Seam-tested in test_runtime.py.

Validation: sweep run on this branch — see checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduler labeling and input sanitization only; allocation behavior is unchanged aside from the job name passed to `salloc`.
> 
> **Overview**
> **Slurm allocations from CollectiveX now get a `--job-name` that matches the GitHub Actions runner**, so inferencex-dash can join `sacct` JobName with `ci_jobs.runner_name` (same convention as production runner launchers).
> 
> Adds `collx_slurm_job_name`, which uses `RUNNER_NAME` when it passes a Slurm-safe token regex and otherwise falls back to `collectivex`. **`collx_salloc_jobid` prepends** `--job-name="$(collx_slurm_job_name)"` before other `salloc` args so an explicit caller `--job-name` still wins (last flag wins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27f05f6e54e40429b30d0309f7fad91947a666e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->