### PR TITLE
[AMD][DSV4] Update dsv4-fp4-mi355x-sglang-agentic-mtp recipe / 更新 dsv4-fp4-mi355x-sglang-agentic-mtp 配方

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_mi355x_sglang_mtp.sh
@@ -73,6 +73,7 @@ export SGLANG_DSV4_REASONING_EFFORT=high
 export SGLANG_USE_ROCM700A=0
 export SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton
 export AITER_BF16_FP8_MOE_BOUND=0
+export TORCH_BLAS_PREFER_HIPBLASLT=1
 # aiter batched GEMM for the absorbed MLA projections, carried by the v0.5.18
 # image and off by default in environ.py.
 export SGLANG_OPT_USE_AITER_BATCHED_GEMM=1
@@ -131,7 +132,14 @@ SGLANG_BACKEND_PORT="$PORT"
 # (the conc>=16 queue-saturation / decode-stall failure mode). 8192 = 32*256,
 # a page-size multiple well under the dsv4 compressor kernel's uint16 token
 # cap; same value the multi-node DeepSeek-V4-Pro-AgentX no_dp profile uses.
-CHUNKED_PREFILL_SIZE=8192
+if [ "$TP" -eq 8 ]; then
+    CHUNKED_PREFILL_SIZE=16384
+elif [ "$TP" -eq 4 ]; then
+    CHUNKED_PREFILL_SIZE=8192
+else
+    echo "Error: unsupported TP '$TP' (expected: 4 or 8)" >&2
+    exit 1
+fi
 # MTP adds a draft KV pool and extra graph captures on top of the spec-none
 # footprint, which ran at 0.90. 0.89 recovers most of that: the DSv4 compressor
 # state pools are sized from the full-attention pool and allocated after it,
@@ -149,7 +157,7 @@ if [ "$DP_ATTENTION" = "true" ]; then
     export SGLANG_DP_SHARED_EXPERT_LOCAL=1
     export SGLANG_DP_USE_GATHERV=1
     export SGLANG_DP_USE_REDUCE_SCATTER=1
-    export GPU_MAX_HW_QUEUES=5
+    export GPU_MAX_HW_QUEUES=2
 
     # Chunked prefill is a whole-engine budget, so widen it by the DP degree.
     CHUNKED_PREFILL_SIZE=$((8192 * TP))

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1750,3 +1750,4 @@ dsv4-fp4-mi355x-sglang-agentic-mtp:
       search-space:
       - { tp: 4, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [1, 2, 4, 8, 10], spec-decoding: mtp }
       - { tp: 8, ep: 1, dp-attn: false, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 32, 48], spec-decoding: mtp }
+      - { tp: 8, ep: 1, dp-attn: false, kv-offloading: none, conc-list: [16], spec-decoding: mtp }

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1737,7 +1737,7 @@ glm5.2-fp4-mi355x-atom-agentic-mtp:
 
 
 dsv4-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260822
+  image: lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6605,4 +6605,4 @@
     - "Export TORCH_BLAS_PREFER_HIPBLASLT=1 to prefer hipBLASLt for dense GEMMs."
     - "Size chunked-prefill by tensor-parallel degree: 16384 tokens at TP8 and 8192 at TP4, erroring on any other TP."
     - "Lower GPU_MAX_HW_QUEUES from 5 to 2 on the DP-attention path."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2784

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6595,3 +6595,14 @@
     - "Update the vLLM B200 Kimi-K3 AgentX configs."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2776
   
+
+- config-keys:
+    - dsv4-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Bump the MI355X SGLang DeepSeek-V4-Pro FP4 AgentX MTP image from lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260822 to lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829."
+    - "Export TORCH_BLAS_PREFER_HIPBLASLT=1 to prefer hipBLASLt for dense GEMMs."
+    - "Size chunked-prefill by tensor-parallel degree: 16384 tokens at TP8 and 8192 at TP4, erroring on any other TP."
+    - "Lower GPU_MAX_HW_QUEUES from 5 to 2 on the DP-attention path."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6605,4 +6605,5 @@
     - "Export TORCH_BLAS_PREFER_HIPBLASLT=1 to prefer hipBLASLt for dense GEMMs."
     - "Size chunked-prefill by tensor-parallel degree: 16384 tokens at TP8 and 8192 at TP4, erroring on any other TP."
     - "Lower GPU_MAX_HW_QUEUES from 5 to 2 on the DP-attention path."
+    - "Add a TP8 EP1 no-offload spec-decoding mtp arm at concurrency 16."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2784


### PR DESCRIPTION
## Summary
Update the `dsv4-fp4-mi355x-sglang-agentic-mtp` recipe (DeepSeek-V4-Pro FP4 AgentX on MI355X, SGLang MTP):

- Bump image `lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260822` -> `...-20260829`.
- Export `TORCH_BLAS_PREFER_HIPBLASLT=1` (prefer hipBLASLt for dense GEMMs).
- Size chunked-prefill by TP degree: `16384` at TP8, `8192` at TP4, error on any other TP.
- Lower `GPU_MAX_HW_QUEUES` from 5 to 2 on the DP-attention path.
- Append the required `perf-changelog.yaml` entry.

## 摘要
更新 `dsv4-fp4-mi355x-sglang-agentic-mtp` 配方（MI355X 上的 DeepSeek-V4-Pro FP4 AgentX，SGLang MTP）：

- 将镜像从 `lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260822` 升级到 `...-20260829`。
- 导出 `TORCH_BLAS_PREFER_HIPBLASLT=1`（为稠密 GEMM 优先使用 hipBLASLt）。
- 按张量并行度设置 chunked-prefill：TP8 为 `16384`，TP4 为 `8192`，其他 TP 报错退出。
- 将 DP-attention 路径中的 `GPU_MAX_HW_QUEUES` 从 5 降到 2。
- 追加所需的 `perf-changelog.yaml` 条目。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and serving-tuning changes for a specific AMD perf recipe; no application auth or data-path logic.
> 
> **Overview**
> Updates the **DeepSeek-V4-Pro FP4 AgentX MTP** recipe on MI355X (SGLang): bumps the container image to `...-20260829`, documents the change in `perf-changelog.yaml`, and extends the benchmark matrix with a **TP8, GPU-resident (no HiCache) MTP point at concurrency 16**.
> 
> The launch script `dsv4_fp4_mi355x_sglang_mtp.sh` picks **hipBLASLt** for dense GEMMs via `TORCH_BLAS_PREFER_HIPBLASLT=1`, sets **chunked-prefill** to **16384** at TP8 and **8192** at TP4 (fails on other TP values), and on the **DP-attention** path lowers **`GPU_MAX_HW_QUEUES` from 5 to 2** (DP mode still scales the global chunked-prefill budget by TP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4493c5c61c83a5ba39c7fedae69fbf1650476c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->