### PR TITLE
perf(agentx): enable aiter AR+RMSNorm fusion and fused QK-norm-rope for GLM-5.2 MI355X SGLang (+23.6%)

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -66,6 +66,8 @@ export SGLANG_TIMEOUT_KEEP_ALIVE=900
 # v1 dispatches to the precompiled HIP op in sgl-kernel (upstream MI355X CI
 # runs DSA models the same way).
 export SGLANG_OPT_USE_TOPK_V2=false
+# FlyDSL token sorting for MoE dispatch — matches Atom's default for GLM-5.2.
+export AITER_USE_FLYDSL_MOE_SORTING=1
  
 # HiCache L2 (host DRAM), optionally extended with Mooncake L3.
 # KV_OFFLOADING=dram requires KV_OFFLOAD_BACKEND=hicache or mooncake.
@@ -236,6 +238,8 @@ SGLANG_CMD=(
     "${CACHE_ARGS[@]}"
     --watchdog-timeout 1800
     --enable-metrics
+    --enable-aiter-allreduce-fusion
+    --enable-fused-qk-norm-rope
 )
  
 printf '%q ' "${SGLANG_CMD[@]}" | tee "$RESULT_DIR/sglang_command.txt"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6576,3 +6576,13 @@
     - "Recipes sourced from srt-slurm (recipes/trtllm/qwen3.5-fp4/inferencex/gb300/{mtp,stp})."
     - "Runner: launch_gb300-nv.sh bumped from NVIDIA/srt-slurm@v1.0.29 to v1.0.72 for the dynamo-trt+qwen3.5+fp4 path."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2730
+
+- config-keys:
+    - glm5.2-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Enable aiter allreduce+RMSNorm fusion (--enable-aiter-allreduce-fusion) and fused QK-norm+RoPE (--enable-fused-qk-norm-rope) for GLM-5.2 MXFP4 MI355X SGLang, matching Atom's default kernel dispatch."
+    - "Add AITER_USE_FLYDSL_MOE_SORTING=1 for FlyDSL token sorting in MoE dispatch."
+    - "Measured +23.6% P90 E2E normalized interactivity (41.9 → 51.8 tok/s/user) at CONC=8 with TP=4/EP=4 HiCache on the AgentX cc-traces workload."
+    - "All three flags activate existing aiter kernels already present in the container image; no kernel code changes required."


### PR DESCRIPTION
## Summary

- Enable `--enable-aiter-allreduce-fusion` and `--enable-fused-qk-norm-rope` server flags for GLM-5.2 MXFP4 MI355X SGLang, matching Atom's default kernel dispatch
- Add `AITER_USE_FLYDSL_MOE_SORTING=1` env var for FlyDSL token sorting in MoE dispatch
- **+23.6% P90 E2E normalized interactivity** (41.9 → 51.8 tok/s/user) at CONC=8 with TP=4/EP=4 HiCache on AgentX cc-traces

## Details

All three flags activate existing aiter kernels already present in the `v0.5.16-rocm720-mi35x-20260728` container image — no kernel code changes required:

| Flag | Effect | Estimated contribution |
|---|---|---|
| `--enable-aiter-allreduce-fusion` | Fuses allreduce into RMSNorm kernel, eliminating ~80 standalone collectives per forward | ~14% |
| `--enable-fused-qk-norm-rope` | Fuses QK-norm + RoPE + KV-cache write into one kernel per attention layer | ~5% |
| `AITER_USE_FLYDSL_MOE_SORTING=1` | FlyDSL token sorting for MoE dispatch | ~2% |

These match what AMD Atom enables by default for GLM-5.2 on MI355X.

## Test plan

- [x] Benchmarked with InferenceX AgentX cc-traces workload at CONC=8, DURATION=600, TP=4/EP=4/HiCache
- [x] Verified 0 error requests across all benchmark runs
- [x] Verified prefix cache hit rate ≥97% (consistent with baseline)
- [x] Confirmed no correctness regression (identical request success rate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and documentation-only changes that flip existing, image-bundled SGLang/aiter feature flags with no application logic or security surface changes.
> 
> **Overview**
> Turns on **Atom-aligned aiter optimizations** for the `glm5.2-fp4-mi355x-sglang-agentic-mtp` benchmark: `AITER_USE_FLYDSL_MOE_SORTING=1` in the launch script and SGLang flags `--enable-aiter-allreduce-fusion` plus `--enable-fused-qk-norm-rope`.
> 
> Documents the change in **perf-changelog.yaml**, including a reported **+23.6% P90 E2E normalized interactivity** (41.9 → 51.8 tok/s/user at CONC=8, TP=4/EP=4 HiCache on AgentX cc-traces). All toggles use kernels already shipped in the container image—no new kernel code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f826b3cc783c9006b526109e43dcef4df2dc1da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->