### PR TITLE
CollectiveX: stage the container squash once per cluster, reuse across runs

### DIFF
--- a/.github/workflows/collectivex-sweep.yml
+++ b/.github/workflows/collectivex-sweep.yml
@@ -27,6 +27,10 @@ on:
         description: "Keep only shards in this comma-list of modes (normal, low-latency); low-latency is a decode-only EP8 addition; blank = all"
         type: string
         default: ''
+      refresh_image:
+        description: "Force a fresh container image import even when a staged squash exists — only needed when a tag moved upstream and its digest could not be resolved from the submit host"
+        type: boolean
+        default: false
       fp8_consume:
         description: "DIAGNOSTIC ONLY. 'dequant' puts the FP8 dequant back inside the chain, so staging is no longer hoisted; changes what is measured. Blank = native (the production model)."
         type: choice
@@ -157,6 +161,9 @@ jobs:
       # unrecognised value, and a blank input would set the variable to "" -- which is not
       # "unset", so os.environ.get's default never applies and every leg would die at import.
       CX_FP8_CONSUME: ${{ inputs.fp8_consume || 'native' }}
+      # The squash cache is content-keyed, so updates normally ride the digest;
+      # this is the manual override for a moved tag with an unresolvable digest.
+      COLLX_IMAGE_REFRESH: ${{ inputs.refresh_image && '1' || '0' }}
       # Consolidated shards run one bounded build-group in one Slurm allocation;
       # every production pool accepts 300 minutes. Allocations release as soon as
       # the shard finishes.

--- a/experimental/CollectiveX/docs/methodology.md
+++ b/experimental/CollectiveX/docs/methodology.md
@@ -665,8 +665,13 @@ execution-specific private base beneath the validated compute-visible account ho
 
 ## Image Pinning And Build Isolation
 
-Enroot imports configured container tags into a per-run-scoped squash keyed by the image tag and
-image platform, so one run never reuses another run's imported filesystem. Image-provided DeepEP is
+Enroot imports configured container tags into a content-keyed squash (image platform + registry
+manifest digest + image reference), staged once per cluster and reused by every run of the same
+image. The digest is resolved from the submit host at launch, so a tag that moved upstream changes
+the key and forces a fresh import; when the digest cannot be resolved the key degrades to the tag
+and the `refresh_image` dispatch input forces an update. Validity is still proven per use
+(`unsquashfs -l`) before any reuse, and superseded stagings of the same image are age-gate reaped
+after a fresh import. Image-provided DeepEP is
 also checked against exact package versions and its expected API. Source-built DeepEP V2 uses
 a separate mode-0700 cluster-local cache mounted only as `/cx-cache`. Its path binds CPU/GPU
 architecture, image, and upstream commit. The cache is never an artifact. Per-execution

--- a/experimental/CollectiveX/docs/methodology.md
+++ b/experimental/CollectiveX/docs/methodology.md
@@ -665,13 +665,14 @@ execution-specific private base beneath the validated compute-visible account ho
 
 ## Image Pinning And Build Isolation
 
-Enroot imports configured container tags into a content-keyed squash (image platform + registry
-manifest digest + image reference), staged once per cluster and reused by every run of the same
-image. The digest is resolved from the submit host at launch, so a tag that moved upstream changes
-the key and forces a fresh import; when the digest cannot be resolved the key degrades to the tag
-and the `refresh_image` dispatch input forces an update. Validity is still proven per use
-(`unsquashfs -l`) before any reuse, and superseded stagings of the same image are age-gate reaped
-after a fresh import. Image-provided DeepEP is
+Enroot imports configured container tags into one squash per (image platform, image reference),
+staged once per cluster and reused by every run of the same image. Freshness is decided against a
+digest sidecar: the registry manifest digest is resolved from the submit host at launch, and a
+resolved digest that differs from the sidecar stamp means the tag moved upstream and forces a
+fresh import. An unresolved digest (no registry egress, a transient blip) reuses whatever is
+staged; the `refresh_image` dispatch input forces an update in that case, discarding only files
+staged before the launch so concurrent legs still import once. Validity is still proven per use
+(`unsquashfs -l`) before any reuse. Image-provided DeepEP is
 also checked against exact package versions and its expected API. Source-built DeepEP V2 uses
 a separate mode-0700 cluster-local cache mounted only as `/cx-cache`. Its path binds CPU/GPU
 architecture, image, and upstream commit. The cache is never an artifact. Per-execution

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -682,49 +682,46 @@ collx_prepare_stage_dir() {
   export COLLX_STAGE_DIR
 }
 
-# The squash is keyed by image CONTENT (platform + manifest digest + reference),
-# never by run: every shard and every later run of the same image on this cluster
-# converges on one staged file, and a tag that moved upstream lands on a new key,
-# which is the update path. Keying by run id here is what used to re-copy ~30-65GB
-# per run per cluster. Without a resolved digest the key degrades to the tag alone
-# ("tag" scope) — reuse still happens, updates then need COLLX_IMAGE_REFRESH=1.
+# One squash per (platform, image reference) — never per run (the run-scoped key
+# is what used to re-copy 30-65GB every run) and never per digest (a digest-scoped
+# key made a transient registry blip miss the staged file and re-import). The
+# resolved digest lives in a `<sq>.digest` sidecar instead and decides staleness.
 collx_squash_path() {
-  local squash_dir="$1" image="$2" key platform content_scope
+  local squash_dir="$1" image="$2" platform
   case "${COLLX_IMAGE_PLATFORM:-}" in
     linux/amd64) platform="" ;;
     linux/arm64) platform="_linux_arm64" ;;
     *) return 1 ;;
   esac
-  if [[ "${COLLX_IMAGE_DIGEST:-}" =~ ^sha256:([0-9a-f]{64})$ ]]; then
-    content_scope="${BASH_REMATCH[1]:0:12}"
-  else
-    content_scope="tag"
-  fi
-  key="${platform}_${content_scope}_$(
-    printf '%s' "$image" | sed 's#[/:@#]#_#g'
-  )"
-  printf '%s' "$squash_dir/${key}.sqsh"
+  printf '%s' "$squash_dir/${platform}_$(printf '%s' "$image" | sed 's#[/:@#]#_#g').sqsh"
 }
 
-# Reap superseded stagings of one image (old digests and the retired per-run
-# keys) once a fresh import has landed, so reuse doesn't turn thin squash disks
-# into a museum. Age-gated: anything touched in the last 2 days may still back a
-# live container on another allocation, and reuse touches the file on each hit.
-collx_reap_stale_squashes() {
-  local squash_dir="$1" image="$2" keep="$3" sanitized
-  sanitized="$(printf '%s' "$image" | sed 's#[/:@#]#_#g')"
-  find "$squash_dir" -maxdepth 1 -type f -name "*_${sanitized}.sqsh" \
-    ! -name "${keep##*/}" -mmin +2880 -delete 2>/dev/null || true
+# Reuse decision for a staged squash (pure read, callers hold the import lock):
+# echoes "reuse", or why to re-import. An unresolved digest reuses whatever is
+# staged (prefer downloaded over re-import); a resolved digest that differs from
+# the sidecar stamp means the tag moved upstream — that is the update path.
+# refresh_epoch (COLLX_IMAGE_REFRESH=1) discards only files staged before this
+# launch, so concurrent legs of the refreshing run still import exactly once.
+collx_squash_verdict() {
+  local sq="$1" digest="$2" refresh_epoch="$3" stamp="" mtime
+  [ -e "$sq" ] || { printf 'absent'; return; }
+  if [ -n "$refresh_epoch" ]; then
+    # GNU stat on the clusters; the BSD fallback keeps the seam testable on macOS.
+    mtime="$(stat -c %Y "$sq" 2>/dev/null || stat -f %m "$sq" 2>/dev/null || echo 0)"
+    [ "$mtime" -ge "$refresh_epoch" ] || { printf 'refresh-requested'; return; }
+  fi
+  [ ! -f "$sq.digest" ] || IFS= read -r stamp < "$sq.digest" || stamp=""
+  if [ -n "$digest" ] && [ -n "$stamp" ] && [ "$stamp" != "$digest" ]; then
+    printf 'digest-moved'; return
+  fi
+  printf 'reuse'
 }
 
 # collx_ensure_squash <squash_dir> <image>  ->  echoes the squash file path.
-# Imports via Enroot only if a valid squash is not already present, under a lock.
-# COLLX_IMAGE_REFRESH=1 discards a squash staged before this launcher started
-# (mtime vs COLLX_LAUNCH_EPOCH), the escape hatch for a moved tag whose digest
-# could not be resolved; a file imported during this launch is never discarded,
-# so concurrent legs still import once.
+# Imports via Enroot only when collx_squash_verdict says the staged file cannot
+# be reused (or it fails validation), under a lock.
 collx_ensure_squash() {
-  local squash_dir="$1" image="$2" key sq locks lock_fd log refresh_epoch=""
+  local squash_dir="$1" image="$2" key sq locks lock_fd log verdict refresh_epoch=""
   local enroot_local="" import_rc=0 machine
   if [ "${COLLX_IMAGE_REFRESH:-0}" = 1 ]; then
     refresh_epoch="${COLLX_LAUNCH_EPOCH:-$(date +%s)}"
@@ -755,20 +752,13 @@ collx_ensure_squash() {
   flock -w 2700 "$lock_fd" 2>> "$log" \
     || { collx_log "ERROR: timed out waiting for the container import lock"
          collx_log_tail "$log"; return 1; }
-  if [ -n "$refresh_epoch" ] && [ -e "$sq" ] \
-      && [ "$(stat -c %Y "$sq" 2>/dev/null || echo 0)" -lt "$refresh_epoch" ]; then
-    collx_log "discarding staged squash on refresh request"
-    rm -f "$sq" 2>> "$log" \
-      || { collx_log_tail "$log"; return 1; }
-  fi
-  if unsquashfs -l "$sq" >/dev/null 2>&1; then
+  verdict="$(collx_squash_verdict "$sq" "${COLLX_IMAGE_DIGEST:-}" "$refresh_epoch")"
+  [ "$verdict" != reuse ] || unsquashfs -l "$sq" >/dev/null 2>&1 || verdict=invalid
+  if [ "$verdict" = reuse ]; then
     collx_log "container squash ready (reusing staged import)"
-    # Reuse marks the file live so the age-gated reaper never takes an image
-    # that is merely stable; other-owner files refuse the touch, which is fine.
-    touch "$sq" 2>/dev/null || true
   else
-    collx_log "importing configured container image"
-    rm -f "$sq" 2>> "$log" \
+    collx_log "importing configured container image ($verdict)"
+    rm -f "$sq" "$sq.digest" 2>> "$log" \
       || { collx_log_tail "$log"; return 1; }
     # </dev/null: never block on an interactive password prompt.
     if [ "${COLLX_ENROOT_LOCAL_IMPORT:-0}" = 1 ]; then
@@ -795,8 +785,14 @@ collx_ensure_squash() {
       || { collx_log_tail "$log"; return 1; }
     # World-readable so a different account's launcher can reuse this staging
     # instead of dying on pyxis's "Invalid image format" against a 0600 file.
+    # The sidecar records what was imported; empty when the digest was unresolved.
     chmod a+r "$sq" 2>/dev/null || true
-    collx_reap_stale_squashes "$squash_dir" "$image" "$sq"
+    printf '%s\n' "${COLLX_IMAGE_DIGEST:-}" > "$sq.digest" 2>> "$log" || true
+    # Retired per-run names of this image never get touched again; the age gate
+    # spares a file a concurrent old-generation run may still be reading.
+    find "$squash_dir" -maxdepth 1 -type f \
+      -name "*_$(printf '%s' "$image" | sed 's#[/:@#]#_#g').sqsh" ! -name "${sq##*/}" \
+      -mmin +2880 -delete 2>/dev/null || true
   fi
   flock -u "$lock_fd"
   exec {lock_fd}>&-
@@ -847,10 +843,11 @@ collx_ensure_squash_on_job() {
       --ntasks-per-node=1 --chdir=/tmp \
       --export="$(collx_host_exports)" \
       bash -s -- "$sq" "$lock" "$image" "$COLLX_IMAGE_PLATFORM" "$refresh_epoch" \
-      "$(printf '%s' "$image" | sed 's#[/:@#]#_#g')" \
+      "${COLLX_IMAGE_DIGEST:-}" "$(printf '%s' "$image" | sed 's#[/:@#]#_#g')" \
       > "$log" 2>&1 <<'BASH' || rc=$?
 set -euo pipefail
-sq="$1"; lock="$2"; image="$3"; platform="$4"; refresh_epoch="${5:-}"; sanitized="${6:-}"
+sq="$1"; lock="$2"; image="$3"; platform="$4"
+refresh_epoch="${5:-}"; digest="${6:-}"; sanitized="${7:-}"
 machine="$(uname -m)"
 case "$platform:$machine" in
   linux/amd64:x86_64|linux/amd64:amd64|linux/arm64:aarch64|linux/arm64:arm64) ;;
@@ -868,24 +865,35 @@ mkdir -p "$(dirname "$sq")" "$(dirname "$lock")" \
 exec 9>"$lock"
 # Shared storage serializes the import; node-local storage imports in parallel.
 flock 9
-# Refresh discards only files staged before this launcher started: on shared
-# storage the first node's fresh import is younger than the epoch, so later
-# nodes reuse it instead of importing the same image again.
-if [ -n "$refresh_epoch" ] && [ -e "$sq" ] \
+# Same reuse rules as collx_squash_verdict, evaluated per node (storage may be
+# node-local): a refresh discards only files staged before this launcher started
+# (a sibling node's fresh import stays); a resolved digest that differs from the
+# sidecar stamp means the tag moved; an unresolved digest reuses what is staged.
+reuse=yes
+if [ ! -e "$sq" ]; then
+  reuse=absent
+elif [ -n "$refresh_epoch" ] \
     && [ "$(stat -c %Y "$sq" 2>/dev/null || echo 0)" -lt "$refresh_epoch" ]; then
-  echo 'discarding staged squash on refresh request'
-  rm -f -- "$sq"
-fi
-if unsquashfs -l "$sq" >/dev/null 2>&1; then
-  echo 'container squash ready (reusing staged import)'
-  touch "$sq" 2>/dev/null || true
+  reuse=refresh-requested
 else
-  rm -f -- "$sq"
+  stamp=""
+  [ ! -f "$sq.digest" ] || IFS= read -r stamp < "$sq.digest" || stamp=""
+  if [ -n "$digest" ] && [ -n "$stamp" ] && [ "$stamp" != "$digest" ]; then
+    reuse=digest-moved
+  fi
+fi
+[ "$reuse" != yes ] || unsquashfs -l "$sq" >/dev/null 2>&1 || reuse=invalid
+if [ "$reuse" = yes ]; then
+  echo 'container squash ready (reusing staged import)'
+else
+  echo "importing configured container image ($reuse)"
+  rm -f -- "$sq" "$sq.digest"
   enroot import -o "$sq" "docker://$image" </dev/null
   unsquashfs -l "$sq" >/dev/null 2>&1
   chmod a+r "$sq" 2>/dev/null || true
-  # Reap superseded stagings of this image (old digests, retired per-run keys)
-  # older than 2 days; reuse above touches live files out of the window.
+  printf '%s\n' "$digest" > "$sq.digest" || true
+  # Retired per-run names of this image never get touched again; the age gate
+  # spares a file a concurrent old-generation run may still be reading.
   find "$(dirname "$sq")" -maxdepth 1 -type f -name "*_${sanitized}.sqsh" \
     ! -name "${sq##*/}" -mmin +2880 -delete 2>/dev/null || true
 fi

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -48,6 +48,10 @@ collx_log_tail() {
 # before any SKU-specific work.
 collx_launcher_prologue() {
   JOB_ID=""
+  # One stable timestamp per launcher invocation: the refresh path discards only
+  # squashes staged before this moment, across salloc retries and both nodes.
+  : "${COLLX_LAUNCH_EPOCH:=$(date +%s)}"
+  export COLLX_LAUNCH_EPOCH
   collx_install_launcher_fail_safe
   [ -n "${COLLX_SHARD_FILE:-}" ] || collx_die "COLLX_SHARD_FILE is required"
   collx_load_operator_config
@@ -508,12 +512,29 @@ collx_cleanup_allocation() {
 }
 
 # Import uses the configured tag because Enroot cannot reliably import a
-# digest-qualified Docker Hub reference non-interactively.
+# digest-qualified Docker Hub reference non-interactively. The digest is still
+# resolved here (best-effort registry HEAD from the submit host) as the squash
+# CACHE KEY only: an unchanged tag reuses the file any earlier run staged, and a
+# tag that moved upstream changes the key, which is what forces the fresh import.
 collx_select_image() {
-  local image="$1"
+  local image="$1" digest
   [[ "$image" =~ ^[A-Za-z0-9._/-]+:[A-Za-z0-9._-]+$ ]] \
     || collx_die "configured image reference is malformed"
   export COLLECTIVEX_IMAGE="$image"
+  if [[ ! "${COLLX_IMAGE_DIGEST:-}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    digest="$(python3 "$COLLX_RUNTIME_DIR/probe.py" image-digest "$image" \
+      2>/dev/null)" || digest=""
+    if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+      export COLLX_IMAGE_DIGEST="$digest"
+      collx_log "image digest $digest"
+    else
+      # No network path to the registry is not an error: the cache key degrades
+      # to the tag, so a previously staged squash is still preferred over a
+      # re-import; a moved tag then needs COLLX_IMAGE_REFRESH=1 to update.
+      unset COLLX_IMAGE_DIGEST
+      collx_log "image digest unresolved; squash cache keyed by tag only"
+    fi
+  fi
 }
 
 # Create a per-UID cache under validated cluster-local storage. Only the fixed
@@ -661,28 +682,53 @@ collx_prepare_stage_dir() {
   export COLLX_STAGE_DIR
 }
 
+# The squash is keyed by image CONTENT (platform + manifest digest + reference),
+# never by run: every shard and every later run of the same image on this cluster
+# converges on one staged file, and a tag that moved upstream lands on a new key,
+# which is the update path. Keying by run id here is what used to re-copy ~30-65GB
+# per run per cluster. Without a resolved digest the key degrades to the tag alone
+# ("tag" scope) — reuse still happens, updates then need COLLX_IMAGE_REFRESH=1.
 collx_squash_path() {
-  local squash_dir="$1" image="$2" key platform run_scope
+  local squash_dir="$1" image="$2" key platform content_scope
   case "${COLLX_IMAGE_PLATFORM:-}" in
     linux/amd64) platform="" ;;
     linux/arm64) platform="_linux_arm64" ;;
     *) return 1 ;;
   esac
-  run_scope="${GITHUB_RUN_ID:-${COLLECTIVEX_EXECUTION_ID:-manual}}-${GITHUB_RUN_ATTEMPT:-1}"
-  run_scope="$(printf '%s' "$run_scope" | tr -cs 'A-Za-z0-9_.-' '-')" || return 1
-  run_scope="${run_scope#-}"; run_scope="${run_scope%-}"
-  [ -n "$run_scope" ] || return 1
-  key="${platform}_${run_scope}_$(
+  if [[ "${COLLX_IMAGE_DIGEST:-}" =~ ^sha256:([0-9a-f]{64})$ ]]; then
+    content_scope="${BASH_REMATCH[1]:0:12}"
+  else
+    content_scope="tag"
+  fi
+  key="${platform}_${content_scope}_$(
     printf '%s' "$image" | sed 's#[/:@#]#_#g'
   )"
   printf '%s' "$squash_dir/${key}.sqsh"
 }
 
+# Reap superseded stagings of one image (old digests and the retired per-run
+# keys) once a fresh import has landed, so reuse doesn't turn thin squash disks
+# into a museum. Age-gated: anything touched in the last 2 days may still back a
+# live container on another allocation, and reuse touches the file on each hit.
+collx_reap_stale_squashes() {
+  local squash_dir="$1" image="$2" keep="$3" sanitized
+  sanitized="$(printf '%s' "$image" | sed 's#[/:@#]#_#g')"
+  find "$squash_dir" -maxdepth 1 -type f -name "*_${sanitized}.sqsh" \
+    ! -name "${keep##*/}" -mmin +2880 -delete 2>/dev/null || true
+}
+
 # collx_ensure_squash <squash_dir> <image>  ->  echoes the squash file path.
 # Imports via Enroot only if a valid squash is not already present, under a lock.
+# COLLX_IMAGE_REFRESH=1 discards a squash staged before this launcher started
+# (mtime vs COLLX_LAUNCH_EPOCH), the escape hatch for a moved tag whose digest
+# could not be resolved; a file imported during this launch is never discarded,
+# so concurrent legs still import once.
 collx_ensure_squash() {
-  local squash_dir="$1" image="$2" key sq locks lock_fd log
+  local squash_dir="$1" image="$2" key sq locks lock_fd log refresh_epoch=""
   local enroot_local="" import_rc=0 machine
+  if [ "${COLLX_IMAGE_REFRESH:-0}" = 1 ]; then
+    refresh_epoch="${COLLX_LAUNCH_EPOCH:-$(date +%s)}"
+  fi
   log="$(collx_private_log_path container-import)"
   machine="$(uname -m)"
   case "${COLLX_IMAGE_PLATFORM:-}:$machine" in
@@ -700,15 +746,26 @@ collx_ensure_squash() {
     || { collx_log_tail "$log"; return 1; }
   { exec {lock_fd}>"$locks/${key}.lock"; } 2>> "$log" \
     || { collx_log_tail "$log"; return 1; }
-  # A concurrent leg of the same run holds this lock for its full import
-  # (measured ~18 minutes for the 32 GB sglang squash on b300), so the wait
-  # must outlast an import and a timeout must say so — the empty import log
-  # would otherwise make this the only silent launcher death.
+  # The lock is content-keyed like the squash, so any concurrent leg — same run
+  # or another run importing the same image — holds it for its full import
+  # (measured ~18 minutes for the 32 GB sglang squash on b300); the wait must
+  # outlast an import and a timeout must say so — the empty import log would
+  # otherwise make this the only silent launcher death. The winner's import is
+  # everyone else's cache hit.
   flock -w 2700 "$lock_fd" 2>> "$log" \
     || { collx_log "ERROR: timed out waiting for the container import lock"
          collx_log_tail "$log"; return 1; }
+  if [ -n "$refresh_epoch" ] && [ -e "$sq" ] \
+      && [ "$(stat -c %Y "$sq" 2>/dev/null || echo 0)" -lt "$refresh_epoch" ]; then
+    collx_log "discarding staged squash on refresh request"
+    rm -f "$sq" 2>> "$log" \
+      || { collx_log_tail "$log"; return 1; }
+  fi
   if unsquashfs -l "$sq" >/dev/null 2>&1; then
-    collx_log "container squash ready"
+    collx_log "container squash ready (reusing staged import)"
+    # Reuse marks the file live so the age-gated reaper never takes an image
+    # that is merely stable; other-owner files refuse the touch, which is fine.
+    touch "$sq" 2>/dev/null || true
   else
     collx_log "importing configured container image"
     rm -f "$sq" 2>> "$log" \
@@ -736,6 +793,10 @@ collx_ensure_squash() {
     fi
     unsquashfs -l "$sq" >> "$log" 2>&1 \
       || { collx_log_tail "$log"; return 1; }
+    # World-readable so a different account's launcher can reuse this staging
+    # instead of dying on pyxis's "Invalid image format" against a 0600 file.
+    chmod a+r "$sq" 2>/dev/null || true
+    collx_reap_stale_squashes "$squash_dir" "$image" "$sq"
   fi
   flock -u "$lock_fd"
   exec {lock_fd}>&-
@@ -746,7 +807,10 @@ collx_ensure_squash() {
 # architecture. The squash directory must be shared with the submit host.
 collx_ensure_squash_on_job() {
   local job_id="$1" squash_dir="$2" image="$3" lock_dir="${4:-}" sq key lock
-  local log_label=container-import log attempt rc
+  local log_label=container-import log attempt rc refresh_epoch=""
+  if [ "${COLLX_IMAGE_REFRESH:-0}" = 1 ]; then
+    refresh_epoch="${COLLX_LAUNCH_EPOCH:-$(date +%s)}"
+  fi
   # The import writes tens of GB to whatever the operator gave as squash storage, and on some
   # clusters that storage is a SOFT-mounted network filesystem, i.e. one that returns an error
   # rather than blocking when its transport is briefly unavailable. gb300's /data is NFSv3 over
@@ -782,10 +846,11 @@ collx_ensure_squash_on_job() {
     srun --jobid="$job_id" --nodes="${COLLX_NODES:-1}" --ntasks="${COLLX_NODES:-1}" \
       --ntasks-per-node=1 --chdir=/tmp \
       --export="$(collx_host_exports)" \
-      bash -s -- "$sq" "$lock" "$image" "$COLLX_IMAGE_PLATFORM" \
+      bash -s -- "$sq" "$lock" "$image" "$COLLX_IMAGE_PLATFORM" "$refresh_epoch" \
+      "$(printf '%s' "$image" | sed 's#[/:@#]#_#g')" \
       > "$log" 2>&1 <<'BASH' || rc=$?
 set -euo pipefail
-sq="$1"; lock="$2"; image="$3"; platform="$4"
+sq="$1"; lock="$2"; image="$3"; platform="$4"; refresh_epoch="${5:-}"; sanitized="${6:-}"
 machine="$(uname -m)"
 case "$platform:$machine" in
   linux/amd64:x86_64|linux/amd64:amd64|linux/arm64:aarch64|linux/arm64:arm64) ;;
@@ -803,12 +868,26 @@ mkdir -p "$(dirname "$sq")" "$(dirname "$lock")" \
 exec 9>"$lock"
 # Shared storage serializes the import; node-local storage imports in parallel.
 flock 9
+# Refresh discards only files staged before this launcher started: on shared
+# storage the first node's fresh import is younger than the epoch, so later
+# nodes reuse it instead of importing the same image again.
+if [ -n "$refresh_epoch" ] && [ -e "$sq" ] \
+    && [ "$(stat -c %Y "$sq" 2>/dev/null || echo 0)" -lt "$refresh_epoch" ]; then
+  echo 'discarding staged squash on refresh request'
+  rm -f -- "$sq"
+fi
 if unsquashfs -l "$sq" >/dev/null 2>&1; then
-  echo 'container squash ready'
+  echo 'container squash ready (reusing staged import)'
+  touch "$sq" 2>/dev/null || true
 else
   rm -f -- "$sq"
   enroot import -o "$sq" "docker://$image" </dev/null
   unsquashfs -l "$sq" >/dev/null 2>&1
+  chmod a+r "$sq" 2>/dev/null || true
+  # Reap superseded stagings of this image (old digests, retired per-run keys)
+  # older than 2 days; reuse above touches live files out of the window.
+  find "$(dirname "$sq")" -maxdepth 1 -type f -name "*_${sanitized}.sqsh" \
+    ! -name "${sq##*/}" -mmin +2880 -delete 2>/dev/null || true
 fi
 BASH
     [ "$rc" = 0 ] && { printf '%s' "$sq"; return 0; }

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -512,10 +512,10 @@ collx_cleanup_allocation() {
 }
 
 # Import uses the configured tag because Enroot cannot reliably import a
-# digest-qualified Docker Hub reference non-interactively. The digest is still
-# resolved here (best-effort registry HEAD from the submit host) as the squash
-# CACHE KEY only: an unchanged tag reuses the file any earlier run staged, and a
-# tag that moved upstream changes the key, which is what forces the fresh import.
+# digest-qualified Docker Hub reference non-interactively. The digest resolved
+# here (best-effort registry HEAD, submit host) only stamps/checks the staged
+# squash's sidecar: a moved tag re-imports, an unresolved digest reuses what is
+# staged (COLLX_IMAGE_REFRESH=1 is then the update hatch).
 collx_select_image() {
   local image="$1" digest
   [[ "$image" =~ ^[A-Za-z0-9._/-]+:[A-Za-z0-9._-]+$ ]] \
@@ -528,11 +528,8 @@ collx_select_image() {
       export COLLX_IMAGE_DIGEST="$digest"
       collx_log "image digest $digest"
     else
-      # No network path to the registry is not an error: the cache key degrades
-      # to the tag, so a previously staged squash is still preferred over a
-      # re-import; a moved tag then needs COLLX_IMAGE_REFRESH=1 to update.
       unset COLLX_IMAGE_DIGEST
-      collx_log "image digest unresolved; squash cache keyed by tag only"
+      collx_log "image digest unresolved; staged squash reused as-is"
     fi
   fi
 }

--- a/experimental/CollectiveX/runtime/probe.py
+++ b/experimental/CollectiveX/runtime/probe.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 
 import argparse
 import ctypes
+import json
 import os
 from pathlib import Path
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
 
 
 def default_route_interface(route_path: Path = Path("/proc/net/route")) -> str:
@@ -24,6 +29,81 @@ def prepare_cache(parent_path: str) -> str:
     path.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(path, 0o700)
     return str(path)
+
+
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+# Every manifest media type a tag can point at; the registry answers with the digest of
+# whichever it holds. For a multi-arch tag that is the index digest, which changes whenever
+# any platform updates — a slightly over-eager cache key, never a stale one.
+MANIFEST_ACCEPT = ", ".join((
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+))
+
+
+def registry_reference(image: str) -> tuple[str, str, str]:
+    """Split host/repository:tag with Docker Hub's implied-registry rules."""
+    name, _, tag = image.rpartition(":")
+    first, _, rest = name.partition("/")
+    if rest and ("." in first or first == "localhost"):
+        return first, rest, tag
+    return "registry-1.docker.io", name if "/" in name else f"library/{name}", tag
+
+
+def bearer_challenge(header: str) -> dict[str, str]:
+    scheme, _, params = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return {}
+    return {key.lower(): value
+            for key, value in re.findall(r'([A-Za-z_]+)="([^"]*)"', params)}
+
+
+def resolve_image_digest(image: str, timeout: float = 10.0, opener=None) -> str:
+    """Best-effort manifest digest for a tag; empty string on any failure.
+
+    Anonymous registry-v2 token dance (docker.io/ghcr.io/nvcr.io all speak it for
+    public images). Only HEAD requests — nothing is pulled.
+    """
+    host, repository, tag = registry_reference(image)
+    if not tag:
+        return ""
+    opener = opener or urllib.request.build_opener()
+    url = f"https://{host}/v2/{repository}/manifests/{tag}"
+
+    def head(token: str = ""):
+        request = urllib.request.Request(
+            url, method="HEAD", headers={"Accept": MANIFEST_ACCEPT})
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        return opener.open(request, timeout=timeout)
+
+    try:
+        try:
+            response = head()
+        except urllib.error.HTTPError as error:
+            if error.code != 401:
+                return ""
+            challenge = bearer_challenge(error.headers.get("WWW-Authenticate", ""))
+            realm = challenge.get("realm", "")
+            if not realm.startswith("https://"):
+                return ""
+            query = {"scope": f"repository:{repository}:pull"}
+            if challenge.get("service"):
+                query["service"] = challenge["service"]
+            with opener.open(f"{realm}?{urllib.parse.urlencode(query)}",
+                             timeout=timeout) as grant:
+                body = json.loads(grant.read().decode())
+            token = body.get("token") or body.get("access_token") or ""
+            if not token:
+                return ""
+            response = head(token)
+        with response:
+            digest = response.headers.get("Docker-Content-Digest", "") or ""
+    except (OSError, ValueError):
+        return ""
+    return digest if DIGEST_PATTERN.fullmatch(digest) else ""
 
 
 def validate_cuda_context(expected: int) -> None:
@@ -205,12 +285,14 @@ def main() -> None:
     commands.add_parser("default-route-interface")
     command = commands.add_parser("prepare-cache"); command.add_argument("parent")
     command = commands.add_parser("cuda-context"); command.add_argument("expected", type=int)
+    command = commands.add_parser("image-digest"); command.add_argument("image")
     commands.add_parser("gpu-health")
     command = commands.add_parser("network-profile"); command.add_argument("socket_names"); command.add_argument("rdma_devices"); command.add_argument("gid_index")
     args = parser.parse_args()
     if args.command == "default-route-interface": print(default_route_interface(), end="")
     elif args.command == "prepare-cache": print(prepare_cache(args.parent), end="")
     elif args.command == "cuda-context": validate_cuda_context(args.expected)
+    elif args.command == "image-digest": print(resolve_image_digest(args.image), end="")
     elif args.command == "gpu-health": validate_gpu_health()
     else: validate_network_profile(args.socket_names, args.rdma_devices, args.gid_index)
 

--- a/experimental/CollectiveX/runtime/probe.py
+++ b/experimental/CollectiveX/runtime/probe.py
@@ -32,9 +32,8 @@ def prepare_cache(parent_path: str) -> str:
 
 
 DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
-# Every manifest media type a tag can point at; the registry answers with the digest of
-# whichever it holds. For a multi-arch tag that is the index digest, which changes whenever
-# any platform updates — a slightly over-eager cache key, never a stale one.
+# Every manifest media type a tag can point at; a multi-arch tag answers with its index
+# digest, which changes whenever any platform updates -- over-eager, never stale.
 MANIFEST_ACCEPT = ", ".join((
     "application/vnd.oci.image.index.v1+json",
     "application/vnd.docker.distribution.manifest.list.v2+json",
@@ -52,23 +51,11 @@ def registry_reference(image: str) -> tuple[str, str, str]:
     return "registry-1.docker.io", name if "/" in name else f"library/{name}", tag
 
 
-def bearer_challenge(header: str) -> dict[str, str]:
-    scheme, _, params = header.partition(" ")
-    if scheme.lower() != "bearer":
-        return {}
-    return {key.lower(): value
-            for key, value in re.findall(r'([A-Za-z_]+)="([^"]*)"', params)}
-
-
 def resolve_image_digest(image: str, timeout: float = 10.0, opener=None) -> str:
-    """Best-effort manifest digest for a tag; empty string on any failure.
-
-    Anonymous registry-v2 token dance (docker.io/ghcr.io/nvcr.io all speak it for
-    public images). Only HEAD requests — nothing is pulled.
-    """
+    """Manifest digest for a tag via anonymous registry-v2 HEADs (docker.io, ghcr.io and
+    nvcr.io all speak the token dance for public images; nothing is pulled). Empty string
+    on any failure -- the launcher then reuses whatever squash is already staged."""
     host, repository, tag = registry_reference(image)
-    if not tag:
-        return ""
     opener = opener or urllib.request.build_opener()
     url = f"https://{host}/v2/{repository}/manifests/{tag}"
 
@@ -83,11 +70,10 @@ def resolve_image_digest(image: str, timeout: float = 10.0, opener=None) -> str:
         try:
             response = head()
         except urllib.error.HTTPError as error:
-            if error.code != 401:
-                return ""
-            challenge = bearer_challenge(error.headers.get("WWW-Authenticate", ""))
+            challenge = dict(re.findall(r'([A-Za-z_]+)="([^"]*)"',
+                                        error.headers.get("WWW-Authenticate", "")))
             realm = challenge.get("realm", "")
-            if not realm.startswith("https://"):
+            if error.code != 401 or not realm.startswith("https://"):
                 return ""
             query = {"scope": f"repository:{repository}:pull"}
             if challenge.get("service"):

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -173,44 +173,71 @@ class ImageDigestResolutionTests(unittest.TestCase):
             probe.resolve_image_digest("ghcr.io/org/image:tag", opener=_Down()), "")
 
 
-# runtime/common.sh collx_squash_path is the stage-once seam: keying the squash by
-# GITHUB_RUN_ID is exactly the defect that re-imported ~30-65GB per run per cluster,
-# so the key must be a pure function of platform + digest + image reference.
+# runtime/common.sh collx_squash_path/collx_squash_verdict are the stage-once seam:
+# keying the squash by GITHUB_RUN_ID is exactly the defect that re-imported 30-65GB
+# per run per cluster, and keying it by digest made a transient registry blip miss
+# the staged file — so the path is a pure function of platform + image reference,
+# and freshness is decided by the verdict against the digest sidecar.
 class SquashCacheKeyTests(unittest.TestCase):
     IMAGE = "rocm/sgl-dev:sglang-v1"
+    DIGEST = "sha256:" + "ab" * 32
 
-    def _path(self, env: dict, image: str | None = None) -> str:
+    def _bash(self, script: str, env: dict, args: list | None = None) -> str:
         result = subprocess.run(
-            ["bash", "-c",
-             f'source "{RUNTIME / "common.sh"}" && collx_squash_path /squash "$1"',
-             "collx", image or self.IMAGE],
+            ["bash", "-c", f'source "{RUNTIME / "common.sh"}" && {script}',
+             "collx", *(args or [])],
             capture_output=True, text=True, check=True,
             env={"PATH": os.environ["PATH"], "COLLX_IMAGE_PLATFORM": "linux/amd64", **env},
         )
         return result.stdout
 
-    def test_the_key_is_invariant_across_runs(self) -> None:
-        first = self._path({"GITHUB_RUN_ID": "1111", "GITHUB_RUN_ATTEMPT": "1"})
-        second = self._path({"GITHUB_RUN_ID": "2222", "GITHUB_RUN_ATTEMPT": "2",
-                             "COLLECTIVEX_EXECUTION_ID": "2222_2_c007"})
-        self.assertEqual(first, second)
-        self.assertNotIn("1111", first)
+    def test_the_path_is_invariant_across_runs_and_digests(self) -> None:
+        paths = {
+            self._bash('collx_squash_path /squash "$1"', env, [self.IMAGE])
+            for env in (
+                {"GITHUB_RUN_ID": "1111", "GITHUB_RUN_ATTEMPT": "1"},
+                {"GITHUB_RUN_ID": "2222", "COLLECTIVEX_EXECUTION_ID": "2222_2_c007"},
+                {"COLLX_IMAGE_DIGEST": self.DIGEST},
+                {},
+            )
+        }
+        self.assertEqual(paths, {"/squash/_rocm_sgl-dev_sglang-v1.sqsh"})
+        arm = self._bash('collx_squash_path /squash "$1"',
+                         {"COLLX_IMAGE_PLATFORM": "linux/arm64"}, [self.IMAGE])
+        self.assertEqual(arm, "/squash/_linux_arm64_rocm_sgl-dev_sglang-v1.sqsh")
 
-    def test_a_resolved_digest_scopes_the_key(self) -> None:
-        path = self._path({"COLLX_IMAGE_DIGEST": "sha256:" + "ab" * 32})
-        self.assertEqual(path, "/squash/_abababababab_rocm_sgl-dev_sglang-v1.sqsh")
+    def _verdict(self, sq: Path, digest: str = "", epoch: str = "") -> str:
+        return self._bash('collx_squash_verdict "$1" "$2" "$3"', {},
+                          [str(sq), digest, epoch])
 
-    def test_an_unresolved_or_malformed_digest_degrades_to_the_tag_key(self) -> None:
-        for env in ({}, {"COLLX_IMAGE_DIGEST": "sha256:short"},
-                    {"COLLX_IMAGE_DIGEST": "md5:" + "ab" * 32}):
-            with self.subTest(env=env):
-                self.assertEqual(self._path(env),
-                                 "/squash/_tag_rocm_sgl-dev_sglang-v1.sqsh")
+    def test_verdict_reuses_what_is_staged_when_the_digest_is_unresolved(self) -> None:
+        # The registry-blip case: a stamped file must be reused, not re-imported,
+        # when this launch could not resolve a digest.
+        with tempfile.TemporaryDirectory() as directory:
+            sq = Path(directory) / "img.sqsh"
+            sq.write_bytes(b"x")
+            (sq.parent / "img.sqsh.digest").write_text(self.DIGEST + "\n")
+            self.assertEqual(self._verdict(sq), "reuse")
 
-    def test_arm64_keys_stay_platform_scoped(self) -> None:
-        path = self._path({"COLLX_IMAGE_PLATFORM": "linux/arm64",
-                           "COLLX_IMAGE_DIGEST": "sha256:" + "cd" * 32})
-        self.assertEqual(path, "/squash/_linux_arm64_cdcdcdcdcdcd_rocm_sgl-dev_sglang-v1.sqsh")
+    def test_verdict_reimports_when_the_tag_moved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            sq = Path(directory) / "img.sqsh"
+            sq.write_bytes(b"x")
+            (sq.parent / "img.sqsh.digest").write_text(self.DIGEST + "\n")
+            moved = "sha256:" + "cd" * 32
+            self.assertEqual(self._verdict(sq, digest=moved), "digest-moved")
+            self.assertEqual(self._verdict(sq, digest=self.DIGEST), "reuse")
+
+    def test_verdict_refresh_discards_only_pre_launch_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            sq = Path(directory) / "img.sqsh"
+            sq.write_bytes(b"x")
+            mtime = int(sq.stat().st_mtime)
+            self.assertEqual(self._verdict(sq, epoch=str(mtime + 10)), "refresh-requested")
+            # A file imported during this launch (mtime >= epoch) is kept, so
+            # concurrent legs of a refreshing run still import exactly once.
+            self.assertEqual(self._verdict(sq, epoch=str(mtime - 10)), "reuse")
+            self.assertEqual(self._verdict(sq.parent / "missing.sqsh"), "absent")
 
 
 class ConfigTests(unittest.TestCase):

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -17,6 +17,7 @@ import tempfile
 import types
 import unittest
 from unittest import mock
+import urllib.error
 
 
 RUNTIME = Path(__file__).resolve().parents[1] / "runtime"
@@ -92,6 +93,124 @@ class ProbeTests(unittest.TestCase):
             self.assertTrue(cache.is_dir())
             self.assertEqual(cache.parent, parent.resolve())
             self.assertEqual(cache.stat().st_mode & 0o777, 0o700)
+
+
+class _FakeRegistryResponse:
+    def __init__(self, headers: dict | None = None, body: bytes = b""):
+        self.headers = headers or {}
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeRegistry:
+    """Registry-v2 anonymous token dance: 401 challenge, token grant, digest HEAD."""
+
+    def __init__(self, digest: str):
+        self.digest = digest
+        self.urls: list[str] = []
+
+    def open(self, request, timeout=None):
+        url = request if isinstance(request, str) else request.full_url
+        self.urls.append(url)
+        if "scope=" in url:
+            return _FakeRegistryResponse(body=json.dumps({"token": "anonymous"}).encode())
+        if not request.get_header("Authorization"):
+            raise urllib.error.HTTPError(url, 401, "unauthorized", {
+                "WWW-Authenticate":
+                    'Bearer realm="https://auth.example/token",service="registry.example"',
+            }, None)
+        return _FakeRegistryResponse(headers={"Docker-Content-Digest": self.digest})
+
+
+# The digest is only a cache key for the staged squash, but a wrong or accepted-malformed
+# digest silently degrades stage-once-reuse-many back into per-run imports (or worse,
+# poisons the key), so the resolution path is pinned without touching the network.
+class ImageDigestResolutionTests(unittest.TestCase):
+    DIGEST = "sha256:" + "0123456789abcdef" * 4
+
+    def test_docker_hub_references_get_the_implied_registry(self) -> None:
+        self.assertEqual(probe.registry_reference("rocm/sgl-dev:v1"),
+                         ("registry-1.docker.io", "rocm/sgl-dev", "v1"))
+        self.assertEqual(probe.registry_reference("python:3.12"),
+                         ("registry-1.docker.io", "library/python", "3.12"))
+
+    def test_explicit_registries_pass_through(self) -> None:
+        self.assertEqual(probe.registry_reference("ghcr.io/org/image:tag"),
+                         ("ghcr.io", "org/image", "tag"))
+        self.assertEqual(probe.registry_reference("nvcr.io/nvidia/pytorch:25.06-py3"),
+                         ("nvcr.io", "nvidia/pytorch", "25.06-py3"))
+
+    def test_resolution_follows_the_anonymous_token_dance(self) -> None:
+        registry = _FakeRegistry(self.DIGEST)
+        self.assertEqual(
+            probe.resolve_image_digest("ghcr.io/org/image:tag", opener=registry),
+            self.DIGEST,
+        )
+        self.assertEqual(registry.urls[0], "https://ghcr.io/v2/org/image/manifests/tag")
+        self.assertIn("scope=repository%3Aorg%2Fimage%3Apull", registry.urls[1])
+        self.assertIn("service=registry.example", registry.urls[1])
+
+    def test_a_malformed_digest_or_registry_failure_yields_empty(self) -> None:
+        self.assertEqual(
+            probe.resolve_image_digest("ghcr.io/org/image:tag",
+                                       opener=_FakeRegistry("sha256:nothex")),
+            "",
+        )
+
+        class _Down:
+            def open(self, request, timeout=None):
+                raise OSError("no route")
+
+        self.assertEqual(
+            probe.resolve_image_digest("ghcr.io/org/image:tag", opener=_Down()), "")
+
+
+# runtime/common.sh collx_squash_path is the stage-once seam: keying the squash by
+# GITHUB_RUN_ID is exactly the defect that re-imported ~30-65GB per run per cluster,
+# so the key must be a pure function of platform + digest + image reference.
+class SquashCacheKeyTests(unittest.TestCase):
+    IMAGE = "rocm/sgl-dev:sglang-v1"
+
+    def _path(self, env: dict, image: str | None = None) -> str:
+        result = subprocess.run(
+            ["bash", "-c",
+             f'source "{RUNTIME / "common.sh"}" && collx_squash_path /squash "$1"',
+             "collx", image or self.IMAGE],
+            capture_output=True, text=True, check=True,
+            env={"PATH": os.environ["PATH"], "COLLX_IMAGE_PLATFORM": "linux/amd64", **env},
+        )
+        return result.stdout
+
+    def test_the_key_is_invariant_across_runs(self) -> None:
+        first = self._path({"GITHUB_RUN_ID": "1111", "GITHUB_RUN_ATTEMPT": "1"})
+        second = self._path({"GITHUB_RUN_ID": "2222", "GITHUB_RUN_ATTEMPT": "2",
+                             "COLLECTIVEX_EXECUTION_ID": "2222_2_c007"})
+        self.assertEqual(first, second)
+        self.assertNotIn("1111", first)
+
+    def test_a_resolved_digest_scopes_the_key(self) -> None:
+        path = self._path({"COLLX_IMAGE_DIGEST": "sha256:" + "ab" * 32})
+        self.assertEqual(path, "/squash/_abababababab_rocm_sgl-dev_sglang-v1.sqsh")
+
+    def test_an_unresolved_or_malformed_digest_degrades_to_the_tag_key(self) -> None:
+        for env in ({}, {"COLLX_IMAGE_DIGEST": "sha256:short"},
+                    {"COLLX_IMAGE_DIGEST": "md5:" + "ab" * 32}):
+            with self.subTest(env=env):
+                self.assertEqual(self._path(env),
+                                 "/squash/_tag_rocm_sgl-dev_sglang-v1.sqsh")
+
+    def test_arm64_keys_stay_platform_scoped(self) -> None:
+        path = self._path({"COLLX_IMAGE_PLATFORM": "linux/arm64",
+                           "COLLX_IMAGE_DIGEST": "sha256:" + "cd" * 32})
+        self.assertEqual(path, "/squash/_linux_arm64_cdcdcdcdcdcd_rocm_sgl-dev_sglang-v1.sqsh")
 
 
 class ConfigTests(unittest.TestCase):

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -95,58 +95,52 @@ class ProbeTests(unittest.TestCase):
             self.assertEqual(cache.stat().st_mode & 0o777, 0o700)
 
 
-class _FakeRegistryResponse:
-    def __init__(self, headers: dict | None = None, body: bytes = b""):
-        self.headers = headers or {}
-        self._body = body
-
-    def read(self) -> bytes:
-        return self._body
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        return False
-
-
 class _FakeRegistry:
     """Registry-v2 anonymous token dance: 401 challenge, token grant, digest HEAD."""
 
+    class _Response:
+        def __init__(self, headers=None, body=b""):
+            self.headers, self._body = headers or {}, body
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
     def __init__(self, digest: str):
-        self.digest = digest
-        self.urls: list[str] = []
+        self.digest, self.urls = digest, []
 
     def open(self, request, timeout=None):
         url = request if isinstance(request, str) else request.full_url
         self.urls.append(url)
         if "scope=" in url:
-            return _FakeRegistryResponse(body=json.dumps({"token": "anonymous"}).encode())
+            return self._Response(body=json.dumps({"token": "anonymous"}).encode())
         if not request.get_header("Authorization"):
             raise urllib.error.HTTPError(url, 401, "unauthorized", {
                 "WWW-Authenticate":
                     'Bearer realm="https://auth.example/token",service="registry.example"',
             }, None)
-        return _FakeRegistryResponse(headers={"Docker-Content-Digest": self.digest})
+        return self._Response(headers={"Docker-Content-Digest": self.digest})
 
 
-# The digest is only a cache key for the staged squash, but a wrong or accepted-malformed
-# digest silently degrades stage-once-reuse-many back into per-run imports (or worse,
-# poisons the key), so the resolution path is pinned without touching the network.
+# The digest only stamps the staged squash's sidecar, but a wrong or accepted-malformed
+# digest silently turns stage-once-reuse-many back into per-launch imports, so the
+# resolution path is pinned without touching the network.
 class ImageDigestResolutionTests(unittest.TestCase):
     DIGEST = "sha256:" + "0123456789abcdef" * 4
 
-    def test_docker_hub_references_get_the_implied_registry(self) -> None:
-        self.assertEqual(probe.registry_reference("rocm/sgl-dev:v1"),
-                         ("registry-1.docker.io", "rocm/sgl-dev", "v1"))
-        self.assertEqual(probe.registry_reference("python:3.12"),
-                         ("registry-1.docker.io", "library/python", "3.12"))
-
-    def test_explicit_registries_pass_through(self) -> None:
-        self.assertEqual(probe.registry_reference("ghcr.io/org/image:tag"),
-                         ("ghcr.io", "org/image", "tag"))
-        self.assertEqual(probe.registry_reference("nvcr.io/nvidia/pytorch:25.06-py3"),
-                         ("nvcr.io", "nvidia/pytorch", "25.06-py3"))
+    def test_references_resolve_with_docker_hub_rules(self) -> None:
+        for image, expected in (
+            ("rocm/sgl-dev:v1", ("registry-1.docker.io", "rocm/sgl-dev", "v1")),
+            ("python:3.12", ("registry-1.docker.io", "library/python", "3.12")),
+            ("ghcr.io/org/image:tag", ("ghcr.io", "org/image", "tag")),
+            ("nvcr.io/nvidia/pytorch:25.06-py3", ("nvcr.io", "nvidia/pytorch", "25.06-py3")),
+        ):
+            self.assertEqual(probe.registry_reference(image), expected, image)
 
     def test_resolution_follows_the_anonymous_token_dance(self) -> None:
         registry = _FakeRegistry(self.DIGEST)
@@ -156,36 +150,26 @@ class ImageDigestResolutionTests(unittest.TestCase):
         )
         self.assertEqual(registry.urls[0], "https://ghcr.io/v2/org/image/manifests/tag")
         self.assertIn("scope=repository%3Aorg%2Fimage%3Apull", registry.urls[1])
-        self.assertIn("service=registry.example", registry.urls[1])
 
     def test_a_malformed_digest_or_registry_failure_yields_empty(self) -> None:
-        self.assertEqual(
-            probe.resolve_image_digest("ghcr.io/org/image:tag",
-                                       opener=_FakeRegistry("sha256:nothex")),
-            "",
-        )
-
-        class _Down:
-            def open(self, request, timeout=None):
-                raise OSError("no route")
-
-        self.assertEqual(
-            probe.resolve_image_digest("ghcr.io/org/image:tag", opener=_Down()), "")
+        down = types.SimpleNamespace(open=mock.Mock(side_effect=OSError("no route")))
+        for opener in (_FakeRegistry("sha256:nothex"), down):
+            self.assertEqual(
+                probe.resolve_image_digest("ghcr.io/org/image:tag", opener=opener), "")
 
 
 # runtime/common.sh collx_squash_path/collx_squash_verdict are the stage-once seam:
 # keying the squash by GITHUB_RUN_ID is exactly the defect that re-imported 30-65GB
 # per run per cluster, and keying it by digest made a transient registry blip miss
-# the staged file — so the path is a pure function of platform + image reference,
+# the staged file -- so the path is a pure function of platform + image reference,
 # and freshness is decided by the verdict against the digest sidecar.
 class SquashCacheKeyTests(unittest.TestCase):
     IMAGE = "rocm/sgl-dev:sglang-v1"
     DIGEST = "sha256:" + "ab" * 32
 
-    def _bash(self, script: str, env: dict, args: list | None = None) -> str:
+    def _bash(self, script: str, env: dict, args: list) -> str:
         result = subprocess.run(
-            ["bash", "-c", f'source "{RUNTIME / "common.sh"}" && {script}',
-             "collx", *(args or [])],
+            ["bash", "-c", f'source "{RUNTIME / "common.sh"}" && {script}', "collx", *args],
             capture_output=True, text=True, check=True,
             env={"PATH": os.environ["PATH"], "COLLX_IMAGE_PLATFORM": "linux/amd64", **env},
         )
@@ -206,38 +190,24 @@ class SquashCacheKeyTests(unittest.TestCase):
                          {"COLLX_IMAGE_PLATFORM": "linux/arm64"}, [self.IMAGE])
         self.assertEqual(arm, "/squash/_linux_arm64_rocm_sgl-dev_sglang-v1.sqsh")
 
-    def _verdict(self, sq: Path, digest: str = "", epoch: str = "") -> str:
-        return self._bash('collx_squash_verdict "$1" "$2" "$3"', {},
-                          [str(sq), digest, epoch])
-
-    def test_verdict_reuses_what_is_staged_when_the_digest_is_unresolved(self) -> None:
-        # The registry-blip case: a stamped file must be reused, not re-imported,
-        # when this launch could not resolve a digest.
+    def test_the_verdict_orders_refresh_stamp_and_reuse_correctly(self) -> None:
+        verdict = lambda sq, digest="", epoch="": self._bash(  # noqa: E731
+            'collx_squash_verdict "$1" "$2" "$3"', {}, [str(sq), digest, epoch])
         with tempfile.TemporaryDirectory() as directory:
             sq = Path(directory) / "img.sqsh"
+            self.assertEqual(verdict(sq), "absent")
             sq.write_bytes(b"x")
-            (sq.parent / "img.sqsh.digest").write_text(self.DIGEST + "\n")
-            self.assertEqual(self._verdict(sq), "reuse")
-
-    def test_verdict_reimports_when_the_tag_moved(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            sq = Path(directory) / "img.sqsh"
-            sq.write_bytes(b"x")
-            (sq.parent / "img.sqsh.digest").write_text(self.DIGEST + "\n")
-            moved = "sha256:" + "cd" * 32
-            self.assertEqual(self._verdict(sq, digest=moved), "digest-moved")
-            self.assertEqual(self._verdict(sq, digest=self.DIGEST), "reuse")
-
-    def test_verdict_refresh_discards_only_pre_launch_files(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            sq = Path(directory) / "img.sqsh"
-            sq.write_bytes(b"x")
+            Path(f"{sq}.digest").write_text(self.DIGEST + "\n")
+            # The registry-blip regression: an unresolved digest must reuse the
+            # stamped file, never re-import tens of GB.
+            self.assertEqual(verdict(sq), "reuse")
+            self.assertEqual(verdict(sq, digest=self.DIGEST), "reuse")
+            self.assertEqual(verdict(sq, digest="sha256:" + "cd" * 32), "digest-moved")
             mtime = int(sq.stat().st_mtime)
-            self.assertEqual(self._verdict(sq, epoch=str(mtime + 10)), "refresh-requested")
+            self.assertEqual(verdict(sq, epoch=str(mtime + 10)), "refresh-requested")
             # A file imported during this launch (mtime >= epoch) is kept, so
             # concurrent legs of a refreshing run still import exactly once.
-            self.assertEqual(self._verdict(sq, epoch=str(mtime - 10)), "reuse")
-            self.assertEqual(self._verdict(sq.parent / "missing.sqsh"), "absent")
+            self.assertEqual(verdict(sq, epoch=str(mtime - 10)), "reuse")
 
 
 class ConfigTests(unittest.TestCase):


### PR DESCRIPTION
## What

The squash cache key was `GITHUB_RUN_ID`-scoped, so **every sweep run re-imported the same 30–65 GB image** onto (often thin) squash disks — ~15–20 min of fixed setup per shard and unbounded disk growth. This keys the squash by content instead: **image platform + registry manifest digest + image reference**.

- Every shard and every later run of the same image converges on one staged file per cluster ("container squash ready (reusing staged import)").
- A tag that moves upstream changes the digest → new key → fresh import automatically. That is the image-update path.
- `probe.py image-digest`: anonymous registry-v2 manifest HEAD from the submit host (docker.io / ghcr.io / nvcr.io token dance; nothing is pulled). Fails soft: no digest → key degrades to the tag, and an already-staged squash is still preferred over a re-import.
- New `refresh_image` dispatch input (`COLLX_IMAGE_REFRESH=1`): discards squashes staged before this launch (mtime vs `COLLX_LAUNCH_EPOCH`) — the escape hatch for a moved tag whose digest can't be resolved. A file imported *during* the launch is never discarded, so concurrent legs still import exactly once even on shared storage.
- Fresh imports `chmod a+r` (defuses the 0600 cross-account pyxis "Invalid image format" trap) and age-gate reap superseded stagings of the same image (old digests + retired per-run keys, 2-day window; reuse touches files live).
- The import flock is content-keyed like the file, so cross-run contention serializes and the winner's import is everyone else's cache hit.

## Tests

- `ImageDigestResolutionTests`: registry reference parsing (Hub implied registry, `library/` prefix, explicit registries), the anonymous token dance against a fake registry, malformed-digest and network-failure fail-soft.
- `SquashCacheKeyTests` (seam contract on `collx_squash_path`): the key is **invariant across `GITHUB_RUN_ID`/attempt/execution-id** — the exact defect that caused per-run staging — digest-scoped when resolved, tag-scoped otherwise, platform-scoped on arm64.
- Full `tests.test_runtime`: 48 pass.
- Live smoke: both production images resolve digests from Docker Hub (`lmsysorg/sglang:v0.5.11-cu130` → `061fb71f…`, `rocm/sgl-dev:…mori-0701` → `ea423753…`); unknown image fails soft to the tag key.

First sweep on each cluster after merge imports fresh (new key); every one after that reuses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared cluster squash storage, registry-dependent staleness, and concurrent import behavior—operational risk to sweep setup time and disk use, not benchmark correctness paths.
> 
> **Overview**
> **CollectiveX no longer re-imports 30–65 GB Enroot squashes on every GitHub Actions run.** Squash files are keyed by **image platform + tag** (not `GITHUB_RUN_ID`), staged once per cluster, and shared across shards and later sweeps.
> 
> **Freshness** is tracked via a **`.digest` sidecar**: at launch, `probe.py image-digest` resolves the registry manifest (anonymous token dance, fail-soft). A resolved digest that differs from the sidecar triggers re-import; if resolution fails, the launcher **reuses** the existing squash instead of forcing a full re-download. The new workflow input **`refresh_image`** sets `COLLX_IMAGE_REFRESH=1` to discard squashes older than `COLLX_LAUNCH_EPOCH` when a tag moved but digest lookup failed.
> 
> Import locking stays **content-keyed** so concurrent legs serialize on one import; new imports are **`chmod a+r`** for cross-account pyxis reuse, and **2-day age-gated** cleanup removes legacy per-run squash filenames. Methodology docs and **`ImageDigestResolutionTests` / `SquashCacheKeyTests`** pin the path and verdict behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10528dc832751095865a1b8355a4ccbf7f28bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->