### PR TITLE
perf(agentx): refresh Kimi-K3 MI355X LMCache curve / 刷新 Kimi-K3 MI355X LMCache 曲线

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export SPEC_DECODING=none
+exec bash "$(dirname "$0")/kimik3_fp4_mi355x_mtp.sh"

--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -149,25 +149,18 @@ case "${KV_OFFLOAD_BACKEND:-}" in
       lmcache)
     require_agentic_kv_offload_backend "$KV_OFFLOAD_BACKEND"
 
-    # Keep the image's tested torch/ROCm stack and install only LMCache's
-    # missing runtime dependencies, same as the MiniMax-M3 lmcache arm.
-    LMCACHE_VERSION="0.5.5.dev60+rocm7.2"
-    LMCACHE_ROCM_INDEX="https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-rocm"
+    # Keep the stock image's torch/ROCm stack and install the LMCache runtime
+    # dependencies used by the validated reference run.
+    LMCACHE_VERSION="0.5.5rc3+rocm7.2"
+    export KV_OFFLOAD_BACKEND_METADATA="{\"name\":\"lmcache\",\"version\":\"${LMCACHE_VERSION}\"}"
+    LMCACHE_RELEASE="v0.5.5rc3"
+    LMCACHE_ROCM_INDEX="https://github.com/LMCache/LMCache/releases/expanded_assets/${LMCACHE_RELEASE}-rocm"
     agentic_pip_install --quiet --no-cache-dir --no-deps \
         "sortedcontainers==2.4.0" \
         "opentelemetry-exporter-prometheus==0.61b0" \
         "cupy-rocm-7-0==14.1.1" \
         "lmcache==${LMCACHE_VERSION}" --find-links "$LMCACHE_ROCM_INDEX"
 
-    # LMCache 0.5.5's transfer-channel layer eagerly imports the Mooncake
-    # backend (mooncake_te_impl.py -> `from mooncake.engine import
-    # TransferEngine`), whose native .so resolves all of its DT_NEEDED libs at
-    # import. The vLLM ROCm image ships none of them, so the import sanity
-    # check below (and the LMCache server) would otherwise fail with
-    # "ImportError: lib*.so: cannot open shared object file" (first libglog,
-    # then libjsoncpp, ...). Provision Mooncake's full runtime lib set from the
-    # distro before importing. apt-get install is idempotent, so run it
-    # whenever any of the libs is still missing rather than gating on one.
     LMCACHE_NATIVE_LIBS=(libglog.so.0 libjsoncpp.so.25 libibverbs.so.1 librdmacm.so.1 libnuma.so.1)
     for lib in "${LMCACHE_NATIVE_LIBS[@]}"; do
         if ! ldconfig -p | grep -q "$lib"; then
@@ -178,17 +171,16 @@ case "${KV_OFFLOAD_BACKEND:-}" in
         fi
     done
     python3 -c \
-        "import cupy; import lmcache.integration.vllm.lmcache_mp_connector; import opentelemetry.exporter.prometheus" \
-        >/dev/null
+        "import cupy; import opentelemetry.exporter.prometheus; from lmcache.v1.multiprocess.http_server import run_http_server"
 
     # One MP server for the node, per the Kimi-K3 recipe
     # (docs.lmcache.ai/recipes/kimi_k3.html), with --chunk-size sized for
     # THIS stack rather than the recipe's CUDA-path 768: the connector
     # requires the chunk to be a multiple of every engine KV group's
-    # tokens_per_block, and the hybrid KDA/MLA layout here registers
-    # attention groups at 1536 ("Setting attention block size to 1536",
-    # run 31644990546) plus a KDA state group at 3072 (run 31645828378),
-    # so 3072 is the minimum valid chunk. The multi-group layout also
+    # tokens_per_block. The hybrid KDA/MLA layout registers attention groups
+    # at 1536 tokens and a KDA state group at 3072. Use 12288 for every point
+    # so it is divisible by both group sizes and matches the tested LMCache
+    # scheduler geometry. The multi-group layout also
     # requires one object group per sliding-window size:
     # --separate-object-groups.
     LMCACHE_PORT=6555
@@ -205,7 +197,7 @@ case "${KV_OFFLOAD_BACKEND:-}" in
         --http-port "$LMCACHE_HTTP_PORT"
         --l1-size-gb "$LMCACHE_L1_SIZE_GB"
         --l1-init-size-gb 10
-        --chunk-size 3072
+        --chunk-size 12288
         --separate-object-groups
         --enable-extra-logging
         --extra-logging-interval 30
@@ -248,19 +240,23 @@ if [ "$EP_SIZE" -gt 1 ]; then
 fi
 
 # ---- Speculative / Util------------------------------------------------------
-case "$CONC" in
-    # No KV offload; the working set fits in HBM.
-    1)
+case "${SPEC_DECODING:-mtp}:$CONC" in
+    mtp:1)
         SYNTHETIC_ACCEPT_LEN=3.75
         SPEC_NUM_TOKENS=6
         GPU_MEM_UTIL=0.9
         MAX_NUM_BATCHED_TOKENS=16384
         ;;
-    2|4|8|10|12|14)
+    mtp:2|mtp:4|mtp:8|mtp:10|mtp:12|mtp:14)
         SYNTHETIC_ACCEPT_LEN=3.00
         SPEC_NUM_TOKENS=3
         GPU_MEM_UTIL=0.9
         MAX_NUM_BATCHED_TOKENS=8192
+        ;;
+    none:40)
+        SPEC_NUM_TOKENS=0
+        GPU_MEM_UTIL=0.88
+        MAX_NUM_BATCHED_TOKENS=16384
         ;;
     *)
         SPEC_NUM_TOKENS=0
@@ -285,10 +281,24 @@ else
 fi
 
 # ---- HIP graph ------------------------------------------------------------
-MAX_NUM_SEQS=$((2 * CONC))
-MAX_CUDAGRAPH_CAPTURE_SIZE=$((MAX_NUM_SEQS * (1 + SPEC_NUM_TOKENS)))
-CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 2 "$MAX_CUDAGRAPH_CAPTURE_SIZE")"
-COMPILATION_CONFIG_ARGS=(--compilation-config "{\"mode\":3,\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"max_cudagraph_capture_size\":$MAX_CUDAGRAPH_CAPTURE_SIZE,\"custom_ops\":[\"+fused_rms_norm_gated\"],\"cudagraph_capture_sizes\":[$CUDAGRAPH_CAPTURE_SIZES]}")
+SERVER_STREAM_ARGS=()
+PREFIX_MATCH_ARGS=()
+ATTENTION_CONFIG='{"mla_prefill_backend":"ROCM_AITER_FA"}'
+COMPILATION_CUSTOM_OPS='["+fused_rms_norm_gated"]'
+if [ "${SPEC_DECODING:-mtp}:$CONC" = "none:40" ]; then
+    MAX_NUM_SEQS=80
+    MAX_CUDAGRAPH_CAPTURE_SIZE=4096
+    CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 1 "$MAX_NUM_SEQS"),128,256,512,1024,2048,4096"
+    SERVER_STREAM_ARGS=(--stream-interval 10)
+    PREFIX_MATCH_ARGS=(--prefix-match-unit 128)
+    ATTENTION_CONFIG='{"mla_prefill_backend":"ROCM_AITER_FA","use_prefill_query_quantization":true}'
+    COMPILATION_CUSTOM_OPS='["+fused_rms_norm_gated","+quant_fp8","+grouped_topk","+sparse_attn_indexer","none"]'
+else
+    MAX_NUM_SEQS=$((2 * CONC))
+    MAX_CUDAGRAPH_CAPTURE_SIZE=$((MAX_NUM_SEQS * (1 + SPEC_NUM_TOKENS)))
+    CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 2 "$MAX_CUDAGRAPH_CAPTURE_SIZE")"
+fi
+COMPILATION_CONFIG_ARGS=(--compilation-config "{\"mode\":3,\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"max_cudagraph_capture_size\":$MAX_CUDAGRAPH_CAPTURE_SIZE,\"custom_ops\":$COMPILATION_CUSTOM_OPS,\"cudagraph_capture_sizes\":[$CUDAGRAPH_CAPTURE_SIZES]}")
 
 echo "Starting vllm server..."
 export PYTHONNOUSERSITE=1
@@ -305,8 +315,18 @@ fi
 CP_ARGS=()
 ATTN_BE_ARGS=()
 if [ "$DCP_SIZE" -gt 1 ]; then
-    CP_ARGS+=(--decode-context-parallel-size "$DCP_SIZE" --dcp-comm-backend a2a)
-    ATTN_BE_ARGS+=(--attention-backend TRITON_MLA)
+    CP_KV_CACHE_INTERLEAVE_SIZE=1
+    if [ "${KV_OFFLOAD_BACKEND:-}" = "lmcache" ]; then
+        CP_KV_CACHE_INTERLEAVE_SIZE=1536
+    fi
+    CP_ARGS+=(
+        --decode-context-parallel-size "$DCP_SIZE"
+        --dcp-comm-backend a2a
+        --cp-kv-cache-interleave-size "$CP_KV_CACHE_INTERLEAVE_SIZE"
+    )
+    ATTN_BE_ARGS+=(--attention-backend ROCM_AITER_MLA)
+    export VLLM_ALLOW_DCP_FULL_CUDAGRAPH=1
+    export PREFIX_CACHING_HASH_ALGO=sha256
 fi
 export VLLM_USE_DIRECT_DCP_A2A=0
 export VLLM_USE_DIRECT_DCP_Q_GATHER=0
@@ -329,10 +349,12 @@ VLLM_CMD=(
     --tool-call-parser kimi_k3
     --reasoning-parser kimi_k3
     --max-model-len 1048576
+    "${SERVER_STREAM_ARGS[@]}"
     --enable-prefix-caching
+    "${PREFIX_MATCH_ARGS[@]}"
     --kv-cache-dtype "fp8"
     --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS"
-    --attention-config '{"mla_prefill_backend":"ROCM_AITER_FA"}'
+    --attention-config "$ATTENTION_CONFIG"
     "${ATTN_BE_ARGS[@]}"
     "${COMPILATION_CONFIG_ARGS[@]}"
     "${SPEC_ARGS[@]}"

--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -186,6 +186,8 @@ case "${KV_OFFLOAD_BACKEND:-}" in
     LMCACHE_PORT=6555
     LMCACHE_HTTP_PORT=8090
     LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
+    LMCACHE_HEARTBEAT_INTERVAL=90.0
+    LMCACHE_WORKER_REAP_TIMEOUT=300
 
     LMCACHE_L1_SIZE_GB="$TOTAL_CPU_DRAM_GB"
 
@@ -205,6 +207,7 @@ case "${KV_OFFLOAD_BACKEND:-}" in
         --max-gpu-workers 1
         --eviction-policy LRU
         --supported-transfer-mode lmcache_driven
+        --worker-reap-timeout-seconds "$LMCACHE_WORKER_REAP_TIMEOUT"
         --shm-name ""
     )
     append_command "$RESULT_DIR/lmcache_command.txt" "${LMCACHE_CMD[@]}"
@@ -221,7 +224,7 @@ case "${KV_OFFLOAD_BACKEND:-}" in
     # same MQ timeout headroom as the MiniMax-M3 arm.
     OFFLOAD_ARGS=(
         --kv-transfer-config
-        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":6000.0}}"
+        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":6000.0,\"lmcache.mp.heartbeat_interval\":$LMCACHE_HEARTBEAT_INTERVAL}}"
     )
     ;;
     *)

--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -253,7 +253,7 @@ case "${SPEC_DECODING:-mtp}:$CONC" in
         GPU_MEM_UTIL=0.9
         MAX_NUM_BATCHED_TOKENS=8192
         ;;
-    none:40)
+    none:40|none:44|none:48)
         SPEC_NUM_TOKENS=0
         GPU_MEM_UTIL=0.88
         MAX_NUM_BATCHED_TOKENS=16384
@@ -285,7 +285,8 @@ SERVER_STREAM_ARGS=()
 PREFIX_MATCH_ARGS=()
 ATTENTION_CONFIG='{"mla_prefill_backend":"ROCM_AITER_FA"}'
 COMPILATION_CUSTOM_OPS='["+fused_rms_norm_gated"]'
-if [ "${SPEC_DECODING:-mtp}:$CONC" = "none:40" ]; then
+case "${SPEC_DECODING:-mtp}:$CONC" in
+    none:40|none:44|none:48)
     MAX_NUM_SEQS=80
     MAX_CUDAGRAPH_CAPTURE_SIZE=4096
     CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 1 "$MAX_NUM_SEQS"),128,256,512,1024,2048,4096"
@@ -293,11 +294,13 @@ if [ "${SPEC_DECODING:-mtp}:$CONC" = "none:40" ]; then
     PREFIX_MATCH_ARGS=(--prefix-match-unit 128)
     ATTENTION_CONFIG='{"mla_prefill_backend":"ROCM_AITER_FA","use_prefill_query_quantization":true}'
     COMPILATION_CUSTOM_OPS='["+fused_rms_norm_gated","+quant_fp8","+grouped_topk","+sparse_attn_indexer","none"]'
-else
+    ;;
+    *)
     MAX_NUM_SEQS=$((2 * CONC))
     MAX_CUDAGRAPH_CAPTURE_SIZE=$((MAX_NUM_SEQS * (1 + SPEC_NUM_TOKENS)))
     CUDAGRAPH_CAPTURE_SIZES="$(seq -s, 2 "$MAX_CUDAGRAPH_CAPTURE_SIZE")"
-fi
+    ;;
+esac
 COMPILATION_CONFIG_ARGS=(--compilation-config "{\"mode\":3,\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"max_cudagraph_capture_size\":$MAX_CUDAGRAPH_CAPTURE_SIZE,\"custom_ops\":$COMPILATION_CUSTOM_OPS,\"cudagraph_capture_sizes\":[$CUDAGRAPH_CAPTURE_SIZES]}")
 
 echo "Starting vllm server..."

--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -186,8 +186,6 @@ case "${KV_OFFLOAD_BACKEND:-}" in
     LMCACHE_PORT=6555
     LMCACHE_HTTP_PORT=8090
     LMCACHE_LOG="$RESULT_DIR/lmcache_server.log"
-    LMCACHE_HEARTBEAT_INTERVAL=90.0
-    LMCACHE_WORKER_REAP_TIMEOUT=300
 
     LMCACHE_L1_SIZE_GB="$TOTAL_CPU_DRAM_GB"
 
@@ -207,7 +205,6 @@ case "${KV_OFFLOAD_BACKEND:-}" in
         --max-gpu-workers 1
         --eviction-policy LRU
         --supported-transfer-mode lmcache_driven
-        --worker-reap-timeout-seconds "$LMCACHE_WORKER_REAP_TIMEOUT"
         --shm-name ""
     )
     append_command "$RESULT_DIR/lmcache_command.txt" "${LMCACHE_CMD[@]}"
@@ -224,7 +221,7 @@ case "${KV_OFFLOAD_BACKEND:-}" in
     # same MQ timeout headroom as the MiniMax-M3 arm.
     OFFLOAD_ARGS=(
         --kv-transfer-config
-        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":6000.0,\"lmcache.mp.heartbeat_interval\":$LMCACHE_HEARTBEAT_INTERVAL}}"
+        "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT,\"lmcache.mp.mq_timeout\":6000.0}}"
     )
     ;;
     *)
@@ -247,13 +244,13 @@ case "${SPEC_DECODING:-mtp}:$CONC" in
     mtp:1)
         SYNTHETIC_ACCEPT_LEN=3.75
         SPEC_NUM_TOKENS=6
-        GPU_MEM_UTIL=0.9
+        GPU_MEM_UTIL=0.88
         MAX_NUM_BATCHED_TOKENS=16384
         ;;
     mtp:2|mtp:4|mtp:8|mtp:10|mtp:12|mtp:14)
         SYNTHETIC_ACCEPT_LEN=3.00
         SPEC_NUM_TOKENS=3
-        GPU_MEM_UTIL=0.9
+        GPU_MEM_UTIL=0.88
         MAX_NUM_BATCHED_TOKENS=8192
         ;;
     none:40|none:44|none:48)

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -625,7 +625,7 @@ dsr1-fp8-mi355x-sglang-disagg-mtp:
           - "DECODE_MTP_SIZE=2"
 
 kimik3-fp4-mi355x-vllm-agentic-mtp:
-  image: vllm/vllm-openai-rocm:nightly-1dc464d42681d22f38caf1fdc1eb632dc4421c45
+  image: vllm/vllm-openai-rocm:nightly-7c5dc571cbd1064ecc8a9b1045637ff647aa22cb
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
   runner: cluster:mi355x-amds
@@ -636,8 +636,8 @@ kimik3-fp4-mi355x-vllm-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.60
       search-space:
-      - { tp: 8, kv-offloading: none, conc-list: [1] , spec-decoding: mtp}
-      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5.dev60+rocm7.2" }, conc-list: [4, 8, 10, 12, 14], spec-decoding: mtp }
+      - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc3+rocm7.2" }, conc-list: [1, 8, 14], spec-decoding: mtp }
+      - { tp: 8, dcp-size: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc3+rocm7.2" }, conc-list: [40], spec-decoding: none }
 
 # Kimi-K3 MXFP4 agentic-coding benchmark on MI355X via ATOM with DSpark
 # speculative decoding. Acceptance is pinned to the committed golden curve in

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -637,7 +637,7 @@ kimik3-fp4-mi355x-vllm-agentic-mtp:
     - dram-utilization: 0.60
       search-space:
       - { tp: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc3+rocm7.2" }, conc-list: [1, 8, 14], spec-decoding: mtp }
-      - { tp: 8, dcp-size: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc3+rocm7.2" }, conc-list: [40], spec-decoding: none }
+      - { tp: 8, dcp-size: 8, ep: 1, kv-offloading: dram, kv-offload-backend: { name: lmcache, version: "0.5.5rc3+rocm7.2" }, conc-list: [40, 44, 48], spec-decoding: none }
 
 # Kimi-K3 MXFP4 agentic-coding benchmark on MI355X via ATOM with DSpark
 # speculative decoding. Acceptance is pinned to the committed golden curve in

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp
@@ -6830,4 +6830,4 @@
     - "Refresh the Kimi-K3 MI355X AgentX recipe from the merged PR #2787 baseline to vLLM ROCm nightly 7c5dc571 and LMCache 0.5.5rc3+rocm7.2."
     - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40 with TP8/DCP8 and no speculative decoding."
     - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40 gpu-memory-utilization to 0.88 while retaining its 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6830,4 +6830,5 @@
     - "Refresh the Kimi-K3 MI355X AgentX recipe from the merged PR #2787 baseline to vLLM ROCm nightly 7c5dc571 and LMCache 0.5.5rc3+rocm7.2."
     - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40, C44, and C48 with TP8/DCP8 and no speculative decoding."
     - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40/C44/C48 gpu-memory-utilization to 0.88 while retaining the 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
+    - "Allow 90 seconds for LMCache MP heartbeats and 300 seconds before reaping workers so transient C14 transfer stalls do not trigger invalid-block recovery."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6828,6 +6828,6 @@
     - agentic-coding
   description:
     - "Refresh the Kimi-K3 MI355X AgentX recipe from the merged PR #2787 baseline to vLLM ROCm nightly 7c5dc571 and LMCache 0.5.5rc3+rocm7.2."
-    - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40 with TP8/DCP8 and no speculative decoding."
-    - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40 gpu-memory-utilization to 0.88 while retaining its 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
+    - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40, C44, and C48 with TP8/DCP8 and no speculative decoding."
+    - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40/C44/C48 gpu-memory-utilization to 0.88 while retaining the 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6821,3 +6821,13 @@
   description:
     - "Refresh to collect TensorRT-LLM server metrics."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2774
+
+- config-keys:
+    - kimik3-fp4-mi355x-vllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Refresh the Kimi-K3 MI355X AgentX recipe from the merged PR #2787 baseline to vLLM ROCm nightly 7c5dc571 and LMCache 0.5.5rc3+rocm7.2."
+    - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40 with TP8/DCP8 and no speculative decoding."
+    - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40 gpu-memory-utilization to 0.88 while retaining its 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6829,6 +6829,5 @@
   description:
     - "Refresh the Kimi-K3 MI355X AgentX recipe from the merged PR #2787 baseline to vLLM ROCm nightly 7c5dc571 and LMCache 0.5.5rc3+rocm7.2."
     - "Run C1, C8, and C14 with TP8 DSpark and LMCache DRAM KV offload; run C40, C44, and C48 with TP8/DCP8 and no speculative decoding."
-    - "Use a 12288-token LMCache chunk and a 1536-token DCP KV-cache interleave; set C40/C44/C48 gpu-memory-utilization to 0.88 while retaining the 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
-    - "Allow 90 seconds for LMCache MP heartbeats and 300 seconds before reaping workers so transient C14 transfer stalls do not trigger invalid-block recovery."
+    - "Use gpu-memory-utilization 0.88 for all six points, a 12288-token LMCache chunk, and a 1536-token DCP KV-cache interleave; C40/C44/C48 retain the 16K batched-token, max-num-seqs 80, and full CUDA-graph profile."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2804


### PR DESCRIPTION
## Description / 说明

- Refreshes the canonical `kimik3-fp4-mi355x-vllm-agentic-mtp` curve while preserving the tuning established by merged PR #2787.
- Bumps vLLM ROCm to `nightly-7c5dc571cbd1064ecc8a9b1045637ff647aa22cb`.
- Pins LMCache to `0.5.5rc3+rocm7.2` and enables LMCache DRAM KV offload for C1, C8, C14, C40, C44, and C48.
- Keeps C1/C8/C14 on TP8 with DSpark MTP and sets `--gpu-memory-utilization 0.88` for all six points.
- Uses the C40 TP8/DCP8 no-spec profile for C40/C44/C48: LMCache chunk size 12288, DCP KV-cache interleave size 1536, max-num-seqs 80, 16K batched tokens, and full CUDA graphs through size 4096.

- 刷新标准的 `kimik3-fp4-mi355x-vllm-agentic-mtp` 曲线，并保留已合并 PR #2787 中验证过的调优配置。
- 将 vLLM ROCm 镜像更新到 `nightly-7c5dc571cbd1064ecc8a9b1045637ff647aa22cb`。
- 固定 LMCache 版本为 `0.5.5rc3+rocm7.2`，并为 C1、C8、C14、C40、C44 和 C48 启用 LMCache DRAM KV offload。
- C1/C8/C14 保持 TP8 和 DSpark MTP 配置，全部六个测试点统一使用 `--gpu-memory-utilization 0.88`。
- C40/C44/C48 使用相同的 TP8/DCP8 无投机解码配置：LMCache chunk size 12288、DCP KV-cache interleave size 1536、max-num-seqs 80、16K batched tokens，以及最大到 4096 的完整 CUDA graph。

## Duplicate-work check / 重复工作检查

This does not duplicate open PR #2795, which removes LMCache and targets a different no-offload C52 profile. It also supersedes the old LMCache 0.5.4rc work in PR #2598 by updating the already-merged canonical PR #2787 recipe to LMCache rc3 and the new vLLM image.

本 PR 不与开放的 PR #2795 重复；该 PR 移除了 LMCache，并针对不同的无 offload C52 配置。本 PR 也取代了 PR #2598 中旧的 LMCache 0.5.4rc 工作，将已合并 PR #2787 的标准配置更新到 LMCache rc3 和新的 vLLM 镜像。

## Type of Change / 变更类型

- [ ] Bug fix / 缺陷修复
- [ ] New feature / 新功能
- [x] Configuration change / 配置变更
- [ ] Documentation update / 文档更新
- [ ] Other / 其他

## Checklist / 检查清单

- [x] I have tested my changes locally / 已在本地测试变更
- [x] I have updated documentation if necessary / 已按需更新文档
- [x] For every performance-affecting benchmark change, I appended an entry to the physical end of `perf-changelog.yaml` without editing historical entries / 每项影响性能的基准变更均已在 `perf-changelog.yaml` 文件末尾追加记录，且未修改历史条目
- [ ] Before merging via reuse, an authorized maintainer has commented `/reuse-sweep-run` after a final all-green sweep with evals passing / 通过复用方式合并前，授权维护者需在最终完整 sweep 和 eval 全部通过后评论 `/reuse-sweep-run`

AI assistance was used to prepare and validate this change. The submitting human must review every changed line and confirm the benchmark results before merge.

本变更使用了 AI 辅助。提交者在合并前必须审阅每一处改动，并确认基准测试结果。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and sweep configuration only; no production runtime or auth paths change, though refreshed numbers will replace the published Kimi-K3 MI355X curve.
> 
> **Overview**
> Refreshes the **`kimik3-fp4-mi355x-vllm-agentic-mtp`** AgentX curve: bumps the vLLM ROCm image to **`nightly-7c5dc571`**, pins LMCache to **`0.5.5rc3+rocm7.2`**, and records the sweep in **`perf-changelog.yaml`**.
> 
> **`amd-master.yaml`** narrows the MTP + LMCache DRAM offload matrix to **C1, C8, C14** and adds **TP8/DCP8** points at **C40, C44, C48** with **`spec-decoding: none`**. A thin **`kimik3_fp4_mi355x.sh`** wrapper sets **`SPEC_DECODING=none`** and delegates to the main script.
> 
> **`kimik3_fp4_mi355x_mtp.sh`** keys tuning on **`${SPEC_DECODING}:${CONC}`**: MTP arms use **`gpu-memory-utilization` 0.88**; high-concurrency no-spec runs get a dedicated server profile (fixed **`max-num-seqs` 80**, expanded CUDA-graph capture through **4096**, **`--stream-interval`**, **`--prefix-match-unit` 128**, prefill FP8 quant in attention config, extra compilation custom ops). LMCache uses **chunk-size 12288**, exports backend metadata, and a lighter import sanity check; with **DCP** and LMCache, **`--cp-kv-cache-interleave-size` 1536**, **`ROCM_AITER_MLA`**, and related env flags replace the prior TRITON-only DCP path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a720a04fc480a4d8fd2640870c366c2971a41d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->