### PR TITLE
fix: align AgentX offload metadata with runtime recipes

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8074,11 +8074,15 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    # Four DP ranks each reserve 180 GiB on an 840 GiB node.
+    - dram-utilization: 0.857143
+      search-space:
       # Keep the checked-in recipes on real MTP verification. Throughput jobs
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
         conc-list: [1152]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 2
@@ -8096,6 +8100,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [1024]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 2
@@ -8113,6 +8119,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [256]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 1
@@ -8130,6 +8138,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [512]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.4.0" }
         prefill:
           num-worker: 1
@@ -8164,6 +8174,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           dp-attn: false
       - spec-decoding: mtp
         conc-list: [128]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.4.0" }
         prefill:
           num-worker: 1
@@ -8181,6 +8193,8 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [256]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.4.0" }
         prefill:
           num-worker: 1
@@ -8265,11 +8279,15 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    # Four DP ranks each reserve 140 GiB on an 840 GiB node.
+    - dram-utilization: 0.666667
+      search-space:
       # Keep the checked-in recipes on real MTP verification. Throughput jobs
       # inject the committed golden AL at launch; EVAL_ONLY leaves them real.
       - spec-decoding: mtp
         conc-list: [576]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 2
@@ -8287,6 +8305,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [512]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 2
@@ -8304,6 +8324,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [256]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 1
@@ -8321,6 +8343,8 @@ dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-disagg:
           dp-attn: true
       - spec-decoding: mtp
         conc-list: [128]
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
         router: { name: dynamo-router, version: "1.3.0.dev20260720" }
         prefill:
           num-worker: 1

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6865,9 +6865,13 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
   disagg: true
   scenarios:
     agentic-coding:
-    - search-space:
+    # Existing recipes reserve 128 GiB per rank; each node has 840 GiB and 4 GPUs.
+    - dram-utilization: 0.609524
+      search-space:
       # 1P1D: 1 prefill (TP1/EP1/dp-attn), 1 decode (TP2/EP2), conc=44
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [44]
         prefill:
           num-worker: 1
@@ -6883,6 +6887,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: false
       # 1P7D: 1 prefill (TP4/EP4/dp-attn), 7 decode (TP8/EP8), conc=7
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [7]
         prefill:
           num-worker: 1
@@ -6898,6 +6904,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: false
       # 2P2D: 2 prefill (TP1/EP1/dp-attn), 2 decode (TP2/EP2), conc=52
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [52]
         prefill:
           num-worker: 2
@@ -6913,6 +6921,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: false
       # 2P3D: 2 prefill (TP2/EP2), 3 decode (TP8/EP8), conc=96
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [96]
         prefill:
           num-worker: 2
@@ -6928,6 +6938,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: false
       # 3P1D: 3 prefill (TP4/EP4/dp-attn), 1 decode (TP16/EP16/dp-attn), conc=565
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [565]
         prefill:
           num-worker: 3
@@ -6943,6 +6955,8 @@ qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg:
           dp-attn: true
       # 3P2D: 3 prefill (TP4/EP4/dp-attn), 2 decode (TP4/EP4/dp-attn), conc=704
       - spec-decoding: "mtp"
+        kv-offloading: dram
+        kv-offload-backend: { name: native, version: "1.3.0rc24" }
         conc-list: [704]
         prefill:
           num-worker: 3

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -29,6 +29,38 @@ from generate_sweep_configs import (
 )
 
 
+def test_qwen_gb300_agentic_master_matches_native_offload_recipes():
+    root = Path(__file__).resolve().parents[2]
+    with (root / "configs/nvidia-master.yaml").open() as handle:
+        configs = yaml.safe_load(handle)
+    with (root / "configs/runners.yaml").open() as handle:
+        runners = yaml.safe_load(handle)
+    key = "qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg"
+    config = configs[key]
+    args = argparse.Namespace(
+        config_keys=[key], seq_lens=None, conc=None,
+        scenario_type=["agentic-coding"], runner_node_filter=None,
+    )
+    entries = generate_test_config_sweep(args, {key: config}, runners)
+    assert len(entries) == 6
+    assert sorted(entry["conc"][0] for entry in entries) == [7, 44, 52, 96, 565, 704]
+    for entry in entries:
+        assert entry["kv-offloading"] == "dram"
+        assert entry["kv-offload-backend"] == {"name": "native", "version": "1.3.0rc24"}
+        assert entry["spec-decoding"] == "mtp"
+        settings = entry["prefill"]["additional-settings"]
+        recipe_path = next(value.removeprefix("CONFIG_FILE=") for value in settings
+                           if value.startswith("CONFIG_FILE="))
+        with (root / "benchmarks/multi_node/srt-slurm-recipes" / recipe_path.removeprefix("recipes/")).open() as handle:
+            recipe = yaml.safe_load(handle)
+        assert entry["image"] == recipe["model"]["container"]
+        for role in ("prefill", "decode"):
+            assert recipe["backend"]["trtllm_config"][role]["kv_cache_config"]["host_cache_size"] == 128 * 1024**3
+        # The shared matrix convention reports the prefill node's budget in decimal GB.
+        ranks_per_node = min(entry["prefill"]["tp"], 4)
+        assert entry["total-cpu-dram-gb"] == (128 * 1024**3 * ranks_per_node) // 10**9
+
+
 def test_aggregated_multinode_node_count_uses_explicit_num_nodes():
     entry = {
         "runner": "unknown",

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -29,38 +29,6 @@ from generate_sweep_configs import (
 )
 
 
-def test_qwen_gb300_agentic_master_matches_native_offload_recipes():
-    root = Path(__file__).resolve().parents[2]
-    with (root / "configs/nvidia-master.yaml").open() as handle:
-        configs = yaml.safe_load(handle)
-    with (root / "configs/runners.yaml").open() as handle:
-        runners = yaml.safe_load(handle)
-    key = "qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg"
-    config = configs[key]
-    args = argparse.Namespace(
-        config_keys=[key], seq_lens=None, conc=None,
-        scenario_type=["agentic-coding"], runner_node_filter=None,
-    )
-    entries = generate_test_config_sweep(args, {key: config}, runners)
-    assert len(entries) == 6
-    assert sorted(entry["conc"][0] for entry in entries) == [7, 44, 52, 96, 565, 704]
-    for entry in entries:
-        assert entry["kv-offloading"] == "dram"
-        assert entry["kv-offload-backend"] == {"name": "native", "version": "1.3.0rc24"}
-        assert entry["spec-decoding"] == "mtp"
-        settings = entry["prefill"]["additional-settings"]
-        recipe_path = next(value.removeprefix("CONFIG_FILE=") for value in settings
-                           if value.startswith("CONFIG_FILE="))
-        with (root / "benchmarks/multi_node/srt-slurm-recipes" / recipe_path.removeprefix("recipes/")).open() as handle:
-            recipe = yaml.safe_load(handle)
-        assert entry["image"] == recipe["model"]["container"]
-        for role in ("prefill", "decode"):
-            assert recipe["backend"]["trtllm_config"][role]["kv_cache_config"]["host_cache_size"] == 128 * 1024**3
-        # The shared matrix convention reports the prefill node's budget in decimal GB.
-        ranks_per_node = min(entry["prefill"]["tp"], 4)
-        assert entry["total-cpu-dram-gb"] == (128 * 1024**3 * ranks_per_node) // 10**9
-
-
 def test_aggregated_multinode_node_count_uses_explicit_num_nodes():
     entry = {
         "runner": "unknown",


### PR DESCRIPTION
Correct offload metadata for Qwen3.5 GB300 Dynamo-TRT and DeepSeek V4 GB200/GB300 Dynamo-vLLM, matching the existing native and Mooncake DRAM caches. Keep the GB300 c4 NIXL-only recipe non-offloaded.

Declare DRAM utilization from the existing per-rank reservations: Qwen 128 GiB; DeepSeek GB300 180 GiB and GB200 140 GiB. No runtime recipes, images, topology, concurrency or benchmark settings change. No new GPU sweep or performance changelog is needed.

Only configs/nvidia-master.yaml changes. Complements InferenceX-app #981 and the DeepSeek offload backfill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML benchmark metadata only; no application code, images, or recipe topology changes.
> 
> **Overview**
> Updates **`configs/nvidia-master.yaml`** so agentic-coding search spaces declare **DRAM KV offload** and **DRAM utilization** for matrix generation, aligning master metadata with recipes that already use KV-offload configs.
> 
> For **Qwen3.5 GB300 Dynamo-TRT** disagg AgentX, all six MTP variants now sit under `dram-utilization: 0.609524` (128 GiB/rank on 840 GiB nodes) with `kv-offloading: dram` and **`native`** `1.3.0rc24`.
> 
> For **DeepSeek-V4-Pro** **GB300** and **GB200** Dynamo-vLLM agentic-coding entries, the same pattern is applied with cluster-specific `dram-utilization` (**0.857143** / **0.666667**) and **`mooncake`** `0.3.11.post1` on the listed concurrency/topology variants. Prefill/decode topology, concurrency, router versions, and `CONFIG_FILE` recipe paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ca651d2cb381a7dfb27797f8ef020c90aea277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->