### PR TITLE
Document required node count labels for scheduled jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Guidance for AI agents working with InferenceX.
 
 ## Non-negotiable benchmark invariants
 
+- Every priority-scheduled benchmark job on a self-hosted cluster must request exactly one `nodes:N` label, where `N` is the positive integer number of physical Slurm nodes required. Single-node jobs use `nodes:1`; generated multi-node jobs must forward their computed `node-count`. A queued job missing this label is ineligible for priority scheduling, and labels cannot be added retroactively, so fix the source branch and dispatch a new run.
 - Every change that can affect benchmark performance and every recipe addition or modification requires a new `perf-changelog.yaml` entry. The file is append-only and byte-sensitive. Preserve all existing bytes and separator whitespace, and append only at the tail.
 - Multi-node srt-slurm changes update the recipe YAML and matching master config together. For image bumps, `model.container` must equal `image`.
 - Every `*_mtp.sh` passes `--use-chat-template` to `run_benchmark_serving`.


### PR DESCRIPTION
## Summary

- require every priority-scheduled self-hosted benchmark job to request exactly one `nodes:N` label
- document `nodes:1` for single-node jobs and forwarding generated `node-count` for multi-node jobs
- clarify that malformed queued jobs must be fixed and redispatched because labels cannot be added retroactively

## Verification

- `git diff --check`
- documentation-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy in AGENTS.md; no workflow or runtime behavior changes.
> 
> **Overview**
> Adds a **non-negotiable benchmark invariant** to `AGENTS.md`: priority-scheduled self-hosted cluster jobs must carry exactly one `nodes:N` label (`nodes:1` for single-node; multi-node flows must pass the computed `node-count`).
> 
> The new bullet also states that jobs queued without the label cannot get priority scheduling and **labels cannot be patched after enqueue**, so fixes require updating the source branch and dispatching a new run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e82f0b63fd23ff3cde65b33dbd6f67922f515e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->