### PR TITLE
perf(agentx): refresh GLM-5.2 B200 SGLang curve / 性能：刷新 GLM-5.2 B200 SGLang 曲线

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_b200_sglang_mtp.sh
@@ -119,21 +119,20 @@ if require_agentic_kv_offload_backend hicache; then
     # against a ~0.97 theoretical ceiling, so every turn re-prefills its
     # whole history; the host tier restores those hits at C2C bandwidth.
     # GLM-5.2 is DSA/MLA-family (attention_backend=dsa): every TP rank holds
-    # complete per-token KV. The original ratio 0.75 gives the main target
-    # host pool only 1,257,728 token slots, which saturates on the c12/c16
-    # working sets. Use an absolute main-pool size at those two points so the
-    # allocation is stable across changes in the HBM pool size. In SGLang
-    # v0.5.16, --hicache-size directly sizes only the target KV host pool;
-    # the DSA indexer and MTP draft pools inherit its token-slot count and use
-    # their own smaller bytes/token. A 270 GB target pool was measured as
-    # 270.00 + 61.88 + 3.46 = 335.34 GB/rank, or 2.683 TB across TP8, with
-    # 6,009,728 slots in each pool. Keep ratio 0.75 on the lower
-    # concurrencies, where the smaller working set does not need the extra
-    # pinned memory.
+    # complete per-token KV. The ratio 0.75 gives the main target host pool
+    # only 1,257,728 token slots. Use a 169 GB/rank absolute target pool at
+    # c12/c16/c20 and keep ratio mode at the lower concurrencies, where the
+    # smaller working set does not need the larger pinned allocation.
+    #
+    # cluster:b200-nscale advertises 2,063,920 MiB and this config exposes 80%,
+    # giving the benchmark 1,731 GB. A 169 GB/rank packed target+MTP pool plus
+    # the coupled 38.73 GB/rank DSA indexer uses about 1,662 GB across TP8.
+    # Keep the 270 GB ceiling so deployments with more usable host DRAM can
+    # explicitly override the default.
     DEFAULT_HICACHE_RATIO=0.75
     DEFAULT_HICACHE_SIZE=0
     case "$CONC" in
-        12|16) DEFAULT_HICACHE_SIZE=270 ;;
+        12|16|20) DEFAULT_HICACHE_SIZE=169 ;;
     esac
     MAX_HICACHE_SIZE=270
     HICACHE_SIZE="${HICACHE_SIZE:-$DEFAULT_HICACHE_SIZE}"
@@ -257,6 +256,14 @@ MEM_FRACTION_STATIC="${MEM_FRACTION_STATIC:-0.83}"
 
 export PYTHONNOUSERSITE=1
 export TORCH_CUDA_ARCH_LIST=10.0
+# Each concurrency in a full sweep is a separate Slurm allocation, while the
+# Nscale home directory is shared. Keep SGLang's FlashInfer autotune, Triton,
+# Inductor, and CUDA JIT caches allocation-local so concurrent cells cannot
+# overwrite the same per-rank runtime-cache files. Non-Slurm launchers can
+# provide an explicit SGLANG_CACHE_DIR override.
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    export SGLANG_CACHE_DIR="${SGLANG_CACHE_DIR:-/tmp/sglang-cache-${SLURM_JOB_ID}}"
+fi
 # Agentic warmup dispatches hundreds of large prompts at once; allow up to
 # 15 minutes of TCP progress before AIPerf declares a connection dead.
 export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
@@ -276,10 +283,9 @@ export SGLANG_TIMEOUT_KEEP_ALIVE=900
 # One curve per model: it was collected on the FP8 checkpoint, and the NVFP4
 # checkpoint ships the same nextn head.
 #
-# SGLANG_SIMULATE_ACC_TOKEN_MODE only exists from SGLang v0.5.16, which is why
-# this recipe pins v0.5.16-cu130 rather than the STP sibling's v0.5.15.post1 --
-# an older image would silently honor ACC_LEN/ACC_METHOD and ignore the
-# token-mode half of the contract.
+# SGLANG_SIMULATE_ACC_TOKEN_MODE only exists from SGLang v0.5.16. An older
+# image would silently honor ACC_LEN/ACC_METHOD and ignore the token-mode half
+# of the contract.
 #
 # EVAL_ONLY leaves simulated acceptance off: it commits drafted tokens
 # regardless of the target logits, so generated text is wrong and the eval

--- a/benchmarks/single_node/agentic/glm5.2_fp4_b200_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_b200_sglang_mtp.sh
@@ -121,7 +121,7 @@ if require_agentic_kv_offload_backend hicache; then
     # GLM-5.2 is DSA/MLA-family (attention_backend=dsa): every TP rank holds
     # complete per-token KV. The ratio 0.75 gives the main target host pool
     # only 1,257,728 token slots. Use a 169 GB/rank absolute target pool at
-    # c12/c16/c20 and keep ratio mode at the lower concurrencies, where the
+    # c12/c16 and keep ratio mode at the lower concurrencies, where the
     # smaller working set does not need the larger pinned allocation.
     #
     # cluster:b200-nscale advertises 2,063,920 MiB and this config exposes 80%,
@@ -132,7 +132,7 @@ if require_agentic_kv_offload_backend hicache; then
     DEFAULT_HICACHE_RATIO=0.75
     DEFAULT_HICACHE_SIZE=0
     case "$CONC" in
-        12|16|20) DEFAULT_HICACHE_SIZE=169 ;;
+        12|16) DEFAULT_HICACHE_SIZE=169 ;;
     esac
     MAX_HICACHE_SIZE=270
     HICACHE_SIZE="${HICACHE_SIZE:-$DEFAULT_HICACHE_SIZE}"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8973,9 +8973,9 @@ glm5.2-fp4-b300-sglang-agentic-mtp:
 # nightly includes FlashInfer 0.6.18's BF16 TRTLLM MoE allocation fix, which is
 # required by GLM-5.2's unquantized EAGLE draft head at CUDA-graph capture.
 #
-# Same single arm as glm5.2-fp4-b300-sglang-agentic-mtp, extended with the c20
-# endpoint: cookbook low-latency TP8 with HiCache host-DRAM offload, conc
-# [1, 4, 8, 12, 16, 20] (steps of at least 2, hard stop at 20). TP8-only for
+# Same single arm and concurrency grid as glm5.2-fp4-b300-sglang-agentic-mtp:
+# cookbook low-latency TP8 with HiCache host-DRAM offload, conc
+# [1, 4, 8, 12, 16] (steps of at least 2, hard stop at 16). TP8-only for
 # memory as well as comparability -- the ~433 GB NVFP4
 # checkpoint needs ~54 GB/GPU across 8 B200s and does not fit below 8.
 glm5.2-fp4-b200-sglang-agentic-mtp:
@@ -8990,7 +8990,7 @@ glm5.2-fp4-b200-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
+      - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16] }
 
 glm5.2-fp4-gb200-dynamo-sglang-agentic-agg:
   image: lmsysorg/sglang:v0.5.17-cu130

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8968,17 +8968,18 @@ glm5.2-fp4-b300-sglang-agentic-mtp:
 # separate STP baseline (MODELS.md). SGLang EAGLE off GLM-5.2's built-in nextn
 # head (num-steps 3, eagle-topk 1, 4 draft tokens = 3 speculative tokens) with
 # acceptance pinned to the golden AL 2.99 (golden_al_distribution/glm5.2_mtp.yaml,
-# thinking_on, K=3) through SGLANG_SIMULATE_ACC_*. Image lmsysorg/sglang:v0.5.16-cu130
-# is the first release that reads SGLANG_SIMULATE_ACC_TOKEN_MODE and is what the
-# B300 sibling runs.
+# thinking_on, K=3) through SGLANG_SIMULATE_ACC_*. SGLang v0.5.16 is the first
+# release that reads SGLANG_SIMULATE_ACC_TOKEN_MODE. The pinned 2026-09-01
+# nightly includes FlashInfer 0.6.18's BF16 TRTLLM MoE allocation fix, which is
+# required by GLM-5.2's unquantized EAGLE draft head at CUDA-graph capture.
 #
-# Same single arm and concurrency grid as glm5.2-fp4-b300-sglang-agentic-mtp so
-# the two SKUs are directly comparable: cookbook low-latency TP8 with HiCache
-# host-DRAM offload, conc [1, 4, 8, 12, 16] (steps of at least 2, hard stop at
-# 16). TP8-only for memory as well as comparability -- the ~433 GB NVFP4
+# Same single arm as glm5.2-fp4-b300-sglang-agentic-mtp, extended with the c20
+# endpoint: cookbook low-latency TP8 with HiCache host-DRAM offload, conc
+# [1, 4, 8, 12, 16, 20] (steps of at least 2, hard stop at 20). TP8-only for
+# memory as well as comparability -- the ~433 GB NVFP4
 # checkpoint needs ~54 GB/GPU across 8 B200s and does not fit below 8.
 glm5.2-fp4-b200-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729
   model: nvidia/GLM-5.2-NVFP4
   model-prefix: glm5.2
   runner: cluster:b200-nscale
@@ -8989,7 +8990,7 @@ glm5.2-fp4-b200-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16] }
+      - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [1, 4, 8, 12, 16, 20] }
 
 glm5.2-fp4-gb200-dynamo-sglang-agentic-agg:
   image: lmsysorg/sglang:v0.5.17-cu130

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6828,6 +6828,6 @@
     - agentic-coding
   description:
     - "Pin the GLM-5.2 B200 SGLang AgentX curve to lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729, which includes FlashInfer 0.6.18's BF16 TRTLLM MoE allocation fix."
-    - "Extend the concurrency grid through c20 and use a 169 GB/rank HiCache target pool at c12, c16, and c20 while retaining ratio mode for lower concurrencies."
+    - "Use a 169 GB/rank HiCache target pool at c12 and c16 while retaining ratio mode for lower concurrencies."
     - "Isolate SGLang runtime caches per Slurm allocation to prevent concurrent sweep cells from sharing per-rank cache files."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2808

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6830,4 +6830,4 @@
     - "Pin the GLM-5.2 B200 SGLang AgentX curve to lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729, which includes FlashInfer 0.6.18's BF16 TRTLLM MoE allocation fix."
     - "Extend the concurrency grid through c20 and use a 169 GB/rank HiCache target pool at c12, c16, and c20 while retaining ratio mode for lower concurrencies."
     - "Isolate SGLang runtime caches per Slurm allocation to prevent concurrent sweep cells from sharing per-rank cache files."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2808

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6821,3 +6821,13 @@
   description:
     - "Refresh to collect TensorRT-LLM server metrics."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2774
+
+- config-keys:
+    - glm5.2-fp4-b200-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Pin the GLM-5.2 B200 SGLang AgentX curve to lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729, which includes FlashInfer 0.6.18's BF16 TRTLLM MoE allocation fix."
+    - "Extend the concurrency grid through c20 and use a 169 GB/rank HiCache target pool at c12, c16, and c20 while retaining ratio mode for lower concurrencies."
+    - "Isolate SGLang runtime caches per Slurm allocation to prevent concurrent sweep cells from sharing per-rank cache files."
+  pr-link: TBD


### PR DESCRIPTION
## Summary / 摘要

- Pin the GLM-5.2 NVFP4 B200 SGLang AgentX curve to `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729`, which includes the FlashInfer 0.6.18 BF16 TRTLLM MoE allocation fix.
- Use a 169 GB/rank HiCache target pool at c12 and c16 while retaining ratio mode at lower concurrencies and the 270 GB/rank override ceiling.
- Isolate SGLang runtime caches per Slurm allocation so concurrent sweep cells do not share per-rank cache files.

- 将 GLM-5.2 NVFP4 B200 SGLang AgentX 曲线固定到 `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729`，该镜像包含 FlashInfer 0.6.18 的 BF16 TRTLLM MoE 分配修复。
- 在 c12 和 c16 使用每个 rank 169 GB 的 HiCache 目标池，同时在较低并发度继续使用比例模式，并保留每个 rank 270 GB 的可覆盖上限。
- 按 Slurm 分配隔离 SGLang 运行时缓存，避免并发 sweep 任务共享每个 rank 的缓存文件。

## Validation / 验证

- `bash -n benchmarks/single_node/agentic/glm5.2_fp4_b200_sglang_mtp.sh`
- YAML parsing for `configs/nvidia-master.yaml`, `configs/runners.yaml`, and `perf-changelog.yaml`
- Exact-key and filtered-family matrix generation: c1/c4/c8/c12/c16 plus the c16 eval leaf
- `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD`
- Focused changelog validator tests: 18 passed
- Submission preflight: speculative-decoding eval guard passed; setup-script and multi-node recipe checks are not applicable
- Image manifest verified for Linux amd64: `sha256:605112675a761001da6fceb21bd811c8bfee02c56993f91ad26d29f86476839d`
- `git diff --check origin/main...HEAD`

已完成 Bash、YAML、精确配置矩阵、筛选后的配置族、c16 评测选择、性能变更日志、提交前检查、镜像清单和差异格式验证。

## Upstream recipe / 上游配方

The matching SGLang cookbook change is [sgl-project/sglang#35368](https://github.com/sgl-project/sglang/pull/35368). It remains open and currently documents the previous 270 GB HiCache value; it must be updated and merged before this PR is merge-ready.

对应的 SGLang cookbook 变更为 [sgl-project/sglang#35368](https://github.com/sgl-project/sglang/pull/35368)。该 PR 仍处于开放状态，目前记录的是先前的 270 GB HiCache 值；在本 PR 达到可合并状态之前，必须先更新并合并该上游 PR。

## Type of change / 变更类型

- [x] Configuration and benchmark recipe update / 配置和基准配方更新

## Checklist / 检查清单

- [x] Local syntax, YAML, matrix, changelog, and diff validation completed / 已完成本地语法、YAML、矩阵、性能变更日志和差异验证
- [x] A new entry was appended to `perf-changelog.yaml` / 已在 `perf-changelog.yaml` 末尾追加新条目
- [ ] Required public full sweep and eval / 尚需完成公开的完整 sweep 和评测
- [ ] Matching SGLang cookbook change merged / 尚需合并对应的 SGLang cookbook 变更

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and config-only changes (container pin, HiCache defaults, Slurm-local caches); no application auth or production serving logic.
> 
> **Overview**
> Refreshes the **GLM-5.2 NVFP4 B200** SGLang AgentX benchmark by pinning **`glm5.2-fp4-b200-sglang-agentic-mtp`** to nightly image `lmsysorg/sglang:nightly-dev-cu13-20260901-07c8f729` (FlashInfer **0.6.18** BF16 TRTLLM MoE allocation fix needed for unquantized EAGLE draft at CUDA-graph capture), replacing `v0.5.16-cu130`.
> 
> The B200 setup script lowers the default **HiCache** absolute target pool at **c12/c16** from **270 GB/rank** to **169 GB/rank** to fit **~80%** of advertised host DRAM on `cluster:b200-nscale`, while **ratio 0.75** at lower concurrencies and **`MAX_HICACHE_SIZE=270`** override ceiling stay unchanged.
> 
> Concurrent Slurm sweep cells now set **`SGLANG_CACHE_DIR`** to a per-job path under `/tmp` so shared home dirs do not collide on FlashInfer/Triton/Inductor/CUDA JIT caches. **`perf-changelog.yaml`** documents the image pin, HiCache sizing, and cache isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79d82b51c52f18137374897f53860e7cea529b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

