### PR TITLE
[Klaud Cold] dsr1-fp8-h200-dynamo-sglang: bump to SGLang v0.5.18-cu130 and stage the H200 8k1k recipes / 将 dsr1-fp8-h200-dynamo-sglang 更新至 SGLang v0.5.18-cu130 并暂存 H200 8k1k 配方

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs128-1p1d-dep-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs128-1p1d-dep-mtp.yaml
@@ -1,0 +1,122 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs128-1p1d-dep-mtp.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs128-1p1d-dep-h200-fp8-mtp"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_node: 8
+
+backend:
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.75
+      max-prefill-tokens: 163840
+      chunked-prefill-size: 163840
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 8
+      ep-size: 8 
+      enable-dp-attention: true
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.85
+      max-running-requests: 192
+      cuda-graph-max-bs: 192
+
+      # MTP settings
+      speculative-algorithm: "EAGLE"
+      speculative-num-steps: 2
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 3
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "32x64x128x256x512"
+  req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs128-1p1d-dep.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs128-1p1d-dep.yaml
@@ -1,0 +1,113 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs128-1p1d-dep.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs128-1p1d-dep-h200-fp8"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 1
+  decode_workers: 1
+  gpus_per_node: 8
+
+backend:
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      watchdog-timeout: 1000000
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.75
+      max-prefill-tokens: 163840
+      chunked-prefill-size: 163840
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 8
+      ep-size: 8 
+      enable-dp-attention: true
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+      watchdog-timeout: 1000000
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.88
+      max-running-requests: 256
+      cuda-graph-max-bs: 256
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "64x128x256"
+  req_rate: "inf"
+

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs16-1p3d-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs16-1p3d-mtp.yaml
@@ -1,0 +1,120 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs16-1p3d-mtp.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs16-1p3d-h200-fp8-mtp"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 3
+  decode_workers: 3
+  gpus_per_node: 8
+
+backend:
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 32
+      cuda-graph-max-bs: 32
+
+      # MTP settings
+      speculative-algorithm: "EAGLE"
+      speculative-num-steps: 2
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 3
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4x8x16x32x64"
+  req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs16-1p3d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs16-1p3d.yaml
@@ -1,0 +1,111 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs16-1p3d.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs16-1p3d-h200-fp8"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 3
+  decode_workers: 3
+  gpus_per_node: 8
+
+backend:
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      watchdog-timeout: 1000000
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+      watchdog-timeout: 1000000
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 32
+      cuda-graph-max-bs: 32
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "8x16x32"
+  req_rate: "inf"
+

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs4-1p7d-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs4-1p7d-mtp.yaml
@@ -1,0 +1,120 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs4-1p7d-mtp.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs4-1p7d-h200-fp8-mtp"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 7
+  decode_workers: 7
+  gpus_per_node: 8
+
+backend:
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.75
+      max-running-requests: 2
+      cuda-graph-max-bs: 2
+
+      # MTP settings
+      speculative-algorithm: "EAGLE"
+      speculative-num-steps: 2
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 3
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1x4x8"
+  req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs4-1p7d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs4-1p7d.yaml
@@ -1,0 +1,111 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs4-1p7d.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs4-1p7d-h200-fp8"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 7
+  decode_workers: 7
+  gpus_per_node: 8
+
+backend:
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      watchdog-timeout: 1000000
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+      watchdog-timeout: 1000000
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 8
+      cuda-graph-max-bs: 8
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "1x4x8"
+  req_rate: "inf"
+

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs64-2p3d-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs64-2p3d-mtp.yaml
@@ -1,0 +1,129 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs64-2p3d-mtp.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs64-2p3d-h200-fp8-mtp"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 2
+  prefill_workers: 2
+  decode_nodes: 3
+  decode_workers: 3
+  gpus_per_node: 8
+
+backend:
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      context-length: 72000
+      max-total-tokens: 128000 
+      # Memory and token limits
+      mem-fraction-static: 0.75
+      max-running-requests: 16
+      cuda-graph-max-bs: 16
+
+      # MTP settings
+      speculative-algorithm: "EAGLE"
+      speculative-num-steps: 2
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 3
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "32x64x128"
+  req_rate: "inf"
+
+# benchmark:
+#   type: "gpqa"
+#   num_examples: 198
+#   repeat: 4
+#   num_threads: 32
+#   max_tokens: 64000

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs64-2p3d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs64-2p3d.yaml
@@ -1,0 +1,119 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs64-2p3d.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs64-2p3d-h200-fp8"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 2
+  prefill_workers: 2
+  decode_nodes: 3
+  decode_workers: 3
+  gpus_per_node: 8
+
+backend:
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      watchdog-timeout: 1000000
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+      watchdog-timeout: 1000000
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      #context-length: 72000
+      # max-total-tokens: 128000 
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 128
+      cuda-graph-max-bs: 128
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "32x64x128"
+  req_rate: "inf"
+
+# benchmark:
+#   type: "gpqa"
+#   num_examples: 198
+#   repeat: 4
+#   num_threads: 32
+#   max_tokens: 64000

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs8-1p6d-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs8-1p6d-mtp.yaml
@@ -1,0 +1,121 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs8-1p6d-mtp.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs8-1p6d-h200-fp8-mtp"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 6
+  decode_workers: 6
+  gpus_per_node: 8
+
+backend:
+
+  # Prefill-specific environment variables
+  prefill_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  # Decode-specific environment variables
+  decode_environment:
+    SGLANG_ENABLE_SPEC_V2: "1"
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+      watchdog-timeout: 1000000
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 16
+      cuda-graph-max-bs: 16
+
+      # MTP settings
+      speculative-algorithm: "EAGLE"
+      speculative-num-steps: 2
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 3
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "2x4x8x16x32"
+  req_rate: "inf"

--- a/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs8-1p6d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/bs8-1p6d.yaml
@@ -1,0 +1,112 @@
+# Staged verbatim from NVIDIA/srt-slurm recipes/h200/8k1k/bs8-1p6d.yaml at commit deb1dfd9934398664f92d194169c183e009da83b
+# (branch sa-submission-q2-2026, the branch runners/launch_h200-dgxc-slurm.sh checks out for this family).
+# Only model.container differs: it must equal the dsr1-fp8-h200-dynamo-sglang image in configs/nvidia-master.yaml
+# so srtctl's container alias resolution maps it to the imported squash file instead of the stale upstream literal.
+name: "bs8-1p6d-h200-fp8"
+
+model:
+  path: "dsr1"
+  container: "lmsysorg/sglang:v0.5.18-cu130"
+  precision: "fp8"
+
+frontend:
+  nginx_container: nginx
+
+resources:
+  gpu_type: "h200"
+  prefill_nodes: 1
+  prefill_workers: 1
+  decode_nodes: 6
+  decode_workers: 6
+  gpus_per_node: 8
+
+backend:
+
+  prefill_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  decode_environment:
+    SGLANG_JIT_DEEPGEMM_FAST_WARMUP: "1"
+    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: "100000"
+    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: "100000"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "100000"
+
+  sglang_config:
+    prefill:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1 
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Radix cache disabled
+      disable-radix-cache: true
+
+      # Other flags
+      # stream-interval: 50
+      watchdog-timeout: 1000000
+      max-running-requests: 16
+      
+
+      # Prefill-specific mode
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "prefill"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-prefill-tokens: 32768
+      chunked-prefill-size: 32768
+
+      # Request handling
+      load-balance-method: "round_robin"
+
+
+    decode:
+      # Model configuration
+      served-model-name: "deepseek-ai/DeepSeek-R1"
+      model-path: "/model/"
+      skip-tokenizer-init: true
+      trust-remote-code: true
+
+      # Parallelism
+      tp-size: 8
+      dp-size: 1
+      ep-size: 1
+
+      # KV cache and attention
+      attention-backend: "flashinfer"
+
+      # Other flags
+      disable-radix-cache: true
+      stream-interval: 10
+      watchdog-timeout: 1000000
+
+      # Disagg
+      disaggregation-bootstrap-port: 30001
+      disaggregation-mode: "decode"
+      disaggregation-transfer-backend: nixl
+
+      # Memory and token limits
+      mem-fraction-static: 0.82
+      max-running-requests: 16
+      cuda-graph-max-bs: 16
+
+benchmark:
+  type: "sa-bench"
+  isl: 8192
+  osl: 1024
+  concurrencies: "4x8x16"
+  req_rate: "inf"
+

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3488,7 +3488,7 @@ dsr1-fp8-gb300-dynamo-trt:
           ep: 8
           dp-attn: true
 dsr1-fp8-h200-dynamo-sglang:
-  image: lmsysorg/sglang:v0.5.8.post1-cu130
+  image: lmsysorg/sglang:v0.5.18-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: cluster:h200-dgxc


### PR DESCRIPTION
## Summary / 摘要

**EN:** Refresh the `dsr1-fp8-h200-dynamo-sglang` family (DeepSeek-R1-0528 FP8, H200, disaggregated dynamo-sglang, 8k/1k) from `lmsysorg/sglang:v0.5.8.post1-cu130` to the current upstream release `lmsysorg/sglang:v0.5.18-cu130`, and stage the family's ten already-referenced srt-slurm recipes locally so `model.container` matches the master image.

**中文：** 将 `dsr1-fp8-h200-dynamo-sglang` 家族（DeepSeek-R1-0528 FP8，H200，分离式 dynamo-sglang，8k/1k）的镜像从 `lmsysorg/sglang:v0.5.8.post1-cu130` 更新至上游当前发布版本 `lmsysorg/sglang:v0.5.18-cu130`，并在本地暂存该家族已引用的 10 个 srt-slurm 配方，使 `model.container` 与主配置镜像一致。

Autonomous Klaud Cold auto-sweep session (candidate `7d2f82b89dfa60c1-047a5787e0abec71`, planner run `33932856011`). / 由 Klaud Cold 自动巡检会话生成。

## Family and evidence / 家族与证据

| Item / 项目 | Value / 值 |
| --- | --- |
| Master family / 主配置家族 | `configs/nvidia-master.yaml` → `dsr1-fp8-h200-dynamo-sglang` (runner `cluster:h200-dgxc`) |
| Public observation / 公开观测 | `/api/v1/latest-images`: dsr1 · h200 · dynamo-sglang · fp8 · spec none · disagg · 8192/1024 · image `lmsysorg/sglang:v0.5.8.post1-cu130` · date 2026-02-07 |
| Release feed / 发布源 | `/api/v1/framework-releases`: `sglang: v0.5.18` (review reason: `release-string-mismatch`) |
| New image / 新镜像 | `lmsysorg/sglang:v0.5.18-cu130`, Docker Hub tag pushed 2026-08-21, manifest list `sha256:9e148f5ac788e856a06166bd6347a831831eb9fcfab4d1770874823a7c29a1a1`, linux/amd64 `sha256:bde16a8447b19e89056b9eea06c72be6c02801dc89d528c9ea90c53368fd74bf` |
| Old image / 旧镜像 | `lmsysorg/sglang:v0.5.8.post1-cu130`, linux/amd64 `sha256:b63cabcb332173e9f9809249a75a58e0ec1fc2d22b812708261a6d04af054dbd` |
| Base SHA / 基线 SHA | `54a35ed28bec9a004cbc2bdc92da1968cdfe1680` (main) |
| Upstream recipe source / 上游配方来源 | `NVIDIA/srt-slurm` branch `sa-submission-q2-2026` @ `deb1dfd9934398664f92d194169c183e009da83b`, `recipes/h200/8k1k/*.yaml` |

The release tag `v0.5.18-cu130` is a versioned upstream release tag, treated as immutable; its digests are recorded above rather than embedded in the tag so the image string stays in the repository's `lmsysorg/sglang:<release>-cu130` convention used by other H200 SGLang families. / `v0.5.18-cu130` 为上游版本化发布标签，视为不可变；摘要记录于上表。

## What changed / 变更内容

1. `configs/nvidia-master.yaml`: only the `image:` line of `dsr1-fp8-h200-dynamo-sglang` (1 line). Model, precision, router metadata, topology, spec-decoding arms, concurrency lists and `CONFIG_FILE` references are unchanged.
2. `benchmarks/multi_node/srt-slurm-recipes/h200/8k1k/*.yaml` (10 new files): byte-for-byte copies of the upstream recipes, plus a 4-line provenance header, with **only** `model.container` changed to `lmsysorg/sglang:v0.5.18-cu130`.

**Why the staged recipes are required / 为什么必须暂存配方：** `runners/launch_h200-dgxc-slurm.sh` clones `NVIDIA/srt-slurm@sa-submission-q2-2026` and copies a workspace recipe over the upstream one only if `benchmarks/multi_node/srt-slurm-recipes/<path>` exists. `srtctl` (`src/srtctl/core/config.py`) resolves `model.container` by exact key lookup in the generated `containers:` map; the launcher registers the master image string, `dynamo-sglang` and `latest`. The upstream recipes hardcode `container: "lmsysorg/sglang:v0.5.8.post1-cu130"`, which is not in that map after the bump, so the literal would pass through and the workers would keep pulling the stale image. A master-only bump would therefore be a silent no-op. Staging the referenced recipes with a matching `model.container` is the mechanism `AGENTS.md` describes ("for image bumps, `model.container` must equal `image`"). / 上游配方硬编码了旧镜像字符串，srtctl 只按精确键解析容器别名，若不暂存配方则会静默沿用旧镜像。

The `recipes/h200/8k1k/*` paths are referenced only by this family (the `configs/deprecated/` copy is not generated). / 这些配方路径仅被本家族引用。

## Upstream compatibility check / 上游兼容性检查

- H200 is Hopper (SM90); the family already runs a `-cu130` image, so the CUDA 13.0 runtime/driver pairing on `cluster:h200-dgxc` is unchanged. v0.5.18 moves to torch 2.13.0, triton 3.7.1, flashinfer 0.6.17, sgl-kernel 0.4.6.post1 (release notes).
- Recipe flags still exist in v0.5.18: `attention-backend flashinfer`, `disaggregation-transfer-backend nixl`, `speculative-algorithm EAGLE` (+ `SGLANG_ENABLE_SPEC_V2`), and env vars `SGLANG_JIT_DEEPGEMM_FAST_WARMUP`, `SGLANG_DISAGGREGATION_{HEARTBEAT_MAX_FAILURE,BOOTSTRAP_TIMEOUT,WAITING_TIMEOUT}` are present in `python/sglang/srt/environ.py` at tag v0.5.18.
- Relevant v0.5.18 notes: "[PD] Add the missing Prefill bootstrap timeout for NIXL" (#34692), "[Fix] Speculative decoding crashes with DP-Attention" (#33892), "perf: add H200 Triton MoE configs for E256 N512" (#34150), "Route per-tensor FP8 checkpoints to FlashInfer on SM90" (#33148). Breaking changes listed upstream (torch 2.13, `SGLANG_CACHE_DIR` consolidation, torchao removal, NVFP4 deferred finalize) do not touch flags used by these FP8 recipes.
- Nothing in the release notes proves the disaggregated H200 FP8 path works; only the fresh benchmark below can. / 发布说明不能证明该路径可用，只有实际基准能证明。

## perf-changelog.yaml conflict / 变更日志冲突说明

`CONTRIBUTING.md` and the PR-review workflow require a new `perf-changelog.yaml` entry for every performance-affecting change. The Klaud Cold task rule for this session explicitly overrides that and requires `perf-changelog.yaml` to stay **byte-for-byte unchanged**, so no entry was appended. Repository checks that require an entry are expected to flag this PR; that is intentional and must not be bypassed. This PR stays a **draft**. A maintainer who wants to take it forward should append the entry at the tail with the canonical procedure in `KLAUD_DEBUG.md` §1.1. / 本会话规则要求 `perf-changelog.yaml` 保持逐字节不变，因此未追加条目；相关检查预期会标记本 PR，这是有意为之，PR 保持草稿状态。

## Local verification / 本地验证

- `generate_sweep_configs.py test-config --config-files configs/nvidia-master.yaml --config-keys dsr1-fp8-h200-dynamo-sglang`: 10 jobs / 36 points / `node-count` `[8, 7, 4, 5, 2, 8, 7, 4, 5, 2]`, identical to the base SHA except the `image` field (10 differing fields, all `image`). Node counts derived from the staged recipes match the master topology.
- `utils/matrix_logic`: `pytest test_generate_sweep_configs.py test_validation.py` → 246 passed. `utils/test_gb300_power_official_contract.py` → 6 passed.
- All 10 staged recipes parse; `diff` against the upstream files shows only the header and the `container:` line.
- `git diff --quiet HEAD -- perf-changelog.yaml` → unchanged.

## Benchmark evidence / 基准证据

Dispatch protocol: `e2e-tests.yml` from `main`, `generate-cli-command="test-config --config-files configs/nvidia-master.yaml --config-keys dsr1-fp8-h200-dynamo-sglang"`, `fail-fast=true`, `klaud-run=true`, `test-name=klaud-33932856011-7d2f82b89dfa60c1-047a5787e0abec71`, no skip-queue, no priority overrides, no sweep labels. Before each dispatch the capacity gate `python -m utils.klaude check-capacity --cluster h200` must exit 0 (telemetry cluster `h200` = 14 nodes = `cluster:h200-dgxc`; `h200-cw` = 2 nodes = `cluster:h200-cw`).

| Attempt / 尝试 | Image / SHA | Run URL | Benchmark / eval result | Per-point deltas vs baseline / 逐点差异 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- |
| Baseline (old image) / 基线（旧镜像） | `lmsysorg/sglang:v0.5.8.post1-cu130` @ `54a35ed28bec9a004cbc2bdc92da1968cdfe1680` | N/A: not dispatched | N/A: not dispatched | N/A (baseline) | Capacity gate `check-capacity --cluster h200` exited 1 at 2026-09-05T00:39:42Z and again at 00:40:16Z: the DGXC telemetry record was older than the 120 s freshness window (stale), so the gate rejects it by design; dispatch deferred. / 容量门禁因遥测过期返回非零，按规则推迟。 |
| Update 1 (new image) / 更新 1（新镜像） | `lmsysorg/sglang:v0.5.18-cu130` @ `e1acafa13a13875afd60ff04ba84f9fcae9d593a` | N/A: not dispatched | N/A: not dispatched | N/A: no baseline | Same capacity gate result; no GPU time was used. Status will be updated if the gate recovers within this session. / 同一容量门禁结果，未使用 GPU。 |


## Limitations / 限制

- A green selected benchmark does not prove that global repository checks pass, and this PR intentionally fails the changelog requirement (see above). / 选定基准通过不代表全局检查通过。
- Performance deltas, when present, compare one fresh old-image run against one fresh new-image run at identical points; they are not statistically repeated. / 性能差异基于单次新旧镜像对比。
- Raw artifacts stay on the linked e2e runs; nothing from private capacity telemetry is published here. / 原始产物保留在链接的 e2e 运行中，未发布任何私有容量遥测数据。
