### PR TITLE
config(dsv4): set H200 CUDA graph capture sizes / 配置(dsv4)：设置 H200 CUDA 图捕获尺寸

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/dsv4_fp8_h200.sh
+++ b/benchmarks/single_node/fixed_seq_len/dsv4_fp8_h200.sh
@@ -50,6 +50,21 @@ if [ "${EP_SIZE:-1}" -gt 1 ]; then
     EP_ARGS=(--enable-expert-parallel)
 fi
 
+CAPTURE_SIZES_JSON=""
+if [[ $CONC == 64 && $DP_ATTENTION == "true" ]]; then
+    CAPTURE_SIZES=(1 2 4)
+    for ((capture_size = 8; capture_size <= 16; capture_size += 2)); do
+        CAPTURE_SIZES+=("$capture_size")
+    done
+    for ((capture_size = 24; capture_size <= 248; capture_size += 8)); do
+        CAPTURE_SIZES+=("$capture_size")
+    done
+    for ((capture_size = 256; capture_size <= 512; capture_size += 16)); do
+        CAPTURE_SIZES+=("$capture_size")
+    done
+    CAPTURE_SIZES_JSON=",\"cudagraph_capture_sizes\":[$(IFS=,; echo "${CAPTURE_SIZES[*]}")]"
+fi
+
 # Start GPU monitoring (power, temperature, clocks every second)
 start_gpu_monitor
 
@@ -67,7 +82,7 @@ $MAX_MODEL_LEN_ARG \
 --max-num-seqs 512 \
 --max-num-batched-tokens 512 \
 --no-enable-flashinfer-autotune \
---compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+--compilation-config "{\"mode\":0,\"cudagraph_mode\":\"FULL_DECODE_ONLY\"${CAPTURE_SIZES_JSON}}" \
 --tokenizer-mode deepseek_v4 \
 --tool-call-parser deepseek_v4 \
 --enable-auto-tool-choice \

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6680,4 +6680,4 @@
   description:
     - "Update the CUDA graph capture-size configuration for dsv4-fp8-h200-vllm."
     - "Use explicit capture sizes for concurrency 64 with DP attention while preserving vLLM defaults for other points."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2791

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6674,3 +6674,10 @@
     - "Bump image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726 to lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260828"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2763
   
+
+- config-keys:
+    - dsv4-fp8-h200-vllm
+  description:
+    - "Update the CUDA graph capture-size configuration for dsv4-fp8-h200-vllm."
+    - "Use explicit capture sizes for concurrency 64 with DP attention while preserving vLLM defaults for other points."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Description

Update `dsv4-fp8-h200-vllm` to use an explicit CUDA graph capture-size schedule only at concurrency 64 with DP attention. The schedule retains vLLM's default granularity and adds capture sizes 10, 12, and 14. All other points continue using vLLM's default capture-size selection.

## 中文说明

更新 `dsv4-fp8-h200-vllm`：仅在并发 64 且启用 DP attention 时设置明确的 CUDA 图捕获尺寸。该列表保留 vLLM 的默认粒度，并增加 10、12 和 14；其他配置点继续使用 vLLM 的默认捕获尺寸选择。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.
