### PR TITLE
Fix MI300X routing for the replacement AMD cluster

### DIFF
--- a/.claude/commands/debug-mi300-enroot-pyxis.md
+++ b/.claude/commands/debug-mi300-enroot-pyxis.md
@@ -4,7 +4,7 @@ argument-hint: [failed-run-or-job-url ...]
 ---
 
 Debug `pyxis: couldn't start container` failures on the MI300X runners
-(`mi300x-amds_*`, nodes `chi-mi300x-*`). The canonical signature in the job log:
+(`mi300x-amd_*`, nodes `chi-mi300x-*`). The canonical signature in the job log:
 
 ```
 error: pyxis:     enroot-nsenter: failed to create user namespace: Permission denied

--- a/KLAUD_DEBUG.md
+++ b/KLAUD_DEBUG.md
@@ -146,7 +146,7 @@ If a sweep job lands on any of these, it'll never start. Nothing can be done at 
 ### 5.3 `chi-mi300x-049` — `/nvme_home` disk-full
 **Symptom:** pyxis container extraction fails with `No space left on device` writing to `/nvme_home/gharunner/.local/share/enroot/pyxis_*/opt/rocm-*/...`. The `/nvme_home` partition is hosted under `/` on this node and has been chronically near-full.
 
-**Fix already landed:** `runners/launch_mi300x-amds.sh` now pins salloc to only known-good mi300x nodes (`chi-mi300x-[034-036,054,057-058]`). See PR #1462. `chi-mi300x-049` is held in `State=DOWN` by a watchdog on the controller (`/home/gharunner/_audit/drain_049_watchdog.sh`) that re-applies the drain every 10s if SLURM auto-clears it (which it does on dynamic-norm nodes).
+**Legacy fix:** PR #1462 pinned the retired fleet to known-good `chi-mi300x-*` nodes. The replacement fleet uses `runners/launch_mi300x-amd.sh` and relies on current Slurm availability instead of those obsolete hard-coded exclusions.
 
 ### 5.4 `chi-mi325x-pod1-017` — orphaned port-8888 process
 **Symptom:** sglang server bind fails with `[Errno 98] Address already in use` on port 8888. Held by an MLPerf accuracy run started outside SLURM.
@@ -218,7 +218,7 @@ between the PR sweep and merge therefore does not require another GPU sweep.
 
 - **`gh pr edit` silently aborts** on a Projects-classic deprecation GraphQL error. Title/body updates won't apply. Use `gh api -X PATCH "repos/<org>/<repo>/pulls/<N>" -f title="..." -F body=@file.md` instead.
 - The same issue affects adding labels. Use `gh api -X POST "repos/<org>/<repo>/issues/<N>/labels" -f "labels[]=<name>"`.
-- `gh pr view ... --jq .headRefName` output can have a trailing `\r`. Strip it: `gh pr view <N> --json headRefName --jq .headRefName | tr -d '\r\n'`. Otherwise shell concatenation produces `branchunners/launch_mi300x-amds.sh`-style corruption.
+- `gh pr view ... --jq .headRefName` output can have a trailing `\r`. Strip it: `gh pr view <N> --json headRefName --jq .headRefName | tr -d '\r\n'`. Otherwise shell concatenation produces `branchunners/launch_mi300x-amd.sh`-style corruption.
 - `gh pr list --json statusCheckRollup` **truncates** each PR's rollup. Never trust it for per-check filters. Re-query each PR individually with `gh pr view <N> --json statusCheckRollup`.
 - `gh` and the GitHub Actions API: `conclusion` is `""` (empty string, not `null`) for in-flight checks, so `jq`'s `// .status` fallback doesn't trigger. Use:
   ```jq

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -432,7 +432,7 @@ qwen3.5-fp8-mi300x-sglang-agentic-mtp:
   image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: cluster:mi300x-amds
+  runner: cluster:mi300x-amd
   precision: fp8
   framework: sglang
   multinode: false
@@ -1535,7 +1535,7 @@ minimaxm3-fp8-mi300x-vllm-agentic-mtp:
   image: vllm/vllm-openai-rocm:v0.27.1
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
-  runner: cluster:mi300x-amds
+  runner: cluster:mi300x-amd
   precision: fp8
   framework: vllm
   multinode: false

--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -66,15 +66,15 @@ labels:
     - b200-nscale-slurm_08
     - b200-nscale-slurm_09
   mi300x:
-    - mi300x-amds_00
-    - mi300x-amds_01
-    - mi300x-amds_02
-    - mi300x-amds_03
-    - mi300x-amds_04
-    - mi300x-amds_05
-    - mi300x-amds_06
-    - mi300x-amds_07
-    - mi300x-amds_08
+    - mi300x-amd_00
+    - mi300x-amd_01
+    - mi300x-amd_02
+    - mi300x-amd_03
+    - mi300x-amd_04
+    - mi300x-amd_05
+    - mi300x-amd_06
+    - mi300x-amd_07
+    - mi300x-amd_08
   mi325x:
     - mi325x-amds_00
     - mi325x-amds_01
@@ -207,16 +207,16 @@ labels:
     - gb300-nv_2
   cluster:rtx6000pro-lat:
     - rtx6000pro-lat_00
-  cluster:mi300x-amds:
-    - mi300x-amds_00
-    - mi300x-amds_01
-    - mi300x-amds_02
-    - mi300x-amds_03
-    - mi300x-amds_04
-    - mi300x-amds_05
-    - mi300x-amds_06
-    - mi300x-amds_07
-    - mi300x-amds_08
+  cluster:mi300x-amd:
+    - mi300x-amd_00
+    - mi300x-amd_01
+    - mi300x-amd_02
+    - mi300x-amd_03
+    - mi300x-amd_04
+    - mi300x-amd_05
+    - mi300x-amd_06
+    - mi300x-amd_07
+    - mi300x-amd_08
   cluster:mi300x-tw:
     - mi300x-tw_00
     - mi300x-tw_01
@@ -269,8 +269,8 @@ hardware:
   cluster:rtx6000pro-lat:
     available-cpu-dram-mib: 1_500_000
     gpus-per-node: 8
-  cluster:mi300x-amds:
-    available-cpu-dram-mib: 2_321_924
+  cluster:mi300x-amd:
+    available-cpu-dram-mib: 1_500_000
     gpus-per-node: 8
   cluster:mi300x-tw:
     available-cpu-dram-mib: 2_322_328

--- a/docs/recovery-results-procedures.md
+++ b/docs/recovery-results-procedures.md
@@ -317,7 +317,7 @@ Canonical source: [MI355X root-owned file recovery](https://github.com/SemiAnaly
 
 ## MI300X cluster debugging: enroot/pyxis user-namespace failures
 
-Canonical signature on `mi300x-amds_*` / `chi-mi300x-*`:
+Canonical signature on `mi300x-amd_*` / `chi-mi300x-*`:
 
 ```text
 error: pyxis:     enroot-nsenter: failed to create user namespace: Permission denied

--- a/docs/recovery-results-procedures_zh.md
+++ b/docs/recovery-results-procedures_zh.md
@@ -317,7 +317,7 @@ jumpbox 没有 sudo；需要使用 agent forwarding 连接到在 `/it-share` 上
 
 ## MI300X 集群调试：enroot/pyxis 用户命名空间故障
 
-`mi300x-amds_*` / `chi-mi300x-*` 上的典型特征：
+`mi300x-amd_*` / `chi-mi300x-*` 上的典型特征：
 
 ```text
 error: pyxis:     enroot-nsenter: failed to create user namespace: Permission denied

--- a/runners/launch_mi300x-amd.sh
+++ b/runners/launch_mi300x-amd.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export HF_HUB_CACHE_MOUNT="/raid/hf-hub-cache/"
+export HF_HUB_CACHE_MOUNT="/raid/inferencex/hf-hub-cache/"
 
 PARTITION="compute"
-SQUASH_DIR="/raid/hf-hub-cache/runtime-cache/enroot"
+SQUASH_DIR="/raid/inferencex/squash"
 SQUASH_FILE="$SQUASH_DIR/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
 LOCK_FILE="${SQUASH_FILE}.lock"
 COMPUTE_TMPDIR="$SQUASH_DIR/tmp-${UID}"
@@ -21,10 +21,7 @@ export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"
 
 set -x
 
-# Exclude known-bad nodes; let Slurm pick from anything else:
-#   chi-mi300x-049: persistent /nvme_home disk-full
-#   chi-mi300x-121: provisioning incomplete; missing /raid and Enroot storage
-JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --exclude=chi-mi300x-049,chi-mi300x-121 --gres=gpu:$GPU_COUNT --cpus-per-task=256 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
+JOB_ID=$(set +o pipefail; salloc --partition=$PARTITION --gres=gpu:$GPU_COUNT --cpus-per-task=128 --time=180 --no-shell --job-name="$RUNNER_NAME" 2>&1 | tee /dev/stderr | grep -oP 'Granted job allocation \K[0-9]+')
 
 if [ -z "$JOB_ID" ]; then
     echo "ERROR: salloc failed to allocate a job" >&2

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -282,7 +282,7 @@ def sample_runner_config():
             "cluster:h200-dgxc": {"available-cpu-dram-mib": 1471356, "gpus-per-node": 8},
             "cluster:b200-nscale": {"available-cpu-dram-mib": 3774874, "gpus-per-node": 8},
             "cluster:b300-nv": {"available-cpu-dram-mib": 2964436, "gpus-per-node": 8},
-            "cluster:mi300x-amds": {"available-cpu-dram-mib": 2321924, "gpus-per-node": 8},
+            "cluster:mi300x-amd": {"available-cpu-dram-mib": 1500000, "gpus-per-node": 8},
             "cluster:mi355x-amds": {"available-cpu-dram-mib": 3095781, "gpus-per-node": 8},
             "cluster:gb200-nv": {"available-cpu-dram-mib": 860160, "gpus-per-node": 4},
         },

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -201,7 +201,7 @@ def valid_runner_config():
             "cluster:h100-dgxc": {"available-cpu-dram-mib": 2063837, "gpus-per-node": 8},
             "cluster:h200-dgxc": {"available-cpu-dram-mib": 1471356, "gpus-per-node": 8},
             "cluster:b200-nscale": {"available-cpu-dram-mib": 3774874, "gpus-per-node": 8},
-            "cluster:mi300x-amds": {"available-cpu-dram-mib": 2321924, "gpus-per-node": 8},
+            "cluster:mi300x-amd": {"available-cpu-dram-mib": 1500000, "gpus-per-node": 8},
             "cluster:gb200-nv": {"available-cpu-dram-mib": 860160, "gpus-per-node": 4},
         },
     }

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -402,7 +402,7 @@ def test_eval_validation_uses_logical_runner_from_metadata(
         tmp_path,
         64,
         logical_runner="mi300x",
-        physical_runner="mi300x-amds_04",
+        physical_runner="mi300x-amd_04",
     )
 
     assert validate_eval_artifacts(tmp_path) == []


### PR DESCRIPTION
## Summary
- replace every active `mi300x-amds` runner, cluster-label, launcher, test, and troubleshooting reference with `mi300x-amd`
- align the runner inventory with the nine live `mi300x-amd_00` through `_08` GitHub runners
- update the launcher for the replacement cluster’s 128-CPU nodes and `/raid/inferencex` storage layout
- update recorded host-memory capacity to the replacement node shape

The sole retained `mi300x-amds` string is an immutable historical entry in append-only `perf-changelog.yaml`. This is a fleet-routing cutover and does not change benchmark recipes, so it does not append a new performance entry.

## Verification
- `python3 -m pytest utils/matrix_logic/ utils/test_validate_reusable_sweep_artifacts.py -q` (281 passed)
- targeted generation for both MI300X AMD master configs
- YAML parse and launcher Bash syntax checks
- verified all nine live GitHub runners are online with `cluster:mi300x-amd`
- verified all nine Slurm compute nodes expose 128 CPUs, 8 GPUs, and writable `/raid/inferencex` cache paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fleet cutover and launcher path/CPU assumptions affect where MI300X jobs land and whether containers start; misconfiguration could waste GPU time or fail sweeps until routing is corrected.
> 
> **Overview**
> This PR **cuts MI300X sweep routing** from the retired `mi300x-amds` / `cluster:mi300x-amds` fleet to the nine live **`cluster:mi300x-amd`** GitHub runners and matching Slurm nodes.
> 
> **Runner inventory** in `configs/runners.yaml` renames all nine labels to `mi300x-amd_*` and updates **`available-cpu-dram-mib`** for `cluster:mi300x-amd` from ~2.32M to **1_500_000** to match replacement node shape. **`configs/amd-master.yaml`** points the Qwen3.5 and MiniMax-M3 MI300X agentic-MTP recipes at `cluster:mi300x-amd`.
> 
> **`runners/launch_mi300x-amd.sh`** is aligned with the new cluster: HF hub cache and Enroot squash live under **`/raid/inferencex/`** (not `/raid/hf-hub-cache/`), **`salloc` uses 128 CPUs** per task (was 256), and **hard-coded `--exclude` for bad `chi-mi300x-*` nodes is removed** so scheduling uses current Slurm availability.
> 
> Operational docs (`KLAUD_DEBUG.md`, recovery procedures, debug command) and matrix/validation tests are updated for the `mi300x-amd` naming. **No benchmark recipe or performance changelog changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c228d68c247905ed9d571ef0ac2272cf7019b1fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->