### PR TITLE
perf(agentx): add LMCache offload arm to Kimi-K3 B300 at conc 56/70

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
@@ -99,12 +99,17 @@ export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
 
 SERVER_LOG="$RESULT_DIR/server.log"
 MOONCAKE_MASTER_LOG="$RESULT_DIR/mooncake_master.log"
+LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
 mkdir -p "$RESULT_DIR"
 MOONCAKE_MASTER_PID=""
+LMCACHE_PID=""
 
 cleanup() {
     if [[ -n "$MOONCAKE_MASTER_PID" ]]; then
         kill "$MOONCAKE_MASTER_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$LMCACHE_PID" ]]; then
+        stop_background_process_tree "$LMCACHE_PID" "LMCache server"
     fi
 }
 trap cleanup EXIT
@@ -188,8 +193,64 @@ EOF
             '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_load_failure_policy":"recompute","kv_connector_extra_config":{"load_async":true,"lookup_async":true,"enable_offload":false}}'
         )
         ;;
+    lmcache)
+        require_agentic_kv_offload_backend lmcache
+        # cp_kv_cache_interleave_size stays at vLLM's default of 1 on this
+        # image, so the connector needs no interleave handling and any DCP-
+        # capable build works. rc2 is the CUDA 13 wheel.
+        LMCACHE_VERSION=0.5.5rc2
+        # LMCache's transfer-channel layer imports mooncake-transfer-engine at
+        # module load; the wheel ships none of its native libs.
+        agentic_pip_install --quiet --no-cache-dir --no-deps \
+            "mooncake-transfer-engine-cuda13==0.3.11.post1"
+        agentic_pip_install --quiet --no-cache-dir --no-deps \
+            "lmcache==$LMCACHE_VERSION"
+        python3 -c "from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPConnector" >/dev/null
+
+        # Under DCP the chunk must be a multiple of block size x DCP_SIZE.
+        # Kimi-K3's hybrid groups resolve a local block of 1536, so DCP 8
+        # gives 12288.
+        LMCACHE_CHUNK_SIZE=$((1536 * DCP_SIZE))
+        LMCACHE_PORT=$((PORT + 13000))
+        LMCACHE_HTTP_PORT=$((PORT + 14000))
+
+        LMCACHE_CMD=(
+            lmcache server
+            --host 127.0.0.1
+            --port "$LMCACHE_PORT"
+            --http-host 127.0.0.1
+            --http-port "$LMCACHE_HTTP_PORT"
+            --l1-size-gb "$TOTAL_CPU_DRAM_GB"
+            --l1-init-size-gb 10
+            --l1-read-ttl-seconds 3600
+            --chunk-size "$LMCACHE_CHUNK_SIZE"
+            --separate-object-groups
+            --enable-extra-logging
+            --extra-logging-interval 30
+            --max-cpu-workers 8
+            --max-gpu-workers "${LMCACHE_GPU_WORKERS:-8}"
+            --eviction-policy LRU
+            --supported-transfer-mode lmcache_driven
+            --shm-name ""
+        )
+        append_command "$RESULT_DIR/lmcache_command.txt" "${LMCACHE_CMD[@]}"
+        "${LMCACHE_CMD[@]}" > "$LMCACHE_LOG" 2>&1 &
+        LMCACHE_PID=$!
+        wait_for_ready \
+            --endpoint "http://127.0.0.1:${LMCACHE_HTTP_PORT}/healthcheck" \
+            --log "$LMCACHE_LOG" \
+            --pid "$LMCACHE_PID" \
+            --sleep-interval 1 \
+            --timeout 600
+
+        # 90k-290k-token agentic prefixes make single retrieves large.
+        OFFLOAD_ARGS=(
+            --kv-transfer-config
+            "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":6000.0}}"
+        )
+        ;;
     *)
-        echo "Error: unsupported KV_OFFLOAD_BACKEND='$KV_OFFLOAD_BACKEND' (expected empty or mooncake)" >&2
+        echo "Error: unsupported KV_OFFLOAD_BACKEND='$KV_OFFLOAD_BACKEND' (expected empty, mooncake, or lmcache)" >&2
         exit 1
         ;;
 esac
@@ -221,6 +282,15 @@ if [ "$NUM_SPEC_TOKENS" -gt 0 ]; then
         SPEC_CONFIG="{\"method\": \"dspark\", \"model\": \"$DRAFT_MODEL_PATH\", \"num_speculative_tokens\": $NUM_SPEC_TOKENS, \"attention_backend\": \"TOKENSPEED_MLA\", \"draft_sample_method\": \"probabilistic\", \"rejection_sample_method\": \"synthetic\", \"synthetic_acceptance_length\": $SYNTHETIC_ACCEPT_LEN}"
     fi
     SPEC_ARGS=(--speculative-config "$SPEC_CONFIG")
+fi
+
+# The LMCache MP connector shares the KV tensors with its out-of-process server
+# over CUDA IPC, and cuMem-allocated memory has no legacy IPC handle:
+# _share_cuda_() returns cudaErrorInvalidValue and the worker dies during
+# initialize_from_config. No other LMCache recipe in the repo enables cumem.
+CUMEM_ARGS=(--enable-cumem-allocator)
+if [ "${KV_OFFLOAD_BACKEND:-}" = "lmcache" ]; then
+    CUMEM_ARGS=()
 fi
 
 MAX_NUM_SEQS=$((2 * CONC))
@@ -275,7 +345,7 @@ VLLM_CMD=(
     --load-format fastsafetensors
     --moe-backend auto
     --no-enable-flashinfer-autotune
-    --enable-cumem-allocator
+    "${CUMEM_ARGS[@]}"
     --enable-prefix-caching
     --prefix-match-unit 128
     --kv-cache-dtype fp8

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1485,12 +1485,12 @@ kimik3-fp4-b300-vllm-agentic-dspark:
   # kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml),
   # and EVAL_ONLY switches to real block verification.
   #
-  # The image carries the Kimi-K3 DCP, DSpark-under-DCP and Mooncake-hybrid
-  # changes (vllm-project/vllm agentx-k3 @ 5894fdf).
-  image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf
+  # agentx-k3 @ 5894fdf was garbage-collected from Docker Hub; 3696c77 is the
+  # newest live x86_64 cu13 build and backs the GB300 DCP8 recipes (arm64 twin).
+  image: vllm/vllm-openai:nightly-dev-x86_64-cu13-3696c77
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: vllm
   multinode: false
@@ -1506,6 +1506,14 @@ kimik3-fp4-b300-vllm-agentic-dspark:
       # DSpark 3 at conc 16, and not at all above. Keep the concurrencies
       # disjoint across arms so exp-names stay unique.
       - { tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 70] }
+      # LMCache arm at the two points where the offload tier carries the run:
+      # GPU prefix cache hit rate falls to 88.0% at conc 56 and 59.9% at conc
+      # 70, against 90.4-96.3% everywhere below, so most prefix reuse has to
+      # come from the external tier. Both points are no-drafting at
+      # gpu-memory-utilization 0.90. The concurrencies overlap the existing
+      # dram arm on purpose - the backend name is in the exp-name, so each
+      # point still yields a distinct series.
+      - { tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc2" }, conc-list: [56, 70] }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7145,3 +7145,15 @@
     - "Update SGLang image from lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, build commit sgl-project/sglang@30705c00) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T22:50:19Z)."
     - "The release image ships the same CUDA 13.0.3, FlashInfer 0.6.18 and sgl-kernel 0.4.6.post1 as the nightly. benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh is unchanged: SGLANG_ENABLE_SPEC_V2 EAGLE MTP at 3 steps, golden acceptance length 3.39, flashinfer attention with allreduce fusion, fp8 quantization and fp8_e4m3 KV, HiCache kernel IO / page_first layout. TP8/EP1 DRAM HiCache concurrency 2 through 24 unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2966
+
+- config-keys:
+    - kimik3-fp4-b300-vllm-agentic-dspark
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add an LMCache 0.5.5rc2 DRAM offload arm at concurrency 56 and 70, where the GPU prefix cache hit rate falls to 88.0% and 59.9%."
+    - "Size the LMCache chunk as block size x DCP size (1536 x 8 = 12288), required for chunking under decode context parallel."
+    - "Raise the LMCache L1 read-lock TTL to 3600s: the lock is held from prefetch to retrieve, and at concurrency 70 a queued request can exceed the 300s default, which fails the retrieve."
+    - "Move the recipe from the decommissioned cluster:b300-nv to cluster:b300-dsxe; the resolved DRAM budget is unchanged at 2249 GB."
+    - "Replace the garbage-collected nightly-dev-x86_64-cu13.0.1-5894fdf image with nightly-dev-x86_64-cu13-3696c77."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2802


### PR DESCRIPTION
## Description

Adds an **LMCache 0.5.5rc2** DRAM offload arm to `kimik3-fp4-b300-vllm-agentic-dspark` at concurrency **56 and 70**.

Those are the two points where the offload tier carries the run. From [run 33472235399](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33472235399), GPU prefix cache hit rate holds 90.4–96.3% from conc 1 through 48, so the external tier is barely exercised there. At conc 56 the KV pool drops to 21.6M tokens under `gpu-memory-utilization` 0.90 and GPU hit falls to 88.0%; at conc 70 it falls to 59.9%. Both are past the drafting cutoff, so they share topology, image and memory budget.

## Configuration

- **`--chunk-size 12288`** = block size x DCP size (1536 x 8), required under decode context parallel. Matches the validated Kimi-K3 DCP8 e2e run [33463265881](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33463265881).
- **No interleave flag.** `5894fdf` defaults `cp_kv_cache_interleave_size` to 1 and has none of the auto-resolution that sets it to the local block size, so DCP runs on the flat layout the connector already supports. [LMCache#4834](https://github.com/LMCache/LMCache/pull/4834) is a no-op at interleave 1 and its hybrid-group rule resolves the same 12288. An image that resolves the interleave to 1536 would need #4834 plus an explicit flag.
- `--separate-object-groups` for the KDA/MLA layout; one MP server per node at the full `TOTAL_CPU_DRAM_GB`; `--max-gpu-workers` 8, overridable via `LMCACHE_GPU_WORKERS`. `dram-utilization` unchanged at 0.75.
- Server ports derived from `PORT` (+13000/+14000) alongside the existing `MOONCAKE_MASTER_PORT` offset, so concurrent runners on a shared host don't collide.
- `mooncake-transfer-engine-cuda13` is installed because LMCache's transfer-channel layer imports it at module load.

## Series behaviour and `append-only`

Both arms land on **one visual series**, and this is by construction rather than a consequence of the flag. `_matrix_visual_series_key` (utils/process_changelog.py:183) keys on model, precision, framework, runner, disagg, scenario and `offload_mode` (`"on"`/`"off"`) — the KV backend is not a series dimension. Per CONTRIBUTING, the recipe fingerprint keeps two recipes at the same concurrency as "distinct database points without splitting the visual curve." Publishing LMCache as its own line is not reachable from this PR; it would require changing the series keying.

`append-only: true` therefore only controls scheduling: the sweep runs the 2 added points and extends the existing curve rather than re-running all 13. Verified against `origin/main` — `append_only_delta` emits exactly `conc56_kvdram-lmcache` and `conc70_kvdram-lmcache`.

The overlapping concurrencies still give distinct exp-names (`kvdram-lmcache` vs `kvdram-mooncake`) via `agentic_kv_offload_suffix`, so the two arms remain separate database points and separate result artifacts at c56/c70.

**Reviewer note:** the resulting published curve will contain DRAM-offload points from two different backends — the existing arm at conc 1–48 and LMCache at conc 56/70 — indistinguishable to a chart reader. Flagging for a call on whether that is acceptable for this recipe before these results are ingested.

Behavioural isolation for the complete-diff review: every script change is inside the `lmcache)` case or gated on `KV_OFFLOAD_BACKEND`, the existing arm's entry is untouched, and its recipe fingerprint is unchanged at `61ba8917bcdef3e3`.

## Test plan

- [ ] Full-sweep validation on `b300-nv`
- [ ] Confirm `chunk_size=12288` in `lmcache_server.log`, no interleave rejection at connector startup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external KV path (background server, pip deps, vLLM connector config) and changes cluster/image for the whole recipe; LMCache-specific allocator gating limits blast radius to that backend.
> 
> **Overview**
> **Adds LMCache 0.5.5rc2 as a DRAM KV offload backend** to the Kimi-K3 B300 agentic vLLM recipe, alongside the existing Mooncake path.
> 
> When `KV_OFFLOAD_BACKEND=lmcache`, the script installs `lmcache` and `mooncake-transfer-engine-cuda13`, starts an out-of-process `lmcache server` (chunk size **1536 × DCP_SIZE**, L1 sized from `TOTAL_CPU_DRAM_GB`, 3600s read TTL, healthcheck wait), wires vLLM via `LMCacheMPConnector`, and tears the server down on exit. **vLLM no longer passes `--enable-cumem-allocator` for LMCache** because cuMem blocks CUDA IPC sharing with the MP server.
> 
> **Benchmark matrix** (`kimik3-fp4-b300-vllm-agentic-dspark`): new search-space points at conc **56 and 70** with `kv-offload-backend: lmcache` (overlapping Mooncake concurrencies but distinct exp-names). Runner moves **`cluster:b300-nv` → `cluster:b300-dsxe`**; Docker image updates from removed **`5894fdf`** to **`3696c77`**. Changelog documents the arm and tuning rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf607b34b9aab4140186383a1eb2fc66b58fac51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->