### PR TITLE
[NV] Add SPEED-Bench AL collectors for Qwen3.8-2.4T-A95B and Qwen3.8-Flash-Next

### DIFF
--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -18,9 +18,12 @@
 # otherwise a copy of so the two AL curves stay directly comparable:
 #   - target model       DeepSeek-V4-Pro-DSpark (was DeepSeek-V4-Pro)
 #   - speculative-config method dspark + draft_sample_method (was method mtp)
-# Every serve flag is left byte-identical to the MTP collector: it already
-# matches the published DSpark recipe, and holding the serving config fixed is
-# what makes "DSpark vs MTP on DSV4-Pro" a like-for-like AL comparison.
+#   - --max-num-seqs and --gpu-memory-utilization pinned (MTP took the defaults)
+# The third one is a memory fix rather than a recipe change. AL is a per-draft
+# accept/reject property that does not depend on batch size or graph capture, so
+# pinning those two still leaves "DSpark vs MTP on DSV4-Pro" like-for-like; every
+# flag that does affect drafting is byte-identical to the MTP collector and to
+# the published DSpark recipe.
 #
 # Usage (inside the vLLM container, on a B300 node):
 #   export MODEL=deepseek-ai/DeepSeek-V4-Pro-DSpark
@@ -35,6 +38,8 @@
 #   DRAFT_SAMPLE_METHOD    greedy|probabilistic     (default greedy)
 #   REJECTION_SAMPLE_METHOD  passed through to speculative-config when non-empty
 #                            (default: unset, i.e. the vLLM default)
+#   MAX_NUM_SEQS      engine max batch size         (default 64)
+#   GPU_MEM_UTIL      --gpu-memory-utilization      (default 0.90)
 
 set -uo pipefail
 source "$(dirname "$0")/../../benchmark_lib.sh"
@@ -64,6 +69,18 @@ SPEEDBENCH_OUTPUT_LEN="${SPEEDBENCH_OUTPUT_LEN:-4096}"
 # nothing here sets speculative_disable_by_batch_size, so drafting stays on at
 # this batch size and the curves remain comparable.
 CONCURRENCY="${CONCURRENCY:-32}"
+# Engine batch size; must stay >= CONCURRENCY or the client's requests just queue.
+# Held far below the vLLM default of 1024 because that default sizes two
+# allocations the memory profiler never sees — the rejection sampler's fp32 logits
+# scratch, max_num_seqs * (1 + num_speculative_tokens) * vocab * 4B, which is
+# 2.5 GB at 4 speculative tokens and 4.4 GB at 8, and the spec-decode CUDA graphs,
+# which grow with the same product. DSV4-Pro has no room for either: 141.5 GiB of
+# weights plus a 100 GiB KV cache already fills 266 of the 268 GiB on each B300,
+# and warmup died asking for 2.47 GiB more at num_speculative_tokens=4.
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-64}"
+# vLLM's own default, exposed so the KV cache can be traded for headroom if some
+# higher num_speculative_tokens still runs out.
+GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.90}"
 TEMPERATURE="${TEMPERATURE:-1.0}"
 # thinking-on chat_template_kwargs. MUST match the production/golden config:
 # the reference matrix (golden_al_distribution/dsv4_mtp.yaml) was measured with
@@ -286,6 +303,8 @@ run_cell() {
         --reasoning-parser deepseek_v4
         --max-cudagraph-capture-size 2048
         --max-model-len 16384
+        --max-num-seqs "$MAX_NUM_SEQS"
+        --gpu-memory-utilization "$GPU_MEM_UTIL"
         --speculative-config "{\"method\": \"dspark\", \"num_speculative_tokens\": $mtp, \"draft_sample_method\": \"$DRAFT_SAMPLE_METHOD\"$SPEC_EXTRA}"
     )
 
@@ -293,7 +312,11 @@ run_cell() {
     vllm serve "$SERVE_MODEL" "${serve_args[@]}" > "$server_log" 2>&1 &
     SERVER_PID=$!
 
-    if ! wait_for_server_ready --port "$PORT" --server-log "$server_log" --server-pid "$SERVER_PID"; then
+    # wait_for_server_ready exits the shell rather than returning when the server
+    # dies, which would make the N/A branch below unreachable and let one bad cell
+    # abort the whole matrix. Running it in a subshell keeps that exit local, so a
+    # cell that cannot start its server costs one cell instead of the run.
+    if ! (wait_for_server_ready --port "$PORT" --server-log "$server_log" --server-pid "$SERVER_PID"); then
         echo "  -> server failed to start (thinking=$mode dspark=$mtp), recording N/A"
         AL_RESULT["${mode}_${mtp}"]="N/A"
         cleanup_server

--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -130,37 +130,58 @@ if [[ ! -f "$SPEEDBENCH_DIR/qualitative.jsonl" ]]; then
     exit 1
 fi
 
-# ---- Temporary shim: add a real --chat-template-kwargs CLI option ----
-# Upstream gap (until vllm-project/vllm#44244 lands): speed_bench/CustomDataset
-# pre-renders the chat template client-side WITHOUT chat_template_kwargs and
-# posts to /v1/completions, so thinking mode cannot be enabled via --extra-body
-# or --default-chat-template-kwargs. This wires a proper --chat-template-kwargs
-# option through get_samples into CustomDataset.sample's apply_chat_template.
-# TODO: delete this whole block once #44244 is released in the benchmark image;
-# the patch is idempotent (marker check) so it is safe to leave until then.
+# ---- Conditional shim: ensure --chat-template-kwargs reaches the chat template ----
+# speed_bench/CustomDataset pre-renders the chat template client-side and posts to
+# /v1/completions, so thinking mode cannot be enabled via --extra-body or
+# --default-chat-template-kwargs — the kwargs must reach apply_chat_template.
+# vllm-project/vllm#44244 added this natively (serve.py declares the CLI option,
+# the speed_bench dispatch forwards it, CustomDataset.sample unpacks it), and it
+# is present in the v0.25.x images this collector runs on. So: probe for native
+# support first and no-op when present; only patch the pieces an older image is
+# missing. Idempotent. Same shim as the Kimi-K3 collector.
 apply_chat_template_kwargs_shim() {
-    echo "=== Patching vLLM benchmark to add --chat-template-kwargs (temporary shim) ==="
+    echo "=== Checking vLLM benchmark --chat-template-kwargs support ==="
     python3 - <<'PYEOF'
+import sys
 import vllm.benchmarks.serve as S
 import vllm.benchmarks.datasets.datasets as D
 
-def patch(mod, edits, marker):
-    f = mod.__file__
-    src = open(f).read()
-    if marker in src:
-        print("already patched:", f)
-        return
+def read(mod):
+    with open(mod.__file__) as fh:
+        return fh.read()
+
+s_src, d_src = read(S), read(D)
+
+# Native (post-#44244) spellings, plus the ones this shim itself writes.
+have_cli = '"--chat-template-kwargs"' in s_src
+have_forward = ('chat_template_kwargs=getattr(args' in d_src
+                or 'chat_template_kwargs=args.chat_template_kwargs' in d_src)
+have_unpack = ('**(chat_template_kwargs or {})' in d_src
+               or '**_ctk' in d_src)
+
+if have_cli and have_forward and have_unpack:
+    print("native --chat-template-kwargs support present; no patching needed")
+    sys.exit(0)
+
+print(f"patching (cli={have_cli} forward={have_forward} unpack={have_unpack})")
+
+def apply(mod, src, edits):
     for old, new in edits:
         n = src.count(old)
-        assert n == 1, f"anchor matched {n} times in {f}, aborting:\n{old[:80]}..."
+        assert n == 1, (
+            f"anchor matched {n} times in {mod.__file__}, aborting. This image's "
+            f"benchmark source differs from both the pre-#44244 and post-#44244 "
+            f"layouts; update the shim.\n{old[:120]}..."
+        )
         src = src.replace(old, new, 1)
-    open(f, "w").write(src)
-    print("patched OK ->", f)
+    with open(mod.__file__, "w") as fh:
+        fh.write(src)
+    print("patched OK ->", mod.__file__)
 
-# Edit 1: serve.py -- declare the --chat-template-kwargs argument before --extra-body
-serve_old = '''    parser.add_argument(
-        "--extra-body",'''
-serve_new = '''    parser.add_argument(
+if not have_cli:
+    # serve.py -- declare the --chat-template-kwargs argument before --extra-body
+    apply(S, s_src, [('''    parser.add_argument(
+        "--extra-body",''', '''    parser.add_argument(
         "--chat-template-kwargs",
         type=json.loads,
         default=None,
@@ -168,18 +189,19 @@ serve_new = '''    parser.add_argument(
         "client-side prompt rendering, e.g. to enable reasoning mode.",
     )
     parser.add_argument(
-        "--extra-body",'''
-patch(S, [(serve_old, serve_new)], marker='"--chat-template-kwargs"')
+        "--extra-body",''')])
 
-# Edit 2: datasets.py -- forward args.chat_template_kwargs into the speed_bench .sample() call
-disp_old = '''                output_len=args.speed_bench_output_len,
-                enable_multimodal_chat=args.enable_multimodal_chat,'''
-disp_new = '''                output_len=args.speed_bench_output_len,
+d_edits = []
+if not have_forward:
+    # datasets.py -- forward args.chat_template_kwargs into the speed_bench .sample() call
+    d_edits.append(('''                output_len=args.speed_bench_output_len,
+                enable_multimodal_chat=args.enable_multimodal_chat,''',
+                    '''                output_len=args.speed_bench_output_len,
                 chat_template_kwargs=args.chat_template_kwargs,
-                enable_multimodal_chat=args.enable_multimodal_chat,'''
-
-# Edit 3: datasets.py -- forward chat_template_kwargs into CustomDataset.sample's template call
-samp_old = '''                # apply template
+                enable_multimodal_chat=args.enable_multimodal_chat,'''))
+if not have_unpack:
+    # datasets.py -- forward chat_template_kwargs into CustomDataset.sample's template call
+    d_edits.append(('''                # apply template
                 if not skip_chat_template:
                     prompt = tokenizer.apply_chat_template(
                         [{"role": "user", "content": prompt}],
@@ -187,8 +209,8 @@ samp_old = '''                # apply template
                         tokenize=False,
                     )
 
-                prompt_len = len(tokenizer(prompt).input_ids)'''
-samp_new = '''                # apply template
+                prompt_len = len(tokenizer(prompt).input_ids)''',
+                    '''                # apply template
                 if not skip_chat_template:
                     _ctk = kwargs.get("chat_template_kwargs") or {}
                     prompt = tokenizer.apply_chat_template(
@@ -198,9 +220,9 @@ samp_new = '''                # apply template
                         **_ctk,
                     )
 
-                prompt_len = len(tokenizer(prompt).input_ids)'''
-patch(D, [(disp_old, disp_new), (samp_old, samp_new)],
-      marker="chat_template_kwargs=args.chat_template_kwargs")
+                prompt_len = len(tokenizer(prompt).input_ids)'''))
+if d_edits:
+    apply(D, d_src, d_edits)
 PYEOF
 }
 

--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -41,8 +41,9 @@ source "$(dirname "$0")/../../benchmark_lib.sh"
 
 MODEL="${MODEL:?MODEL env var required (e.g. deepseek-ai/DeepSeek-V4-Pro-DSpark)}"
 # Serve from the local weights dir resolved by the launcher (MODEL_PATH points
-# at the pre-staged copy, e.g. /scratch/models/DeepSeek-V4-Pro-DSpark). Falls
-# back to MODEL for a standalone local run where MODEL is itself a path.
+# at the writable models dir, e.g. /data/models/DeepSeek-V4-Pro-DSpark, until the
+# checkpoint is staged; see the download block below). Falls back to MODEL for a
+# standalone local run where MODEL is itself a path.
 SERVE_MODEL="${MODEL_PATH:-$MODEL}"
 TP="${TP:-8}"
 DP_ATTENTION="${DP_ATTENTION:-false}"
@@ -57,11 +58,12 @@ CATEGORY="${CATEGORY:-coding}"
 # lowercased.
 MODEL_KEY="${MODEL_KEY:-$(basename "$SERVE_MODEL" | tr '[:upper:]' '[:lower:]')}"
 SPEEDBENCH_OUTPUT_LEN="${SPEEDBENCH_OUTPUT_LEN:-4096}"
-# Kept at 1 to match the DSV4 MTP collector that produced the existing
-# deepseek-v4-pro golden curve; the DSpark numbers are only meaningful against
-# MTP if both were measured the same way. Raise it if the 8h allocation is the
-# binding constraint (AL itself is concurrency-independent).
-CONCURRENCY="${CONCURRENCY:-1}"
+# AL is a per-draft accept/reject property and is independent of batch size, so
+# the SPEED-Bench pass is batched to cut wall-clock. Note this differs from the
+# DSV4 MTP collector, which measured the existing deepseek-v4-pro curve at 1;
+# nothing here sets speculative_disable_by_batch_size, so drafting stays on at
+# this batch size and the curves remain comparable.
+CONCURRENCY="${CONCURRENCY:-32}"
 TEMPERATURE="${TEMPERATURE:-1.0}"
 # thinking-on chat_template_kwargs. MUST match the production/golden config:
 # the reference matrix (golden_al_distribution/dsv4_mtp.yaml) was measured with
@@ -96,18 +98,21 @@ mkdir -p "$RESULTS_DIR"
 nvidia-smi
 
 # ---- Resolve target weights ----
-# DeepSeek-V4-Pro-DSpark is in the launcher's STAGED_MODELS, so MODEL_PATH
-# resolves to the read-only staged mount and this block is a no-op. It still
-# covers a standalone run where the weights are not staged.
+# The DSpark checkpoint is NOT in the launcher's STAGED_MODELS (it is not staged
+# on the B300 cluster yet), so MODEL_PATH resolves to the writable models dir and
+# the ~960 GB download below runs once, on the first collection. Add the basename
+# back to STAGED_MODELS once the weights are staged to read them from the faster
+# read-only mount instead.
 if [[ -n "${MODEL_PATH:-}" ]]; then
     if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
         if [[ ! -w "$(dirname "$MODEL_PATH")" ]]; then
             echo "CRITICAL: $MODEL_PATH is empty and $(dirname "$MODEL_PATH") is not writable."
-            echo "The DSpark checkpoint is not staged on this node. Ask for it to be staged,"
-            echo "or drop DeepSeek-V4-Pro-DSpark from STAGED_MODELS so MODEL_PATH resolves to"
-            echo "the writable models dir and the download below can run."
+            echo "This means the basename is listed in the launcher's STAGED_MODELS but the"
+            echo "weights were never staged. Either get them staged, or remove it from"
+            echo "STAGED_MODELS so MODEL_PATH resolves to the writable models dir instead."
             exit 1
         fi
+        echo "=== $MODEL_PATH is empty; downloading $MODEL (~960 GB, first run only) ==="
         hf download "$MODEL" --local-dir "$MODEL_PATH"
     fi
 else

--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -130,16 +130,20 @@ if [[ ! -f "$SPEEDBENCH_DIR/qualitative.jsonl" ]]; then
     exit 1
 fi
 
-# ---- Conditional shim: ensure --chat-template-kwargs reaches the chat template ----
+# ---- Preflight: --chat-template-kwargs must reach the chat template ----
 # speed_bench/CustomDataset pre-renders the chat template client-side and posts to
 # /v1/completions, so thinking mode cannot be enabled via --extra-body or
-# --default-chat-template-kwargs — the kwargs must reach apply_chat_template.
-# vllm-project/vllm#44244 added this natively (serve.py declares the CLI option,
-# the speed_bench dispatch forwards it, CustomDataset.sample unpacks it), and it
-# is present in the v0.25.x images this collector runs on. So: probe for native
-# support first and no-op when present; only patch the pieces an older image is
-# missing. Idempotent. Same shim as the Kimi-K3 collector.
-apply_chat_template_kwargs_shim() {
+# --default-chat-template-kwargs — the kwargs have to reach apply_chat_template.
+# vllm-project/vllm#44244 made that native and the images this collector runs on
+# carry it, so there is nothing to patch (the older collectors monkey-patched
+# site-packages here; that is what this replaces).
+#
+# It is still worth asserting rather than assuming, because the failure is silent
+# in one direction: if the CLI option exists but the speed_bench path does not
+# forward it, the flag is accepted and ignored, every thinking_on prompt renders
+# without thinking, and the cell reports a non-thinking AL under the thinking_on
+# key. A missing CLI option, by contrast, would fail loudly at argument parsing.
+assert_chat_template_kwargs_support() {
     echo "=== Checking vLLM benchmark --chat-template-kwargs support ==="
     python3 - <<'PYEOF'
 import sys
@@ -152,84 +156,31 @@ def read(mod):
 
 s_src, d_src = read(S), read(D)
 
-# Native (post-#44244) spellings, plus the ones this shim itself writes.
-have_cli = '"--chat-template-kwargs"' in s_src
-have_forward = ('chat_template_kwargs=getattr(args' in d_src
-                or 'chat_template_kwargs=args.chat_template_kwargs' in d_src)
-have_unpack = ('**(chat_template_kwargs or {})' in d_src
-               or '**_ctk' in d_src)
+missing = []
+if '"--chat-template-kwargs"' not in s_src:
+    missing.append(f"CLI option in {S.__file__}")
+if ('chat_template_kwargs=getattr(args' not in d_src
+        and 'chat_template_kwargs=args.chat_template_kwargs' not in d_src):
+    missing.append(f"speed_bench forward in {D.__file__}")
+if '**(chat_template_kwargs or {})' not in d_src:
+    missing.append(f"apply_chat_template unpack in {D.__file__}")
 
-if have_cli and have_forward and have_unpack:
-    print("native --chat-template-kwargs support present; no patching needed")
-    sys.exit(0)
+if missing:
+    print("CRITICAL: this image lacks native --chat-template-kwargs support:")
+    for item in missing:
+        print("  missing:", item)
+    print("thinking_on cells would silently measure a non-thinking AL. Use an")
+    print("image that contains vllm-project/vllm#44244.")
+    sys.exit(1)
 
-print(f"patching (cli={have_cli} forward={have_forward} unpack={have_unpack})")
-
-def apply(mod, src, edits):
-    for old, new in edits:
-        n = src.count(old)
-        assert n == 1, (
-            f"anchor matched {n} times in {mod.__file__}, aborting. This image's "
-            f"benchmark source differs from both the pre-#44244 and post-#44244 "
-            f"layouts; update the shim.\n{old[:120]}..."
-        )
-        src = src.replace(old, new, 1)
-    with open(mod.__file__, "w") as fh:
-        fh.write(src)
-    print("patched OK ->", mod.__file__)
-
-if not have_cli:
-    # serve.py -- declare the --chat-template-kwargs argument before --extra-body
-    apply(S, s_src, [('''    parser.add_argument(
-        "--extra-body",''', '''    parser.add_argument(
-        "--chat-template-kwargs",
-        type=json.loads,
-        default=None,
-        help="JSON dict forwarded to apply_chat_template during "
-        "client-side prompt rendering, e.g. to enable reasoning mode.",
-    )
-    parser.add_argument(
-        "--extra-body",''')])
-
-d_edits = []
-if not have_forward:
-    # datasets.py -- forward args.chat_template_kwargs into the speed_bench .sample() call
-    d_edits.append(('''                output_len=args.speed_bench_output_len,
-                enable_multimodal_chat=args.enable_multimodal_chat,''',
-                    '''                output_len=args.speed_bench_output_len,
-                chat_template_kwargs=args.chat_template_kwargs,
-                enable_multimodal_chat=args.enable_multimodal_chat,'''))
-if not have_unpack:
-    # datasets.py -- forward chat_template_kwargs into CustomDataset.sample's template call
-    d_edits.append(('''                # apply template
-                if not skip_chat_template:
-                    prompt = tokenizer.apply_chat_template(
-                        [{"role": "user", "content": prompt}],
-                        add_generation_prompt=True,
-                        tokenize=False,
-                    )
-
-                prompt_len = len(tokenizer(prompt).input_ids)''',
-                    '''                # apply template
-                if not skip_chat_template:
-                    _ctk = kwargs.get("chat_template_kwargs") or {}
-                    prompt = tokenizer.apply_chat_template(
-                        [{"role": "user", "content": prompt}],
-                        add_generation_prompt=True,
-                        tokenize=False,
-                        **_ctk,
-                    )
-
-                prompt_len = len(tokenizer(prompt).input_ids)'''))
-if d_edits:
-    apply(D, d_src, d_edits)
+print("native --chat-template-kwargs support confirmed")
 PYEOF
 }
 
-# Apply the shim once if any thinking-on cell is requested.
+# Only thinking-on cells pass chat_template_kwargs, so only they need the support.
 if [[ " $THINKING_MODES " == *" on "* ]]; then
-    if ! apply_chat_template_kwargs_shim; then
-        echo "CRITICAL: --chat-template-kwargs shim failed — aborting"
+    if ! assert_chat_template_kwargs_support; then
+        echo "CRITICAL: --chat-template-kwargs preflight failed — aborting"
         exit 1
     fi
 fi

--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+
+# DSV4-Pro B300 vLLM SPEED-Bench AL matrix collector for DSpark speculative
+# decoding.
+#
+# Produces the golden acceptance-length (AL) reference matrix consumed by the
+# synthetic-acceptance framework: for each thinking mode (on/off) and each
+# DSpark speculative-token count, measure the REAL AL on a single SPEED-Bench
+# category (default: coding) and emit a YAML matrix identical in shape to the
+# other golden_al_distribution curves.
+#
+# DSpark is DeepSeek's own speculative-decoding scheme and ships as a separate
+# checkpoint (deepseek-ai/DeepSeek-V4-Pro-DSpark, 960 GB) with the draft baked
+# in — unlike the Kimi-K3 DSpark collector there is no external draft head to
+# download and no "model" key in the speculative-config.
+#
+# Differences vs the DSV4 MTP collector (dsv4_fp4_b300_vllm.sh), which this is
+# otherwise a copy of so the two AL curves stay directly comparable:
+#   - target model       DeepSeek-V4-Pro-DSpark (was DeepSeek-V4-Pro)
+#   - speculative-config method dspark + draft_sample_method (was method mtp)
+# Every serve flag is left byte-identical to the MTP collector: it already
+# matches the published DSpark recipe, and holding the serving config fixed is
+# what makes "DSpark vs MTP on DSV4-Pro" a like-for-like AL comparison.
+#
+# Usage (inside the vLLM container, on a B300 node):
+#   export MODEL=deepseek-ai/DeepSeek-V4-Pro-DSpark
+#   bash benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+#
+# Tunables (env):
+#   MTP_LIST          space-separated DSpark spec-token counts (default "1 2 3 4 5 6 7 8")
+#   THINKING_MODES    space-separated: off|on       (default "off on")
+#   CATEGORY          SPEED-Bench category          (default coding)
+#   SPEEDBENCH_OUTPUT_LEN  per-request output len   (default 4096)
+#   OUT_YAML          output matrix path            (default $RESULTS_DIR/speedbench-reference-al.yaml)
+#   DRAFT_SAMPLE_METHOD    greedy|probabilistic     (default greedy)
+#   REJECTION_SAMPLE_METHOD  passed through to speculative-config when non-empty
+#                            (default: unset, i.e. the vLLM default)
+
+set -uo pipefail
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+MODEL="${MODEL:?MODEL env var required (e.g. deepseek-ai/DeepSeek-V4-Pro-DSpark)}"
+# Serve from the local weights dir resolved by the launcher (MODEL_PATH points
+# at the pre-staged copy, e.g. /scratch/models/DeepSeek-V4-Pro-DSpark). Falls
+# back to MODEL for a standalone local run where MODEL is itself a path.
+SERVE_MODEL="${MODEL_PATH:-$MODEL}"
+TP="${TP:-8}"
+DP_ATTENTION="${DP_ATTENTION:-false}"
+EP_SIZE="${EP_SIZE:-1}"
+PORT="${PORT:-8888}"
+
+MTP_LIST="${MTP_LIST:-1 2 3 4 5 6 7 8}"
+THINKING_MODES="${THINKING_MODES:-off on}"
+CATEGORY="${CATEGORY:-coding}"
+# Top-level key in the emitted YAML matrix. Derived from the model by the
+# workflow (e.g. deepseek-v4-pro-dspark); falls back to the model basename,
+# lowercased.
+MODEL_KEY="${MODEL_KEY:-$(basename "$SERVE_MODEL" | tr '[:upper:]' '[:lower:]')}"
+SPEEDBENCH_OUTPUT_LEN="${SPEEDBENCH_OUTPUT_LEN:-4096}"
+# Kept at 1 to match the DSV4 MTP collector that produced the existing
+# deepseek-v4-pro golden curve; the DSpark numbers are only meaningful against
+# MTP if both were measured the same way. Raise it if the 8h allocation is the
+# binding constraint (AL itself is concurrency-independent).
+CONCURRENCY="${CONCURRENCY:-1}"
+TEMPERATURE="${TEMPERATURE:-1.0}"
+# thinking-on chat_template_kwargs. MUST match the production/golden config:
+# the reference matrix (golden_al_distribution/dsv4_mtp.yaml) was measured with
+# reasoning_effort=high.
+DEFAULT_CHAT_TEMPLATE_KWARGS_ON='{"thinking": true, "reasoning_effort": "high"}'
+CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"
+# The greedy/probabilistic knob Benjamin asked to characterize on DSV4-Pro. The
+# published recipe uses greedy; probabilistic won at every level on Kimi-K3
+# (golden_al_distribution/kimik3_dspark*.yaml). vLLM accepts exactly these two
+# values (vllm/config/speculative.py: DraftSampleMethod).
+DRAFT_SAMPLE_METHOD="${DRAFT_SAMPLE_METHOD:-greedy}"
+case "$DRAFT_SAMPLE_METHOD" in
+    greedy|probabilistic) ;;
+    *)
+        echo "CRITICAL: DRAFT_SAMPLE_METHOD must be 'greedy' or 'probabilistic' (got '$DRAFT_SAMPLE_METHOD')"
+        exit 1
+        ;;
+esac
+# Left unset by default. The K3 probabilistic variant also flipped this to
+# "block", but that bundles two variables into one measurement and the forced-AL
+# config has to stay on a sampling method TRT-LLM supports too, so it is opt-in
+# here rather than tied to draft_sample_method.
+REJECTION_SAMPLE_METHOD="${REJECTION_SAMPLE_METHOD:-}"
+
+SPEEDBENCH_DIR="${SPEEDBENCH_DIR:-/workspace/speed_bench_data}"
+RESULTS_DIR="${RESULTS_DIR:-/workspace/speedbench_results}"
+OUT_YAML="${OUT_YAML:-$RESULTS_DIR/speedbench-reference-al.yaml}"
+
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+mkdir -p "$RESULTS_DIR"
+nvidia-smi
+
+# ---- Resolve target weights ----
+# DeepSeek-V4-Pro-DSpark is in the launcher's STAGED_MODELS, so MODEL_PATH
+# resolves to the read-only staged mount and this block is a no-op. It still
+# covers a standalone run where the weights are not staged.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        if [[ ! -w "$(dirname "$MODEL_PATH")" ]]; then
+            echo "CRITICAL: $MODEL_PATH is empty and $(dirname "$MODEL_PATH") is not writable."
+            echo "The DSpark checkpoint is not staged on this node. Ask for it to be staged,"
+            echo "or drop DeepSeek-V4-Pro-DSpark from STAGED_MODELS so MODEL_PATH resolves to"
+            echo "the writable models dir and the download below can run."
+            exit 1
+        fi
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    if [[ "$SERVE_MODEL" != /* ]]; then hf download "$SERVE_MODEL"; fi
+fi
+
+# ---- Download SPEED-Bench dataset ----
+echo "=== Downloading SPEED-Bench dataset ==="
+pip install -q datasets tiktoken
+curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \
+  | python3 - --config qualitative --output_dir "$SPEEDBENCH_DIR"
+
+if [[ ! -f "$SPEEDBENCH_DIR/qualitative.jsonl" ]]; then
+    echo "CRITICAL: SPEED-Bench download failed — $SPEEDBENCH_DIR/qualitative.jsonl not found"
+    exit 1
+fi
+
+# ---- Temporary shim: add a real --chat-template-kwargs CLI option ----
+# Upstream gap (until vllm-project/vllm#44244 lands): speed_bench/CustomDataset
+# pre-renders the chat template client-side WITHOUT chat_template_kwargs and
+# posts to /v1/completions, so thinking mode cannot be enabled via --extra-body
+# or --default-chat-template-kwargs. This wires a proper --chat-template-kwargs
+# option through get_samples into CustomDataset.sample's apply_chat_template.
+# TODO: delete this whole block once #44244 is released in the benchmark image;
+# the patch is idempotent (marker check) so it is safe to leave until then.
+apply_chat_template_kwargs_shim() {
+    echo "=== Patching vLLM benchmark to add --chat-template-kwargs (temporary shim) ==="
+    python3 - <<'PYEOF'
+import vllm.benchmarks.serve as S
+import vllm.benchmarks.datasets.datasets as D
+
+def patch(mod, edits, marker):
+    f = mod.__file__
+    src = open(f).read()
+    if marker in src:
+        print("already patched:", f)
+        return
+    for old, new in edits:
+        n = src.count(old)
+        assert n == 1, f"anchor matched {n} times in {f}, aborting:\n{old[:80]}..."
+        src = src.replace(old, new, 1)
+    open(f, "w").write(src)
+    print("patched OK ->", f)
+
+# Edit 1: serve.py -- declare the --chat-template-kwargs argument before --extra-body
+serve_old = '''    parser.add_argument(
+        "--extra-body",'''
+serve_new = '''    parser.add_argument(
+        "--chat-template-kwargs",
+        type=json.loads,
+        default=None,
+        help="JSON dict forwarded to apply_chat_template during "
+        "client-side prompt rendering, e.g. to enable reasoning mode.",
+    )
+    parser.add_argument(
+        "--extra-body",'''
+patch(S, [(serve_old, serve_new)], marker='"--chat-template-kwargs"')
+
+# Edit 2: datasets.py -- forward args.chat_template_kwargs into the speed_bench .sample() call
+disp_old = '''                output_len=args.speed_bench_output_len,
+                enable_multimodal_chat=args.enable_multimodal_chat,'''
+disp_new = '''                output_len=args.speed_bench_output_len,
+                chat_template_kwargs=args.chat_template_kwargs,
+                enable_multimodal_chat=args.enable_multimodal_chat,'''
+
+# Edit 3: datasets.py -- forward chat_template_kwargs into CustomDataset.sample's template call
+samp_old = '''                # apply template
+                if not skip_chat_template:
+                    prompt = tokenizer.apply_chat_template(
+                        [{"role": "user", "content": prompt}],
+                        add_generation_prompt=True,
+                        tokenize=False,
+                    )
+
+                prompt_len = len(tokenizer(prompt).input_ids)'''
+samp_new = '''                # apply template
+                if not skip_chat_template:
+                    _ctk = kwargs.get("chat_template_kwargs") or {}
+                    prompt = tokenizer.apply_chat_template(
+                        [{"role": "user", "content": prompt}],
+                        add_generation_prompt=True,
+                        tokenize=False,
+                        **_ctk,
+                    )
+
+                prompt_len = len(tokenizer(prompt).input_ids)'''
+patch(D, [(disp_old, disp_new), (samp_old, samp_new)],
+      marker="chat_template_kwargs=args.chat_template_kwargs")
+PYEOF
+}
+
+# Apply the shim once if any thinking-on cell is requested.
+if [[ " $THINKING_MODES " == *" on "* ]]; then
+    if ! apply_chat_template_kwargs_shim; then
+        echo "CRITICAL: --chat-template-kwargs shim failed — aborting"
+        exit 1
+    fi
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+MOE_ARGS=()
+if [ "${DP_ATTENTION}" = "true" ]; then
+    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
+fi
+
+# Optional extra speculative-config keys, rendered once so run_cell only has to
+# interpolate num_speculative_tokens.
+SPEC_EXTRA=""
+if [[ -n "$REJECTION_SAMPLE_METHOD" ]]; then
+    SPEC_EXTRA=", \"rejection_sample_method\": \"$REJECTION_SAMPLE_METHOD\""
+fi
+
+fetch_metric() {
+    local port="$1" name="$2"
+    curl -s "http://localhost:${port}/metrics" \
+      | grep -oP "${name}\\{[^}]*\\} \\K[0-9.]+" || echo "0"
+}
+
+SERVER_PID=""
+# List all descendant PIDs of $1 recursively, matched by PARENT pid. This can
+# never include this script (the script is an ancestor of the server, not a
+# descendant), so it avoids the self-kill a name-based `pkill -f vllm` caused
+# (the script filename contains "vllm").
+_descendants() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        echo "$child"
+        _descendants "$child"
+    done
+}
+cleanup_server() {
+    if [[ -n "$SERVER_PID" ]]; then
+        # Snapshot the server's worker/EngineCore subprocesses BEFORE killing the
+        # parent: once the parent dies the children reparent to init and the tree
+        # link is lost. Killing the captured PIDs guarantees no orphaned worker
+        # survives to hold GPU memory and OOM the next server start.
+        local descendants
+        descendants=$(_descendants "$SERVER_PID")
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        local pid
+        for pid in $descendants; do
+            kill -9 "$pid" 2>/dev/null || true
+        done
+        # Wait for GPU memory to actually free before the next server starts.
+        local waited=0
+        while [[ $waited -lt 120 ]]; do
+            local used
+            used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | sort -rn | head -1)
+            if [[ -z "$used" || "$used" -lt 2000 ]]; then break; fi
+            sleep 3; waited=$((waited + 3))
+        done
+        SERVER_PID=""
+    fi
+}
+trap 'cleanup_server' EXIT
+
+start_gpu_monitor
+
+# Per-cell AL is collected into associative arrays keyed by "mode_mtp".
+declare -A AL_RESULT
+
+run_cell() {
+    local mode="$1" mtp="$2"
+    local think_args=()
+    if [[ "$mode" == "on" ]]; then
+        think_args=(--chat-template-kwargs "$CHAT_TEMPLATE_KWARGS_ON")
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "  Cell: thinking=$mode  DSPARK=$mtp  category=$CATEGORY"
+    echo "  draft_sample_method=$DRAFT_SAMPLE_METHOD"
+    echo "=========================================="
+
+    local serve_args=(
+        --host 0.0.0.0 --port "$PORT"
+        "${PARALLEL_ARGS[@]}"
+        --pipeline-parallel-size 1
+        --kv-cache-dtype fp8
+        --trust-remote-code
+        --block-size 256
+        --no-enable-prefix-caching
+        "${EP_ARGS[@]}"
+        "${MOE_ARGS[@]}"
+        --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+        --attention_config.use_fp4_indexer_cache True
+        --tokenizer-mode deepseek_v4
+        --tool-call-parser deepseek_v4
+        --enable-auto-tool-choice
+        --reasoning-parser deepseek_v4
+        --max-cudagraph-capture-size 2048
+        --max-model-len 16384
+        --speculative-config "{\"method\": \"dspark\", \"num_speculative_tokens\": $mtp, \"draft_sample_method\": \"$DRAFT_SAMPLE_METHOD\"$SPEC_EXTRA}"
+    )
+
+    local server_log="$RESULTS_DIR/server_${mode}_mtp${mtp}.log"
+    vllm serve "$SERVE_MODEL" "${serve_args[@]}" > "$server_log" 2>&1 &
+    SERVER_PID=$!
+
+    if ! wait_for_server_ready --port "$PORT" --server-log "$server_log" --server-pid "$SERVER_PID"; then
+        echo "  -> server failed to start (thinking=$mode dspark=$mtp), recording N/A"
+        AL_RESULT["${mode}_${mtp}"]="N/A"
+        cleanup_server
+        return
+    fi
+
+    local acc_before drf_before acc_after drf_after
+    acc_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    vllm bench serve \
+        --model "$SERVE_MODEL" \
+        --port "$PORT" \
+        --dataset-name speed_bench \
+        --dataset-path "$SPEEDBENCH_DIR" \
+        --speed-bench-category "$CATEGORY" \
+        --speed-bench-output-len "$SPEEDBENCH_OUTPUT_LEN" \
+        --num-prompts -1 \
+        --max-concurrency "$CONCURRENCY" \
+        --save-result \
+        --save-detailed \
+        --result-dir "$RESULTS_DIR" \
+        --result-filename "speedbench_${mode}_mtp${mtp}" \
+        --trust-remote-code \
+        --tokenizer-mode deepseek_v4 \
+        --temperature "$TEMPERATURE" \
+        "${think_args[@]}"
+
+    acc_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    local delta_acc delta_drf al
+    delta_acc=$(awk "BEGIN {printf \"%d\", $acc_after - $acc_before}")
+    delta_drf=$(awk "BEGIN {printf \"%d\", $drf_after - $drf_before}")
+    if [[ "$delta_drf" -gt 0 ]]; then
+        al=$(awk "BEGIN {printf \"%.2f\", 1 + ($delta_acc / $delta_drf)}")
+    else
+        al="N/A"
+    fi
+    echo "  -> thinking=$mode DSPARK=$mtp AL=$al (accepted=$delta_acc drafts=$delta_drf)"
+    AL_RESULT["${mode}_${mtp}"]="$al"
+
+    cleanup_server
+}
+
+for mode in $THINKING_MODES; do
+    for mtp in $MTP_LIST; do
+        run_cell "$mode" "$mtp"
+    done
+done
+
+stop_gpu_monitor
+
+# ---- Emit the YAML matrix ----
+emit_mode_block() {
+    local mode="$1"
+    for mtp in $MTP_LIST; do
+        echo "    $mtp: ${AL_RESULT[${mode}_${mtp}]:-N/A}"
+    done
+}
+
+SPEC_SUMMARY="method=dspark | draft_sample_method=$DRAFT_SAMPLE_METHOD"
+if [[ -n "$REJECTION_SAMPLE_METHOD" ]]; then
+    SPEC_SUMMARY="$SPEC_SUMMARY | rejection_sample_method=$REJECTION_SAMPLE_METHOD"
+fi
+
+{
+    echo "# Acceptance Length (AL) reference values measured with SPEED-Bench."
+    echo "# dataset: $CATEGORY | temperature: $TEMPERATURE | output_len: $SPEEDBENCH_OUTPUT_LEN"
+    echo "# thinking_on chat_template_kwargs: $CHAT_TEMPLATE_KWARGS_ON"
+    echo "# speculative-config: $SPEC_SUMMARY"
+    echo "# Measured on $MODEL_KEY (B300, vLLM DSpark), per num_speculative_tokens."
+    echo "# Auto-generated by benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh (speedbench-al.yml)."
+    echo "#"
+    echo "# key = num_speculative_tokens (DSpark level); value = golden AL"
+    echo "${MODEL_KEY}:"
+    if [[ " $THINKING_MODES " == *" on "* ]]; then
+        echo "  thinking_on:"
+        emit_mode_block on
+    fi
+    if [[ " $THINKING_MODES " == *" off "* ]]; then
+        echo "  thinking_off:"
+        emit_mode_block off
+    fi
+} > "$OUT_YAML"
+
+echo ""
+echo "=========================================="
+echo "  SPEED-Bench AL matrix written to: $OUT_YAML"
+echo "=========================================="
+cat "$OUT_YAML"
+
+# A matrix where every cell is N/A is a failed collection, not a result: fail the
+# job so it is not mistaken for a curve worth reviewing.
+MEASURED=0
+for mode in $THINKING_MODES; do
+    for mtp in $MTP_LIST; do
+        [[ "${AL_RESULT[${mode}_${mtp}]:-N/A}" != "N/A" ]] && MEASURED=$((MEASURED + 1))
+    done
+done
+if [[ "$MEASURED" -eq 0 ]]; then
+    echo "CRITICAL: no cell produced an AL value — see the server logs and the"
+    echo "benchmark client output above."
+    exit 1
+fi

--- a/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dspark_fp4_b300_vllm.sh
@@ -18,12 +18,13 @@
 # otherwise a copy of so the two AL curves stay directly comparable:
 #   - target model       DeepSeek-V4-Pro-DSpark (was DeepSeek-V4-Pro)
 #   - speculative-config method dspark + draft_sample_method (was method mtp)
+#   - expert parallel + deep_gemm_mega_moe, per the published B300 DSpark recipe
 #   - --max-num-seqs and --gpu-memory-utilization pinned (MTP took the defaults)
-# The third one is a memory fix rather than a recipe change. AL is a per-draft
-# accept/reject property that does not depend on batch size or graph capture, so
-# pinning those two still leaves "DSpark vs MTP on DSV4-Pro" like-for-like; every
-# flag that does affect drafting is byte-identical to the MTP collector and to
-# the published DSpark recipe.
+# The last two are about fitting in memory, not about drafting: see the TEP block
+# and MAX_NUM_SEQS below for what each one was fixing. AL is a per-draft
+# accept/reject property, independent of expert placement, batch size and graph
+# capture, so they leave "DSpark vs MTP on DSV4-Pro" like-for-like. Every flag
+# that does affect drafting is byte-identical to the MTP collector.
 #
 # Usage (inside the vLLM container, on a B300 node):
 #   export MODEL=deepseek-ai/DeepSeek-V4-Pro-DSpark
@@ -51,8 +52,6 @@ MODEL="${MODEL:?MODEL env var required (e.g. deepseek-ai/DeepSeek-V4-Pro-DSpark)
 # standalone local run where MODEL is itself a path.
 SERVE_MODEL="${MODEL_PATH:-$MODEL}"
 TP="${TP:-8}"
-DP_ATTENTION="${DP_ATTENTION:-false}"
-EP_SIZE="${EP_SIZE:-1}"
 PORT="${PORT:-8888}"
 
 MTP_LIST="${MTP_LIST:-1 2 3 4 5 6 7 8}"
@@ -202,18 +201,24 @@ if [[ " $THINKING_MODES " == *" on "* ]]; then
     fi
 fi
 
+# TEP8, exactly as the published B300 DSpark recipe (vllm-project/recipes: TP 8 +
+# --enable-expert-parallel + --moe-backend deep_gemm_mega_moe).
+#
+# This is hard-coded rather than driven by the EP_SIZE / DP_ATTENTION knobs the
+# MTP collector carries, because speedbench-al.yml exports EP_SIZE=1 and
+# DP_ATTENTION=false for every model in the matrix, which silently turned the
+# recipe into plain TP. That cost real memory: TP-sharding the FP4 experts loaded
+# 141.53 GiB per GPU, 8x that being 1132 GiB against an 831 GiB checkpoint, so
+# roughly 37 GiB per GPU went to sharding overhead on weights that expert
+# parallel keeps whole. With a ~100 GiB KV cache on top, 266 of the 268 GiB were
+# gone before warmup, which is what made the num_speculative_tokens=4 cell OOM.
+#
+# TP stays 8 (not the DP+EP variant the recipe also lists) to match the MTP
+# collector's parallelism. Either way AL is unaffected: expert placement changes
+# where a matmul runs, not which draft tokens the target model accepts.
 PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
-if [ "${DP_ATTENTION}" = "true" ]; then
-    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
-fi
-EP_ARGS=()
-if [ "${EP_SIZE:-1}" -gt 1 ]; then
-    EP_ARGS=(--enable-expert-parallel)
-fi
-MOE_ARGS=()
-if [ "${DP_ATTENTION}" = "true" ]; then
-    MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
-fi
+EP_ARGS=(--enable-expert-parallel)
+MOE_ARGS=(--moe-backend deep_gemm_mega_moe)
 
 # Optional extra speculative-config keys, rendered once so run_cell only has to
 # interpolate num_speculative_tokens.

--- a/benchmarks/single_node/speedbench/dsv4dsparkprob_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/dsv4dsparkprob_fp4_b300_vllm.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Probabilistic-drafting arm of the DSV4-Pro DSpark AL collection.
+#
+# Identical to dsv4dspark_fp4_b300_vllm.sh in every respect except
+# draft_sample_method, which becomes "probabilistic" instead of the published
+# recipe's "greedy". Running both arms is what answers the open question on
+# DSV4-Pro (probabilistic beat greedy at every level on Kimi-K3, see
+# golden_al_distribution/kimik3_dspark*.yaml, but that has not been shown here).
+#
+# This exists as a separate file only because speedbench-al.yml resolves the
+# collector purely as ${model-prefix}_fp4_b300_vllm.sh, so a second dispatchable
+# entry point is the only way to launch the second arm. It delegates instead of
+# duplicating the collector so the two arms cannot drift apart.
+#
+# Dispatch with model-prefix=dsv4dsparkprob.
+
+exec env DRAFT_SAMPLE_METHOD=probabilistic \
+    bash "$(dirname "$0")/dsv4dspark_fp4_b300_vllm.sh" "$@"

--- a/benchmarks/single_node/speedbench/qwen3.8_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/qwen3.8_fp4_b300_vllm.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+
+# Qwen3.8-2.4T-A95B B300 vLLM SPEED-Bench AL matrix collector.
+#
+# Model-specific notes (all per the Qwen3.8-2.4T-A95B card / recipe):
+#   - THINKING-ONLY: thinking cannot be disabled (the chat template raises on
+#     enable_thinking=false), so only the "on" arm is collected; a stray "off"
+#     (e.g. the workflow's default "off on") is dropped below.
+#   - Sampling (thinking): temp 1.0, top_p 0.95, top_k 20, presence_penalty 0.0.
+#   - reasoning_effort is xhigh (default) / medium / low — there is no "high".
+#   - parsers: reasoning qwen3, tool-call qwen3_coder.
+#   - --max-num-seqs 256 bounds the recurrent-state cache and MTP logits buffer:
+#     with a small --max-model-len the engine would otherwise admit ~500 seqs and
+#     OOM this 1.32 TiB NVFP4 model on B300 (268 GB/GPU, tighter than GB300).
+#     --max-cudagraph-capture-size is kept <= max-num-seqs so the hybrid GDN
+#     backbone does not trip the "num_cache_lines >= batch" capture assert.
+#
+# Dispatch requirements (NOT set here — pass via speedbench-al.yml inputs):
+#   - image: vLLM nightly WITH transformers>=5.4.0 (the v0.21.x default won't load it).
+#   - thinking-kwargs: {"enable_thinking": true, "reasoning_effort": "xhigh"}
+#     (the workflow default {"thinking": true, "reasoning_effort": "high"} is
+#     invalid here and is rejected below).
+#   - model: Inferact/Qwen3.8-2.4T-A95B-NVFP4 (1.32 TiB; only NVFP4 fits 8xB300 TP8).
+
+set -uo pipefail
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+MODEL="${MODEL:?MODEL env var required (e.g. /scratch/models/Qwen3.8-2.4T-A95B-NVFP4)}"
+SERVE_MODEL="${MODEL_PATH:-$MODEL}"
+TP="${TP:-8}"
+DP_ATTENTION="${DP_ATTENTION:-false}"
+EP_SIZE="${EP_SIZE:-1}"
+PORT="${PORT:-8888}"
+
+MTP_LIST="${MTP_LIST:-1 2 3 4 5 6 7 8}"
+THINKING_MODES="${THINKING_MODES:-on}"
+CATEGORY="${CATEGORY:-coding}"
+MODEL_KEY="${MODEL_KEY:-qwen3.8-2.4t-a95b}"
+SPEEDBENCH_OUTPUT_LEN="${SPEEDBENCH_OUTPUT_LEN:-4096}"
+CONCURRENCY="${CONCURRENCY:-16}"
+# Sampling per the card (thinking); min_p 0.0 / repetition_penalty 1.0 are vLLM defaults.
+TEMPERATURE_ON="${TEMPERATURE_ON:-1.0}"; TOP_P_ON="${TOP_P_ON:-0.95}"; TOP_K_ON="${TOP_K_ON:-20}"; PRESENCE_PENALTY_ON="${PRESENCE_PENALTY_ON:-0.0}"
+SEED="${SEED:-}"
+SAVE_DETAILED="${SAVE_DETAILED:-}"
+
+# Thinking-only: drop any "off" (e.g. the workflow's default "off on") so a
+# default dispatch still yields the on-only matrix instead of aborting.
+_modes=""
+for _m in $THINKING_MODES; do
+    if [[ "$_m" == "off" ]]; then
+        echo "WARNING: Qwen3.8-2.4T-A95B is thinking-only; skipping thinking=off."
+    else
+        _modes="$_modes $_m"
+    fi
+done
+THINKING_MODES="${_modes# }"
+
+REASONING_EFFORT="${REASONING_EFFORT:-xhigh}"
+DEFAULT_CHAT_TEMPLATE_KWARGS_ON="{\"enable_thinking\": true, \"reasoning_effort\": \"$REASONING_EFFORT\"}"
+CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"
+# Guard the deepseek-shaped workflow default ({"thinking": true, "reasoning_effort":
+# "high"}): Qwen needs the enable_thinking key and only accepts xhigh/medium/low.
+if [[ "$CHAT_TEMPLATE_KWARGS_ON" != *enable_thinking* || "$CHAT_TEMPLATE_KWARGS_ON" == *'"high"'* ]]; then
+    echo "CRITICAL: thinking-on chat_template_kwargs must use enable_thinking and reasoning_effort xhigh/medium/low."
+    echo "Got: $CHAT_TEMPLATE_KWARGS_ON  (set the workflow 'thinking-kwargs' input accordingly)"
+    exit 1
+fi
+
+SPEEDBENCH_DIR="${SPEEDBENCH_DIR:-/workspace/speed_bench_data}"
+# Flat results dir to match the speedbench-al.yml artifact glob
+# (speedbench_results/server_*.log) and its pre-run `rm -rf speedbench_results`.
+RESULTS_DIR="${RESULTS_DIR:-/workspace/speedbench_results}"
+OUT_YAML="${OUT_YAML:-$RESULTS_DIR/speedbench-reference-al.yaml}"
+
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+mkdir -p "$RESULTS_DIR"
+nvidia-smi
+
+# ---- Resolve target weights ----
+# Not in the launcher's STAGED_MODELS, so MODEL_PATH points at the writable models
+# dir and the NVFP4 weights (~1.3 TiB) download once here on the first run. Add the
+# basename to STAGED_MODELS once staged to read from the faster read-only mount.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        if [[ ! -w "$(dirname "$MODEL_PATH")" ]]; then
+            echo "CRITICAL: $MODEL_PATH is empty and $(dirname "$MODEL_PATH") is not writable."
+            echo "This means the basename is listed in the launcher's STAGED_MODELS but the"
+            echo "weights were never staged. Either get them staged, or remove it from"
+            echo "STAGED_MODELS so MODEL_PATH resolves to the writable models dir instead."
+            exit 1
+        fi
+        echo "=== $MODEL_PATH is empty; downloading $MODEL (~1.3 TiB, first run only) ==="
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    if [[ "$SERVE_MODEL" != /* ]]; then hf download "$SERVE_MODEL"; fi
+fi
+
+# ---- Download SPEED-Bench dataset ----
+echo "=== Downloading SPEED-Bench dataset ==="
+pip install -q datasets tiktoken
+curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \
+  | python3 - --config qualitative --output_dir "$SPEEDBENCH_DIR"
+
+if [[ ! -f "$SPEEDBENCH_DIR/qualitative.jsonl" ]]; then
+    echo "CRITICAL: SPEED-Bench download failed — $SPEEDBENCH_DIR/qualitative.jsonl not found"
+    exit 1
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+if [ "${DP_ATTENTION}" = "true" ]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+EP_ARGS=()
+if [ "${EP_SIZE:-1}" -gt 1 ]; then
+    EP_ARGS=(--enable-expert-parallel)
+fi
+
+fetch_metric() {
+    local port="$1" name="$2"
+    curl -s "http://localhost:${port}/metrics" \
+      | grep -oP "${name}\\{[^}]*\\} \\K[0-9.]+" || echo "0"
+}
+
+SERVER_PID=""
+_descendants() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        echo "$child"
+        _descendants "$child"
+    done
+}
+cleanup_server() {
+    if [[ -n "$SERVER_PID" ]]; then
+        local descendants
+        descendants=$(_descendants "$SERVER_PID")
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        local pid
+        for pid in $descendants; do
+            kill -9 "$pid" 2>/dev/null || true
+        done
+        local waited=0
+        while [[ $waited -lt 120 ]]; do
+            local used
+            used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | sort -rn | head -1)
+            if [[ -z "$used" || "$used" -lt 2000 ]]; then break; fi
+            sleep 3; waited=$((waited + 3))
+        done
+        SERVER_PID=""
+    fi
+}
+trap 'cleanup_server' EXIT
+
+start_gpu_monitor
+
+declare -A AL_RESULT
+
+run_cell() {
+    local mode="$1" mtp="$2"
+    local think_args=()
+    local temp top_p top_k pp
+    # Thinking-only: mode is always "on".
+    [[ -n "$CHAT_TEMPLATE_KWARGS_ON" ]] && think_args=(--chat-template-kwargs "$CHAT_TEMPLATE_KWARGS_ON")
+    temp="$TEMPERATURE_ON"; top_p="$TOP_P_ON"; top_k="$TOP_K_ON"; pp="$PRESENCE_PENALTY_ON"
+
+    local seed_args=()
+    [[ -n "$SEED" ]] && seed_args=(--seed "$SEED")
+    local detail_args=()
+    [[ -n "$SAVE_DETAILED" ]] && detail_args=(--save-detailed)
+
+    echo ""
+    echo "=========================================="
+    echo "  Cell: thinking=$mode  MTP=$mtp  category=$CATEGORY"
+    echo "=========================================="
+
+    local serve_args=(
+        --host 0.0.0.0 --port "$PORT"
+        "${PARALLEL_ARGS[@]}"
+        --pipeline-parallel-size 1
+        --kv-cache-dtype fp8
+        --trust-remote-code
+        --no-enable-prefix-caching
+        "${EP_ARGS[@]}"
+        --reasoning-parser qwen3
+        --tool-call-parser qwen3_coder
+        --enable-auto-tool-choice
+        --max-num-seqs 256
+        --gpu-memory-utilization 0.90
+        --max-cudagraph-capture-size 256
+        --max-model-len 16384
+        --speculative-config "{\"method\": \"mtp\", \"num_speculative_tokens\": $mtp}"
+    )
+
+    local server_log="$RESULTS_DIR/server_${mode}_mtp${mtp}.log"
+    vllm serve "$SERVE_MODEL" "${serve_args[@]}" > "$server_log" 2>&1 &
+    SERVER_PID=$!
+
+    # wait_for_server_ready exits the shell (not return) when the server dies, which
+    # would make the N/A branch unreachable and let one bad cell abort the whole
+    # matrix. The subshell keeps that exit local: a cell that cannot start its
+    # server costs one cell instead of the run.
+    if ! (wait_for_server_ready --port "$PORT" --server-log "$server_log" --server-pid "$SERVER_PID"); then
+        echo "  -> server failed to start (thinking=$mode mtp=$mtp), recording N/A"
+        AL_RESULT["${mode}_${mtp}"]="N/A"
+        cleanup_server
+        return
+    fi
+
+    local acc_before drf_before acc_after drf_after
+    acc_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    vllm bench serve \
+        --model "$SERVE_MODEL" \
+        --port "$PORT" \
+        --dataset-name speed_bench \
+        --dataset-path "$SPEEDBENCH_DIR" \
+        --speed-bench-category "$CATEGORY" \
+        --speed-bench-output-len "$SPEEDBENCH_OUTPUT_LEN" \
+        --num-prompts -1 \
+        --max-concurrency "$CONCURRENCY" \
+        --save-result \
+        --save-detailed \
+        --result-dir "$RESULTS_DIR" \
+        --result-filename "speedbench_${mode}_mtp${mtp}" \
+        --trust-remote-code \
+        --temperature "$temp" \
+        --top-p "$top_p" \
+        --top-k "$top_k" \
+        --presence-penalty "$pp" \
+        "${seed_args[@]}" \
+        "${detail_args[@]}" \
+        "${think_args[@]}"
+
+    acc_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    local delta_acc delta_drf al
+    delta_acc=$(awk "BEGIN {printf \"%d\", $acc_after - $acc_before}")
+    delta_drf=$(awk "BEGIN {printf \"%d\", $drf_after - $drf_before}")
+    if [[ "$delta_drf" -gt 0 ]]; then
+        al=$(awk "BEGIN {printf \"%.2f\", 1 + ($delta_acc / $delta_drf)}")
+    else
+        al="N/A"
+    fi
+    echo "  -> thinking=$mode MTP=$mtp AL=$al (accepted=$delta_acc drafts=$delta_drf)"
+    AL_RESULT["${mode}_${mtp}"]="$al"
+
+    cleanup_server
+}
+
+for mode in $THINKING_MODES; do
+    for mtp in $MTP_LIST; do
+        run_cell "$mode" "$mtp"
+    done
+done
+
+stop_gpu_monitor
+
+# ---- Emit the YAML matrix ----
+emit_mode_block() {
+    local mode="$1"
+    for mtp in $MTP_LIST; do
+        echo "    $mtp: ${AL_RESULT[${mode}_${mtp}]:-N/A}"
+    done
+}
+
+{
+    echo "# Acceptance Length (AL) reference values measured with SPEED-Bench."
+    echo "# dataset: $CATEGORY | output_len: $SPEEDBENCH_OUTPUT_LEN"
+    echo "# thinking_on : temp $TEMPERATURE_ON top_p $TOP_P_ON top_k $TOP_K_ON presence_penalty $PRESENCE_PENALTY_ON | chat_template_kwargs: $CHAT_TEMPLATE_KWARGS_ON"
+    echo "# Thinking-only model (enable_thinking=false is rejected by the chat template)."
+    echo "# Measured on $MODEL_KEY (B300, vLLM MTP), per num_speculative_tokens."
+    echo "# Auto-generated by benchmarks/single_node/speedbench/qwen3.8_fp4_b300_vllm.sh (speedbench-al.yml)."
+    echo "#"
+    echo "# key = num_speculative_tokens (MTP level); value = golden AL"
+    echo "${MODEL_KEY}:"
+    if [[ " $THINKING_MODES " == *" on "* ]]; then
+        echo "  thinking_on:"
+        emit_mode_block on
+    fi
+} > "$OUT_YAML"
+
+echo ""
+echo "=== Wrote AL matrix to $OUT_YAML ==="
+cat "$OUT_YAML"

--- a/benchmarks/single_node/speedbench/qwen3.8flashnext_fp4_b300_vllm.sh
+++ b/benchmarks/single_node/speedbench/qwen3.8flashnext_fp4_b300_vllm.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# Qwen3.8-Flash-Next B300 vLLM SPEED-Bench AL matrix collector.
+#
+# Emits the golden AL matrix (thinking on/off x MTP level) in the same shape as
+# benchmarks/speedbench-reference-al.yaml. Adapted from qwen3.5_fp4_b300_vllm.sh.
+#
+# Model-specific notes (all per the Qwen3.8-Flash-Next card / recipe):
+#   - tool-call-parser qwen3_xml (NOT qwen3_coder); reasoning-parser qwen3.
+#   - TP is HARD-CODED to 4 (recipe-validated; QSA has only 2 KV heads, TP8 is
+#     never validated). AL is parallelism-independent so this only pins the config.
+#   - recipe serve extras: --max-num-seqs 256, --gpu-memory-utilization 0.90,
+#     --no-enable-flashinfer-autotune; --max-cudagraph-capture-size kept
+#     <= max-num-seqs so the hybrid GDN backbone does not trip the capture assert.
+#   - thinking on/off via the enable_thinking key; reasoning_effort is
+#     xhigh (default) / medium / low — there is no "high".
+#   - weights are BF16 Qwen/Qwen3.8-Flash-Next (~423 GB, fits 4x B300); the
+#     "_fp4_" in the filename is only the shared naming convention.
+#
+# Dispatch requirements (NOT set here — pass via speedbench-al.yml inputs):
+#   - image: the dedicated vllm/vllm-openai:qwen38-flash-next (PyPI is unsupported).
+#   - thinking-kwargs: {"enable_thinking": true, "reasoning_effort": "xhigh"}
+#     (the workflow default {"thinking": true, "reasoning_effort": "high"} is
+#     invalid here and is rejected below).
+#   - model: Qwen/Qwen3.8-Flash-Next.
+
+set -uo pipefail
+source "$(dirname "$0")/../../benchmark_lib.sh"
+
+MODEL="${MODEL:?MODEL env var required (e.g. Qwen/Qwen3.8-Flash-Next)}"
+SERVE_MODEL="${MODEL_PATH:-$MODEL}"
+# TP pinned to 4 (recipe-validated); not driven by the workflow's TP=8.
+TP=4
+PORT="${PORT:-8888}"
+
+MTP_LIST="${MTP_LIST:-1 2 3 4 5 6 7 8}"
+THINKING_MODES="${THINKING_MODES:-off on}"
+CATEGORY="${CATEGORY:-coding}"
+MODEL_KEY="${MODEL_KEY:-qwen3.8-flash-next}"
+SPEEDBENCH_OUTPUT_LEN="${SPEEDBENCH_OUTPUT_LEN:-4096}"
+CONCURRENCY="${CONCURRENCY:-16}"
+# Sampling per the card, per-mode (min_p 0.0 / repetition_penalty 1.0 are vLLM defaults):
+#   thinking : temp 1.0, top_p 0.95, top_k 20, presence_penalty 0.0
+#   instruct : temp 0.7, top_p 0.80, top_k 20, presence_penalty 1.5
+TEMPERATURE_ON="${TEMPERATURE_ON:-1.0}";  TOP_P_ON="${TOP_P_ON:-0.95}";  TOP_K_ON="${TOP_K_ON:-20}";  PRESENCE_PENALTY_ON="${PRESENCE_PENALTY_ON:-0.0}"
+TEMPERATURE_OFF="${TEMPERATURE_OFF:-0.7}"; TOP_P_OFF="${TOP_P_OFF:-0.8}"; TOP_K_OFF="${TOP_K_OFF:-20}"; PRESENCE_PENALTY_OFF="${PRESENCE_PENALTY_OFF:-1.5}"
+SEED="${SEED:-}"
+SAVE_DETAILED="${SAVE_DETAILED:-}"
+
+REASONING_EFFORT="${REASONING_EFFORT:-xhigh}"
+DEFAULT_CHAT_TEMPLATE_KWARGS_ON="{\"enable_thinking\": true, \"reasoning_effort\": \"$REASONING_EFFORT\"}"
+DEFAULT_CHAT_TEMPLATE_KWARGS_OFF='{"enable_thinking": false}'
+CHAT_TEMPLATE_KWARGS_ON="${CHAT_TEMPLATE_KWARGS_ON:-$DEFAULT_CHAT_TEMPLATE_KWARGS_ON}"
+CHAT_TEMPLATE_KWARGS_OFF="${CHAT_TEMPLATE_KWARGS_OFF:-$DEFAULT_CHAT_TEMPLATE_KWARGS_OFF}"
+# Guard the deepseek-shaped workflow default ({"thinking": true, "reasoning_effort":
+# "high"}): Qwen needs the enable_thinking key and only accepts xhigh/medium/low.
+if [[ "$CHAT_TEMPLATE_KWARGS_ON" != *enable_thinking* || "$CHAT_TEMPLATE_KWARGS_ON" == *'"high"'* ]]; then
+    echo "CRITICAL: thinking-on chat_template_kwargs must use enable_thinking and reasoning_effort xhigh/medium/low."
+    echo "Got: $CHAT_TEMPLATE_KWARGS_ON  (set the workflow 'thinking-kwargs' input accordingly)"
+    exit 1
+fi
+
+SPEEDBENCH_DIR="${SPEEDBENCH_DIR:-/workspace/speed_bench_data}"
+# Flat results dir to match the speedbench-al.yml artifact glob
+# (speedbench_results/server_*.log) and its pre-run `rm -rf speedbench_results`.
+RESULTS_DIR="${RESULTS_DIR:-/workspace/speedbench_results}"
+OUT_YAML="${OUT_YAML:-$RESULTS_DIR/speedbench-reference-al.yaml}"
+
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+
+mkdir -p "$RESULTS_DIR"
+nvidia-smi
+
+# ---- Resolve target weights ----
+# Not in the launcher's STAGED_MODELS, so MODEL_PATH points at the writable models
+# dir and the BF16 weights (~423 GB) download once here on the first run. Add the
+# basename to STAGED_MODELS once staged to read from the faster read-only mount.
+if [[ -n "${MODEL_PATH:-}" ]]; then
+    if [[ ! -d "$MODEL_PATH" || -z "$(ls -A "$MODEL_PATH" 2>/dev/null)" ]]; then
+        if [[ ! -w "$(dirname "$MODEL_PATH")" ]]; then
+            echo "CRITICAL: $MODEL_PATH is empty and $(dirname "$MODEL_PATH") is not writable."
+            echo "This means the basename is listed in the launcher's STAGED_MODELS but the"
+            echo "weights were never staged. Either get them staged, or remove it from"
+            echo "STAGED_MODELS so MODEL_PATH resolves to the writable models dir instead."
+            exit 1
+        fi
+        echo "=== $MODEL_PATH is empty; downloading $MODEL (~423 GB, first run only) ==="
+        hf download "$MODEL" --local-dir "$MODEL_PATH"
+    fi
+else
+    if [[ "$SERVE_MODEL" != /* ]]; then hf download "$SERVE_MODEL"; fi
+fi
+
+# ---- Download SPEED-Bench dataset ----
+echo "=== Downloading SPEED-Bench dataset ==="
+pip install -q datasets tiktoken
+curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \
+  | python3 - --config qualitative --output_dir "$SPEEDBENCH_DIR"
+
+if [[ ! -f "$SPEEDBENCH_DIR/qualitative.jsonl" ]]; then
+    echo "CRITICAL: SPEED-Bench download failed — $SPEEDBENCH_DIR/qualitative.jsonl not found"
+    exit 1
+fi
+
+PARALLEL_ARGS=(--tensor-parallel-size "$TP" --data-parallel-size 1)
+
+fetch_metric() {
+    local port="$1" name="$2"
+    curl -s "http://localhost:${port}/metrics" \
+      | grep -oP "${name}\\{[^}]*\\} \\K[0-9.]+" || echo "0"
+}
+
+SERVER_PID=""
+_descendants() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        echo "$child"
+        _descendants "$child"
+    done
+}
+cleanup_server() {
+    if [[ -n "$SERVER_PID" ]]; then
+        local descendants
+        descendants=$(_descendants "$SERVER_PID")
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        local pid
+        for pid in $descendants; do
+            kill -9 "$pid" 2>/dev/null || true
+        done
+        local waited=0
+        while [[ $waited -lt 120 ]]; do
+            local used
+            used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | sort -rn | head -1)
+            if [[ -z "$used" || "$used" -lt 2000 ]]; then break; fi
+            sleep 3; waited=$((waited + 3))
+        done
+        SERVER_PID=""
+    fi
+}
+trap 'cleanup_server' EXIT
+
+start_gpu_monitor
+
+declare -A AL_RESULT
+
+run_cell() {
+    local mode="$1" mtp="$2"
+    local think_args=()
+    local temp top_p top_k pp
+    if [[ "$mode" == "on" ]]; then
+        [[ -n "$CHAT_TEMPLATE_KWARGS_ON" ]] && think_args=(--chat-template-kwargs "$CHAT_TEMPLATE_KWARGS_ON")
+        temp="$TEMPERATURE_ON";  top_p="$TOP_P_ON";  top_k="$TOP_K_ON";  pp="$PRESENCE_PENALTY_ON"
+    else
+        [[ -n "$CHAT_TEMPLATE_KWARGS_OFF" ]] && think_args=(--chat-template-kwargs "$CHAT_TEMPLATE_KWARGS_OFF")
+        temp="$TEMPERATURE_OFF"; top_p="$TOP_P_OFF"; top_k="$TOP_K_OFF"; pp="$PRESENCE_PENALTY_OFF"
+    fi
+    local seed_args=()
+    [[ -n "$SEED" ]] && seed_args=(--seed "$SEED")
+    local detail_args=()
+    [[ -n "$SAVE_DETAILED" ]] && detail_args=(--save-detailed)
+
+    echo ""
+    echo "=========================================="
+    echo "  Cell: thinking=$mode  MTP=$mtp  category=$CATEGORY"
+    echo "=========================================="
+
+    local serve_args=(
+        --host 0.0.0.0 --port "$PORT"
+        "${PARALLEL_ARGS[@]}"
+        --pipeline-parallel-size 1
+        --trust-remote-code
+        --no-enable-prefix-caching
+        --max-num-seqs 256
+        --gpu-memory-utilization 0.90
+        --no-enable-flashinfer-autotune
+        --reasoning-parser qwen3
+        --tool-call-parser qwen3_xml
+        --enable-auto-tool-choice
+        --max-cudagraph-capture-size 256
+        --max-model-len 16384
+        --speculative-config "{\"method\": \"mtp\", \"num_speculative_tokens\": $mtp}"
+    )
+
+    local server_log="$RESULTS_DIR/server_${mode}_mtp${mtp}.log"
+    vllm serve "$SERVE_MODEL" "${serve_args[@]}" > "$server_log" 2>&1 &
+    SERVER_PID=$!
+
+    # wait_for_server_ready exits the shell (not return) when the server dies, which
+    # would make the N/A branch unreachable and let one bad cell abort the whole
+    # matrix. The subshell keeps that exit local: a cell that cannot start its
+    # server costs one cell instead of the run.
+    if ! (wait_for_server_ready --port "$PORT" --server-log "$server_log" --server-pid "$SERVER_PID"); then
+        echo "  -> server failed to start (thinking=$mode mtp=$mtp), recording N/A"
+        AL_RESULT["${mode}_${mtp}"]="N/A"
+        cleanup_server
+        return
+    fi
+
+    local acc_before drf_before acc_after drf_after
+    acc_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_before=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    vllm bench serve \
+        --model "$SERVE_MODEL" \
+        --port "$PORT" \
+        --dataset-name speed_bench \
+        --dataset-path "$SPEEDBENCH_DIR" \
+        --speed-bench-category "$CATEGORY" \
+        --speed-bench-output-len "$SPEEDBENCH_OUTPUT_LEN" \
+        --num-prompts -1 \
+        --max-concurrency "$CONCURRENCY" \
+        --save-result \
+        --save-detailed \
+        --result-dir "$RESULTS_DIR" \
+        --result-filename "speedbench_${mode}_mtp${mtp}" \
+        --trust-remote-code \
+        --temperature "$temp" \
+        --top-p "$top_p" \
+        --top-k "$top_k" \
+        --presence-penalty "$pp" \
+        "${seed_args[@]}" \
+        "${detail_args[@]}" \
+        "${think_args[@]}"
+
+    acc_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_accepted_tokens_total")
+    drf_after=$(fetch_metric "$PORT" "vllm:spec_decode_num_drafts_total")
+
+    local delta_acc delta_drf al
+    delta_acc=$(awk "BEGIN {printf \"%d\", $acc_after - $acc_before}")
+    delta_drf=$(awk "BEGIN {printf \"%d\", $drf_after - $drf_before}")
+    if [[ "$delta_drf" -gt 0 ]]; then
+        al=$(awk "BEGIN {printf \"%.2f\", 1 + ($delta_acc / $delta_drf)}")
+    else
+        al="N/A"
+    fi
+    echo "  -> thinking=$mode MTP=$mtp AL=$al (accepted=$delta_acc drafts=$delta_drf)"
+    AL_RESULT["${mode}_${mtp}"]="$al"
+
+    cleanup_server
+}
+
+for mode in $THINKING_MODES; do
+    for mtp in $MTP_LIST; do
+        run_cell "$mode" "$mtp"
+    done
+done
+
+stop_gpu_monitor
+
+# ---- Emit the YAML matrix ----
+emit_mode_block() {
+    local mode="$1"
+    for mtp in $MTP_LIST; do
+        echo "    $mtp: ${AL_RESULT[${mode}_${mtp}]:-N/A}"
+    done
+}
+
+{
+    echo "# Acceptance Length (AL) reference values measured with SPEED-Bench."
+    echo "# dataset: $CATEGORY | output_len: $SPEEDBENCH_OUTPUT_LEN"
+    echo "# thinking_on : temp $TEMPERATURE_ON top_p $TOP_P_ON top_k $TOP_K_ON presence_penalty $PRESENCE_PENALTY_ON | chat_template_kwargs: $CHAT_TEMPLATE_KWARGS_ON"
+    echo "# thinking_off: temp $TEMPERATURE_OFF top_p $TOP_P_OFF top_k $TOP_K_OFF presence_penalty $PRESENCE_PENALTY_OFF | chat_template_kwargs: $CHAT_TEMPLATE_KWARGS_OFF"
+    echo "# Measured on $MODEL_KEY (B300, TP4, vLLM MTP), per num_speculative_tokens."
+    echo "# Auto-generated by benchmarks/single_node/speedbench/qwen3.8flashnext_fp4_b300_vllm.sh (speedbench-al.yml)."
+    echo "#"
+    echo "# key = num_speculative_tokens (MTP level); value = golden AL"
+    echo "${MODEL_KEY}:"
+    if [[ " $THINKING_MODES " == *" on "* ]]; then
+        echo "  thinking_on:"
+        emit_mode_block on
+    fi
+    if [[ " $THINKING_MODES " == *" off "* ]]; then
+        echo "  thinking_off:"
+        emit_mode_block off
+    fi
+} > "$OUT_YAML"
+
+echo ""
+echo "=== Wrote AL matrix to $OUT_YAML ==="
+cat "$OUT_YAML"

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -1,0 +1,515 @@
+#!/usr/bin/bash
+
+# Launcher for the B300 DSXE Slurm cluster (dsxe-sa-b300-prd0), runners run as sa-gha-runner.
+#
+# Every cluster-specific fact lives in this block. The rest of the file is generic:
+# multi-node jobs go through srt-slurm/srtctl, single-node jobs through salloc + pyxis.
+
+SLURM_PARTITION="batch_1"
+SLURM_ACCOUNT="benchmark"
+
+# enroot squash images. Must be on storage every compute node mounts and writable
+# by the runner user (/data/squash is root-owned, hence the per-user default).
+SQUASH_DIR="/data/home/sa-gha-runner/squash"
+
+# Weights. MODEL_ROOT is node-local NVMe with the same layout on every compute node;
+# it is read-only from the job's point of view. Anything not in STAGED_MODELS is
+# downloaded into WRITABLE_MODELS_DIR (shared Lustre) by the single-node scripts.
+MODEL_ROOT="/scratch/models"
+WRITABLE_MODELS_DIR="/data/home/sa-gha-runner/models"
+
+# Official power (dcgm-power) runs use a separate, pinned producer; CI derives
+# POWER_PRODUCER_SHA from the stamp this script writes. Keep in sync with the other launchers.
+POWER_SRT_SLURM_URL="https://github.com/edwingao28/srt-slurm.git"
+POWER_SRT_SLURM_PIN="e5c837f06a362dc888dfea2ee588e9f19c298270"
+
+# Directory names under MODEL_ROOT (upstream HF repo basenames).
+STAGED_MODELS=(
+    DeepSeek-R1-0528
+    DeepSeek-R1-0528-NVFP4-v2
+    DeepSeek-V4-Pro
+    DeepSeek-V4-Pro-0813
+    DeepSeek-V4-Pro-NVFP4
+    GLM-5.2-NVFP4
+    Kimi-K2.6-NVFP4
+    Kimi-K3
+    MiniMax-M3
+    MiniMax-M3-MXFP8
+    MiniMax-M3-NVFP4
+    Qwen3.5-397B-A17B-FP8
+    Qwen3.5-397B-A17B-NVFP4
+    Qwen3.5-397B-A17B-NVFP4-V2
+    Qwen3.8-2.4T-A95B-FP8
+)
+
+# srt-slurm recipes refer to models by alias (model.path in the recipe yaml). Every
+# alias below is written into srtslurm.yaml, so no per-model branching is needed.
+# Several aliases map to the same directory because recipes are not consistent.
+declare -A MODEL_ALIASES=(
+    [dsr1]="DeepSeek-R1-0528-NVFP4-v2"
+    [dsr1-fp8]="DeepSeek-R1-0528"
+    [deepseek-v4-pro]="DeepSeek-V4-Pro"
+    [deepseek-ai/DeepSeek-V4-Pro]="DeepSeek-V4-Pro"
+    [glm-5.2-fp4]="GLM-5.2-NVFP4"
+    [nvidia/GLM-5.2-NVFP4]="GLM-5.2-NVFP4"
+    [kimi-k2.6-nvfp4]="Kimi-K2.6-NVFP4"
+    [kimi-k3]="Kimi-K3"
+    [kimik3]="Kimi-K3"
+    [moonshotai/Kimi-K3]="Kimi-K3"
+    [minimax-m3-nvfp4]="MiniMax-M3-NVFP4"
+    [nvidia/MiniMax-M3-NVFP4]="MiniMax-M3-NVFP4"
+    [minimax-m3-mxfp8]="MiniMax-M3-MXFP8"
+    [MiniMaxAI/MiniMax-M3-MXFP8]="MiniMax-M3-MXFP8"
+    [qwen3.5-fp4]="Qwen3.5-397B-A17B-NVFP4-V2"
+    [qwen3.5-fp8]="Qwen3.5-397B-A17B-FP8"
+    [nvidia/Qwen3.5-397B-A17B-NVFP4-V2]="Qwen3.5-397B-A17B-NVFP4-V2"
+)
+
+
+mkdir -p "$SQUASH_DIR"
+set -x
+
+# !! KEEP THIS DEFINITION ABOVE THE IS_MULTINODE BRANCH BELOW. !!
+# Both the multi-node and single-node paths call it. Bash only defines a function
+# when execution reaches it, so moving this inside either branch silently removes
+# it from the other and the job dies on "command not found" at import time.
+#
+# Import a container image into the shared squash dir. Concurrent callers target the
+# same path, so serialize on a per-file lock and skip when a valid squash file exists.
+# --time bounds the step; an unbounded srun hangs the job if its step is lost.
+#
+# The import itself must run on a compute node: enroot builds the squashfs over an
+# overlay mount, which the shared filesystem cannot back, and the login host is too
+# small to unpack a multi-GB image. Reading the finished file is just I/O, so probe
+# it here first -- a warm cache then costs no Slurm allocation at all. The in-srun
+# check under the lock stays authoritative, so a stale probe only costs one step.
+import_squash_image() {
+    local image_ref="$1"
+    local sqsh="$2"
+    local lock="${2}.lock"
+
+    if unsquashfs -l "$sqsh" > /dev/null 2>&1; then
+        echo "Squash file already present, skipping import: $sqsh"
+        return 0
+    fi
+
+    srun -N 1 -A "$SLURM_ACCOUNT" -p "$SLURM_PARTITION" \
+        --time="${ENROOT_IMPORT_TIME_LIMIT:-120}" bash -c "
+        set -euo pipefail
+        exec 9>\"$lock\"
+        flock -w 3600 9
+        if unsquashfs -l \"$sqsh\" > /dev/null 2>&1; then
+            exit 0
+        fi
+        rm -f \"$sqsh\"
+        enroot import -o \"$sqsh\" \"docker://$image_ref\"
+        unsquashfs -l \"$sqsh\" > /dev/null
+    " || { echo "Error: enroot import failed for $image_ref -> $sqsh" >&2; exit 1; }
+
+    test -r "$sqsh" || { echo "Error: squash file not readable: $sqsh" >&2; exit 1; }
+}
+
+if [[ "$IS_MULTINODE" == "true" ]]; then
+
+# Validate framework
+if [[ $FRAMEWORK != "dynamo-sglang" && $FRAMEWORK != "dynamo-trt" && $FRAMEWORK != "dynamo-vllm" ]]; then
+    echo "Unsupported framework: $FRAMEWORK. Supported frameworks are: dynamo-trt, dynamo-sglang, dynamo-vllm"
+    exit 1
+fi
+
+USES_DCGM_POWER=0
+_RECIPE_REL="${CONFIG_FILE%%:*}"
+_RECIPE_SRC="$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/${_RECIPE_REL#recipes/}"
+if [[ -n "$CONFIG_FILE" && -f "$_RECIPE_SRC" ]] && awk '
+    /^telemetry:/ { t = 1; next }
+    t && /^[^ ]/  { t = 0 }
+    t && /^  provider: dcgm-power$/ { p = 1 }
+    t && /^  enabled: true$/        { e = 1 }
+    END { exit !(p && e) }
+' "$_RECIPE_SRC"; then
+    USES_DCGM_POWER=1
+fi
+if [[ "$USES_DCGM_POWER" == "1" && (
+    "${IS_AGENTIC:-0}" == "1" ||
+    "$MODEL_PREFIX" != "dsv4" ||
+    "$PRECISION" != "fp4" ||
+    ( "$FRAMEWORK" != "dynamo-sglang" && "$FRAMEWORK" != "dynamo-vllm" )
+) ]]; then
+    echo "Error: B300 dcgm-power is limited to fixed-sequence DSV4 FP4 dynamo-sglang/vllm" >&2
+    exit 1
+fi
+
+# Default is the newest tag. Add a branch here to pin a ref per model / precision /
+# framework when a recipe needs one, so results stay reproducible.
+select_srt_slurm_version() {
+    if false; then
+        :
+    else
+        SRT_SLURM_REPO="https://github.com/NVIDIA/srt-slurm.git"
+        SRT_SLURM_REF="v1.0.87"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# srt-slurm checkout: one clone at the selected ref, plus every in-repo recipe.
+# ---------------------------------------------------------------------------
+SRT_REPO_DIR="srt-slurm"
+rm -rf "$SRT_REPO_DIR"
+
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    SRT_SLURM_REPO="$POWER_SRT_SLURM_URL"
+    SRT_SLURM_REF="$POWER_SRT_SLURM_PIN"
+else
+    select_srt_slurm_version
+fi
+
+echo "Cloning srt-slurm ($SRT_SLURM_REPO @ $SRT_SLURM_REF)..."
+git clone "$SRT_SLURM_REPO" "$SRT_REPO_DIR" || exit 1
+cd "$SRT_REPO_DIR" || exit 1
+git checkout --quiet "$SRT_SLURM_REF" || exit 1
+git rev-parse HEAD > "$GITHUB_WORKSPACE/srt-slurm-sha.txt"
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    test "$(git rev-parse HEAD)" = "$POWER_SRT_SLURM_PIN" \
+        || { echo "Error: srt-slurm HEAD does not match POWER_SRT_SLURM_PIN=$POWER_SRT_SLURM_PIN" >&2; exit 1; }
+    cp "$GITHUB_WORKSPACE/srt-slurm-sha.txt" "$GITHUB_WORKSPACE/power-producer-sha.txt"
+fi
+
+# Recipes live in this repo; overlay all of them onto the checkout's recipes/ dir.
+mkdir -p recipes
+cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes" recipes || exit 1
+
+if [[ "${EVAL_FRAMEWORK:-lm-eval}" != "lm-eval" ]]; then
+    python3 "$GITHUB_WORKSPACE/runners/patch_srt_eval_dispatch.py" "$(pwd)" || exit 1
+fi
+
+echo "Installing srtctl..."
+export UV_INSTALL_DIR="$GITHUB_WORKSPACE/.local/bin"
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$UV_INSTALL_DIR:$PATH"
+
+uv venv "$GITHUB_WORKSPACE/.venv"
+source "$GITHUB_WORKSPACE/.venv/bin/activate"
+uv pip install -e .
+
+if ! command -v srtctl &> /dev/null; then
+    echo "Error: Failed to install srtctl"
+    exit 1
+fi
+
+# Map container images to local squash files
+NGINX_IMAGE="nginx:1.27.4"
+SQUASH_FILE="$SQUASH_DIR/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+NGINX_SQUASH_FILE="$SQUASH_DIR/$(echo "$NGINX_IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+
+# Import containers via enroot
+import_squash_image "$IMAGE" "$SQUASH_FILE"
+import_squash_image "$NGINX_IMAGE" "$NGINX_SQUASH_FILE"
+
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    DCGM_EXPORTER_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.6.0-4.8.3-distroless"
+    # enroot resolves bare paths against Docker Hub; nvcr.io pulls need the registry# form
+    DCGM_EXPORTER_ENROOT_REF="${DCGM_EXPORTER_IMAGE/nvcr.io\//nvcr.io#}"
+    DCGM_EXPORTER_SQSH="$SQUASH_DIR/$(echo "$DCGM_EXPORTER_IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    import_squash_image "$DCGM_EXPORTER_ENROOT_REF" "$DCGM_EXPORTER_SQSH"
+    sha256sum "$DCGM_EXPORTER_SQSH" > "$GITHUB_WORKSPACE/exporter-image.sha256"
+fi
+
+export ISL="$ISL"
+export OSL="$OSL"
+export EVAL_ONLY="${EVAL_ONLY:-false}"
+
+# ---------------------------------------------------------------------------
+# srtslurm.yaml: cluster defaults, every model alias, container aliases.
+# ---------------------------------------------------------------------------
+SRTCTL_ROOT="${GITHUB_WORKSPACE}/${SRT_REPO_DIR}"
+echo "Creating srtslurm.yaml configuration..."
+{
+    cat <<EOF
+# SRT SLURM Configuration for B300 DSXE (generated by launch_b300-dsxe.sh)
+default_account: "${SLURM_ACCOUNT}"
+default_partition: "${SLURM_PARTITION}"
+gpus_per_node: 8
+network_interface: ""
+srtctl_root: "${SRTCTL_ROOT}"
+model_paths:
+EOF
+    for alias in "${!MODEL_ALIASES[@]}"; do
+        printf '  "%s": "%s/%s"\n' "$alias" "$MODEL_ROOT" "${MODEL_ALIASES[$alias]}"
+    done | sort
+    cat <<EOF
+containers:
+  dynamo-trtllm: "${SQUASH_FILE}"
+  dynamo-sglang: "${SQUASH_FILE}"
+  dynamo-vllm: "${SQUASH_FILE}"
+  "${IMAGE}": "${SQUASH_FILE}"
+  nginx-sqsh: "${NGINX_SQUASH_FILE}"
+EOF
+    if [[ "$USES_DCGM_POWER" == "1" ]]; then
+        printf '  dcgm-exporter: "%s"\n' "$DCGM_EXPORTER_SQSH"
+    fi
+    echo "use_exclusive_sbatch_directive: true"
+} > srtslurm.yaml
+
+echo "Generated srtslurm.yaml:"
+cat srtslurm.yaml
+
+echo "Running make setup..."
+make setup ARCH=x86_64
+
+# Export eval-related env vars for srt-slurm post-benchmark eval
+export INFMAX_WORKSPACE="$GITHUB_WORKSPACE"
+
+echo "Submitting job with srtctl..."
+
+if [[ -z "$CONFIG_FILE" ]]; then
+    echo "Error: CONFIG_FILE is not set. The srt-slurm path requires a CONFIG_FILE in additional-settings." >&2
+    echo "Config: MODEL_PREFIX=${MODEL_PREFIX} PRECISION=${PRECISION} FRAMEWORK=${FRAMEWORK}" >&2
+    exit 1
+fi
+
+# Resolve the recipe path before editing it. CONFIG_FILE may include an
+# srt-slurm matrix selector such as :zip_override_dep4_dep8[0].
+CONFIG_PATH="${CONFIG_FILE%%:*}"
+if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "Error: CONFIG_FILE does not exist after srt-slurm setup: $CONFIG_PATH" >&2
+    exit 1
+fi
+
+# Override the job name in the recipe with the runner name.
+sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_PATH"
+if [[ "${EVAL_ONLY:-false}" == "true" ]]; then
+    python3 "$GITHUB_WORKSPACE/runners/inject_synthetic_acceptance.py" \
+        "$CONFIG_PATH" "$FRAMEWORK" || exit 1
+fi
+
+# Weights live on node-local MODEL_ROOT, which this login host cannot stat, so
+# srtctl's preflight model.path check is always skipped. Runtime loading still
+# validates the path on the compute nodes.
+SRTCTL_APPLY_ARGS=(
+    -f "$CONFIG_FILE"
+    --no-preflight
+    --tags "b300,${MODEL_PREFIX},${PRECISION},${ISL}x${OSL},infmax-$(date +%Y%m%d)"
+)
+SRTCTL_OUTPUT=$(srtctl apply "${SRTCTL_APPLY_ARGS[@]}" 2>&1)
+echo "$SRTCTL_OUTPUT"
+
+# Extract JOB_ID from srtctl output
+JOB_ID=$(echo "$SRTCTL_OUTPUT" | grep -oP '✅ Job \K[0-9]+' || echo "$SRTCTL_OUTPUT" | grep -oP 'Job \K[0-9]+')
+
+set +x
+
+if [ -z "$JOB_ID" ]; then
+    echo "Error: Failed to extract JOB_ID from srtctl output"
+    exit 1
+fi
+
+echo "Extracted JOB_ID: $JOB_ID"
+
+# Use the JOB_ID to find the logs directory
+# srtctl creates logs in outputs/JOB_ID/logs/
+LOGS_DIR="outputs/$JOB_ID/logs"
+LOG_FILE="$LOGS_DIR/sweep_${JOB_ID}.log"
+
+# Wait for log file to appear (also check job is still alive)
+while ! ls "$LOG_FILE" &>/dev/null; do
+    if ! squeue -j "$JOB_ID" --noheader 2>/dev/null | grep -q "$JOB_ID"; then
+        echo "ERROR: Job $JOB_ID failed before creating log file"
+        scontrol show job "$JOB_ID"
+        exit 1
+    fi
+    echo "Waiting for JOB_ID $JOB_ID to begin and $LOG_FILE to appear..."
+    sleep 5
+done
+
+# Poll for job completion in background
+(
+    while squeue -j "$JOB_ID" --noheader 2>/dev/null | grep -q "$JOB_ID"; do
+        sleep 10
+    done
+) &
+POLL_PID=$!
+
+echo "Tailing LOG_FILE: $LOG_FILE"
+
+# Stream the log file until job completes (-F follows by name, polls instead of inotify for NFS)
+tail -F -s 2 -n+1 "$LOG_FILE" --pid=$POLL_PID 2>/dev/null
+
+wait $POLL_PID
+
+set -x
+
+echo "Job $JOB_ID completed!"
+echo "Collecting results..."
+
+if [ ! -d "$LOGS_DIR" ]; then
+    echo "Warning: Logs directory not found at $LOGS_DIR"
+    exit 1
+fi
+
+echo "Found logs directory: $LOGS_DIR"
+
+if [[ "$USES_DCGM_POWER" == "1" ]]; then
+    mkdir -p "$LOGS_DIR/power"
+    cp "$GITHUB_WORKSPACE/exporter-image.sha256" "$LOGS_DIR/power/exporter-image.sha256"
+    cp "$GITHUB_WORKSPACE/power-producer-sha.txt" "$LOGS_DIR/power/power-producer-sha.txt"
+fi
+
+cp -r "$LOGS_DIR" "$GITHUB_WORKSPACE/LOGS"
+tar czf "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz" -C "$LOGS_DIR" .
+
+if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
+    # Find all result subdirectories
+    RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
+
+    if [ -z "$RESULT_SUBDIRS" ]; then
+        echo "Warning: No result subdirectories found in $LOGS_DIR"
+    else
+        # Process results from all configurations
+        for result_subdir in $RESULT_SUBDIRS; do
+            echo "Processing result subdirectory: $result_subdir"
+
+            # Extract configuration info from directory name
+            CONFIG_NAME=$(basename "$result_subdir")
+
+            # Find all result JSON files
+            RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
+
+            for result_file in $RESULT_FILES; do
+                if [ -f "$result_file" ]; then
+                    # Extract metadata from filename
+                    # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
+                    filename=$(basename "$result_file")
+                    concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
+                    gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
+                    ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
+                    gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
+
+                    echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
+
+                    if [ -n "$ctx" ] && [ -n "$gen" ]; then
+                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
+                    else
+                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
+                    fi
+                    cp "$result_file" "$WORKSPACE_RESULT_FILE"
+
+                    echo "Copied result file to: $WORKSPACE_RESULT_FILE"
+                fi
+            done
+        done
+    fi
+
+    echo "All result files processed"
+else
+    echo "EVAL_ONLY=true: Skipping benchmark result collection"
+fi
+
+# Collect eval results if eval was requested
+if [[ "${RUN_EVAL:-false}" == "true" || "${EVAL_ONLY:-false}" == "true" ]]; then
+    EVAL_DIR="$LOGS_DIR/eval_results"
+    if [ -d "$EVAL_DIR" ]; then
+        echo "Extracting eval results from $EVAL_DIR"
+        shopt -s nullglob
+        for eval_file in "$EVAL_DIR"/*; do
+            [ -f "$eval_file" ] || continue
+            cp "$eval_file" "$GITHUB_WORKSPACE/"
+            echo "Copied eval artifact: $(basename "$eval_file")"
+        done
+        shopt -u nullglob
+    else
+        echo "WARNING: RUN_EVAL=true but no eval results found at $EVAL_DIR"
+    fi
+fi
+
+# Clean up srt-slurm outputs to prevent NFS silly-rename lock files
+# from blocking the next job's checkout on this runner
+echo "Cleaning up srt-slurm outputs..."
+for i in 1 2 3 4 5; do
+    rm -rf outputs 2>/dev/null && break
+    echo "Retry $i/5: Waiting for NFS locks to release..."
+    sleep 10
+done
+find . -name '.nfs*' -delete 2>/dev/null || true
+
+else
+    # HF_HUB_CACHE is set to help with dataset download inside the container
+    # for eval jobs.
+    export HF_HUB_CACHE="$HOME/.cache/huggingface"
+
+    # MODEL stays the HF id for the client; MODEL_PATH is where the server reads
+    # weights. Only the root holding MODEL_PATH is mounted -- mounting both roots
+    # makes pyxis fail whenever the unused one is absent on the node.
+    MODEL_BASENAME="${MODEL##*/}"
+    if [[ " ${STAGED_MODELS[*]} " == *" ${MODEL_BASENAME} "* ]]; then
+        MODEL_MOUNT_DIR="$MODEL_ROOT"
+    else
+        MODEL_MOUNT_DIR="$WRITABLE_MODELS_DIR"
+        mkdir -p "$WRITABLE_MODELS_DIR"
+    fi
+    export MODEL_PATH="${MODEL_MOUNT_DIR}/${MODEL_BASENAME}"
+
+    SQUASH_FILE="$SQUASH_DIR/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
+    SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+    # Prefer a framework-tagged script (e.g. dsv4_fp4_b300_sglang.sh); fall back to
+    # the untagged historical name for scripts that haven't been retagged yet.
+    BENCH_BASE="benchmarks/single_node/${SCENARIO_SUBDIR}${EXP_NAME%%_*}_${PRECISION}_b300"
+    BENCH_SCRIPT="${BENCH_BASE}_${FRAMEWORK}${SPEC_SUFFIX}.sh"
+    if [[ ! -f "$BENCH_SCRIPT" ]]; then
+        LEGACY_FW_SUFFIX=$([[ "$FRAMEWORK" == "trt" ]] && printf '_trt' || printf '')
+        BENCH_SCRIPT="${BENCH_BASE}${LEGACY_FW_SUFFIX}${SPEC_SUFFIX}.sh"
+    fi
+
+    # Allow callers (e.g. the speedbench-al.yml AL-collection workflow) to run a
+    # specific script instead of the auto-selected throughput benchmark.
+    if [[ -n "${BENCH_SCRIPT_OVERRIDE:-}" ]]; then
+        BENCH_SCRIPT="$BENCH_SCRIPT_OVERRIDE"
+    fi
+
+    # These images install sglang editable under /workspace, so the default
+    # workspace bind-mount masks the install and breaks `import sglang`. Mount at
+    # /ix instead; drop this once the images stop installing there.
+    if [[ "$IMAGE" == *deepseek-v4-blackwell* || "$IMAGE" == *deepseek-v4-bw-ultra* || "$IMAGE" == *deepseek-v4-b300* || "$IMAGE" == *sglang-b300* ]]; then
+        CONTAINER_MOUNT_DIR=/ix
+    else
+        CONTAINER_MOUNT_DIR=/workspace
+    fi
+
+    import_squash_image "$IMAGE" "$SQUASH_FILE"
+
+    export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"
+
+    SALLOC_ARGS=(
+        --partition="$SLURM_PARTITION"
+        --account="$SLURM_ACCOUNT"
+        -N 1
+        --gres="gpu:$GPU_COUNT"
+        --exclusive
+        --mem=0
+        --time="${SALLOC_TIME_LIMIT:-480}"
+        --no-shell
+        --job-name="$RUNNER_NAME"
+    )
+    # Optional escape hatch for taking a bad node out of rotation without a code change.
+    if [[ -n "${SALLOC_EXCLUDE:-}" ]]; then
+        SALLOC_ARGS+=(--exclude="$SALLOC_EXCLUDE")
+    fi
+    salloc "${SALLOC_ARGS[@]}"
+    JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
+
+    CONTAINER_MOUNTS=(
+        "$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR"
+        "$MODEL_MOUNT_DIR:$MODEL_MOUNT_DIR"
+    )
+    CONTAINER_MOUNTS_ARG=$(IFS=,; printf '%s' "${CONTAINER_MOUNTS[*]}")
+
+    srun --jobid="$JOB_ID" \
+        --mpi=none \
+        --container-image="$SQUASH_FILE" \
+        --container-mounts="$CONTAINER_MOUNTS_ARG" \
+        --no-container-mount-home \
+        --container-remap-root \
+        --container-workdir="$CONTAINER_MOUNT_DIR" \
+        --no-container-entrypoint --export=ALL,PORT=8888 \
+        bash "$BENCH_SCRIPT"
+
+fi

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -383,7 +383,6 @@ else
         DeepSeek-R1-0528-NVFP4-v2
         DeepSeek-V4-Flash
         DeepSeek-V4-Pro
-        DeepSeek-V4-Pro-DSpark
         GLM-5-FP8
         GLM-5-NVFP4
         GLM-5.1

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -383,6 +383,7 @@ else
         DeepSeek-R1-0528-NVFP4-v2
         DeepSeek-V4-Flash
         DeepSeek-V4-Pro
+        DeepSeek-V4-Pro-DSpark
         GLM-5-FP8
         GLM-5-NVFP4
         GLM-5.1

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -383,6 +383,7 @@ else
         DeepSeek-R1-0528-NVFP4-v2
         DeepSeek-V4-Flash
         DeepSeek-V4-Pro
+        DeepSeek-V4-Pro-0813
         GLM-5-FP8
         GLM-5-NVFP4
         GLM-5.1

--- a/runners/launch_b300-nv.sh
+++ b/runners/launch_b300-nv.sh
@@ -383,7 +383,6 @@ else
         DeepSeek-R1-0528-NVFP4-v2
         DeepSeek-V4-Flash
         DeepSeek-V4-Pro
-        DeepSeek-V4-Pro-0813
         GLM-5-FP8
         GLM-5-NVFP4
         GLM-5.1


### PR DESCRIPTION
## Summary
Add two SPEED-Bench AL collector scripts, following the existing DSV4/Qwen3.5 pattern:
- `qwen3.8_fp4_b300_vllm.sh` — Qwen3.8-2.4T-A95B (NVFP4, TP8, thinking-only)
- `qwen3.8flashnext_fp4_b300_vllm.sh` — Qwen3.8-Flash-Next (BF16, TP4, thinking on/off)

Sampling params, reasoning-effort levels (xhigh/medium/low), reasoning/tool-call parsers, and chat-template kwargs match the official model cards. Models are downloaded via `hf download` at runtime (not staged).

## Test plan
- [ ] Trigger `speedbench-al.yml` for both model-prefixes on B300
- [ ] Confirm AL tables produced for the expected thinking modes