### PR TITLE
[Klaud Cold] qwen3.5-fp4-b300-sglang-mtp: bump SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp4-b300-sglang-mtp 的 SGLang 镜像升级至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1364,7 +1364,7 @@ qwen3.5-fp4-rtx6000pro-sglang-mtp:
       - { tp: 4, ep: 4, conc-list: [1, 4, 16, 64], spec-decoding: mtp }
 
 qwen3.5-fp4-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
   model-prefix: qwen3.5
   runner: b300


### PR DESCRIPTION
## Summary / 摘要

Klaud Cold image refresh for the single-node family `qwen3.5-fp4-b300-sglang-mtp` in `configs/nvidia-master.yaml`: `lmsysorg/sglang:v0.5.14-cu130` → `lmsysorg/sglang:v0.5.19-cu130`. Only the master `image` field changes. Model (`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`), precision, runner, topology (TP4/EP1 and TP2/EP2), MTP speculative decoding, 8k/1k workload, concurrency range, commands and resources are unchanged. No srt-slurm recipe references this family.

Klaud Cold 对 `configs/nvidia-master.yaml` 中的单节点配置族 `qwen3.5-fp4-b300-sglang-mtp` 进行镜像刷新：`lmsysorg/sglang:v0.5.14-cu130` → `lmsysorg/sglang:v0.5.19-cu130`。仅修改主配置的 `image` 字段。模型（`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`）、精度、runner、拓扑（TP4/EP1 与 TP2/EP2）、MTP 投机解码、8k/1k 工作负载、并发范围、命令和资源均不变。没有 srt-slurm 配方引用该配置族。

**Status / 状态: DEFERRED — the updated image is NOT yet validated on GPUs.** The only attempt sat queued behind human B300 work for over three hours without any job starting, and the B300 telemetry capacity gate then failed on two consecutive checks. Per the Klaud Cold rules this is a stop condition, so the queued run was cancelled before it consumed GPU time. This PR remains a draft; a maintainer or a later Klaud session must re-run validation.

**状态：已推迟 —— 更新后的镜像尚未在 GPU 上验证。** 唯一一次尝试在人工 B300 任务之后排队超过三小时，没有任何作业启动，随后 B300 遥测容量门禁连续两次检查失败。按照 Klaud Cold 规则这属于停止条件，因此在消耗 GPU 时间之前取消了排队的运行。本 PR 保持草稿状态；需由维护者或后续 Klaud 会话重新运行验证。

## Candidate / 候选

- Candidate ID: `2614d976576dc9e9-3d9c146c5e9ad2d6`; family `configs/nvidia-master.yaml:qwen3.5-fp4-b300-sglang-mtp`; base SHA `fdcca1e9998fef265237b50b238383f0cee7fcb3`; measured SHA `924af5cbed570cc323425ec77f4fd4b56c68f4ca`.
- Public observation: `latest-images` reported `lmsysorg/sglang:v0.5.14-cu130` for qwen3.5 / b300 / sglang / fp4 / mtp while `framework-releases` reports SGLang `v0.5.19` (review reason: release-string-mismatch). The 1k/1k observation maps to the deprecated 1k1k config; the only live single-node family for this identity is the 8k/1k entry above, which uses the same old image.
- Upstream verification: Docker Hub tag `lmsysorg/sglang:v0.5.19-cu130` exists (pushed 2026-09-04, manifest digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, linux/amd64 `sha256:37bbbd3444732a464bbc68dee4fb0164e0ce9e18e2f027f3fc967f1152d3c262`). CUDA 13.0 build, the same `-cu130` line the B300 fleet already runs. SGLang v0.5.16–v0.5.19 breaking-change notes were checked against the launch flags in `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_b300_mtp.sh`: only `--fp4-gemm-backend cutlass` was removed (v0.5.16); this recipe uses `flashinfer_cutlass`, which remains valid. v0.5.19 makes the unified radix tree the default, which is irrelevant here because the recipe passes `--disable-radix-cache`. The tag follows the plain release-tag convention of the sibling single-node entries; the digest above is recorded for reproducibility.
- Routing: runner `b300` resolves in `configs/runners.yaml` only to `b300-dsxe_00..17` (telemetry cluster `b300-dsxe`). `python -m utils.klaude check-capacity --cluster b300-dsxe` returned exit 0 before edits (03:57 UTC), before branch creation (04:00 UTC) and immediately before dispatch (04:01 UTC); it returned exit 1 at 07:17 UTC and again at 07:22 UTC.
- Overlap recheck immediately before claiming the branch: no open PR modifies this key or its benchmark script; the branch did not exist and was created atomically at the base SHA.
- Local checks: YAML parse OK; `bash -n` OK; `generate_sweep_configs.py test-config` emits the same 12 points as base with only `image` changed (single node, `nodes:1`); `pytest utils/matrix_logic/` 246 passed. The dispatched run's 16 GPU jobs all carried `self-hosted`, `b300`, `nodes:1` and the `klaud |` priority marker.

## perf-changelog.yaml policy conflict / perf-changelog.yaml 规则冲突

`CONTRIBUTING.md` and the PR-review workflow require a new `perf-changelog.yaml` entry for every recipe/image change. The Klaud Cold task rule explicitly overrides this and keeps `perf-changelog.yaml` byte-for-byte unchanged, so the changelog check is expected to flag this PR. The PR stays a draft; checks are not bypassed, and a maintainer must add the changelog entry (and the `full-sweep-fail-fast` label, if desired) before any merge.

`CONTRIBUTING.md` 与 PR 审查工作流要求每次配方/镜像变更都新增一条 `perf-changelog.yaml` 记录。Klaud Cold 任务规则明确覆盖了这一要求，保持 `perf-changelog.yaml` 逐字节不变，因此预期 changelog 检查会标记本 PR。本 PR 保持草稿状态，不绕过任何检查；合并前需由维护者补充 changelog 记录（以及如需要的 `full-sweep-fail-fast` 标签）。

## Baseline / 基线

Published data from the public dashboard API (frozen for all attempts; the old image was never rerun):

- `GET /api/v1/workflow-info?date=2026-07-04` → producer run [28719981652](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719981652) (`Run Sweep - [Klaud Cold] Update qwen3.5-fp4-b300-sglang (+mtp) SGLang image to v0.5.14-cu130`, changelog keys `qwen3.5-fp4-b300-sglang`, `qwen3.5-fp4-b300-sglang-mtp`).
- `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true`, filtered to hardware=b300, framework=sglang, precision=fp4, spec_method=mtp, isl=8192, osl=1024, disagg=false → 12 points, all `image=lmsysorg/sglang:v0.5.14-cu130`, all `run_url=https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719981652/attempts/1` (curve snapshot id 2120 is not the producer). Topology and concurrency match the generated matrix exactly (TP4/EP1 and TP2/EP2 × conc 4, 8, 16, 32, 64, 128).
- `GET /api/v1/evaluations` filtered to the same identity, date 2026-07-04 → gsm8k on 4 eval points (TP4/EP1 conc 64, 128; TP2/EP2 conc 64, 128), producer run 28719981652.
- Note: `latest-images` lists a later same-image publication (2026-08-10) for this 8k/1k identity; per the task, the candidate observation date 2026-07-04 is the frozen baseline.

Baseline points (published 2026-07-04, `lmsysorg/sglang:v0.5.14-cu130`, 4 GPUs per point):

| Topology | Conc | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TTFT (s) | median TPOT (s) | median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| TP4/EP1 | 4 | 2545.80 | 283.12 | 0.2401 | 0.00322 | 3.165 |
| TP4/EP1 | 8 | 3707.15 | 416.63 | 0.2918 | 0.00448 | 4.365 |
| TP4/EP1 | 16 | 5257.66 | 582.42 | 0.5691 | 0.00603 | 6.067 |
| TP4/EP1 | 32 | 7222.99 | 807.49 | 0.8217 | 0.00902 | 9.068 |
| TP4/EP1 | 64 | 9534.91 | 1057.51 | 1.1954 | 0.01372 | 13.750 |
| TP4/EP1 | 128 | 11205.64 | 1240.76 | 1.8330 | 0.02367 | 23.401 |
| TP2/EP2 | 4 | 3919.79 | 435.93 | 0.3063 | 0.00417 | 4.082 |
| TP2/EP2 | 8 | 5678.87 | 638.23 | 0.3148 | 0.00573 | 5.631 |
| TP2/EP2 | 16 | 7851.81 | 869.79 | 0.7576 | 0.00811 | 8.245 |
| TP2/EP2 | 32 | 10801.95 | 1207.60 | 1.1528 | 0.01186 | 12.005 |
| TP2/EP2 | 64 | 14273.55 | 1583.07 | 1.5349 | 0.01836 | 18.296 |
| TP2/EP2 | 128 | 17274.58 | 1912.75 | 2.4676 | 0.03086 | 30.479 |

Baseline gsm8k (em_strict): TP4/EP1 c64 0.9697, c128 0.9644; TP2/EP2 c64 0.9689, c128 0.9719.

## Results / 结果

| Attempt / 尝试 | Image / SHA | Run | Benchmarks / 基准 | Evals / 评测 | Per-point deltas vs baseline / 逐点相对基线变化 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- | --- |
| Baseline (published 2026-07-04) / 基线（发布于 2026-07-04） | `lmsysorg/sglang:v0.5.14-cu130` (producer run 28719981652) | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719981652 | 12/12 points published (table above) | gsm8k em_strict 0.9644–0.9719 on 4 points | — | Reference. / 参考基线。 |
| Attempt 1 (initial update) / 尝试 1（初次更新） | `lmsysorg/sglang:v0.5.19-cu130` @ `924af5cbed570cc323425ec77f4fd4b56c68f4ca` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33943452388 | N/A — cancelled while all 12 benchmark jobs were still queued (0 started; the green `collect-results`/`calc-success-rate` jobs only aggregated empty artifacts and prove nothing) | N/A — cancelled while all 4 eval-only jobs were still queued | N/A — no measurements exist for the updated image | Dispatched 04:01 UTC with `klaud-run=true` (background priority). For 3 h 15 min no job started: no B300 job was in progress anywhere, but a human sweep (run 33921762092) had 33 queued B300 jobs demanding 2–13 nodes each ahead of this run. The `b300-dsxe` capacity gate then failed at 07:17 and 07:22 UTC (Klaud stop condition: capacity loss), so the run was cancelled by Klaud Cold before consuming GPU time. Not an image failure. / 04:01 UTC 以后台优先级派发，3 小时 15 分内没有作业启动：B300 上没有任何作业在运行，但人工 sweep（run 33921762092）有 33 个每个需要 2–13 节点的 B300 作业排在前面。随后 `b300-dsxe` 容量门禁在 07:17 与 07:22 UTC 两次失败（Klaud 停止条件：容量丢失），因此 Klaud Cold 在消耗 GPU 时间之前取消了该运行。并非镜像故障。 |

Repairs used: 0 of 3. No repair was attempted because no failure of the updated image was observed. / 已用修复次数：0/3。由于未观察到更新镜像的任何故障，未尝试修复。

## Limitations / 限制

- The updated image has not been executed on B300 in this PR. Compatibility evidence is limited to the upstream tag/digest check, the release-note review of flag changes and local matrix validation.
- Even a future green selected benchmark run would prove only that the updated image serves this family's points and default evals; it would not prove that global PR checks (changelog gate, full sweep, CODEOWNER sign-off) pass. Performance deltas would be single-run measurements without a rejection threshold.

- 本 PR 中更新后的镜像尚未在 B300 上运行。兼容性证据仅限于上游标签/摘要检查、发布说明中的参数变更审查以及本地矩阵验证。
- 即使未来选定基准运行通过，也仅证明更新后的镜像可以为该配置族的数据点及默认评测提供服务；不能证明全局 PR 检查（changelog 门禁、完整 sweep、CODEOWNER 签核）通过。性能变化为单次运行测量，不设拒绝阈值。
