### PR TITLE
[PowerX] collect AMD power across 8k1k worker pools / 采集 AMD 各工作进程组的 8k1k 功耗

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -499,6 +499,7 @@ jobs:
             agg_${{ env.RESULT_FILENAME }}_*.json
             power_validation_${{ env.RESULT_FILENAME }}_*.json
             LOGS/power/**
+            LOGS/native_power/**
             result_processing_${{ env.RESULT_FILENAME }}.json
             slurm_job_*_outcome.txt
             LOGS/*/results_*.json

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -153,8 +153,12 @@ unset _benchmark_caller
 # --------------------------------
 
 GPU_MONITOR_PID=""
+GPU_MONITOR_SOURCE_PID=""
+GPU_MONITOR_PIPE=""
 GPU_MONITOR_VENDOR=""
 GPU_MONITOR_INTERVAL=1
+# Bounded wait for AMD telemetry to cover a stop request; 0 skips the wait.
+AMD_MONITOR_STOP_TIMEOUT_S="${AMD_MONITOR_STOP_TIMEOUT_S:-30}"
 GPU_METRICS_CSV="${GPU_METRICS_CSV:-gpu_metrics.csv}"
 NVIDIA_GPU_MONITOR_QUERY="timestamp,index,power.draw,temperature.gpu,clocks.current.sm,clocks.current.memory,utilization.gpu,utilization.memory"
 export GPU_METRICS_CSV
@@ -177,6 +181,7 @@ start_gpu_monitor() {
     GPU_METRICS_CSV="$output"
     GPU_MONITOR_INTERVAL="$interval"
     export GPU_METRICS_CSV
+    printf '{"timestamp_timezone":"UTC"}\n' > "${output%.csv}_context.json"
 
     if command -v nvidia-smi &>/dev/null; then
         GPU_MONITOR_VENDOR="nvidia"
@@ -185,7 +190,7 @@ start_gpu_monitor() {
             rm -f "${output%.csv}_identity.csv"
             echo "[GPU Monitor] Warning: NVIDIA identity sidecar failed" >&2
         fi
-        nvidia-smi --query-gpu="$NVIDIA_GPU_MONITOR_QUERY" \
+        TZ=UTC nvidia-smi --query-gpu="$NVIDIA_GPU_MONITOR_QUERY" \
             --format=csv -l "$interval" > "$output" 2>/dev/null &
         GPU_MONITOR_PID=$!
         echo "[GPU Monitor] Started NVIDIA (PID=$GPU_MONITOR_PID, interval=${interval}s, output=$output)"
@@ -196,8 +201,15 @@ start_gpu_monitor() {
         # Python; measured on MI355X: trailing ticks were lost at kill without it).
         # Pipe through awk to: skip preamble lines, keep first CSV header, skip repeated
         # headers, and flush every row so killing the pipe cannot discard buffered samples.
-        PYTHONUNBUFFERED=1 amd-smi metric -p -c -t -u -w "$interval" --csv 2>/dev/null \
-            | awk '/^timestamp,/{if(!h){print;h=1};next} h{print;fflush()}' > "$output" &
+        # Track both processes: killing only awk can leave amd-smi alive until
+        # its next write. Keep the FIFO beside this run's raw CSV, never shared.
+        GPU_MONITOR_PIPE="${output}.pipe.$$"
+        mkfifo "$GPU_MONITOR_PIPE" || return 1
+        PYTHONUNBUFFERED=1 TZ=UTC amd-smi metric -p -c -t -u -w "$interval" --csv \
+            > "$GPU_MONITOR_PIPE" 2>/dev/null &
+        GPU_MONITOR_SOURCE_PID=$!
+        awk '/^timestamp,/{if(!h){print;h=1};next} h{print;fflush()}' \
+            < "$GPU_MONITOR_PIPE" > "$output" &
         GPU_MONITOR_PID=$!
         # Hardware energy-accumulator + identity snapshots; the end-side twin in
         # stop_gpu_monitor lets auditors cross-check the integrated energy
@@ -215,24 +227,26 @@ start_gpu_monitor() {
 # Stop the background GPU monitor and report file size.
 stop_gpu_monitor() {
     if [[ -n "$GPU_MONITOR_PID" ]] && kill -0 "$GPU_MONITOR_PID" 2>/dev/null; then
-        # benchmark_end_time_unix is recorded shortly before the benchmark
-        # process exits, so the stream must cover one more sample past it for
-        # deterministic boundary interpolation. NVIDIA appends a one-shot
-        # post-exit sample below; amd-smi one-shot CSV has no timestamp column,
-        # so the AMD path instead lets the watch stream emit final ticks before
-        # the kill. Two extra intervals: amd-smi stamps integer seconds, so a
-        # tick in the same second as the window end still fails bracketing —
-        # the stream needs a tick at the NEXT whole second (measured on MI355X:
-        # end=...153.325 vs last sample ...153.0).
+        # The aggregator requires, for every GPU, a usable sample stamped at or
+        # after the (fractional) benchmark window end, which is always <= the
+        # wall clock when this stop runs. NVIDIA appends a one-shot post-exit
+        # sample below; amd-smi one-shot CSV has no timestamp column, so the
+        # AMD path polls the output file until every GPU's watch stream shows
+        # a usable tick at the next whole second — amd-smi stamps integer
+        # seconds, so that tick strictly covers any fractional window end
+        # (measured on MI355X: end=...609.157 vs last sample ...605). Observing
+        # the file rather than sleeping also defeats pipe-buffer loss when the
+        # awk consumer is killed: covered rows are already on disk.
         if [[ "$GPU_MONITOR_VENDOR" == "amd" ]]; then
-            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
+            _wait_for_amd_stop_coverage
         fi
-        kill "$GPU_MONITOR_PID" 2>/dev/null
+        # The monitor may exit during the coverage wait; still finish cleanup.
+        kill "$GPU_MONITOR_PID" 2>/dev/null || true
         wait "$GPU_MONITOR_PID" 2>/dev/null || true
         case "$GPU_MONITOR_VENDOR" in
             nvidia)
                 if _repair_truncated_gpu_metrics_tail; then
-                    nvidia-smi --query-gpu="$NVIDIA_GPU_MONITOR_QUERY" \
+                    TZ=UTC nvidia-smi --query-gpu="$NVIDIA_GPU_MONITOR_QUERY" \
                         --format=csv,noheader >> "$GPU_METRICS_CSV" 2>/dev/null ||
                         echo "[GPU Monitor] Warning: final NVIDIA sample failed" >&2
                 fi
@@ -249,6 +263,13 @@ stop_gpu_monitor() {
             echo "[GPU Monitor] Collected $lines rows -> $GPU_METRICS_CSV"
         fi
     fi
+    if [[ -n "$GPU_MONITOR_SOURCE_PID" ]]; then
+        kill "$GPU_MONITOR_SOURCE_PID" 2>/dev/null || true
+        wait "$GPU_MONITOR_SOURCE_PID" 2>/dev/null || true
+    fi
+    [[ -z "$GPU_MONITOR_PIPE" ]] || rm -f "$GPU_MONITOR_PIPE"
+    GPU_MONITOR_SOURCE_PID=""
+    GPU_MONITOR_PIPE=""
     GPU_MONITOR_PID=""
     GPU_MONITOR_VENDOR=""
 }
@@ -269,6 +290,109 @@ _repair_truncated_gpu_metrics_tail() {
         fi
     fi
     return 0
+}
+
+# Print the newest telemetry tick (whole epoch seconds) that EVERY observed
+# GPU has covered with a usable sample (numeric epoch timestamp, numeric
+# power > 0), or nothing when the stream holds no usable epoch-stamped row
+# (e.g. an amd-smi build emitting ISO timestamps). Column detection mirrors
+# _POWER_COL_RE/_POWER_EXCLUDE_RE/_GPU_INDEX_COL_RE in utils/aggregate_power.py.
+# POSIX awk only: the ROCm container images ship mawk/busybox awk.
+_amd_monitor_min_covered_tick() {
+    [[ -f "$GPU_METRICS_CSV" ]] || return 0
+    awk -F, '
+        NR == 1 {
+            for (i = 1; i <= NF; i++) {
+                name = tolower($i)
+                gsub(/^ +| +$/, "", name)
+                sub(/\r$/, "", name)
+                if (!power_col && name ~ /power/ && name !~ /limit|cap|max|min/)
+                    power_col = i
+                if (!gpu_col && name ~ /^(index|gpu|gpu_id|gpu_index|card|device)$/)
+                    gpu_col = i
+            }
+            next
+        }
+        !power_col || !gpu_col { next }
+        {
+            # amd-smi quotes list-valued cells that embed commas; neutralize
+            # them so the power cell keeps its header-relative position.
+            line = $0
+            sub(/\r$/, "", line)
+            if (line ~ /"/) {
+                n = split(line, seg, /"/)
+                line = ""
+                for (i = 1; i <= n; i++) {
+                    if (i % 2 == 0) gsub(/,/, ";", seg[i])
+                    line = line seg[i]
+                }
+            }
+            count = split(line, cell, /,/)
+            if (count < power_col || count < gpu_col) next
+            if (cell[1] !~ /^[0-9]+(\.[0-9]+)?$/) next
+            if (cell[power_col] !~ /^[0-9]+(\.[0-9]+)?$/) next
+            if (cell[power_col] + 0 <= 0) next
+            if (cell[gpu_col] == "") next
+            ts = cell[1] + 0
+            # Mirror _parse_timestamp in utils/aggregate_power.py: normalize
+            # millisecond epochs so a ms-stamping amd-smi build cannot
+            # trivially satisfy any second-scale stop target.
+            if (ts > 1e12) ts /= 1000
+            gpu = cell[gpu_col]
+            if (!(gpu in newest) || ts > newest[gpu])
+                newest[gpu] = ts
+        }
+        END {
+            have = 0
+            for (gpu in newest)
+                if (!have || newest[gpu] < min) { min = newest[gpu]; have = 1 }
+            if (have) printf "%d\n", min
+        }
+    ' "$GPU_METRICS_CSV" 2>/dev/null
+    return 0
+}
+
+# Block until every observed GPU has a usable tick at/after the first whole
+# second past stop entry, so any window end preceding the stop request is
+# bracketed on file. Bounded by AMD_MONITOR_STOP_TIMEOUT_S; always returns 0 —
+# on timeout or early monitor death it warns and lets aggregation attribute
+# the missing coverage (fail-safe, never fail-silent).
+_wait_for_amd_stop_coverage() {
+    local target deadline covered timeout_s
+    # A non-integer timeout (e.g. "30s") would abort the whole stop_gpu_monitor
+    # call under `set -e` at the arithmetic below, leaking the monitor process
+    # and skipping tail repair + the energy sidecar; fall back to the default.
+    timeout_s="${AMD_MONITOR_STOP_TIMEOUT_S:-30}"
+    if [[ ! "$timeout_s" =~ ^-?[0-9]+$ ]]; then
+        echo "[GPU Monitor] Warning: ignoring non-integer AMD_MONITOR_STOP_TIMEOUT_S='$timeout_s', using 30" >&2
+        timeout_s=30
+    fi
+    if [[ "$timeout_s" -le 0 ]]; then
+        return 0
+    fi
+    target=$(( $(date +%s) + 1 ))
+    deadline=$(( target + timeout_s ))
+    while :; do
+        covered=$(_amd_monitor_min_covered_tick)
+        if [[ -z "$covered" ]]; then
+            # Non-epoch timestamps or an unusable stream: keep the legacy
+            # fixed tail so older amd-smi builds behave exactly as before.
+            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
+            return 0
+        fi
+        if [[ "$covered" -ge "$target" ]]; then
+            return 0
+        fi
+        if ! _background_process_is_running "$GPU_MONITOR_PID"; then
+            echo "[GPU Monitor] Warning: AMD monitor exited before covering the stop request (covered=$covered target=$target)" >&2
+            return 0
+        fi
+        if [[ "$(date +%s)" -ge "$deadline" ]]; then
+            echo "[GPU Monitor] Warning: AMD telemetry never covered the stop request within ${timeout_s}s (covered=$covered target=$target)" >&2
+            return 0
+        fi
+        sleep 1
+    done
 }
 
 # Write one best-effort amd-smi snapshot; remove the file rather than keep a
@@ -3283,9 +3407,15 @@ run_agentic_replay_and_write_outputs() (
     esac
 
     _stop_agentx_power_monitor() {
+        local mode="${1:-}"
         if [ "$agentx_monitor_stopped" = "0" ]; then
-            agentx_monitor_stopped=1
+            if [ "$mode" = "abort" ]; then
+                # A cancelled run's power validity is moot; skip the AMD
+                # coverage wait so signal teardown stays fast.
+                AMD_MONITOR_STOP_TIMEOUT_S=0
+            fi
             stop_gpu_monitor
+            agentx_monitor_stopped=1
         fi
     }
 
@@ -3329,10 +3459,11 @@ run_agentic_replay_and_write_outputs() (
         agentx_monitor_stopped=0
         # This function runs in a subshell, so these handlers cannot replace
         # launcher-owned traps. The stopped flag keeps explicit and signal/EXIT
-        # cleanup idempotent.
-        trap '_stop_agentx_power_monitor' EXIT
-        trap '_stop_agentx_power_monitor; exit 130' INT
-        trap '_stop_agentx_power_monitor; exit 143' TERM
+        # cleanup idempotent after stopping completes. If a signal interrupts
+        # the normal coverage wait, abort cleanup must still kill the monitor.
+        trap '_stop_agentx_power_monitor abort' EXIT
+        trap '_stop_agentx_power_monitor abort; exit 130' INT
+        trap '_stop_agentx_power_monitor abort; exit 143' TERM
     fi
 
     echo "$REPLAY_CMD" > "$result_dir/benchmark_command.txt"

--- a/benchmarks/multi_node/amd_utils/bench.sh
+++ b/benchmarks/multi_node/amd_utils/bench.sh
@@ -52,6 +52,9 @@ profile_folder="${log_path}/${ENGINE}_isl_${chosen_isl}_osl_${chosen_osl}"
 mkdir -p "$profile_folder"
 
 source "$(dirname "$0")/../../benchmark_lib.sh"
+source "$(dirname "$0")/power.sh"
+wait_amd_multinode_power ready || exit 1
+benchmark_exit_code=0
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
@@ -101,6 +104,7 @@ for max_concurrency in "${chosen_concurrencies[@]}"; do
         fi
     fi
 
+    point_exit_code=0
     run_benchmark_serving \
         --bench-serving-dir "$REPO_ROOT" \
         --model "$BENCH_MODEL" \
@@ -113,7 +117,8 @@ for max_concurrency in "${chosen_concurrencies[@]}"; do
         --max-concurrency "$max_concurrency" \
         --result-filename "$export_file" \
         --result-dir /workspace/ \
-        $extra_flags
+        $extra_flags || point_exit_code=$?
+    if [[ "$point_exit_code" != 0 ]]; then benchmark_exit_code=$point_exit_code; break; fi
 
     echo "-----------------------------------------"
 
@@ -123,3 +128,7 @@ for max_concurrency in "${chosen_concurrencies[@]}"; do
         sleep 10
     fi
 done
+
+# Stop every node while all prefill/decode servers are still alive.
+wait_amd_multinode_power done || benchmark_exit_code=1
+exit "$benchmark_exit_code"

--- a/benchmarks/multi_node/amd_utils/job.slurm
+++ b/benchmarks/multi_node/amd_utils/job.slurm
@@ -237,8 +237,9 @@ fi
 # Node Selection
 # =============================================================================
 
-NUM_NODES=$((xP + yD))
-echo "NUM_NODES: $NUM_NODES (xP=$xP + yD=$yD)"
+# Workers can span multiple physical nodes. Preserve the submit-time count.
+NUM_NODES="${NUM_NODES:-$(( ((PREFILL_TP_SIZE + GPUS_PER_NODE - 1) / GPUS_PER_NODE) * xP + ((DECODE_TP_SIZE + GPUS_PER_NODE - 1) / GPUS_PER_NODE) * yD ))}"
+echo "NUM_NODES: $NUM_NODES (prefill workers=$xP, decode workers=$yD)"
 
 FULL_NODELIST=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
 SELECTED_NODES=$(echo "$FULL_NODELIST" | head -n $NUM_NODES)
@@ -318,6 +319,10 @@ export DRY_RUN="${DRY_RUN:-0}"
 export BENCHMARK_LOGS_DIR="${BENCHMARK_LOGS_DIR:-$(pwd)/benchmark_logs}"
 export KEEP_CONTAINERS="${KEEP_CONTAINERS:-0}"
 export ENGINE=$ENGINE
+export POWERX_HOST_UID=$(id -u)
+export POWERX_HOST_GID=$(id -g)
+export POWERX_COLLECTOR_REVISION=$(git -C "$DI_REPO_DIR" rev-parse HEAD)
+mkdir -p "$BENCHMARK_LOGS_DIR/power-control-${SLURM_JOB_ID}"
 
 # Eval-related env vars (threaded from submit.sh)
 export RUN_EVAL="${RUN_EVAL:-false}"
@@ -377,6 +382,16 @@ else
     echo "[WARN] $RDMA_CHECK_SCRIPT not found; skipping RDMA QoS/DCQCN pre-flight check"
 fi
 
+stage_native_power() {
+    srun --overlap --nodelist="$SELECTED_NODELIST_SRUN" --ntasks="$NUM_NODES" bash -c '
+        src="/tmp/slurm_job-${SLURM_JOB_ID}/native_power/node-${SLURM_PROCID}"
+        if [[ -d "$src" ]]; then
+            mkdir -p "$BENCHMARK_LOGS_DIR/native_power"
+            cp -r "$src" "$BENCHMARK_LOGS_DIR/native_power/"
+        fi
+    '
+}
+
 cleanup() {
   echo "[${SLURM_JOB_ID}] termination received on $(hostname); cleaning up container + stale logs..."
   # Backstop: on scancel/timeout/step-hang the foreground `exec docker run`
@@ -386,11 +401,13 @@ cleanup() {
   # other users' containers. (Ported from InferenceY 51ebfa88.)
   srun --nodelist="$SELECTED_NODELIST_SRUN" \
     bash -c 'eval "$DOCKER_CMD_DETECT"; $DOCKER_CMD rm -f '"$DOCKER_CONT_NAME"' 2>/dev/null || true' 2>/dev/null || true
+  stage_native_power || true
   rm -rf ${SLURM_SUBMIT_DIR}/logs 2>/dev/null || true
   echo "[${SLURM_JOB_ID}] cleanup done."
 }
 
-trap cleanup INT TERM HUP
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM HUP
 
 # Force NFS cache refresh on all nodes
 echo "Refreshing NFS caches on all nodes..."
@@ -412,6 +429,11 @@ DOCKER_ENV_COMMON=(
     -e SLURM_JOB_ID=\$SLURM_JOB_ID
     -e SLURM_JOB_NODELIST=\$SLURM_JOB_NODELIST
     -e NNODES=\$NNODES
+    -e POWERX_HOST_UID=\$POWERX_HOST_UID
+    -e POWERX_HOST_GID=\$POWERX_HOST_GID
+    -e POWERX_COLLECTOR_REVISION=\$POWERX_COLLECTOR_REVISION
+    -e POWERX_NODE_NAME=\$POWERX_NODE_NAME
+    -e POWERX_CLOCK_SYNCHRONIZED=\$POWERX_CLOCK_SYNCHRONIZED
     -e NODE_RANK=\$SLURM_PROCID
     -e NODE0_ADDR=\$NODE0_ADDR
     -e MODEL_DIR=/models
@@ -601,6 +623,10 @@ set -euo pipefail
 
 echo \"Rank \$SLURM_PROCID on \$(hostname)\"
 
+# Capture the host's synchronization state, not the container's missing D-Bus.
+export POWERX_NODE_NAME=\$(hostname)
+export POWERX_CLOCK_SYNCHRONIZED=\$(timedatectl show -p NTPSynchronized --value 2>/dev/null || true)
+
 # Per-node docker privilege detection
 eval \"\$DOCKER_CMD_DETECT\"
 echo \"[docker-detect] rank \$SLURM_PROCID: DOCKER_CMD=\$DOCKER_CMD\"
@@ -784,6 +810,11 @@ echo \"[rank 0] Main container exited (rc=\$DOCKER_EXIT_CODE). Stopping vllm-rou
 exit \$DOCKER_EXIT_CODE
 "
 
+BENCHMARK_STEP_RC=$?
+# Each host copies its own node-local, root-created artifacts as the runner user.
+# No raw telemetry is written as root into the shared checkout.
+stage_native_power || BENCHMARK_STEP_RC=1
+
 if [[ "${KEEP_CONTAINERS}" != "1" ]]; then
     srun --nodelist="$SELECTED_NODELIST_SRUN" bash -c 'eval "$DOCKER_CMD_DETECT"; $DOCKER_CMD rm -f '"$DOCKER_CONT_NAME"' '"$CLIENT_CONT_NAME"' 2>/dev/null || true'
 
@@ -794,3 +825,5 @@ if [[ "${KEEP_CONTAINERS}" != "1" ]]; then
         '
     fi
 fi
+
+exit "$BENCHMARK_STEP_RC"

--- a/benchmarks/multi_node/amd_utils/power.sh
+++ b/benchmarks/multi_node/amd_utils/power.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+start_amd_multinode_power() {
+    [[ "${BENCH_INPUT_LEN:-}" == 8192 && "${BENCH_OUTPUT_LEN:-}" == 1024 &&
+       "${EVAL_ONLY:-false}" != true && "${IS_AGENTIC:-0}" != 1 &&
+       "${IS_AGENTIC:-false}" != true && "${DRY_RUN:-0}" != 1 ]] || return 0
+    local prefill_nodes_per_worker decode_nodes_per_worker prefill_nodes total_nodes role tp worker_nodes gpu_count gpu_indices
+    prefill_nodes_per_worker=$(( (PREFILL_TP_SIZE + GPUS_PER_NODE - 1) / GPUS_PER_NODE ))
+    decode_nodes_per_worker=$(( (DECODE_TP_SIZE + GPUS_PER_NODE - 1) / GPUS_PER_NODE ))
+    prefill_nodes=$(( prefill_nodes_per_worker * xP ))
+    total_nodes=$(( prefill_nodes + decode_nodes_per_worker * yD ))
+    [[ "$total_nodes" == "$NNODES" ]] || { echo 'PowerX: inconsistent AMD node topology' >&2; return 1; }
+    if (( NODE_RANK < prefill_nodes )); then
+        role=prefill; tp=$PREFILL_TP_SIZE; worker_nodes=$prefill_nodes_per_worker
+    else
+        role=decode; tp=$DECODE_TP_SIZE; worker_nodes=$decode_nodes_per_worker
+    fi
+    # Distributed tensor parallelism assigns equal local ranks to every node,
+    # e.g. TP12 across two nodes uses GPU0..5 on each, not 8 GPUs plus 4 GPUs.
+    (( tp % worker_nodes == 0 )) || { echo 'PowerX: uneven per-node TP layout' >&2; return 1; }
+    gpu_count=$(( tp / worker_nodes ))
+    gpu_indices=$(seq 0 $((gpu_count - 1)) | paste -sd, -)
+    export POWERX_CONTROL_DIR="${BENCHMARK_LOGS_DIR}/power-control-${SLURM_JOB_ID}"
+    local native_dir="/run_logs/slurm_job-${SLURM_JOB_ID}/native_power/node-${NODE_RANK}"
+    bash "$WS_PATH/../../native_power_collect.sh" "$native_dir" "$POWERX_CONTROL_DIR" \
+        amd "$NODE_RANK" "$role" "$gpu_indices" "$total_nodes" &
+    POWERX_COLLECTOR_PID=$!
+    # EXIT remains independent of serving-engine INT/TERM handlers.
+    trap 'if [[ -n "${POWERX_COLLECTOR_PID:-}" ]]; then kill "$POWERX_COLLECTOR_PID" 2>/dev/null || true; wait "$POWERX_COLLECTOR_PID" 2>/dev/null || true; fi' EXIT
+}
+
+wait_amd_multinode_power() {
+    local stage=$1 deadline=$((SECONDS + 60)) ready rank
+    [[ -n "${POWERX_CONTROL_DIR:-}" ]] || return 0
+    if [[ "$stage" == done ]]; then
+        printf 'stop\n' > "$POWERX_CONTROL_DIR/stop"
+        chown "$POWERX_HOST_UID:$POWERX_HOST_GID" "$POWERX_CONTROL_DIR/stop"
+    fi
+    while (( SECONDS < deadline )); do
+        ready=1
+        for ((rank=0; rank<NNODES; rank++)); do
+            if [[ "$stage" == ready && -f "$POWERX_CONTROL_DIR/done-$rank" ]]; then
+                echo "PowerX: node $rank collector exited before benchmark" >&2; return 1
+            fi
+            [[ -f "$POWERX_CONTROL_DIR/$stage-$rank" ]] || ready=0
+        done
+        if [[ "$ready" == 1 ]]; then
+            if [[ "$stage" == done ]]; then
+                for ((rank=0; rank<NNODES; rank++)); do
+                    [[ "$(cat "$POWERX_CONTROL_DIR/done-$rank")" == 0 ]] || return 1
+                done
+            fi
+            return 0
+        fi
+        sleep 1
+    done
+    echo "PowerX: timed out waiting for collector $stage receipts" >&2
+    return 1
+}

--- a/benchmarks/multi_node/amd_utils/server.sh
+++ b/benchmarks/multi_node/amd_utils/server.sh
@@ -11,6 +11,9 @@ ENGINE="${ENGINE:-sglang-disagg}"
 WS_PATH="${WS_PATH:-${SGLANG_WS_PATH:-${VLLM_WS_PATH:-${ATOM_WS_PATH:-$(dirname "${BASH_SOURCE[0]}")}}}}"
 export WS_PATH ENGINE
 
+source "$WS_PATH/power.sh"
+start_amd_multinode_power || exit 1
+
 echo "[DISPATCHER] ENGINE=$ENGINE  WS_PATH=$WS_PATH"
 
 if [[ "$ENGINE" == "vllm-disagg" ]]; then

--- a/benchmarks/multi_node/amd_utils/server_atom.sh
+++ b/benchmarks/multi_node/amd_utils/server_atom.sh
@@ -378,7 +378,8 @@ if [ "$NODE_RANK" -eq 0 ]; then
         echo "DRY RUN: $BENCH_CMD"
     else
         set -x
-        eval "$BENCH_CMD"
+        BENCHMARK_EXIT_CODE=0
+        eval "$BENCH_CMD" || BENCHMARK_EXIT_CODE=$?
         set +x
     fi
 
@@ -619,4 +620,4 @@ else
 fi
 
 echo "Script completed successfully"
-exit 0
+exit "${BENCHMARK_EXIT_CODE:-0}"

--- a/benchmarks/multi_node/amd_utils/server_sglang.sh
+++ b/benchmarks/multi_node/amd_utils/server_sglang.sh
@@ -1064,7 +1064,8 @@ print(json.dumps(json.loads(sys.stdin.read())))' <<<"$_val")" || {
         set +x
     else
         set -x
-        eval "$BENCH_CMD"
+        BENCHMARK_EXIT_CODE=0
+        eval "$BENCH_CMD" || BENCHMARK_EXIT_CODE=$?
         set +x
     fi
 
@@ -1371,4 +1372,4 @@ else
 fi
 
 echo "Script completed successfully"
-exit 0
+exit "${BENCHMARK_EXIT_CODE:-0}"

--- a/benchmarks/multi_node/amd_utils/server_vllm.sh
+++ b/benchmarks/multi_node/amd_utils/server_vllm.sh
@@ -323,7 +323,8 @@ if [ "$NODE_RANK" -eq 0 ]; then
         echo "DRY RUN: $BENCH_CMD"
     else
         set -x
-        eval "$BENCH_CMD"
+        BENCHMARK_EXIT_CODE=0
+        eval "$BENCH_CMD" || BENCHMARK_EXIT_CODE=$?
         set +x
     fi
 
@@ -539,4 +540,4 @@ fi
 # pkill -f etcd 2>/dev/null || true
 
 echo "Script completed successfully"
-exit 0
+exit "${BENCHMARK_EXIT_CODE:-0}"

--- a/benchmarks/native_power_collect.sh
+++ b/benchmarks/native_power_collect.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# One native SMI collector per serving node. Raw files stay on node-local scratch;
+# the launcher stages them as its host user after containers stop.
+set -uo pipefail
+power_dir=$1
+control_dir=$2
+vendor=$3
+rank=$4
+role=$5
+gpu_indices=$6
+num_nodes=$7
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+export PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}"
+source "$repo_root/benchmarks/benchmark_lib.sh"
+mkdir -p "$power_dir"
+collector_rc=0
+finished=0
+
+write_control() {
+    local path="$control_dir/$1"
+    printf '%s\n' "$2" > "$path"
+    # The control directory is created by the host user before Docker starts.
+    # Containers must not strand root-owned files in the shared runner tree.
+    if [[ -n "${POWERX_HOST_UID:-}" && -n "${POWERX_HOST_GID:-}" ]]; then
+        chown "$POWERX_HOST_UID:$POWERX_HOST_GID" "$path"
+    fi
+}
+
+finish() {
+    local incoming_rc=$?
+    [[ "$finished" == 0 ]] || return
+    if [[ "$incoming_rc" != 0 ]]; then collector_rc=$incoming_rc; fi
+    if ! _background_process_is_running "${GPU_MONITOR_PID:-}"; then collector_rc=1; fi
+    stop_gpu_monitor
+    if [[ "$vendor" == amd ]]; then
+        _write_amd_smi_sidecar "$power_dir/gpu_metrics_devices_end.json" list --json
+    else
+        nvidia-smi --query-gpu=index,uuid,pci.bus_id,name,driver_version --format=csv \
+            > "$power_dir/gpu_metrics_identity_end.csv" || collector_rc=1
+    fi
+    python3 -m infx.results.power.native_multinode end --directory "$power_dir" \
+        --collector-exit-code "$collector_rc" || collector_rc=1
+    if [[ -n "${POWERX_HOST_UID:-}" && -n "${POWERX_HOST_GID:-}" ]]; then
+        chown -R "$POWERX_HOST_UID:$POWERX_HOST_GID" "$power_dir" || collector_rc=1
+    fi
+    write_control "done-$rank" "$collector_rc"
+    finished=1
+}
+trap finish EXIT
+trap 'collector_rc=130; AMD_MONITOR_STOP_TIMEOUT_S=0; exit 130' INT
+trap 'collector_rc=143; AMD_MONITOR_STOP_TIMEOUT_S=0; exit 143' TERM HUP
+
+case "${POWERX_CLOCK_SYNCHRONIZED:-false}" in
+    yes|true) clock_synchronized=true ;;
+    *) clock_synchronized=false ;;
+esac
+
+python3 -m infx.results.power.native_multinode begin --directory "$power_dir" \
+    --vendor "$vendor" --rank "$rank" --role "$role" --gpu-indices "$gpu_indices" \
+    --num-nodes "$num_nodes" --clock-synchronized "$clock_synchronized" || exit 1
+start_gpu_monitor --output "$power_dir/gpu_metrics.csv" || exit 1
+[[ "$GPU_MONITOR_VENDOR" == "$vendor" ]] || exit 1
+if [[ "$vendor" == amd ]]; then
+    _write_amd_smi_sidecar "$power_dir/gpu_metrics_devices.json" list --json
+fi
+write_control "ready-$rank" ready
+while [[ ! -f "$control_dir/stop" ]]; do
+    _background_process_is_running "$GPU_MONITOR_PID" || exit 1
+    sleep 1 &
+    wait $! || true
+done

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -112,6 +112,14 @@ The runner-name prefix is load-bearing: workflow routing uses `launch_${RUNNER_N
 6. Verify every runner is **Idle** in [repository runner settings](https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners) before adding it to sweep traffic.
 7. Verify launcher mounts for `_work`, HF cache, staged weights, and squash images from a compute node. Root containers must not leave root-owned files in the shared workspace.
 
+## Native PowerX collection for fixed-sequence multinode runs
+
+The AMD SGLang/ATOM/vLLM launchers enable native SMI collection for 8192-input/1024-output runs. Every serving node starts `benchmarks/native_power_collect.sh`; the client waits for all `ready-<rank>` receipts, then requests `stop` and waits for all `done-<rank>` receipts before tearing down servers. The shared collector also accepts NVIDIA SMI for launchers that do not use the srt-slurm/DCGM contract.
+
+Keep `native_power/node-<rank>/gpu_metrics.csv`, the start/end device identity snapshots and `manifest.json` together. Select the actual serving GPU indices, preserve physical node counts when workers span nodes, and stage node-local files as the host runner user into `LOGS/native_power`. The result processor uses each client's formal window, validates all node/role counts and UUID membership, and reuses the shared integration/percentile math. Aggregate deployments emit whole-deployment metrics; role metrics require real separate prefill/decode pools.
+
+Host `timedatectl NTPSynchronized` is recorded as clock context. The shared collector accepts `yes` or `true` as synchronized; other or missing values remain unsynchronized. It does not measure the offset between nodes; common-window trace coverage is still required, and runtime clock alignment remains part of fleet qualification. Missing clock context, a replaced UUID, a missing node or an incomplete collector lifecycle makes power unavailable. Local fixtures prove the format and failure behavior, not GPU runtime or dashboard publication.
+
 ## Register an srt-slurm recipe
 
 Mapping source: [`benchmarks/multi_node/srt-slurm-recipes/RECIPES.md`](../benchmarks/multi_node/srt-slurm-recipes/RECIPES.md). Checked-in recipes: [`benchmarks/multi_node/srt-slurm-recipes/`](../benchmarks/multi_node/srt-slurm-recipes/).

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -112,6 +112,14 @@ runner 名称前缀是关键契约：workflow 通过 `launch_${RUNNER_NAME%%_*}.
 6. 将 runner 加入 sweep 流量前，在[仓库 runner 设置页](https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners)确认每个 runner 都是 **Idle**。
 7. 从计算节点验证 launcher 对 `_work`、HF cache、预置权重和 squash 镜像的挂载。root 容器不得在共享 workspace 留下 root 所有的文件。
 
+## 固定序列长度多节点运行的原生 PowerX 采集
+
+AMD SGLang/ATOM/vLLM launcher 为 8192 输入、1024 输出的运行启用原生 SMI 采集。每个服务节点启动 `benchmarks/native_power_collect.sh`；客户端等待全部 `ready-<rank>` 回执，然后在基准结束后请求 `stop`，等待全部 `done-<rank>` 回执，再关闭服务。共享采集器也支持 NVIDIA SMI，供未采用 srt-slurm/DCGM 契约的 launcher 使用。
+
+将 `native_power/node-<rank>/gpu_metrics.csv`、开始和结束时的设备身份快照及 `manifest.json` 一起保留。选择实际服务进程使用的 GPU 索引，worker 跨节点时保留真实物理节点数，并由宿主机 runner 用户将节点本地文件暂存到 `LOGS/native_power`。结果处理器使用每个客户端的正式窗口，验证全部节点、角色数量及 UUID 归属，再复用共享积分与百分位计算。聚合部署只输出全部署指标；角色指标要求实际分离的 prefill/decode 池。
+
+宿主机的 `timedatectl NTPSynchronized` 状态作为时钟上下文记录。共享采集器将 `yes` 或 `true` 视为已同步；其他值或缺失值均视为未同步。它不测量节点间时钟偏移；仍需验证共同窗口的轨迹覆盖，并在集群运行验证中检查时钟对齐。缺失时钟上下文、UUID 被替换、节点缺失或采集生命周期未完成都会使功耗不可用。本地 fixture 只证明格式和失败处理行为，不能证明 GPU 运行或 dashboard 发布完成。
+
 ## 注册 srt-slurm 配方
 
 映射来源：[`benchmarks/multi_node/srt-slurm-recipes/RECIPES.md`](../benchmarks/multi_node/srt-slurm-recipes/RECIPES.md)。检入的配方：[`benchmarks/multi_node/srt-slurm-recipes/`](../benchmarks/multi_node/srt-slurm-recipes/)。

--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -96,6 +96,12 @@ Single-node GPU count is `tp * pp * pcp_size`. DCP does not multiply the physica
 
 InferenceX-app treats routing fields as columns or config dimensions and stores numeric measurements in `benchmark_results.metrics` JSONB. The mapper supports v1 shared topology, v2 split prefill/decode topology, and nested v3 AgentX metrics. Unknown numeric metrics are retained and warned about, which permits schema growth without silently losing numeric data.
 
+### Power telemetry stop and validation
+
+The single-node AMD monitor in [`benchmark_lib.sh`](../benchmarks/benchmark_lib.sh) waits for every observed GPU to have a positive, numeric power sample at or beyond the first whole second after the stop request. `AMD_MONITOR_STOP_TIMEOUT_S` bounds the wait (default `30`; `0` skips it). Streams without usable epoch timestamps use the legacy fixed tail wait. A timeout does not certify coverage: the aggregator still rejects an unbracketed benchmark window. AgentX cancellation skips the coverage wait and stops the monitor, including when cancellation arrives during a normal stop.
+
+[`single_node.py`](../infx/results/power/single_node.py) excludes unusable power rows outside the formal window from integration and bracketing. Within the boundary search band, these rows are counted per GPU in `power_validation.json` under `boundary_degenerate_rows`, even when no usable samples remain. In-window validation is unchanged; these counters are diagnostic evidence, not replacement measurements.
+
 ### Fixed-sequence outcomes and PowerX audits
 
 The serving client records `benchmark_outcome` before saving its raw result. It retains the existing maximum request-failure rate of 5%, including the requested/completed/failed counts. The processor verifies this record, copies it to the aggregate, and returns failure even when telemetry is valid. Zero successful requests retain a diagnostic aggregate without fabricated reciprocal latency. Legacy results without outcome metadata remain distinguishable; power validity alone never establishes benchmark success or answer quality.

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -96,6 +96,12 @@ shape:    array of benchmark row objects
 
 InferenceX-app 将路由字段作为列或配置维度，并把数值测量存入 `benchmark_results.metrics` JSONB。映射器支持共享拓扑的 v1、拆分 prefill/decode 拓扑的 v2，以及嵌套 AgentX 指标的 v3。未知数值指标会被保留并产生警告，因此架构可以扩展，同时不会无提示地丢失数值数据。
 
+### 功耗遥测停止与校验
+
+[`benchmark_lib.sh`](../benchmarks/benchmark_lib.sh) 中的单节点 AMD 监控会等待每个已观测 GPU 都记录到有效的正数功耗样本，且时间戳不早于停止请求之后的第一个整秒。`AMD_MONITOR_STOP_TIMEOUT_S` 限制等待时长（默认 `30`；设为 `0` 可跳过等待）。没有可用 Unix 时间戳样本的数据流沿用原有的固定尾部等待。超时不代表覆盖有效：聚合器仍会拒绝未被样本完整包围的基准窗口。AgentX 取消运行时会跳过覆盖等待并停止监控，即使取消发生在正常停止的等待过程中。
+
+[`single_node.py`](../infx/results/power/single_node.py) 不会将正式窗口之外的无效功耗行用于积分或边界覆盖。在边界搜索范围内，这些行会按 GPU 计入 `power_validation.json` 的 `boundary_degenerate_rows`，即使最终没有任何可用样本也会保留计数。窗口内的校验规则保持不变；这些计数仅供诊断，不能替代实测数据。
+
 ### 固定序列基准结果状态与 PowerX 审计
 
 服务客户端在保存原始结果前写入 `benchmark_outcome`，保留现有的 5% 最大请求失败率，以及请求总数、完成数和失败数。处理器检查该记录并复制到聚合结果中；即使遥测有效，请求失败率超限仍返回失败。零成功请求会保留诊断聚合结果，但不会生成不存在的延迟倒数。没有状态元数据的历史结果仍可区分；功耗有效不能证明基准成功或答案质量。

--- a/infx/results/fixed_sequence.py
+++ b/infx/results/fixed_sequence.py
@@ -248,6 +248,21 @@ def aggregate_power_result(
         expected_num_gpus = int(env['TP']) * int(env.get('PP_SIZE', '1')) * int(env.get('PCP_SIZE', '1'))
     try:
         if is_multinode:
+            native_dir = Path(env.get('POWERX_NATIVE_DIR', 'LOGS/native_power'))
+            if env.get('POWERX_NATIVE_DIR') or native_dir.is_dir():
+                if source.is_dir() and source != native_dir:
+                    raise ValueError('Both native and SRT power packages are present')
+                source = native_dir
+                from .power.native_multinode import run
+
+                return run(
+                    native_dir, bench_path, agg_path,
+                    expected_prefill_gpus=prefill_gpus,
+                    expected_decode_gpus=decode_gpus,
+                    expected_aggregate_gpus=aggregate_gpus,
+                    validation_result=validation_path,
+                    require_power=require_power,
+                )
             from .power.multinode import run
 
             return run(

--- a/infx/results/power/native_multinode.py
+++ b/infx/results/power/native_multinode.py
@@ -1,0 +1,281 @@
+"""Validate native SMI traces from each node of one fixed-sequence deployment.
+
+This format is owned by InferenceX. It does not claim the srt-slurm/DCGM wire
+contract. The launcher records real serving-device membership and synchronized
+host clocks; the normal result processor binds every trace to the client window.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import os
+import socket
+import time
+from datetime import timezone
+from pathlib import Path
+
+from . import ALL_POWER_METRIC_KEYS
+from .common import (
+    _load_benchmark_data, _write_json_atomic, benchmark_window_payload,
+    patch_power_metrics,
+)
+from .single_node import _derived_metrics, _detect_columns, _parse_timestamp, integrate_power
+
+
+def _identity(path: Path, vendor: str) -> dict[str, str]:
+    """Map the vendor enumeration index to a physical UUID; never use PCI alone."""
+    if vendor == "nvidia":
+        with path.open(newline="") as stream:
+            rows = []
+            for row in csv.DictReader(stream, skipinitialspace=True):
+                if any(not isinstance(k, str) or not isinstance(v, str) for k, v in row.items()):
+                    raise ValueError("invalid_device_identity")
+                rows.append({k.strip().lower(): v.strip() for k, v in row.items()})
+    elif vendor == "amd":
+        payload = json.loads(path.read_text())
+        rows = []
+
+        def visit(value: object) -> None:
+            if isinstance(value, list):
+                for item in value:
+                    visit(item)
+            elif isinstance(value, dict):
+                row = {str(k).lower(): v for k, v in value.items()}
+                if "gpu" in row and "uuid" in row:
+                    rows.append(row)
+                else:
+                    for item in value.values():
+                        visit(item)
+
+        visit(payload)
+    else:
+        raise ValueError("unsupported_native_vendor")
+    identities = {}
+    for row in rows:
+        index = str(row.get("index", row.get("gpu", ""))).strip()
+        uuid = str(row.get("uuid", "")).strip()
+        if not index.isdigit() or not uuid or uuid.lower() in {"n/a", "none", "null"}:
+            raise ValueError("invalid_device_identity")
+        if index in identities or uuid in identities.values():
+            raise ValueError("duplicate_device_identity")
+        identities[index] = uuid
+    if not identities:
+        raise ValueError("device_identity_missing")
+    return identities
+
+
+def record_begin(directory: Path, *, vendor: str, node: str, rank: int,
+                 role: str, gpu_indices: list[int], num_nodes: int, job_id: str,
+                 clock_synchronized: bool, revision: str) -> None:
+    if (role not in {"prefill", "decode", "aggregate"} or rank < 0 or
+            num_nodes <= rank or not gpu_indices or min(gpu_indices) < 0 or
+            len(set(gpu_indices)) != len(gpu_indices)):
+        raise ValueError("invalid_native_topology")
+    directory.mkdir(parents=True, exist_ok=True)
+    _write_json_atomic(directory / "manifest.json", {
+        "schema_version": 1, "collector": "inferencex-native-smi",
+        "vendor": vendor, "node": node, "rank": rank, "role": role,
+        "selected_gpu_indices": gpu_indices, "expected_num_nodes": num_nodes,
+        "job_id": job_id, "collector_revision": revision,
+        "clock_source": "utc_ntp", "clock_synchronized": clock_synchronized,
+        "clock_observation": "timedatectl NTPSynchronized on serving host; no measured clock offset",
+        "collection_start_unix": time.time(), "lifecycle": "collecting",
+    })
+
+
+def record_end(directory: Path, *, collector_exit_code: int) -> None:
+    manifest = json.loads((directory / "manifest.json").read_text())
+    manifest.update(collection_end_unix=time.time(),
+                    collector_exit_code=collector_exit_code,
+                    lifecycle="complete" if collector_exit_code == 0 else "failed")
+    _write_json_atomic(directory / "manifest.json", manifest)
+
+
+def run(power_dir: Path, bench_result: Path, agg_result: Path, *,
+        expected_prefill_gpus: int, expected_decode_gpus: int, expected_aggregate_gpus: int = 0,
+        validation_result: Path | None = None, require_power: bool = False) -> int:
+    validation_result = validation_result or bench_result.with_name(
+        f"power_validation_{bench_result.stem}.json")
+    benchmark, reasons = _load_benchmark_data(bench_result)
+    expected_gpus = expected_prefill_gpus + expected_decode_gpus + expected_aggregate_gpus
+    if expected_aggregate_gpus and (expected_prefill_gpus or expected_decode_gpus):
+        reasons.append("native_mixed_aggregate_role_topology")
+    roles: dict[str, list[str]] = {"prefill": [], "decode": [], "aggregate": []}
+    receipts = []
+    samples = []
+    ranks = []
+    nodes = []
+    jobs = set()
+    revisions = set()
+    expected_nodes = set()
+    paths = sorted(power_dir.glob("node-*/manifest.json"))
+    if not paths:
+        reasons.append("native_manifests_missing")
+    if expected_gpus <= 0 or min(expected_prefill_gpus, expected_decode_gpus, expected_aggregate_gpus) < 0:
+        reasons.append("invalid_expected_gpu_count")
+    for path in paths:
+        try:
+            manifest = json.loads(path.read_text())
+            rank = manifest["rank"]
+            role = manifest["role"]
+            if (manifest.get("schema_version") != 1 or
+                    manifest.get("collector") != "inferencex-native-smi" or
+                    type(rank) is not int or rank < 0 or role not in roles or
+                    path.parent.name != f"node-{rank}"):
+                raise ValueError("invalid_native_manifest")
+            if (not isinstance(manifest.get("node"), str) or not manifest["node"] or
+                    not isinstance(manifest.get("job_id"), str) or
+                    not isinstance(manifest.get("collector_revision"), str) or
+                    type(manifest.get("expected_num_nodes")) is not int or
+                    manifest["expected_num_nodes"] <= 0):
+                raise ValueError("invalid_native_run_identity")
+            ranks.append(rank)
+            nodes.append(manifest["node"])
+            expected_nodes.add(manifest["expected_num_nodes"])
+            jobs.add(manifest["job_id"])
+            revisions.add(manifest["collector_revision"])
+            if (manifest.get("lifecycle") != "complete" or
+                    manifest.get("collector_exit_code") != 0):
+                reasons.append("native_collector_incomplete")
+            if (manifest.get("clock_source") != "utc_ntp" or
+                    manifest.get("clock_synchronized") is not True):
+                reasons.append("native_clock_not_synchronized")
+            start, end = manifest["collection_start_unix"], manifest["collection_end_unix"]
+            if (not all(type(x) in (int, float) and math.isfinite(x) for x in (start, end))
+                    or end <= start or (benchmark is not None and
+                    (start > benchmark.start_unix or end < benchmark.end_unix))):
+                reasons.append("native_collection_window_mismatch")
+            selected = manifest["selected_gpu_indices"]
+            if (not isinstance(selected, list) or not selected or
+                    any(type(i) is not int or i < 0 for i in selected) or
+                    len(set(selected)) != len(selected)):
+                raise ValueError("invalid_native_gpu_selection")
+            suffix = "csv" if manifest["vendor"] == "nvidia" else "json"
+            stem = "gpu_metrics_identity" if suffix == "csv" else "gpu_metrics_devices"
+            first_path = path.parent / f"{stem}.{suffix}"
+            last_path = path.parent / f"{stem}_end.{suffix}"
+            first = _identity(first_path, manifest["vendor"])
+            last = _identity(last_path, manifest["vendor"])
+            selected_ids = {str(i): first[str(i)] for i in selected}
+            if any(last.get(i) != uuid for i, uuid in selected_ids.items()):
+                reasons.append("native_device_identity_changed")
+            previous = {uuid for members in roles.values() for uuid in members}
+            if previous.intersection(selected_ids.values()):
+                reasons.append("native_duplicate_physical_gpu")
+            roles[role].extend(selected_ids.values())
+            csv_path = path.parent / "gpu_metrics.csv"
+            with csv_path.open(newline="") as stream:
+                reader = csv.DictReader(stream, skipinitialspace=True)
+                reader.fieldnames = [c.strip() for c in (reader.fieldnames or [])]
+                t_col, p_col, g_col = _detect_columns(reader.fieldnames)
+                if not all((t_col, p_col, g_col)):
+                    raise ValueError("native_telemetry_columns_missing")
+                for row in reader:
+                    gpu = (row.get(g_col) or "").strip()
+                    if gpu not in first:
+                        reasons.append("native_unknown_device_index")
+                        continue
+                    if gpu not in selected_ids:
+                        continue
+                    timestamp = _parse_timestamp((row.get(t_col) or ""), naive_timezone=timezone.utc)
+                    # Invalid rows are retained for the common validator to reject.
+                    samples.append((timestamp, selected_ids[gpu], row.get(p_col) or ""))
+            receipts.append({**manifest, "physical_gpu_ids": selected_ids,
+                             "manifest_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                             "telemetry_sha256": hashlib.sha256(csv_path.read_bytes()).hexdigest(),
+                             "identity_sha256": hashlib.sha256(first_path.read_bytes()).hexdigest(),
+                             "identity_end_sha256": hashlib.sha256(last_path.read_bytes()).hexdigest()})
+        except (OSError, ValueError, KeyError, TypeError, csv.Error) as exc:
+            reasons.append(f"native_node_invalid:{path.parent.name}:{type(exc).__name__}:{exc}")
+    if (len(expected_nodes) != 1 or not expected_nodes or
+            type(next(iter(expected_nodes), None)) is not int or
+            set(ranks) != set(range(next(iter(expected_nodes), 0))) or
+            len(set(nodes)) != len(nodes) or len(ranks) != len(set(ranks))):
+        reasons.append("native_node_topology_mismatch")
+    if len(jobs) != 1 or "" in jobs or len(revisions) != 1 or "" in revisions:
+        reasons.append("native_run_identity_mismatch")
+    if expected_aggregate_gpus:
+        if roles["prefill"] or roles["decode"] or len(roles["aggregate"]) != expected_aggregate_gpus:
+            reasons.append("native_role_gpu_count_mismatch")
+    elif expected_decode_gpus:
+        if roles["aggregate"] or len(roles["prefill"]) != expected_prefill_gpus or len(roles["decode"]) != expected_decode_gpus:
+            reasons.append("native_role_gpu_count_mismatch")
+    elif roles["decode"] or len(roles["aggregate"] + roles["prefill"]) != expected_prefill_gpus:
+        reasons.append("native_role_gpu_count_mismatch")
+    combined_path = validation_result.with_name(f"{validation_result.stem}_native.csv")
+    combined_path.parent.mkdir(parents=True, exist_ok=True)
+    with combined_path.open("w", newline="") as stream:
+        writer = csv.writer(stream)
+        writer.writerow(["timestamp", "gpu", "power"])
+        writer.writerows(samples)
+    integration = None
+    if benchmark is not None:
+        integration = integrate_power(combined_path, start_unix=benchmark.start_unix,
+                                      end_unix=benchmark.end_unix, expected_num_gpus=expected_gpus)
+        reasons.extend(integration.invalid_reasons)
+    metrics = {}
+    if not reasons and integration is not None and benchmark is not None:
+        metrics = _derived_metrics(integration, benchmark)
+        if expected_decode_gpus:
+            prefill = sum(integration.per_gpu_energy_j[uuid] for uuid in roles["prefill"])
+            decode = sum(integration.per_gpu_energy_j[uuid] for uuid in roles["decode"])
+            metrics.update(prefill_gpu_energy_j=prefill, decode_gpu_energy_j=decode,
+                           prefill_avg_power_w=prefill / benchmark.integration_duration_s / expected_prefill_gpus,
+                           decode_avg_power_w=decode / benchmark.integration_duration_s / expected_decode_gpus,
+                           prefill_joules_per_input_token=prefill / benchmark.total_input_tokens,
+                           decode_joules_per_output_token=decode / benchmark.total_output_tokens)
+    valid = not reasons
+    try:
+        patch_power_metrics(agg_result, metric_keys=ALL_POWER_METRIC_KEYS, power_valid=valid, metrics=metrics)
+    except (OSError, ValueError):
+        reasons.append("aggregate_result_unwritable")
+        valid, metrics = False, {}
+    audit = {"schema_version": 1, "telemetry_kind": "native_multinode_smi",
+             "power_valid": valid, "reasons": list(dict.fromkeys(reasons)),
+             "benchmark_result": str(bench_result),
+             "benchmark_result_sha256": hashlib.sha256(bench_result.read_bytes()).hexdigest() if bench_result.is_file() else None,
+             "benchmark_window": benchmark_window_payload(benchmark),
+             "expected_gpu_count": expected_gpus, "nodes": receipts,
+             "observed_gpu_count": integration.observed_num_gpus if integration else 0,
+             "per_gpu_role": {uuid: role for role, uuids in roles.items() for uuid in uuids},
+             "per_gpu_max_sample_gap_s": integration.per_gpu_max_sample_gap_s if integration else {},
+             "producer": {"name": "inferencex-native-smi", "revisions": sorted(revisions)},
+             "integration_method": "per_device_trapezoidal_with_linear_boundary_interpolation",
+             "power_percentile_method": "time_weighted_synchronized_total_piecewise_linear",
+             "metrics": metrics}
+    _write_json_atomic(validation_result, audit)
+    return int(require_power and not valid)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+    begin = sub.add_parser("begin")
+    begin.add_argument("--directory", type=Path, required=True)
+    begin.add_argument("--vendor", choices=("amd", "nvidia"), required=True)
+    begin.add_argument("--node", default=os.environ.get("POWERX_NODE_NAME", socket.gethostname()))
+    begin.add_argument("--rank", type=int, required=True)
+    begin.add_argument("--role", choices=("prefill", "decode", "aggregate"), required=True)
+    begin.add_argument("--gpu-indices", required=True)
+    begin.add_argument("--num-nodes", type=int, required=True)
+    begin.add_argument("--job-id", default=os.environ.get("SLURM_JOB_ID", ""))
+    begin.add_argument("--revision", default=os.environ.get("POWERX_COLLECTOR_REVISION", ""))
+    begin.add_argument("--clock-synchronized", choices=("true", "false"), default="false")
+    end = sub.add_parser("end")
+    end.add_argument("--directory", type=Path, required=True)
+    end.add_argument("--collector-exit-code", type=int, required=True)
+    args = vars(parser.parse_args())
+    action = args.pop("action")
+    if action == "begin":
+        args["gpu_indices"] = [int(i) for i in args["gpu_indices"].split(",")]
+        args["clock_synchronized"] = args["clock_synchronized"] == "true"
+        record_begin(**args)
+    else:
+        record_end(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/infx/results/power/single_node.py
+++ b/infx/results/power/single_node.py
@@ -9,7 +9,11 @@ Ordinary benchmark runs are best-effort: invalid telemetry is recorded in the
 aggregate and a validation sidecar, but does not fail the benchmark. Power
 studies can set ``REQUIRE_POWER=1`` to fail after those audit artifacts exist.
 The aggregate carries numeric ``power_valid`` (1/0) for metric ingestion; the
-sidecar is the canonical source for boolean validity and reason codes.
+sidecar is the canonical source for boolean validity and reason codes. Rows in
+the ingest band but outside the formal window whose power is missing,
+non-finite, or <= 0 are teardown noise: they are skipped and counted in the
+sidecar's ``boundary_degenerate_rows`` instead of poisoning validity or faking
+window bracketing.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ import math
 import os
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -65,6 +69,10 @@ class PowerIntegration:
     per_gpu_max_sample_gap_s: dict[str, float]
     per_gpu_energy_j: dict[str, float]
     device_issues: dict[str, list[str]]
+    # Rows in the ingest band but outside the formal window whose power was
+    # missing/N-A/non-finite/<=0, skipped and counted per GPU; "unknown"
+    # buckets rows without a GPU identity.
+    boundary_degenerate_rows: dict[str, int] = field(default_factory=dict)
     avg_power_w: float | None = None
     p75_power_w: float | None = None
     p75_total_gpu_power_w: float | None = None
@@ -78,7 +86,7 @@ class PowerIntegration:
         return len(self.observed_gpu_ids)
 
 
-def _parse_timestamp(value: str) -> float | None:
+def _parse_timestamp(value: str, *, naive_timezone: timezone | None = None) -> float | None:
     """Best-effort timestamp parse to Unix epoch seconds (local wall clock).
 
     Handles the formats observed in practice:
@@ -96,7 +104,7 @@ def _parse_timestamp(value: str) -> float | None:
     # nvidia-smi: "YYYY/MM/DD HH:MM:SS.ffffff"
     for fmt in ("%Y/%m/%d %H:%M:%S.%f", "%Y/%m/%d %H:%M:%S"):
         try:
-            return datetime.strptime(value, fmt).timestamp()
+            return datetime.strptime(value, fmt).replace(tzinfo=naive_timezone).timestamp()
         except ValueError:
             pass
     # ISO 8601 (amd-smi variants). fromisoformat tolerates 'T' or space separator
@@ -108,7 +116,7 @@ def _parse_timestamp(value: str) -> float | None:
         return None
     if dt.tzinfo is None:
         # Treat naive timestamps as local time (matches nvidia-smi convention).
-        return dt.timestamp()
+        return dt.replace(tzinfo=naive_timezone).timestamp()
     return dt.astimezone(timezone.utc).timestamp()
 
 
@@ -146,6 +154,16 @@ def _detect_columns(header: list[str]) -> tuple[str | None, str | None, str | No
     return timestamp_col, power_col, gpu_col
 
 
+def _telemetry_timezone(csv_path: Path) -> timezone | None:
+    context = csv_path.with_name(f"{csv_path.stem}_context.json")
+    if not context.is_file():
+        return None
+    payload = json.loads(context.read_text())
+    if not isinstance(payload, dict) or payload.get("timestamp_timezone") != "UTC":
+        raise ValueError("unsupported_telemetry_timezone")
+    return timezone.utc
+
+
 def aggregate_power(
     csv_path: Path,
     start_unix: float,
@@ -162,6 +180,7 @@ def aggregate_power(
         return None
 
     try:
+        timestamp_timezone = _telemetry_timezone(csv_path)
         with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
             reader = csv.DictReader(f, skipinitialspace=True)
             header = [c.strip() for c in (reader.fieldnames or [])]
@@ -189,7 +208,7 @@ def aggregate_power(
             for row in reader:
                 ts_raw = (row.get(timestamp_col) or "").strip()
                 pw_raw = (row.get(power_col) or "").strip()
-                ts = _parse_timestamp(ts_raw)
+                ts = _parse_timestamp(ts_raw, naive_timezone=timestamp_timezone)
                 pw = _parse_power(pw_raw)
                 if ts is None or pw is None:
                     continue
@@ -237,6 +256,7 @@ def _empty_integration(
     *,
     expected_num_gpus: int | None,
     reasons: list[str],
+    boundary_degenerate_rows: dict[str, int] | None = None,
 ) -> PowerIntegration:
     """Build an invalid integration result when no device data is available."""
     return PowerIntegration(
@@ -248,6 +268,7 @@ def _empty_integration(
         per_gpu_max_sample_gap_s={},
         per_gpu_energy_j={},
         device_issues={},
+        boundary_degenerate_rows=boundary_degenerate_rows or {},
     )
 
 
@@ -308,8 +329,10 @@ def integrate_power(
     # expose timestamps at lower resolution than their sampling cadence, so
     # duplicate-timestamp readings are averaged rather than treated as corrupt.
     raw_samples: dict[str, dict[float, list[float]]] = {}
+    boundary_degenerate: dict[str, int] = {}
     saw_missing_gpu_identity = False
     try:
+        timestamp_timezone = _telemetry_timezone(csv_path)
         with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
             reader = csv.DictReader(f, skipinitialspace=True)
             header = [column.strip() for column in (reader.fieldnames or [])]
@@ -332,7 +355,7 @@ def integrate_power(
                 )
 
             for row in reader:
-                timestamp = _parse_timestamp((row.get(timestamp_col) or "").strip())
+                timestamp = _parse_timestamp((row.get(timestamp_col) or "").strip(), naive_timezone=timestamp_timezone)
                 if timestamp is None or not math.isfinite(timestamp):
                     _append_reason(reasons, "invalid_timestamp_sample")
                     continue
@@ -348,6 +371,15 @@ def integrate_power(
 
                 power = _parse_power((row.get(power_col) or "").strip())
                 gpu_id = (row.get(gpu_col) or "").strip()
+                if (power is None or not math.isfinite(power) or power <= 0.0) and (
+                    timestamp < start_unix or timestamp > end_unix
+                ):
+                    # SMI teardown rows can carry N/A or 0 W cells: outside the
+                    # formal window they are counted, never used to satisfy
+                    # bracketing or to poison in-window validity.
+                    key = gpu_id or "unknown"
+                    boundary_degenerate[key] = boundary_degenerate.get(key, 0) + 1
+                    continue
                 if power is None:
                     _append_reason(reasons, "invalid_power_sample")
                     continue
@@ -359,11 +391,12 @@ def integrate_power(
                     continue
                 values = raw_samples.setdefault(gpu_id, {}).setdefault(timestamp, [])
                 values.append(power)
-    except (OSError, csv.Error):
+    except (OSError, csv.Error, ValueError):
         _append_reason(reasons, "telemetry_file_unreadable")
         return _empty_integration(
             expected_num_gpus=expected_num_gpus,
             reasons=reasons,
+            boundary_degenerate_rows=boundary_degenerate,
         )
 
     if saw_missing_gpu_identity:
@@ -373,6 +406,7 @@ def integrate_power(
         return _empty_integration(
             expected_num_gpus=expected_num_gpus,
             reasons=reasons,
+            boundary_degenerate_rows=boundary_degenerate,
         )
 
     observed_gpu_ids = tuple(sorted(raw_samples, key=_gpu_sort_key))
@@ -450,6 +484,7 @@ def integrate_power(
         per_gpu_max_sample_gap_s=per_gpu_max_sample_gap_s,
         per_gpu_energy_j=per_gpu_energy_j,
         device_issues=device_issues,
+        boundary_degenerate_rows=boundary_degenerate,
         avg_power_w=avg_power_w,
         p75_power_w=p75_total / len(observed_gpu_ids) if p75_total is not None else None,
         p75_total_gpu_power_w=p75_total,
@@ -485,6 +520,7 @@ def _read_energy_snapshot(path: Path) -> dict[str, float] | None:
 def _stream_samples_by_gpu(csv_path: Path) -> dict[str, list[tuple[float, float]]]:
     """Group every parseable (timestamp, watt) sample per GPU, sorted in time."""
     samples: dict[str, list[tuple[float, float]]] = {}
+    timestamp_timezone = _telemetry_timezone(csv_path)
     with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
         reader = csv.DictReader(f, skipinitialspace=True)
         header = [column.strip() for column in (reader.fieldnames or [])]
@@ -493,7 +529,7 @@ def _stream_samples_by_gpu(csv_path: Path) -> dict[str, list[tuple[float, float]
         if not timestamp_col or not power_col or not gpu_col:
             return {}
         for row in reader:
-            timestamp = _parse_timestamp((row.get(timestamp_col) or "").strip())
+            timestamp = _parse_timestamp((row.get(timestamp_col) or "").strip(), naive_timezone=timestamp_timezone)
             power = _parse_power((row.get(power_col) or "").strip())
             gpu_id = (row.get(gpu_col) or "").strip()
             if timestamp is None or power is None or not gpu_id:
@@ -679,6 +715,7 @@ def _validation_payload(
         "per_gpu_max_sample_gap_s": integration.per_gpu_max_sample_gap_s,
         "per_gpu_energy_j": integration.per_gpu_energy_j,
         "device_issues": integration.device_issues,
+        "boundary_degenerate_rows": integration.boundary_degenerate_rows,
         "accumulator_check": accumulator_check,
         "metrics": audit_metrics(metrics),
     }
@@ -754,7 +791,7 @@ def run(
 
     try:
         accumulator_check = cross_check_accumulator(csv_path)
-    except (OSError, csv.Error):
+    except (OSError, csv.Error, ValueError):
         accumulator_check = {"available": False, "reason": "cross_check_error"}
 
     try:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7339,3 +7339,53 @@
     - "Stop llm-d workers through the coordinator's final status instead of cancelling successful allocations, and preserve failed concurrency outcomes."
     - "通过协调进程的最终状态停止 llm-d 工作进程，避免取消成功的分配，并保留并发点的失败状态。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3026
+
+- config-keys:
+  - dsr1-fp4-mi355x-sglang
+  - dsr1-fp4-mi355x-sglang-mtp
+  - dsr1-fp4-mi355x-atom
+  - dsr1-fp4-mi355x-atom-mtp
+  - dsr1-fp8-mi300x-sglang
+  - dsr1-fp8-mi325x-sglang
+  - dsv4-fp8-mi300x-vllm
+  - dsv4-fp8-mi300x-vllm-mtp
+  - dsr1-fp8-mi355x-sglang
+  - dsr1-fp8-mi355x-sglang-mtp
+  - qwen3.5-fp8-mi325x-sglang
+  - qwen3.5-fp8-mi355x-sglang
+  - qwen3.5-fp8-mi355x-sglang-mtp
+  - qwen3.5-fp8-mi355x-atom
+  - qwen3.5-fp8-mi355x-atom-mtp
+  - qwen3.5-fp8-mi355x-sglang-disagg
+  - qwen3.5-fp4-mi355x-sglang
+  - qwen3.5-fp4-mi355x-atom
+  - qwen3.5-fp4-mi355x-sglang-mtp
+  - qwen3.5-fp4-mi355x-sglang-disagg
+  - qwen3.5-fp8-mi300x-sglang
+  - dsr1-fp8-mi355x-atom
+  - dsr1-fp8-mi355x-atom-mtp
+  - dsr1-fp8-mi355x-sglang-disagg
+  - dsr1-fp8-mi355x-sglang-disagg-mtp
+  - dsr1-fp4-mi355x-sglang-disagg
+  - dsr1-fp4-mi355x-sglang-disagg-8k1k-mtp
+  - dsv4-fp4-mi355x-sglang-disagg
+  - dsv4-fp4-mi355x-sglang-disagg-mtp
+  - dsv4-fp4-mi355x-sglang
+  - dsv4-fp4-mi355x-sglang-mtp
+  - dsv4-fp4-mi355x-vllm
+  - dsv4-fp4-mi355x-vllm-mtp
+  - dsv4-fp4-mi355x-atom
+  - dsv4-fp4-mi355x-atom-mtp
+  - dsr1-fp8-mi325x-sglang-mtp
+  - qwen3.5-fp8-mi325x-sglang-mtp
+  - dsr1-fp4-mi355x-sglang-disagg-mtp
+  - dsv4-fp4-mi355x-atom-disagg
+  - dsv4-fp8-mi325x-vllm
+  - dsv4-fp8-mi325x-vllm-mtp
+  scenario-type:
+  - fixed-seq-len
+  description:
+  - Collect native AMD power across every 8K/1K worker node, preserve device identity and stop-window coverage,
+    and reject incomplete role telemetry.
+  - 为 8K/1K 各 AMD 工作节点采集原生功耗，保留设备身份和停止窗口覆盖，并拒绝不完整的角色遥测。
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2767

--- a/runners/launch_mi355x-amds.sh
+++ b/runners/launch_mi355x-amds.sh
@@ -59,6 +59,10 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
         if [[ -n "${GITHUB_ACTIONS:-}" && -n "${JOB_ID:-}" ]]; then
             local art_dir="$GITHUB_WORKSPACE/benchmark_artifacts"
             mkdir -p "$art_dir"
+            if [[ -d "$BENCHMARK_LOGS_DIR/native_power" ]]; then
+                mkdir -p "$GITHUB_WORKSPACE/LOGS/native_power"
+                cp -r "$BENCHMARK_LOGS_DIR/native_power/". "$GITHUB_WORKSPACE/LOGS/native_power/" || true
+            fi
             cp -r "$BENCHMARK_LOGS_DIR"/slurm_job-${JOB_ID}.{out,err} "$art_dir/" 2>/dev/null || true
         fi
         # Print .err inline so failures are visible in CI output
@@ -123,11 +127,22 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
 
     wait $POLL_PID
 
+    source "$GITHUB_WORKSPACE/runners/slurm_utils.sh"
+    slurm_outcome_rc=0
+    verify_slurm_job_completion "$JOB_ID" || slurm_outcome_rc=$?
+
     set -x
 
     # FIXME: The below is bad and is a result of the indirection of the ways in which
     # Dynamo jobs are launched. In a follow-up PR, the location of the result file should not
     # depend on the runner, it should always be in the same spot in the GH workspace.
+
+    # Preserve native power evidence before cleanup, even when result processing fails.
+    if [[ -d "$BENCHMARK_LOGS_DIR/native_power" ]]; then
+        mkdir -p "$GITHUB_WORKSPACE/LOGS/native_power"
+        cp -r "$BENCHMARK_LOGS_DIR/native_power/". "$GITHUB_WORKSPACE/LOGS/native_power/"
+        export POWERX_NATIVE_DIR="$GITHUB_WORKSPACE/LOGS/native_power"
+    fi
 
     # Process results from all configurations
 
@@ -249,6 +264,7 @@ PY
     sudo rm -rf "$BENCHMARK_LOGS_DIR/logs" 2>/dev/null || true
 
     # Log preservation and cleanup handled by EXIT trap (cleanup_and_save_logs)
+    exit "$slurm_outcome_rc"
 
 else
 

--- a/utils/agentic/aggregation/test_power_lifecycle.py
+++ b/utils/agentic/aggregation/test_power_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import os
 import re
@@ -278,7 +279,9 @@ source {str(BENCHMARK_LIB)!r}
 start_gpu_monitor() {{
     printf 'monitor-pid:%s\n' "${{BASHPID:-$$}}" >> {str(event_log)!r}
 }}
-stop_gpu_monitor() {{ printf 'monitor-stop\n' >> {str(event_log)!r}; }}
+stop_gpu_monitor() {{
+    printf 'monitor-stop:%s\n' "${{AMD_MONITOR_STOP_TIMEOUT_S:-unset}}" >> {str(event_log)!r}
+}}
 fake_replay() {{
     printf 'replay-ready\n' >> {str(event_log)!r}
     exec sleep 30
@@ -321,7 +324,355 @@ run_agentic_replay_and_write_outputs {str(result_dir)!r}
 
     assert proc.returncode == expected_rc, stderr
     events = _events(tmp_path)
-    assert events.count("monitor-stop") == 1
+    stop_events = [event for event in events if event.startswith("monitor-stop")]
+    # Signal teardown must stop exactly once, in abort mode: the coverage wait
+    # is skipped by setting AMD_MONITOR_STOP_TIMEOUT_S=0 before stopping.
+    assert stop_events == ["monitor-stop:0"]
     expected_parent_event = "parent-int" if sent_signal == signal.SIGINT else "parent-term"
     assert expected_parent_event in events
     assert events[-1] == "parent-exit"
+
+
+
+@pytest.mark.parametrize(
+    ("sent_signal", "expected_rc"),
+    [(signal.SIGINT, 130), (signal.SIGTERM, 143)],
+)
+def test_signal_during_amd_coverage_wait_stops_monitor(
+    tmp_path: Path, sent_signal: signal.Signals, expected_rc: int
+):
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    event_log = tmp_path / "events.log"
+    script = f"""
+source {str(BENCHMARK_LIB)!r}
+start_gpu_monitor() {{
+    GPU_METRICS_CSV="$2"
+    printf 'timestamp,gpu,socket_power\n1,0,500\n' > "$GPU_METRICS_CSV"
+    command sleep 60 >/dev/null 2>&1 &
+    GPU_MONITOR_PID=$!
+    GPU_MONITOR_VENDOR=amd
+    printf 'monitor:%s\nlifecycle:%s\n' "$GPU_MONITOR_PID" "${{BASHPID:-$(exec sh -c 'echo "$PPID"')}}" >> {str(event_log)!r}
+}}
+sleep() {{
+    printf 'coverage-wait\n' >> {str(event_log)!r}
+    command sleep "$@"
+}}
+_write_amd_smi_sidecar() {{ :; }}
+fake_replay() {{ :; }}
+trap 'printf "parent-exit\\n" >> {str(event_log)!r}' EXIT
+REPLAY_CMD=fake_replay
+ENABLE_AGENTX_POWER=1
+IS_MULTINODE=false
+AMD_MONITOR_STOP_TIMEOUT_S=30
+run_agentic_replay_and_write_outputs {str(result_dir)!r}
+exit $?
+"""
+    proc = subprocess.Popen(
+        ["bash", "-c", script],
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            events = _events(tmp_path) if event_log.exists() else []
+            if "coverage-wait" in events:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("AMD coverage wait did not start")
+
+        pids = dict(event.split(":") for event in events if ":" in event)
+        # Signal only the lifecycle shell: signalling the whole group would
+        # kill the monitor directly and hide a broken cleanup handler.
+        os.kill(int(pids["lifecycle"]), sent_signal)
+        _, stderr = proc.communicate(timeout=5)
+        assert proc.returncode == expected_rc, stderr
+        assert _events(tmp_path)[-1] == "parent-exit"
+        with pytest.raises(ProcessLookupError):
+            os.kill(int(pids["monitor"]), 0)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.communicate()
+
+
+# AMDSMI 26.2.0 `metric -p -c -t -u -w 1 --csv` header (order-faithful subset,
+# measured on MI355X; mirrors test_detect_columns_amd_watch_mode_real_header).
+_MI355X_WATCH_HEADER = (
+    "timestamp,gpu,gfx_activity,umc_activity,mm_activity,vcn_activity,"
+    "jpeg_activity,gfx_busy_inst_xcp_0,jpeg_busy_xcp_0,vcn_busy_xcp_0,"
+    "socket_power,gfx_voltage,soc_voltage,mem_voltage,throttle_status,"
+    "power_management,gfx_0_clk,mem_0_clk,edge,hotspot,mem"
+)
+
+# amd-smi quotes list-valued cells with embedded commas; the coverage helper
+# must keep the power cell at its header-relative position through them.
+_WATCH_ROW_FORMAT = (
+    "%s,%s,0,0,N/A,\"['N/A', 'N/A']\",\"['N/A', 'N/A']\",\"[0, 0]\","
+    "\"[0, 0]\",\"[0, 0]\",%s,N/A,N/A,N/A,N/A,ENABLED,1404,2000,N/A,40,25\\n"
+)
+
+
+def _bash_single_quote(text: str) -> str:
+    return "'" + text.replace("'", "'\\''") + "'"
+
+
+def _run_amd_stop(
+    tmp_path: Path,
+    *,
+    producer_script: str,
+    timeout_s: int | str,
+    interval: int = 1,
+    setup_script: str = "",
+) -> subprocess.CompletedProcess[str]:
+    """Run the real stop_gpu_monitor against a scripted AMD telemetry producer."""
+    csv_path = tmp_path / "gpu_metrics.csv"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    amd_smi = bin_dir / "amd-smi"
+    amd_smi.write_text("#!/bin/bash\nprintf 'gpu,total_energy_consumption\\n0,100.0\\n'\n")
+    amd_smi.chmod(0o755)
+    script = f"""
+set -e
+source {str(BENCHMARK_LIB)!r}
+GPU_METRICS_CSV={str(csv_path)!r}
+printf '%s\\n' {_bash_single_quote(_MI355X_WATCH_HEADER)} > "$GPU_METRICS_CSV"
+emit_row() {{
+    printf {_bash_single_quote(_WATCH_ROW_FORMAT)} "$1" "$2" "$3" >> "$GPU_METRICS_CSV"
+}}
+{setup_script}
+( {producer_script} ) &
+GPU_MONITOR_PID=$!
+printf '%s\\n' "$GPU_MONITOR_PID" > {str(tmp_path / "producer.pid")!r}
+GPU_MONITOR_VENDOR=amd
+GPU_MONITOR_INTERVAL={interval}
+AMD_MONITOR_STOP_TIMEOUT_S={timeout_s}
+date +%s > {str(tmp_path / "pre.txt")!r}
+stop_gpu_monitor
+date +%s > {str(tmp_path / "post.txt")!r}
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _min_covered_tick(csv_path: Path) -> int:
+    """Newest usable tick (numeric ts, power > 0) covered by every GPU."""
+    newest: dict[str, float] = {}
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            try:
+                timestamp = float((row.get("timestamp") or "").strip())
+                power = float((row.get("socket_power") or "").strip())
+            except ValueError:
+                continue
+            if timestamp > 1e12:  # millisecond epoch, mirror _parse_timestamp
+                timestamp /= 1000.0
+            gpu = (row.get("gpu") or "").strip()
+            if not gpu or power <= 0:
+                continue
+            newest[gpu] = max(newest.get(gpu, 0.0), timestamp)
+    assert newest, "no usable telemetry rows"
+    return int(min(newest.values()))
+
+
+def _stop_epochs(tmp_path: Path) -> tuple[int, int]:
+    pre = int((tmp_path / "pre.txt").read_text().strip())
+    post = int((tmp_path / "post.txt").read_text().strip())
+    return pre, post
+
+
+def _assert_producer_dead(tmp_path: Path) -> None:
+    producer_pid = int((tmp_path / "producer.pid").read_text().strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(producer_pid, 0)
+
+
+def test_amd_stop_waits_until_every_gpu_covers_stop_request(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    # Every GPU has a usable tick at/after the first whole second past stop
+    # entry, so any fractional window end before the stop is bracketed.
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_ignores_degenerate_rows_for_coverage(tmp_path: Path):
+    setup = """
+stale=$(( $(date +%s) - 30 ))
+emit_row "$stale" 0 500
+emit_row "$stale" 1 505
+"""
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 N/A
+    emit_row "$now" 1 N/A
+    sleep 0.2
+done
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script=producer,
+        timeout_s=2,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" in result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    assert post - pre >= 2
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_requires_coverage_per_gpu(tmp_path: Path):
+    setup = """
+stale=$(( $(date +%s) - 30 ))
+emit_row "$stale" 1 505
+"""
+    producer = """
+while :; do
+    emit_row "$(date +%s)" 0 500
+    sleep 0.2
+done
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script=producer,
+        timeout_s=2,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    # GPU 1 never covers the stop request, so min-over-GPUs coverage times out
+    # even though GPU 0 keeps producing fresh usable ticks.
+    assert "never covered the stop request" in result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    assert post - pre >= 2
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_preserves_outputs_when_monitor_exits_during_wait(tmp_path: Path):
+    setup = """
+emit_row 1 0 500
+sleep() {
+    # End the real producer on the first coverage poll without a timing race.
+    kill "$GPU_MONITOR_PID"
+    wait "$GPU_MONITOR_PID" 2>/dev/null || true
+}
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script="exec /bin/sleep 60",
+        timeout_s=3,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AMD monitor exited before covering the stop request" in result.stderr
+    assert (tmp_path / "gpu_metrics_energy_end.csv").read_text() == (
+        "gpu,total_energy_consumption\n0,100.0\n"
+    )
+    _stop_epochs(tmp_path)  # The caller continued after stop under set -e.
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_survives_non_integer_timeout(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s="30s")
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    # A non-integer timeout must not unwind stop_gpu_monitor via a bash
+    # arithmetic error (which would leak the monitor and skip tail repair
+    # and the energy sidecar): it warns, falls back to 30, and still waits.
+    assert "ignoring non-integer AMD_MONITOR_STOP_TIMEOUT_S='30s'" in result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_normalizes_millisecond_epoch_timestamps(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(( $(date +%s) * 1000 + 123 ))
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    # Raw millisecond epochs (~1.8e12) dwarf any second-scale target, so
+    # without normalization the poll would return
+    # instantly with zero tail coverage; mirrored _parse_timestamp
+    # normalization makes the poll wait for real coverage instead.
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_falls_back_to_fixed_tail_for_iso_timestamps(tmp_path: Path):
+    producer = """
+while :; do
+    emit_row "$(date +%Y-%m-%dT%H:%M:%S)" 0 500
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30, interval=0)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    assert "exited before covering" not in result.stdout + result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    # Non-epoch timestamps keep the legacy interval+2 fixed tail (one shot).
+    assert post - pre >= 2
+    assert duration < 10
+    _assert_producer_dead(tmp_path)

--- a/utils/test_aggregate_power.py
+++ b/utils/test_aggregate_power.py
@@ -574,6 +574,201 @@ def test_run_rejects_malformed_telemetry_inside_window(
     assert audit["reasons"] == [expected_reason]
 
 
+
+# AMDSMI 26.2.0 `metric -p -c -t -u -w 1 --csv` header (order-faithful subset,
+# measured on MI355X; see test_detect_columns_amd_watch_mode_real_header).
+_MI355X_WATCH_HEADER = (
+    "timestamp,gpu,gfx_activity,umc_activity,mm_activity,vcn_activity,"
+    "jpeg_activity,gfx_busy_inst_xcp_0,jpeg_busy_xcp_0,vcn_busy_xcp_0,"
+    "socket_power,gfx_voltage,soc_voltage,mem_voltage,throttle_status,"
+    "power_management,gfx_0_clk,mem_0_clk,edge,hotspot,mem"
+)
+
+
+def _mi355x_watch_row(timestamp: int, gpu: int, socket_power: str) -> str:
+    """One data row in the shape captured from run 32433563482 (conc1):
+    integer-second epoch, quoted list cells with embedded commas, N/A cells,
+    and a trailing carriage return."""
+    return (
+        f"{timestamp},{gpu},0,0,N/A,\"['N/A', 'N/A', 'N/A', 'N/A']\","
+        "\"['N/A', 'N/A']\",\"[0, 0, 0, 0, 0, 0, 0, 0]\",\"[0, 0]\",\"[0, 0]\","
+        f"{socket_power},N/A,N/A,N/A,N/A,ENABLED,1404,2000,N/A,40,25\r"
+    )
+
+
+def test_integrate_power_skips_na_power_rows_outside_window(tmp_path: Path):
+    """N/A-power teardown rows past the window end are counted, not poisonous."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    for offset in range(-2, 13):
+        for gpu in range(2):
+            lines.append(f"{base + offset},{gpu},500.0,65")
+    for gpu in range(2):
+        lines.append(f"{base + 11},{gpu},N/A,65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is True
+    assert result.invalid_reasons == ()
+    assert result.boundary_degenerate_rows == {"0": 1, "1": 1}
+    assert result.total_gpu_energy_j == pytest.approx(10_000.0)
+
+
+def test_integrate_power_does_not_bracket_with_zero_power_tail(tmp_path: Path):
+    """A 0 W teardown row past the window end must not fake end bracketing.
+
+    Legacy behavior accepted the 0 W row as a valid boundary sample, corrupting
+    the end interpolation with a bogus value; this intentionally flips that
+    case to an explicit benchmark_window_not_bracketed failure."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    # Good rows stop at end-4; the only post-end sample per GPU has power 0.
+    for offset in range(-1, 7):
+        for gpu in range(2):
+            lines.append(f"{base + offset},{gpu},500.0,65")
+    for gpu in range(2):
+        lines.append(f"{base + 11},{gpu},0,65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is False
+    assert "benchmark_window_not_bracketed" in result.invalid_reasons
+    assert result.boundary_degenerate_rows == {"0": 1, "1": 1}
+
+
+def test_integrate_power_preserves_boundary_counts_without_usable_samples(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    csv.write_text(
+        "timestamp,gpu,socket_power\n"
+        "1699999999,0,N/A\n"
+        "1700000011,0,0\n"
+        "1700000011,1,N/A\n",
+        encoding="utf-8",
+    )
+
+    result = integrate_power(
+        csv,
+        start_unix=1_700_000_000,
+        end_unix=1_700_000_010,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is False
+    assert "no_usable_power_samples" in result.invalid_reasons
+    assert result.boundary_degenerate_rows == {"0": 2, "1": 1}
+
+
+def test_integrate_power_keeps_zero_power_semantics_inside_window(tmp_path: Path):
+    """Frozen legacy behavior: an in-window 0 W sample still integrates."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    for offset in range(-1, 12):
+        watts = "0.0" if offset == 5 else "500.0"
+        lines.append(f"{base + offset},0,{watts},65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=1,
+    )
+
+    assert result.power_valid is True
+    assert result.invalid_reasons == ()
+    assert result.boundary_degenerate_rows == {}
+    # Trapezoids dip to 0 at t=5: 8 x 500 + 2 x 250 = 4500 J.
+    assert result.total_gpu_energy_j == pytest.approx(4_500.0)
+
+
+def test_run_writes_boundary_degenerate_rows_to_sidecar(tmp_path: Path):
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_constant_window_samples(
+        csv,
+        start=base,
+        end=base + 10,
+        watts_per_gpu=500.0,
+        num_gpus=2,
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    validation = tmp_path / "power_validation.json"
+    _write_bench_result(
+        bench,
+        start=base,
+        end=base + 10,
+        duration=10.0,
+        total_output=2_000,
+        total_input=10_000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x"}), encoding="utf-8")
+
+    exit_code = run(csv, bench, agg, expected_num_gpus=2, validation_result=validation)
+
+    assert exit_code == 0
+    audit = json.loads(validation.read_text())
+    # Present-and-empty for clean streams: readers can rely on the key.
+    assert audit["boundary_degenerate_rows"] == {}
+
+
+def test_integrate_power_regression_mi355x_integer_ticks_end_gap(tmp_path: Path):
+    """Run-32433563482 conc1 regression: amd-smi integer-second ticks stop 4 s
+    before the fractional aiperf window end (last tick 1787277605 vs end
+    ...609.157497), so bracketing fails and the producer-side telemetry loss is
+    attributed as benchmark_window_not_bracketed on every GPU.
+
+    The retrieved artifact's trailing rows all carry valid socket_power
+    (254-264 W) with N/A activity/voltage cells; the N/A- and 0-power teardown
+    rows appended past the window end are the documented synthetic degenerate
+    shapes, asserting they are counted rather than used for bracketing."""
+    csv = tmp_path / "gpu_metrics.csv"
+    start = 1_787_277_560.155891
+    end = 1_787_277_609.157497
+    last_tick = 1_787_277_605
+    powers = [259, 255, 263, 264, 256, 254, 259, 259]
+    lines = [_MI355X_WATCH_HEADER]
+    for tick in range(1_787_277_555, last_tick + 1):
+        for gpu in range(8):
+            lines.append(_mi355x_watch_row(tick, gpu, str(powers[gpu])))
+        # amd-smi watch mode emits a blank line between tick groups.
+        lines.append("")
+    for gpu in range(8):
+        lines.append(_mi355x_watch_row(1_787_277_610, gpu, "N/A"))
+    for gpu in range(8):
+        lines.append(_mi355x_watch_row(1_787_277_611, gpu, "0"))
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=start,
+        end_unix=end,
+        expected_num_gpus=8,
+    )
+
+    assert result.power_valid is False
+    assert result.invalid_reasons == ("benchmark_window_not_bracketed",)
+    assert result.device_issues == {
+        str(gpu): ["benchmark_window_not_bracketed"] for gpu in range(8)
+    }
+    assert result.boundary_degenerate_rows == {str(gpu): 2 for gpu in range(8)}
+
+
 def test_run_patches_agg_with_power_and_joules(tmp_path: Path):
     base = 1_700_000_000.0
     csv = tmp_path / "gpu_metrics.csv"
@@ -1434,12 +1629,12 @@ def test_power_percentiles_uses_synchronized_total_not_device_percentiles(tmp_pa
 
 def test_power_percentiles_weights_time_and_clips_the_validated_window(tmp_path):
     csv_path = tmp_path / "power.csv"
-    # Dense readings near the high end must not bias a uniform linear ramp.
-    _write_amd_csv(csv_path, [(0, 0, 0), (1, 0, 100), (1.9, 0, 190), (2, 0, 200)])
+    # Dense readings must not bias the uniform 150-250 W ramp inside the window.
+    _write_amd_csv(csv_path, [(0, 0, 100), (1, 0, 200), (1.9, 0, 290), (2, 0, 300)])
     result = integrate_power(csv_path, start_unix=0.5, end_unix=1.5, expected_num_gpus=1)
     assert result.power_valid
-    assert result.p75_power_w == pytest.approx(125)
-    assert result.p90_power_w == pytest.approx(140)
+    assert result.p75_power_w == pytest.approx(225)
+    assert result.p90_power_w == pytest.approx(240)
 
 
 def test_power_percentiles_is_withheld_for_invalid_telemetry(tmp_path):

--- a/utils/test_native_multinode_power.py
+++ b/utils/test_native_multinode_power.py
@@ -1,0 +1,246 @@
+"""Native collector acceptance uses independent, hand-computed two-node traces."""
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from infx.results.power.native_multinode import record_begin, record_end, run
+from infx.results.power.single_node import integrate_power
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _package(tmp_path, vendor="amd"):
+    root = tmp_path / "native_power"
+    for rank, role, watts in ((0, "prefill", 100), (1, "decode", 300)):
+        node = root / f"node-{rank}"
+        record_begin(node, vendor=vendor, node=f"host-{rank}", rank=rank, role=role,
+                     gpu_indices=[0], num_nodes=2, job_id="job-123", revision="revision-abc",
+                     clock_synchronized=True)
+        record_end(node, collector_exit_code=0)
+        manifest = json.loads((node / "manifest.json").read_text())
+        manifest.update(collection_start_unix=0, collection_end_unix=5)
+        (node / "manifest.json").write_text(json.dumps(manifest))
+        for ending in ("", "_end"):
+            if vendor == "amd":
+                (node / f"gpu_metrics_devices{ending}.json").write_text(json.dumps([
+                    {"gpu": 0, "uuid": f"uuid-{rank}"}, {"gpu": 1, "uuid": f"unused-{rank}"}]))
+            else:
+                (node / f"gpu_metrics_identity{ending}.csv").write_text(
+                    f"index, uuid, pci.bus_id\n0, uuid-{rank}, 0000:01:00.0\n1, unused-{rank}, 0000:02:00.0\n")
+        # The spare physical GPU is visible but does not belong to the server.
+        (node / "gpu_metrics.csv").write_text("timestamp,gpu,power\n" + "".join(
+            f"{tick},0,{watts}\n{tick},1,900\n" for tick in range(5)))
+    bench = tmp_path / "result.json"
+    bench.write_text(json.dumps({"benchmark_start_time_unix": 1, "benchmark_end_time_unix": 3,
+                                "duration": 2, "completed": 2, "total_input_tokens": 20,
+                                "total_output_tokens": 10}))
+    agg = tmp_path / "agg.json"
+    agg.write_text(json.dumps({"avg_power_w": 999, "prefill_gpu_energy_j": 999}))
+    return root, bench, agg
+
+
+@pytest.mark.parametrize("vendor", ["amd", "nvidia"])
+def test_native_whole_fleet_and_role_energy_use_only_serving_devices(tmp_path, vendor):
+    root, bench, agg = _package(tmp_path, vendor)
+    assert run(root, bench, agg, expected_prefill_gpus=1, expected_decode_gpus=1, require_power=True) == 0
+    actual = json.loads(agg.read_text())
+    assert actual["power_valid"] == 1
+    assert actual["total_gpu_energy_j"] == 800
+    assert actual["avg_power_w"] == 200
+    assert actual["p90_power_w"] == 200
+    assert actual["p75_power_w"] == 200
+    assert actual["joules_per_successful_query"] == 400
+    assert actual["prefill_gpu_energy_j"] == 200
+    assert actual["decode_gpu_energy_j"] == 600
+    assert actual["prefill_joules_per_input_token"] == 10
+    assert actual["decode_joules_per_output_token"] == 60
+    audit = json.loads((tmp_path / "power_validation_result.json").read_text())
+    assert audit["observed_gpu_count"] == 2
+    assert audit["per_gpu_role"] == {"uuid-0": "prefill", "uuid-1": "decode"}
+    assert len(audit["nodes"][0]["telemetry_sha256"]) == 64
+
+
+@pytest.mark.parametrize(("field", "value", "reason"), [
+    ("clock_synchronized", False, "native_clock_not_synchronized"),
+    ("lifecycle", "collecting", "native_collector_incomplete"),
+    ("collection_end_unix", 2, "native_collection_window_mismatch"),
+    ("job_id", "other-job", "native_run_identity_mismatch"),
+    ("role", "prefill", "native_role_gpu_count_mismatch"),
+    ("expected_num_nodes", 3, "native_node_topology_mismatch"),
+])
+def test_native_invalid_evidence_clears_stale_metrics_and_writes_audit(tmp_path, field, value, reason):
+    root, bench, agg = _package(tmp_path)
+    path = root / "node-1/manifest.json"
+    manifest = json.loads(path.read_text()); manifest[field] = value
+    path.write_text(json.dumps(manifest))
+    assert run(root, bench, agg, expected_prefill_gpus=1, expected_decode_gpus=1, require_power=True) == 1
+    actual = json.loads(agg.read_text())
+    assert actual["power_valid"] == 0
+    assert "avg_power_w" not in actual
+    assert "prefill_gpu_energy_j" not in actual
+    audit = json.loads((tmp_path / "power_validation_result.json").read_text())
+    assert reason in audit["reasons"]
+
+
+def test_native_device_replacement_cannot_preserve_validity(tmp_path):
+    root, bench, agg = _package(tmp_path)
+    (root / "node-1/gpu_metrics_devices_end.json").write_text('[{"gpu":0,"uuid":"replacement"}]')
+    assert run(root, bench, agg, expected_prefill_gpus=1, expected_decode_gpus=1, require_power=True) == 1
+    assert "native_device_identity_changed" in json.loads((tmp_path / "power_validation_result.json").read_text())["reasons"]
+
+
+def test_native_aggregate_nodes_do_not_invent_prefill_decode_metrics(tmp_path):
+    root, bench, agg = _package(tmp_path)
+    for path in root.glob("*/manifest.json"):
+        manifest = json.loads(path.read_text()); manifest["role"] = "aggregate"
+        path.write_text(json.dumps(manifest))
+    assert run(root, bench, agg, expected_prefill_gpus=0, expected_decode_gpus=0,
+               expected_aggregate_gpus=2, require_power=True) == 0
+    actual = json.loads(agg.read_text())
+    assert actual["avg_power_w"] == 200
+    assert "prefill_gpu_energy_j" not in actual
+
+
+def test_utc_context_replays_in_a_different_timezone(tmp_path):
+    csv = tmp_path / "gpu_metrics.csv"
+    csv.write_text("timestamp,index,power.draw [W]\n2026/01/01 00:00:00,0,100\n2026/01/01 00:00:02,0,100\n")
+    (tmp_path / "gpu_metrics_context.json").write_text('{"timestamp_timezone":"UTC"}')
+    script = "from pathlib import Path; from infx.results.power.single_node import integrate_power; " + \
+        f"r=integrate_power(Path({str(csv)!r}),start_unix=1767225600,end_unix=1767225602,expected_num_gpus=1); assert r.power_valid; assert r.total_gpu_energy_j == 200"
+    subprocess.run([sys.executable, "-c", script], cwd=REPO,
+                   env={**os.environ, "TZ": "America/Los_Angeles"}, check=True, timeout=10)
+
+
+@pytest.mark.parametrize("clock_value, synchronized", [
+    ("yes", True), ("true", True), ("no", False), ("false", False), ("", False),
+])
+def test_native_supervisor_reaps_monitor_and_writes_completion(tmp_path, clock_value, synchronized):
+    binary = tmp_path / "bin"; binary.mkdir()
+    (binary / "python3").symlink_to(sys.executable)
+    fake = binary / "nvidia-smi"
+    fake.write_text(f'''#!{sys.executable}
+import datetime, os, sys, time
+if any("index,uuid" in arg for arg in sys.argv):
+    print("index, uuid, pci.bus_id"); print("0, gpu-0, 0000:01:00.0")
+else:
+    with open({str(tmp_path / 'monitor.pid')!r}, "w") as stream: stream.write(str(os.getpid()))
+    if "-l" in sys.argv: print("timestamp,index,power.draw [W]", flush=True)
+    while True:
+        print(datetime.datetime.now(datetime.timezone.utc).strftime("%Y/%m/%d %H:%M:%S.%f") + ",0,100", flush=True)
+        if "-l" not in sys.argv: break
+        time.sleep(0.1)
+''')
+    fake.chmod(0o755)
+    control = tmp_path / "control"; control.mkdir()
+    node = tmp_path / "node-0"
+    process = subprocess.Popen(["bash", str(REPO / "benchmarks/native_power_collect.sh"),
+                                str(node), str(control), "nvidia", "0", "aggregate", "0", "1"],
+                               env={**os.environ, "PATH": f"{binary}:{os.environ['PATH']}",
+                                    "SLURM_JOB_ID": "test-job", "POWERX_COLLECTOR_REVISION": "revision",
+                                    "POWERX_CLOCK_SYNCHRONIZED": clock_value}, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, text=True)
+    try:
+        deadline = time.monotonic() + 10
+        while not (control / "ready-0").exists():
+            assert process.poll() is None
+            assert time.monotonic() < deadline
+            time.sleep(0.02)
+        (control / "stop").write_text("stop")
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, (stdout, stderr)
+        assert (control / "done-0").read_text().strip() == "0"
+        manifest = json.loads((node / "manifest.json").read_text())
+        assert manifest["lifecycle"] == "complete"
+        assert manifest["clock_synchronized"] is synchronized
+        assert (node / "gpu_metrics_identity_end.csv").exists()
+    finally:
+        if process.poll() is None:
+            process.terminate(); process.communicate(timeout=10)
+
+
+def test_amd_stop_coverage_uses_slowest_gpu_and_normalizes_milliseconds(tmp_path):
+    csv = tmp_path / "gpu_metrics.csv"
+    csv.write_text('timestamp,gpu,vcn_activity,socket_power\n'
+                   '1700000002000,0,"[0, 0]",250\n'
+                   '1700000001000,1,"[0, 0]",250\n'
+                   '1700000009000,1,"[0, 0]",N/A\n')
+    result = subprocess.run(["bash", "-c", 'source "$1"; GPU_METRICS_CSV="$2"; _amd_monitor_min_covered_tick',
+                             "test", str(REPO / "benchmarks/benchmark_lib.sh"), str(csv)],
+                            capture_output=True, text=True, check=True, timeout=10)
+    assert result.stdout.strip() == "1700000001"
+
+
+def test_amd_shutdown_kills_both_pipeline_processes_when_stream_dies(tmp_path):
+    binary = tmp_path / "bin"; binary.mkdir()
+    fake = binary / "amd-smi"
+    fake.write_text(f'''#!{sys.executable}
+import json, sys, time
+if "-w" in sys.argv:
+    print("timestamp,gpu,socket_power", flush=True)
+    while True:
+        print(str(int(time.time())) + ",0,250", flush=True); time.sleep(.1)
+else:
+    print("[]")
+''')
+    fake.chmod(0o755)
+    csv = tmp_path / "gpu_metrics.csv"
+    script = '''source "$1"
+start_gpu_monitor --output "$2"
+source_pid=$GPU_MONITOR_SOURCE_PID
+sink_pid=$GPU_MONITOR_PID
+kill "$sink_pid"
+wait "$sink_pid" 2>/dev/null || true
+AMD_MONITOR_STOP_TIMEOUT_S=0
+stop_gpu_monitor
+if kill -0 "$source_pid" 2>/dev/null; then echo 'source leaked'; exit 1; fi
+if kill -0 "$sink_pid" 2>/dev/null; then echo 'sink leaked'; exit 1; fi
+[[ ! -p "$2.pipe.$$" ]]
+'''
+    subprocess.run(["bash", "-c", script, "test", str(REPO / "benchmarks/benchmark_lib.sh"), str(csv)],
+                   env={**os.environ, "PATH": f"{binary}:{os.environ['PATH']}"},
+                   capture_output=True, text=True, check=True, timeout=10)
+
+
+def test_amd_multinode_selects_equal_local_tensor_ranks(tmp_path):
+    arguments = tmp_path / "collector.args"
+    # Mock only the downstream collector command; exercise actual topology routing.
+    script = f'''source {str(REPO / 'benchmarks/multi_node/amd_utils/power.sh')!r}
+bash() {{ printf '%s\\0' "$@" > {str(arguments)!r}; }}
+start_amd_multinode_power
+wait "$POWERX_COLLECTOR_PID"
+'''
+    subprocess.run(["bash", "-c", script], env={**os.environ, "BENCH_INPUT_LEN": "8192",
+                   "BENCH_OUTPUT_LEN": "1024", "PREFILL_TP_SIZE": "12", "DECODE_TP_SIZE": "12",
+                   "GPUS_PER_NODE": "8", "xP": "1", "yD": "1", "NNODES": "4", "NODE_RANK": "1",
+                   "WS_PATH": str(tmp_path), "BENCHMARK_LOGS_DIR": str(tmp_path), "SLURM_JOB_ID": "123",
+                   "IS_AGENTIC": "0", "EVAL_ONLY": "false", "DRY_RUN": "0"},
+                   capture_output=True, text=True, timeout=10, check=True)
+    args = arguments.read_bytes().decode().split("\0")
+    assert args[-6:-1] == ["amd", "1", "prefill", "0,1,2,3,4,5", "4"]
+
+
+def test_result_processor_discovers_staged_native_package(tmp_path, monkeypatch):
+    from infx.results.fixed_sequence import aggregate_power_result
+
+    root, bench, agg = _package(tmp_path)
+    logs = tmp_path / "LOGS"
+    logs.mkdir()
+    root.rename(logs / "native_power")
+    monkeypatch.chdir(tmp_path)
+    env = {"IS_MULTINODE": "true", "PREFILL_GPUS": "1", "DECODE_GPUS": "1",
+           "RESULT_FILENAME": "result", "REQUIRE_POWER": "1"}
+    assert aggregate_power_result(env, bench, agg) == 0
+    assert json.loads(agg.read_text())["total_gpu_energy_j"] == 800
+    assert (tmp_path / "power_validation_result.json").is_file()
+
+    # Two competing formats must not silently select one package.
+    (logs / "power").mkdir()
+    assert aggregate_power_result(env, bench, agg) == 1
+    invalid = json.loads(agg.read_text())
+    assert invalid["power_valid"] == 0
+    assert "total_gpu_energy_j" not in invalid

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -1118,8 +1119,13 @@ stop_gpu_monitor
             final_sample,
         ]
 
-    def test_stop_gpu_monitor_amd_waits_one_tick_and_snapshots_energy(self, tmp_path):
-        """AMD stop lets the watch stream bracket the window, then snapshots energy."""
+    def test_stop_gpu_monitor_amd_covers_stop_request_and_snapshots_energy(self, tmp_path):
+        """AMD stop returns once telemetry covers the stop entry, then snapshots energy.
+
+        A usable tick stamped past the stop request satisfies the coverage
+        poll on its first pass: the legacy fixed tail sleep never runs, the
+        stream is not mutated, and the end-side accumulator snapshot is
+        written."""
         fake_bin = tmp_path / "bin"
         fake_bin.mkdir()
         args_log = tmp_path / "amd_args.txt"
@@ -1131,7 +1137,8 @@ stop_gpu_monitor
         )
         fake_amd_smi.chmod(0o755)
         sleep_log = tmp_path / "sleep_args.txt"
-        contents = "timestamp,gpu,socket_power\n1785881113,0,238\n"
+        covered_tick = int(time.time()) + 30
+        contents = f"timestamp,gpu,socket_power\n{covered_tick},0,238\n"
         metrics = tmp_path / "gpu_metrics.csv"
         metrics.write_text(contents)
         benchmark_lib = Path(__file__).parents[1] / "benchmarks/benchmark_lib.sh"
@@ -1139,7 +1146,7 @@ stop_gpu_monitor
 source {str(benchmark_lib)!r}
 kill() {{ return 0; }}
 wait() {{ return 0; }}
-sleep() {{ printf '%s\\n' "$1" > {str(sleep_log)!r}; }}
+sleep() {{ printf '%s\\n' "$1" >> {str(sleep_log)!r}; }}
 GPU_MONITOR_PID=999
 GPU_MONITOR_VENDOR=amd
 GPU_MONITOR_INTERVAL=3
@@ -1160,7 +1167,8 @@ stop_gpu_monitor
         )
 
         assert result.returncode == 0, result.stderr
-        assert sleep_log.read_text().strip() == "5"
+        assert not sleep_log.exists()
+        assert "never covered the stop request" not in result.stderr
         assert metrics.read_text() == contents
         assert "metric -E --csv" in args_log.read_text()
         energy_end = tmp_path / "gpu_metrics_energy_end.csv"
@@ -1189,6 +1197,7 @@ sleep() {{ return 0; }}
 GPU_MONITOR_PID=999
 GPU_MONITOR_VENDOR=amd
 GPU_METRICS_CSV={str(metrics)!r}
+AMD_MONITOR_STOP_TIMEOUT_S=0
 stop_gpu_monitor
 """
         env = {


### PR DESCRIPTION
## Description

Collect measured GPU power for AMD 8K/1K worker pools and retain usable telemetry through shutdown. Stack on #3026 for failure preservation and incomplete-sweep detection.

为 AMD 8K/1K 各工作进程组采集实测 GPU 功耗，并在停止时保留覆盖完整窗口的遥测。本 PR 基于 #3026，复用失败保留和不完整扫描检测。

- Preserve the existing AMD window-bracketing fix and early-monitor-exit recovery. Drain the producer and consumer separately; outside-window invalid tail rows cannot fake a measurement boundary.
- Collect native per-node telemetry, serving GPU identities, synchronization state and shutdown receipts. Validate topology and measurement coverage before emitting aggregate or role-specific energy.
- Discover staged native packages in result processing, reject ambiguous collector sources, and retain raw packages in diagnostic uploads. Shared workers retain deployment totals without invented prefill/decode splits.

- 保留现有 AMD 窗口边界修复及监控进程提前退出恢复；分别结束数据生产和消费进程，窗口外无效尾部样本不能伪造测量边界。
- 逐节点保存遥测、实际服务 GPU 身份、时钟同步状态和退出记录；通过拓扑与窗口覆盖校验后输出整体或分角色能耗。
- 结果处理自动识别原生数据包，拒绝存在多个采集源的歧义情况，并在诊断产物中保留原始包。共享工作进程仅保留整体能耗，不推断 prefill/decode 拆分。

### Validation / 验证

- AMD power/result suites: 212 passed during preparation. Native collection checks after synchronization parsing: 20 passed.
- Combined routing integration: 294 passed; one test stopped before the newly relocated cleanup/exit block. Its boundary was corrected, and all 30 affected launcher/AMD lifecycle checks passed, including retained upstream early-monitor-exit coverage.
- [Automatic CPU CI](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34654132269) passed on attempt 2 at the same commit. Attempt 1 timed out in an unchanged signal test; no code or timeout change was made.
- Changed shell syntax, workflow YAML parsing and append-only changelog matrix checks passed.
- Local CPU/fixture checks only. Real AMD cancellation/ownership checks, hardware sweeps with evals and artifact → database → API → chart qualification remain required before rollout. No production migration or historical re-ingest is included.

- 准备阶段 AMD 功耗/结果测试 212 项通过；同步状态解析修复后原生采集测试 20 项通过。
- 组合集成检查 294 项通过；一个测试截取范围未包含调整后的清理和退出代码。修正测试范围后，受影响的启动器及 AMD 生命周期测试 30 项全部通过，包含上游监控进程提前退出回归测试。
- 同一提交的自动 CPU CI 在第 2 次运行通过。第 1 次在未修改的信号测试中超时；没有修改代码或放宽超时。
- 修改的 shell 语法、工作流 YAML 和仅追加 changelog 矩阵检查通过。
- 当前证据仅来自本地 CPU 与固定样本测试。上线前仍需 AMD 硬件取消/文件属主验证、带 eval 的扫描及产物到数据库、API 和图表的完整验证；不包含生产迁移或历史重新入库。

## Related Issue

Depends on #3026. Dashboard audit transport: SemiAnalysisAI/InferenceX-app#939.

依赖 #3026；仪表盘审计字段传输由 SemiAnalysisAI/InferenceX-app#939 处理。

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark teardown timing (up to ~30s on AMD) and alters power validity when re-aggregating artifacts with degenerate tail rows; core benchmark paths and NVIDIA stop behavior are unchanged.
> 
> **Overview**
> Fixes AMD single-node GPU power validation failures where `amd-smi` telemetry stopped before the fractional benchmark window end (`benchmark_window_not_bracketed`).
> 
> **Benchmark stop path:** `stop_gpu_monitor` no longer uses a fixed `sleep interval+2` on AMD. It polls `gpu_metrics.csv` until every GPU has a usable sample (numeric epoch timestamp, power > 0) at or after the first whole second past stop entry, bounded by `AMD_MONITOR_STOP_TIMEOUT_S` (default 30; `0` skips). File-based polling avoids pipe-buffer loss when the awk consumer is killed. ISO timestamps fall back to the legacy tail wait; millisecond epochs are normalized to seconds. AgentX `INT`/`TERM`/`EXIT` traps use **abort** mode (`AMD_MONITOR_STOP_TIMEOUT_S=0`) so cancelled runs tear down quickly.
> 
> **Aggregation:** `integrate_power` in `single_node.py` skips (and counts per GPU in `power_validation.json` as `boundary_degenerate_rows`) ingest-band rows **outside** the formal window with missing, non-finite, or ≤0 power—so teardown N/A/0 W rows no longer poison validity or fake end bracketing. In-window semantics are unchanged.
> 
> Docs (EN/ZH) describe the stop contract and sidecar field. Tests cover AMD stop polling, abort-on-signal, boundary-degenerate integration, and a MI355X regression fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 363a4115f68ffbaa5d0f202b5c43a3d2c58c30c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

