### PR TITLE
Fix sweep priority classifier authentication / 修复扫描优先级分类器身份验证

### DIFF
--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -237,10 +237,13 @@ jobs:
             - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
             - name: Classify priority criteria
               id: classify
-              if: vars.PRIORITY_SCHEDULER_ENABLED == 'true'
+              if: >-
+                  vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
+                  github.event_name == 'pull_request'
               continue-on-error: true
               uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1.0.174
               with:
+                  github_token: ${{ github.token }}
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   track_progress: false
                   settings: |
@@ -251,11 +254,7 @@ jobs:
                       --allowedTools "Read,Glob,Grep,Bash(git diff:*)"
                       --json-schema '{"type":"object","properties":{"criteria":{"type":"array","items":{"type":"string","enum":["multi-node","agentic","eval-only","fp4","mtp","eagle","eagle3","sglang","vllm","dynamo-sglang","dynamo-vllm","glm5","glm5.1","kimik2.5","kimik3","dsv4","minimaxm3","qwen3.5","dsr1","checklist-complete","patchwork"]},"uniqueItems":true},"reason":{"type":"string"}},"required":["criteria","reason"]}'
                   prompt: |
-                      Inspect this Actions run's change range.
-
-                      - For a pull request, compare the head against its base branch.
-                      - For a push, compare `${{ github.event.before }}` to `${{ github.sha }}`.
-                      - Do not return `checklist-complete` for a push: it is PR-only.
+                      Inspect this pull request's diff against its base branch.
 
                       Return every matching priority criterion:
 

--- a/utils/changelog_gate_tests/test_run_sweep_gating.py
+++ b/utils/changelog_gate_tests/test_run_sweep_gating.py
@@ -25,9 +25,10 @@ _WF = yaml.load(
 )
 CHECK_IF = _WF["jobs"]["check-changelog"]["if"]
 GATE_IF = _WF["jobs"]["reuse-sweep-gate"]["if"]
-CLASSIFIER_IF = next(
-    step["if"] for step in _WF["jobs"]["setup"]["steps"] if step.get("id") == "classify"
+CLASSIFIER_STEP = next(
+    step for step in _WF["jobs"]["setup"]["steps"] if step.get("id") == "classify"
 )
+CLASSIFIER_IF = CLASSIFIER_STEP["if"]
 SETUP_IF = _WF["jobs"]["setup"]["if"]
 PR_TYPES = set(_WF["on"]["pull_request"]["types"])
 
@@ -417,7 +418,7 @@ def test_e2e_workflow_cannot_dispatch_database_ingest() -> None:
     assert "INFX_FRONTEND_PAT" not in workflow
 
 
-def test_priority_classifier_runs_for_enabled_actions() -> None:
+def test_priority_classifier_runs_only_for_enabled_pull_requests() -> None:
     scenario = {
         **_PR,
         "action": "synchronize",
@@ -429,7 +430,12 @@ def test_priority_classifier_runs_for_enabled_actions() -> None:
 
     assert not _eval(CLASSIFIER_IF, disabled)
     assert _eval(CLASSIFIER_IF, enabled_pr)
-    assert _eval(CLASSIFIER_IF, enabled_push)
+    assert not _eval(CLASSIFIER_IF, enabled_push)
+
+
+def test_priority_classifier_uses_read_only_workflow_token() -> None:
+    assert CLASSIFIER_STEP["with"]["github_token"] == "${{ github.token }}"
+    assert "id-token" not in _WF["jobs"]["setup"]["permissions"]
 
 def test_reuse_dispatches_source_directly_without_artifact_relay() -> None:
     jobs = _WF["jobs"]

--- a/utils/changelog_gate_tests/test_validate_perf_changelog.py
+++ b/utils/changelog_gate_tests/test_validate_perf_changelog.py
@@ -325,7 +325,10 @@ def test_run_sweep_checks_changelog_before_reuse_and_setup() -> None:
     classifier = next(
         step for step in jobs["setup"]["steps"] if step.get("id") == "classify"
     )
-    assert classifier["if"] == "vars.PRIORITY_SCHEDULER_ENABLED == 'true'"
+    assert classifier["if"] == (
+        "vars.PRIORITY_SCHEDULER_ENABLED == 'true' && "
+        "github.event_name == 'pull_request'"
+    )
     assert (
         "needs.check-changelog.result == 'success'"
         in jobs["reuse-sweep-gate"]["if"]


### PR DESCRIPTION
## Summary

- Pass the setup job's read-only `github.token` to the priority classifier so `claude-code-action` does not attempt an unavailable OIDC exchange.
- Restrict classification to pull request events because the pinned action rejects push events. Push runs retain the existing conservative patchwork fallback.
- Cover the authentication and event-scope contracts in the sweep gating tests.

## Validation

- `python3 -m pytest utils/changelog_gate_tests/test_run_sweep_gating.py -q` (42 passed)

## 中文说明

- 将 setup 作业的只读 `github.token` 传给优先级分类器，避免 `claude-code-action` 尝试不可用的 OIDC 令牌交换。
- 将分类限制为拉取请求事件，因为当前固定版本的 action 不支持 push 事件。push 运行继续使用现有的保守 patchwork 回退策略。
- 在扫描门控测试中覆盖身份验证和事件范围约束。

## 验证

- `python3 -m pytest utils/changelog_gate_tests/test_run_sweep_gating.py -q`（42 项通过）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and test-only changes to sweep priority classification; no runtime product or secrets exposure beyond standard github.token usage.
> 
> **Overview**
> Fixes **Run Sweep** setup so the Claude-based **priority classifier** authenticates reliably and only runs where the action supports it.
> 
> The **Classify priority criteria** step now passes **`github.token`** into `claude-code-action`, avoiding a failed OIDC token exchange when the job only has read-scoped workflow permissions. Its **`if`** also requires **`github.event_name == 'pull_request'`**, so push-triggered sweeps skip classification; the classifier prompt is narrowed to PR-vs-base diffs only. Push runs still get queue priority via the existing **Normalize priority classification** path (default **`patchwork`** when classification did not run).
> 
> **Changelog gate tests** assert the new gate expression, PR-only scheduling, and the read-only token contract (no **`id-token`** on **`setup`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d7eac75fa805f6aab1c0bcf53a5bd17f32015e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->