### PR TITLE
Route all GB300 workloads to batch_1

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8482,7 +8482,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-1p4d-dep4-tep8-c4-b1-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 4
           tp: 8
@@ -8499,7 +8499,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-1p6d-dep4-tep4-c24-b4-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 6
           tp: 4
@@ -8516,7 +8516,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-1p1d-dep8-dep32-c388-b4-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 32
@@ -8533,7 +8533,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-2p1d-dep8-dep32-c736-b8-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 32
@@ -8550,7 +8550,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-3p1d-dep8-dep16-c1152-b32-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 16
@@ -8567,7 +8567,7 @@ dsv4-fp4-gb300-dynamo-trt-agentx:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/dynamo-disagg-gb300-5p1d-dep8-dep16-c2626-b96-mtp.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 16
@@ -9337,7 +9337,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-agg-mtp:
           dp-attn: false
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-agg-gb300-tp8-c1-b2-mtp8.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
 # GLM-5.2 NVFP4 TensorRT-LLM AgentX on GB300 with Dynamo disaggregated serving.
 # Six topology variants use NIXL KV transfer and MTP3/MTP5 decoding.
 glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
@@ -9366,7 +9366,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-1p4d-tep4-c30-b2-mtp5.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 4
           tp: 4
@@ -9383,7 +9383,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-1p1d-tep8-c20-b5-mtp5.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 8
@@ -9400,7 +9400,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-3p4d-tep4-c60-b5-mtp5.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 4
           tp: 4
@@ -9417,7 +9417,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-5p1d-dep16-c152-b16-mtp3.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 16
@@ -9434,7 +9434,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-8p1d-dep16-c259-b16-mtp3.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 16
@@ -9451,7 +9451,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
           additional-settings:
           - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/glm5.2/gb300-fp4/agentic/dynamo-disagg-gb300-6p1d-dep8-c227-b16-mtp3.yaml"
-          - "SLURM_PARTITION=batch_3"
+          - "SLURM_PARTITION=batch_1"
         decode:
           num-worker: 1
           tp: 8


### PR DESCRIPTION
## Summary

- route all explicit GB300 Slurm partition overrides from `batch_3` to `batch_1`
- align generated workloads with the default `launch_gb300-nv.sh` partition and the production telemetry collector

## Validation

- `python3 -m pytest utils/matrix_logic/ -q` (246 passed)
- parsed all affected master configurations and confirmed no functional `batch_3` references remain
- confirmed `sa-shared` / `benchmark` has `batch_1_qos` access and active allocations on `batch_1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Slurm partition overrides in benchmark YAML only; no runtime, auth, or serving logic changes.
> 
> **Overview**
> Updates **`configs/nvidia-master.yaml`** so every GB300 benchmark that set **`SLURM_PARTITION=batch_3`** in `additional-settings` now uses **`batch_1`** instead.
> 
> The edits cover DeepSeek v4 and GLM-5.2 TensorRT-LLM Dynamo disaggregated (and related) operating points, plus one GLM-5.2 aggregated recipe—**13** partition overrides in total, with no other topology or config fields changed.
> 
> This matches the default GB300 launch partition and keeps scheduled jobs aligned with production telemetry collection on **`batch_1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a395bb459b6af26c36e90dd0d5be9398dd5cca95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->