### PR TITLE
[Klaud Cold] dsv4-fp4-b200-dynamo-vllm-mtp: bump vLLM image to v0.28.0 / 将 dsv4-fp4-b200-dynamo-vllm-mtp 的 vLLM 镜像更新至 v0.28.0

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-dep8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-dep8-mtp.yaml
@@ -2,12 +2,12 @@ name: "svf-vllm-disagg-b200-1p1d-dep8-dep8-mtp"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 dynamo:
   install: true
-  wheel: "1.2.0.dev20260426"
+  wheel: "1.5.0.dev20260904"
 
 health_check:
   max_attempts: 90
@@ -78,7 +78,7 @@ backend:
       enforce-eager: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 16
       max-num-batched-tokens: 16384
@@ -105,7 +105,7 @@ backend:
       enable-ep-weight-filter: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 512
       max-cudagraph-capture-size: 512

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-tp8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-tp8-mtp.yaml
@@ -2,12 +2,12 @@ name: "svf-vllm-disagg-b200-1p1d-dep8-tp8-mtp"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 dynamo:
   install: true
-  wheel: "1.2.0.dev20260426"
+  wheel: "1.5.0.dev20260904"
 
 sbatch_directives:
   segment: "1"
@@ -71,7 +71,7 @@ backend:
       max-model-len: 9280
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-num-seqs: 16
       max-num-batched-tokens: 16384
       trust-remote-code: true

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p2d-dep8-dep8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-1p2d-dep8-dep8-mtp.yaml
@@ -2,12 +2,12 @@ name: "svf-vllm-disagg-b200-1p2d-dep8-dep8-mtp"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 dynamo:
   install: true
-  wheel: "1.2.0.dev20260426"
+  wheel: "1.5.0.dev20260904"
 
 sbatch_directives:
   segment: "1"
@@ -78,7 +78,7 @@ backend:
       enforce-eager: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 16
       max-num-batched-tokens: 16384
@@ -106,7 +106,7 @@ backend:
       enable-ep-weight-filter: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 128
       max-cudagraph-capture-size: 128

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-2p1d-dep8-dep8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-2p1d-dep8-dep8-mtp.yaml
@@ -2,12 +2,12 @@ name: "svf-vllm-disagg-b200-2p1d-dep8-dep8-mtp"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 dynamo:
   install: true
-  wheel: "1.2.0.dev20260426"
+  wheel: "1.5.0.dev20260904"
 
 sbatch_directives:
   segment: "1"
@@ -78,7 +78,7 @@ backend:
       enforce-eager: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 16
       max-num-batched-tokens: 16384
@@ -105,7 +105,7 @@ backend:
       enable-ep-weight-filter: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 512
       max-cudagraph-capture-size: 512

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-3p1d-dep8-dep8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-3p1d-dep8-dep8-mtp.yaml
@@ -2,12 +2,12 @@ name: "svf-vllm-disagg-b200-3p1d-dep8-dep8-mtp"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 dynamo:
   install: true
-  wheel: "1.2.0.dev20260426"
+  wheel: "1.5.0.dev20260904"
 
 health_check:
   max_attempts: 90
@@ -78,7 +78,7 @@ backend:
       enforce-eager: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":1}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 16
       max-num-batched-tokens: 16384
@@ -105,7 +105,7 @@ backend:
       enable-ep-weight-filter: true
       speculative-config: '{"method":"mtp","num_speculative_tokens":1}'
       attention-config: '{"use_fp4_indexer_cache":true}'
-      moe-backend: "deep_gemm_amxf4_mega_moe"
+      moe-backend: "deep_gemm_mega_moe"
       max-model-len: 9280
       max-num-seqs: 512
       max-cudagraph-capture-size: 512

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -5500,7 +5500,7 @@ dsv4-fp4-b200-dynamo-sglang-mtp:
           dp-attn: true
 
 dsv4-fp4-b200-dynamo-vllm-mtp:
-  image: vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9
+  image: vllm/vllm-openai:v0.28.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:b200-nscale


### PR DESCRIPTION
## Summary / 摘要

**Family / 家族:** `configs/nvidia-master.yaml:dsv4-fp4-b200-dynamo-vllm-mtp` (DeepSeek-V4-Pro FP4, B200, Dynamo-vLLM, disaggregated, MTP, 8k/1k, runner `cluster:b200-nscale`).

**Klaud Cold candidate / 候选:** `95461d0c22050af8-c035e766ed4b72b7`, planner run `33936369665`, base `7bde875890c35ad30eb647b8190d42c3ea906dbb`.

This PR refreshes the family image from the side-branch build `vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9` to the upstream release `vllm/vllm-openai:v0.28.0`. The public `latest-images` observation for this identity (dated 2026-08-26) still reports the old image while `framework-releases` reports vLLM `v0.28.0`.

本 PR 将该家族的镜像从旁支构建 `vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9` 更新至上游发布版 `vllm/vllm-openai:v0.28.0`。公开 `latest-images` 对该身份（2026-08-26）的观测仍为旧镜像，而 `framework-releases` 报告 vLLM 为 `v0.28.0`。

## Changes / 变更

| File / 文件 | Change / 变更 |
| --- | --- |
| `configs/nvidia-master.yaml` | `dsv4-fp4-b200-dynamo-vllm-mtp.image` → `vllm/vllm-openai:v0.28.0` |
| `benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/8k1k/disagg-b200-{1p1d-dep8-tp8,1p2d-dep8-dep8,1p1d-dep8-dep8,2p1d-dep8-dep8,3p1d-dep8-dep8}-mtp.yaml` | `model.container` → `vllm/vllm-openai:v0.28.0` (equal to master `image`); `moe-backend` `deep_gemm_amxf4_mega_moe` → `deep_gemm_mega_moe`; `dynamo.wheel` `1.2.0.dev20260426` → `1.5.0.dev20260904` |

Model, precision, topology (1P1D/1P2D/2P1D/3P1D, prefill DEP8, decode DEP8 or TP8), MTP speculative config, synthetic-acceptance settings, concurrencies (1/8/16, 128/256, 512, 1024, 4096), `nodes:N` demand (2/3/2/3/4), evals, telemetry, resources and recipe references are unchanged. The generated matrix for the family differs from base only in the `image` field (5 points before and after).

模型、精度、拓扑（1P1D/1P2D/2P1D/3P1D，prefill DEP8，decode DEP8 或 TP8）、MTP 投机配置、合成接受率设置、并发度（1/8/16、128/256、512、1024、4096）、`nodes:N` 需求（2/3/2/3/4）、评测、遥测、资源与配方引用均未改动。该家族生成的矩阵与基线相比仅 `image` 字段不同（前后均为 5 个点）。

## Compatibility evidence / 兼容性依据

- `vllm/vllm-openai:v0.28.0` (Docker Hub, pushed 2026-08-26) is the CUDA 13.0 default tag: `CUDA_VERSION=13.0.2`, `TORCH_CUDA_ARCH_LIST` includes `10.0` (B200), build commit `2cf0a6915ce544dc493a0990f2ea38d81601128a` = upstream tag `v0.28.0`. amd64 manifest digest `sha256:2286e8533ca8b6bc777594bae30524f1426ba46ca21797524e06df6a94b06635` (multi-arch index `sha256:61fc8a896b0a4fbbbdc063bc4b0dbc25ce98e02b5050c24aeb7830ac02039b14`). The release tag is used verbatim to match every other vLLM release entry in this repository; the digest is recorded here for pinning.
- The old image was built from commit `7a33ba95` ("update deepgemm", 2026-07-16), which is **not** an ancestor of `v0.28.0`: 21 side-branch commits (including "[DeepSeek V4] MXFP4 x MXFP4 MegaMoE support") never landed upstream. Its `--moe-backend deep_gemm_amxf4_mega_moe` value does not exist in the v0.28.0 source; the upstream `MoEBackend` literal offers `deep_gemm_mega_moe`, which the DSV4 NVIDIA model accepts for `expert_dtype=fp4` + `sqrtsoftplus` + expert parallel on SM100 (matches this checkpoint and these recipes). Note the upstream kernel uses FP8 activations (`deep_gemm.fp8_fp4_mega_moe`), while the side branch used MXFP4 activations; a throughput difference is possible and is reported below rather than hidden.
- Every other recipe flag (`enable-ep-weight-filter`, `data-parallel-hybrid-lb`, `tokenizer-mode deepseek_v4`, `speculative-config mtp`, `stream-interval`, `numa-bind`, `enable-sleep-mode`, `no-disable-hybrid-kv-cache-manager`, `compilation-config FULL_DECODE_ONLY`, ...) is present in v0.28.0. `attention-config use_fp4_indexer_cache` is deprecated there in favour of `indexer_kv_dtype: mxfp4` but still maps to the same behaviour with a warning, so it is left unchanged. The env var `VLLM_DSV4_MEGA_FP8_COMBINE` is side-branch-only and is ignored by v0.28.0; it is left in place to keep the diff minimal.
- ai-dynamo: the pinned srt-slurm fork installs exact `ai-dynamo` + `ai-dynamo-runtime` wheels (`pip download --no-deps`), so vLLM inside the image is never replaced. Upstream ai-dynamo bumped its vLLM pin to 0.28.0 in `7122645` (2026-08-31); the earlier 0.27.1 bump (`08f12f7`) changed the core `dynamo/vllm/handlers.py`, so the April `1.2.0.dev20260426` wheel is not expected to load against v0.28.0. `1.5.0.dev20260904` is the current nightly that pins `vllm==0.28.0` and ships `ai_dynamo_runtime-1.5.0.dev20260904-cp310-abi3-manylinux_2_28_x86_64.whl`.

- `vllm/vllm-openai:v0.28.0`（Docker Hub，2026-08-26 推送）为 CUDA 13.0 默认标签：`CUDA_VERSION=13.0.2`，`TORCH_CUDA_ARCH_LIST` 含 `10.0`（B200），构建提交 `2cf0a6915ce544dc493a0990f2ea38d81601128a` 即上游标签 `v0.28.0`。amd64 清单摘要 `sha256:2286e8533ca8b6bc777594bae30524f1426ba46ca21797524e06df6a94b06635`。为与仓库中其他 vLLM 发布版条目保持一致，直接使用发布标签，摘要记录于此以便钉定。
- 旧镜像来自提交 `7a33ba95`（2026-07-16），**不是** `v0.28.0` 的祖先：21 个旁支提交（含 MXFP4×MXFP4 MegaMoE 支持）从未进入上游。其 `--moe-backend deep_gemm_amxf4_mega_moe` 在 v0.28.0 源码中不存在；上游提供 `deep_gemm_mega_moe`，DSV4 NVIDIA 模型在 `expert_dtype=fp4` + `sqrtsoftplus` + 专家并行 + SM100 条件下接受该值（与本检查点及配方一致）。注意上游内核使用 FP8 激活，旁支使用 MXFP4 激活，吞吐可能有差异，下文如实报告。
- 其余配方参数在 v0.28.0 中均存在。`use_fp4_indexer_cache` 已被弃用（建议改用 `indexer_kv_dtype: mxfp4`），但仍映射到相同行为并给出警告，故保持不变。环境变量 `VLLM_DSV4_MEGA_FP8_COMBINE` 仅旁支使用，v0.28.0 会忽略，为保持最小改动予以保留。
- ai-dynamo：钉定的 srt-slurm 分支只安装精确的 `ai-dynamo` + `ai-dynamo-runtime` wheel（`pip download --no-deps`），不会替换镜像内的 vLLM。上游 ai-dynamo 在 `7122645`（2026-08-31）将 vLLM 锁定至 0.28.0；更早的 0.27.1 升级（`08f12f7`）修改了核心 `dynamo/vllm/handlers.py`，因此 4 月的 `1.2.0.dev20260426` wheel 预计无法与 v0.28.0 一起加载。`1.5.0.dev20260904` 是当前锁定 `vllm==0.28.0` 的 nightly，并提供 x86_64 runtime wheel。

## Benchmark runs / 基准运行

Dispatched from `main` via `e2e-tests.yml` with `generate-cli-command="test-config --config-files configs/nvidia-master.yaml --config-keys dsv4-fp4-b200-dynamo-vllm-mtp"`, `fail-fast=true`, `klaud-run=true` (lowest scheduler priority), default evals on. Rows are updated as runs finish.

通过 `main` 上的 `e2e-tests.yml` 调度，`fail-fast=true`，`klaud-run=true`（最低调度优先级），默认评测开启。运行结束后更新表格。

| Attempt / 尝试 | Image / SHA | Run / 运行 | Benchmark / 基准 | Evals / 评测 | Δ vs baseline / 相对基线 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- | --- |
| Baseline / 基线 | `vllm/vllm-openai:vllm-x86_64-cu13-0.25.1-7a33ba9` @ `7bde8758` | [33937504543](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33937504543) | running / 运行中 | running / 运行中 | N/A (baseline / 基线) | — |
| Update 1 / 更新 1 | `vllm/vllm-openai:v0.28.0` @ `0ed0ec41` | [33937505574](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33937505574) | running / 运行中 | running / 运行中 | pending / 待定 | — |

## perf-changelog.yaml conflict / 变更日志冲突

The Klaud Cold task rules keep `perf-changelog.yaml` byte-for-byte unchanged, so **no changelog entry is appended** here. This conflicts with `CONTRIBUTING.md` and the PR review workflow, which require a new entry for every image bump; the changelog check is expected to flag this. The PR therefore stays a **draft**; no check is bypassed and no merge is requested. A maintainer taking this over should append the entry at the tail of the file.

Klaud Cold 任务规则要求 `perf-changelog.yaml` 逐字节保持不变，因此本 PR **未追加变更日志条目**。这与 `CONTRIBUTING.md` 及 PR 审查流程（每次镜像更新都需新增条目）冲突，预计变更日志检查会标记此项。故本 PR 保持**草稿**状态，不绕过任何检查，也不请求合并。接手的维护者应在文件末尾追加条目。

## Limitations / 限制

- A green selected benchmark proves this family runs on the new image; it does not prove that global PR checks pass or that other families are unaffected (none are edited).
- Performance deltas come from one fresh old-image run and one new-image run on the same cluster; they are single-sample comparisons.
- 选定基准通过仅证明该家族可在新镜像上运行，不证明全局 PR 检查通过或其他家族不受影响（未改动其他家族）。
- 性能差异来自同一集群上各一次的新旧镜像运行，属单样本比较。
