### PR TITLE
ci: use Fable 5.1 for all Claude Code invocations

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,7 +53,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__inferencemax-repos__*,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Write,Edit,Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -257,7 +257,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -249,7 +249,7 @@ jobs:
                   settings: |
                       {"fastMode": true}
                   claude_args: |
-                      --model 'claude-fable-5'
+                      --model 'claude-fable-5-1'
                       --max-turns 8
                       --allowedTools "Read,Glob,Grep,Bash(git diff:*)"
                       --json-schema '{"type":"object","properties":{"criteria":{"type":"array","items":{"type":"string","enum":["multi-node","agentic","eval-only","fp4","mtp","eagle","eagle3","sglang","vllm","dynamo-sglang","dynamo-vllm","glm5","glm5.1","kimik2.5","kimik3","dsv4","minimaxm3","qwen3.5","dsr1","checklist-complete","patchwork"]},"uniqueItems":true},"reason":{"type":"string"}},"required":["criteria","reason"]}'


### PR DESCRIPTION
## Summary

Change all four Claude Code invocations from `claude-fable-5` to `claude-fable-5-1`:
- Interactive issue/comment bot
- PR review
- CODEOWNER sign-off verification
- Sweep-priority classification

Uses the [documented Fable 5.1 model ID](https://platform.claude.com/docs/en/models/fable-5-1/overview). Prompts, permissions, action versions, and other settings are unchanged. No benchmark recipe changes or performance changelog entry are needed.

## Validation

- `actionlint -shellcheck= -pyflakes=` on all four changed workflows: passed.
- `python3 -m pytest utils/test_ci_priority.py utils/changelog_gate_tests/test_run_sweep_gating.py -q`: 66 passed.
- Repository-wide invocation audit: all four Claude Code actions select `claude-fable-5-1`.
- `git diff --check`: passed.

Live model execution has not been tested; the workflows use the existing Anthropic API credentials.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only model string change with no application code, secrets, or permission changes; main risk is provider/model behavior differences until runs are exercised in CI.
> 
> **Overview**
> Updates every **Claude Code** GitHub Actions step from `--model 'claude-fable-5'` to **`claude-fable-5-1`** across four workflows: interactive `@claude` / `@Klaud-Cold` assistant (`claude.yml`), `@pr-claude` PR review (`claude-pr-review.yml`), CODEOWNER sign-off verification (`codeowner-signoff-verify.yml`), and sweep priority classification in `run-sweep.yml`.
> 
> Prompts, MCP config, allowed tools, `fastMode`, and action pins are unchanged—only the Anthropic model identifier moves to the documented Fable 5.1 ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47f859bcade9f851dfb35db18c090f970d40300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->