### PR TITLE
config(minimaxm3): refresh full GB200 aggregate AgentX curve / 刷新完整 GB200 聚合 AgentX 曲线

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml
@@ -39,6 +39,9 @@ backend:
   connector: null
   kv_events_config: { aggregated: true }
   aggregated_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
     VLLM_ENGINE_READY_TIMEOUT_S: "7200"
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7825,7 +7825,7 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.83"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7796,8 +7796,8 @@ minimaxm3-fp4-b200-trtllm-agentic-mtp:
       search-space:
       - { tp: 4, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [5, 10, 15, 20, 25, 30, 35, 40, 45] }
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 5] }
-# Preserve the B200 TP4 search space and add the GB200 Pareto candidates found
-# by direct DEP and P/D tuning.
+# Retain the GB200 aggregate SimpleCPU-offload configuration at concurrency 20
+# and 30.
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4
@@ -7813,22 +7813,9 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
     - dram-utilization: 0.61
       search-space:
       - spec-decoding: mtp
-        kv-offloading: none
-        conc-list: [1, 2, 5, 8, 10, 12, 15, 20]
-        num-nodes: 1
-        worker:
-          num-worker: 1
-          tp: 4
-          ep: 1
-          dp-attn: false
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic.yaml"
-          - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-      - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple }
-        conc-list: [20, 30, 40]
+        conc-list: [20, 30]
         num-nodes: 1
         worker:
           num-worker: 1
@@ -7838,48 +7825,7 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-      - spec-decoding: mtp
-        kv-offloading: none
-        conc-list: [4, 32]
-        num-nodes: 1
-        worker:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-agentic.yaml"
-          - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-      - spec-decoding: mtp
-        kv-offloading: dram
-        kv-offload-backend: { name: vllm-simple }
-        conc-list: [32, 40]
-        num-nodes: 1
-        worker:
-          num-worker: 1
-          tp: 4
-          ep: 4
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-vllm-simple-agentic.yaml"
-          - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-      - spec-decoding: mtp
-        kv-offloading: none
-        conc-list: [48]
-        num-nodes: 2
-        worker:
-          num-worker: 1
-          tp: 8
-          ep: 8
-          dp-attn: true
-          additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep8-agentic.yaml"
-          - "SYNTHETIC_ACCEPTANCE=true"
-          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
-
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.83"
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7796,8 +7796,8 @@ minimaxm3-fp4-b200-trtllm-agentic-mtp:
       search-space:
       - { tp: 4, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [5, 10, 15, 20, 25, 30, 35, 40, 45] }
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 5] }
-# Retain the GB200 aggregate SimpleCPU-offload configuration at concurrency 20
-# and 30.
+# Preserve the B200 TP4 search space and add the GB200 Pareto candidates found
+# by direct DEP and P/D tuning.
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4
@@ -7813,9 +7813,22 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
     - dram-utilization: 0.61
       search-space:
       - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [1, 2, 5, 8, 10, 12, 15, 20]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
         kv-offloading: dram
         kv-offload-backend: { name: vllm-simple }
-        conc-list: [20, 30]
+        conc-list: [20, 30, 40]
         num-nodes: 1
         worker:
           num-worker: 1
@@ -7826,6 +7839,47 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [4, 32]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-agentic.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: vllm-simple }
+        conc-list: [32, 40]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep4-vllm-simple-agentic.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [48]
+        num-nodes: 2
+        worker:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-dep8-agentic.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
   image: vllm/vllm-openai:v0.27.1
   model: nvidia/MiniMax-M3-NVFP4

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6827,6 +6827,7 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Limit the GB200 aggregate Dynamo-vLLM configuration to the SimpleCPU-offload concurrency 20 and 30 recipes."
+    - "Refresh the full GB200 aggregate Dynamo-vLLM AgentX configuration."
+    - "Use the mounted Hugging Face cache for the TP4 SimpleCPU-offload backend."
     - "Use the committed MiniMax-M3 thinking-on EAGLE3-GQA acceptance target."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2806

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6821,3 +6821,12 @@
   description:
     - "Refresh to collect TensorRT-LLM server metrics."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2774
+
+- config-keys:
+    - minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Limit the GB200 aggregate Dynamo-vLLM configuration to the SimpleCPU-offload concurrency 20 and 30 recipes."
+    - "Use the committed MiniMax-M3 thinking-on EAGLE3-GQA acceptance target."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2806


### PR DESCRIPTION
## Description

Refresh the complete MiniMax-M3 NVFP4 GB200 aggregate Dynamo-vLLM AgentX configuration so the full sweep covers every configured concurrency point. Use the mounted Hugging Face cache for the TP4 SimpleCPU-offload backend and the committed thinking-on MiniMax-M3 EAGLE3-GQA acceptance target.

## 中文说明

刷新完整的 MiniMax-M3 NVFP4 GB200 聚合 Dynamo-vLLM AgentX 配置，使完整扫描覆盖所有已配置的并发点。TP4 SimpleCPU 卸载后端使用已挂载的 Hugging Face 缓存，并采用仓库中已提交的 MiniMax-M3 thinking-on EAGLE3-GQA 接受长度目标。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark recipe and changelog-only changes with no application logic or security impact.
> 
> **Overview**
> Updates the **GB200 TP4 aggregate Dynamo-vLLM SimpleCPU-offload** agentic recipe (`agg-tp4-vllm-simple-agentic.yaml`) so **`aggregated_environment`** sets `HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, and `TRANSFORMERS_CACHE` to **`/hf_hub_cache`**, aligning model download/cache behavior with other MiniMax-M3 agentic recipes that use the mounted hub cache.
> 
> Adds a **`perf-changelog.yaml`** entry for **`minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp`** (agentic-coding) documenting a refresh of that aggregate AgentX configuration, including the HF cache change and the committed thinking-on EAGLE3-GQA acceptance target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d4221974b9b23049c3e2bc25bbdddc7396ad11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->