### PR TITLE
Remove decommissioned B300 runner fleet

### DIFF
--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -99,24 +99,6 @@ labels:
     - gb200-nv_0
     - gb200-nv_1
     - gb200-nv_2
-  b300:
-    - b300-nv_01
-    - b300-nv_02
-    - b300-nv_03
-    - b300-nv_04
-    - b300-nv_05
-    - b300-nv_06
-    - b300-nv_07
-    - b300-nv_08
-    - b300-nv_09
-    - b300-nv_10
-    - b300-nv_11
-    - b300-nv_12
-    - b300-nv_13
-    - b300-nv_14
-    - b300-nv_15
-    - b300-nv_16
-    - b300-nv_17
   gb300:
     - gb300-nv_0
     - gb300-nv_1
@@ -178,24 +160,6 @@ labels:
     - b200-nscale-slurm_07
     - b200-nscale-slurm_08
     - b200-nscale-slurm_09
-  cluster:b300-nv:
-    - b300-nv_01
-    - b300-nv_02
-    - b300-nv_03
-    - b300-nv_04
-    - b300-nv_05
-    - b300-nv_06
-    - b300-nv_07
-    - b300-nv_08
-    - b300-nv_09
-    - b300-nv_10
-    - b300-nv_11
-    - b300-nv_12
-    - b300-nv_13
-    - b300-nv_14
-    - b300-nv_15
-    - b300-nv_16
-    - b300-nv_17
   cluster:gb200-nv:
     - gb200-nv_0
     - gb200-nv_1
@@ -256,9 +220,6 @@ hardware:
     gpus-per-node: 8
   cluster:b200-nscale:
     available-cpu-dram-mib: 2_063_920
-    gpus-per-node: 8
-  cluster:b300-nv:
-    available-cpu-dram-mib: 2_964_436
     gpus-per-node: 8
   cluster:gb200-nv:
     available-cpu-dram-mib: 860_160


### PR DESCRIPTION
## Summary
- remove the decommissioned `b300-nv_01` through `b300-nv_17` runner inventory
- remove the `cluster:b300-nv` runner mapping and runner hardware profile
- retain B300 workload and benchmark references so they can be retargeted separately

## Validation
- `python3 -m pytest utils/matrix_logic/test_validation.py utils/matrix_logic/test_generate_sweep_configs.py -q` (246 passed)
- parsed `configs/runners.yaml` successfully
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of decommissioned runners; no auth, data, or runtime logic changes, though any matrix still pointing at `b300` or `cluster:b300-nv` will need retargeting.
> 
> **Overview**
> Removes the decommissioned **B300** CI runner inventory from `configs/runners.yaml` so jobs can no longer target hosts that no longer exist.
> 
> The change drops the `b300` label listing `b300-nv_01`–`b300-nv_17`, the `cluster:b300-nv` label mapping for the same nodes, and the `cluster:b300-nv` hardware profile (`available-cpu-dram-mib`, `gpus-per-node`). **B300** workload/benchmark configs elsewhere are intentionally unchanged so they can be retargeted in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e471c95318c6217271c710cab155575757b1a140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->