### PR TITLE
[Klaud Cold] qwen3.5-fp8-gb200-dynamo-sglang: bump SGLang image to v0.5.19-cu130 / 将 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
@@ -15,7 +15,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/1p1d-tp4-tp4.yaml
@@ -4,8 +4,11 @@ sbatch_directives:
   mem: "0"
 
 dynamo:
-  hash: 46520ca59afe992fb5ef61b3197b2316f8df9b2b
-  install: true
+  # lmsysorg/sglang:v0.5.19-cu130 bundles ai-dynamo 1.5.0.dev20260904, built after
+  # dynamo f3d0ed0f/b1c5147f followed SGLang's server_args_config_parser move (#36681).
+  # The previous source pin 46520ca5 (ai-dynamo 1.2.0) imports the removed module and
+  # cannot start on this image, so use the container's bundled Dynamo instead.
+  install: false
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/4p1d-dep4-dep16.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/4p1d-dep4-dep16.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/4p1d-dep4-dep16.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/4p1d-dep4-dep16.yaml
@@ -6,8 +6,11 @@ sbatch_directives:
   mem: "0"
 
 dynamo:
-  hash: 46520ca59afe992fb5ef61b3197b2316f8df9b2b
-  install: true
+  # lmsysorg/sglang:v0.5.19-cu130 bundles ai-dynamo 1.5.0.dev20260904, built after
+  # dynamo f3d0ed0f/b1c5147f followed SGLang's server_args_config_parser move (#36681).
+  # The previous source pin 46520ca5 (ai-dynamo 1.2.0) imports the removed module and
+  # cannot start on this image, so use the container's bundled Dynamo instead.
+  install: false
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/8p1d-dep4-dep16.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/8p1d-dep4-dep16.yaml
@@ -9,8 +9,11 @@ infra:
   etcd_nats_dedicated_node: true
 
 dynamo:
-  hash: 46520ca59afe992fb5ef61b3197b2316f8df9b2b
-  install: true
+  # lmsysorg/sglang:v0.5.19-cu130 bundles ai-dynamo 1.5.0.dev20260904, built after
+  # dynamo f3d0ed0f/b1c5147f followed SGLang's server_args_config_parser move (#36681).
+  # The previous source pin 46520ca5 (ai-dynamo 1.2.0) imports the removed module and
+  # cannot start on this image, so use the container's bundled Dynamo instead.
+  install: false
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/8p1d-dep4-dep16.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/8p1d-dep4-dep16.yaml
@@ -20,7 +20,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -4967,7 +4967,7 @@ dsv4-fp4-gb200-dynamo-sglang:
           dp-attn: true
 
 qwen3.5-fp8-gb200-dynamo-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: gb200


### PR DESCRIPTION
> **Status / 状态 (2026-09-05T20:55Z):** This PR was closed by a maintainer at 2026-09-05T19:37:19Z (after PR #2842 changed the Klaud Cold policy) while repair attempt 2 was still running. Klaud Cold did not reopen it. Attempt 2 later **completed successfully** (11/11 benchmark points, 3/3 gsm8k evals) and this body was finalized with the terminal results below. Both owned e2e runs are terminal (33983865337 failure, 33986258530 success). The head branch `klaude/auto-daa7a1a5144e3543-ed613715f3bfca2a` @ `fd71d273c…` was left in place as the maintainer left it; note the planner treats an existing `klaude/auto-*` branch as an occupied candidate, so this family will not be re-selected by auto-sweep until that branch is deleted. / 本 PR 由维护者于 2026-09-05T19:37:19Z 关闭（在 PR #2842 修改 Klaud Cold 策略之后），当时第 2 次修复尝试仍在运行；Klaud Cold 未重新打开。第 2 次尝试随后**成功完成**（11/11 个基准点，3/3 gsm8k 评测），下方为最终结果。两个 e2e 运行均已结束。分支 `klaude/auto-daa7a1a5144e3543-ed613715f3bfca2a` 按维护者的处理保留；规划器会将现存的 `klaude/auto-*` 分支视为已占用候选，删除该分支后 auto-sweep 才会重新选择此配置。

## Summary / 摘要

**EN:** Klaud Cold image refresh for the master family `qwen3.5-fp8-gb200-dynamo-sglang` (configs/nvidia-master.yaml). The family still pinned the unstable nightly `lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc`; this PR moves it to the SGLang `v0.5.19` release (`lmsysorg/sglang:v0.5.19-cu130`, pinned by manifest-list digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`) and updates `model.container` in the three 8k1k GB200 FP8 srt-slurm recipes that only this family references, so recipe container == master image. After attempt 1 failed, the same three recipes were changed to `dynamo.install: false` (the source pin `46520ca5` / ai-dynamo 1.2.0 imports a module removed in SGLang v0.5.19; the image's bundled ai-dynamo 1.5.0.dev20260904 is used instead). Nothing else changes: model, precision, topology (1P1D TP4/TP4, 4P1D DEP4/DEP16, 8P1D DEP4/DEP16), concurrency lists, SGLang flags, resources and recipe references are preserved.

**ZH:** Klaud Cold 对主配置 `qwen3.5-fp8-gb200-dynamo-sglang`（configs/nvidia-master.yaml）的镜像刷新。该配置仍固定在不稳定的 nightly 镜像 `lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc`；本 PR 将其更新为 SGLang `v0.5.19` 正式版（`lmsysorg/sglang:v0.5.19-cu130`，按 manifest-list digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9` 固定），并同步更新仅由该配置引用的三个 8k1k GB200 FP8 srt-slurm 配方中的 `model.container`，保证配方容器与主配置镜像一致。第 1 次尝试失败后，同样三个配方改为 `dynamo.install: false`（源码固定版本 `46520ca5` / ai-dynamo 1.2.0 导入了 SGLang v0.5.19 已移除的模块，改用镜像内置的 ai-dynamo 1.5.0.dev20260904）。其余内容（模型、精度、拓扑 1P1D TP4/TP4、4P1D DEP4/DEP16、8P1D DEP4/DEP16、并发列表、SGLang 参数、资源与配方引用）均保持不变。

## Family and evidence / 配置与证据

| Item / 项目 | Value / 值 |
| --- | --- |
| Candidate / 候选 | `daa7a1a5144e3543-ed613715f3bfca2a` (latest-images observation: qwen3.5 · gb200 · dynamo-sglang · fp8 · spec none · disagg · 8192/1024 · single_turn · 2026-06-22) |
| Family / 配置键 | `configs/nvidia-master.yaml:qwen3.5-fp8-gb200-dynamo-sglang` (`runner: gb200` → `gb200-nv_0..2`, single GB200 cluster, telemetry cluster `gb200`) |
| Base SHA / 基准提交 | `80677d89d69d4cd7d23ae91391efb0ff446ec836` |
| Old image / 旧镜像 | `lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc` |
| New image / 新镜像 | `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9` (Docker Hub tag pushed 2026-09-04, amd64 + arm64; release `v0.5.19` published 2026-09-05; `framework-releases` feed reports sglang `v0.5.19`) |
| Digest convention / digest 约定 | Same manifest-list digest style already used by the sibling `qwen3.5-fp8-gb200-dynamo-sglang-mtp` (`v0.5.14-cu130@sha256:5027e95b…`); `runners/launch_gb200-nv.sh` converts `tag@digest` to the enroot registry syntax |
| Changed files / 改动文件 | `configs/nvidia-master.yaml` (1 line); `benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/{1p1d-tp4-tp4,4p1d-dep4-dep16,8p1d-dep4-dep16}.yaml` (`model.container` line, plus the `dynamo:` block → `install: false` with an explanatory comment; commits `0ce3b78a` and `fd71d273`). Grep confirms these three recipe paths are referenced only by this family's `CONFIG_FILE` settings (the deprecated `configs/deprecated/nvidia-1k1k-master.yaml` references the 1k1k recipes, which are untouched). |
| Local checks / 本地检查 | `generate_sweep_configs.py test-config --config-files configs/nvidia-master.yaml --config-keys qwen3.5-fp8-gb200-dynamo-sglang` → 3 matrix entries (nodes 2 / 8 / 12), identical to `main` except `image`; `pytest utils/matrix_logic/` → 246 passed |
| Compatibility review / 兼容性审查 | All recipe server flags exist in `v0.5.19` `server_args.py`; `--mamba-scheduler-strategy` and `--cuda-graph-max-bs` are still accepted as deprecated aliases. `v0.5.19` ships DeepEP as the `sgl-deep-ep==0.1.2` wheel (low-latency `kNumMaxTopK = 16`, covers Qwen3.5 top-10). The recipes' `setup_script: rebuild-deepep.sh` is inert in CI because the launcher passes `--setup-script install-torchao.sh`, which `srtctl do_sweep` uses to replace `config.setup_script`; it is left unchanged. |

**Router metadata follow-up / router 元数据待办：** with `dynamo.install: false` the runs use the image's bundled ai-dynamo `1.5.0.dev20260904`, but the master entry still declares `router: { name: dynamo-router, version: "46520ca59afe992fb5ef61b3197b2316f8df9b2b" }`. Klaud Cold's edit scope is limited to the master `image` and the unshared recipe compatibility settings, so this metadata line was **not** changed; a maintainer should update `router.version` to `1.5.0.dev20260904` (the pip version string form is already used by the dsr1 GB200 families) before merge so published results are labeled with the router actually used. / 由于 `dynamo.install: false` 使用镜像内置的 ai-dynamo `1.5.0.dev20260904`，而主配置中的 `router.version` 仍为 `46520ca5…`；该元数据行超出 Klaud Cold 的编辑范围，未作修改，合并前请维护者将其更新为 `1.5.0.dev20260904`。

## perf-changelog.yaml policy conflict / perf-changelog.yaml 策略冲突

**EN:** `CONTRIBUTING.md`, `AGENTS.md` and the PR review workflow require a new `perf-changelog.yaml` entry for every image bump. The Klaud Cold task rule explicitly overrides this and requires `perf-changelog.yaml` to stay byte-for-byte unchanged, so this PR does **not** append an entry. The local gate confirms the consequence: `validate_perf_changelog.py --base-ref 80677d89d… --head-ref 0ce3b78ab…` exits 1 with `ValueError: No additions found in the changelog file.`, so the setup/changelog check on this PR is expected to fail for that reason alone. This PR stays a draft; no check is bypassed, and a maintainer must add the entry (or decide otherwise) before any merge.

**ZH:** `CONTRIBUTING.md`、`AGENTS.md` 与 PR 审查工作流要求每次镜像更新都在 `perf-changelog.yaml` 追加条目。Klaud Cold 任务规则明确覆盖该要求，要求 `perf-changelog.yaml` 逐字节不变，因此本 PR **未**追加条目。本地检查已确认后果：`validate_perf_changelog.py` 对 base `80677d89d…`/head `0ce3b78ab…` 以退出码 1 报告 `ValueError: No additions found in the changelog file.`，因此本 PR 的 setup/changelog 检查预计仅因此失败。本 PR 保持草稿状态，不绕过任何检查；合并前需由维护者补充条目（或另行决定）。

## Baseline / 基线

**EN:** Published dashboard data, frozen for all attempts (never re-run): `GET /api/v1/workflow-info?date=2026-06-22` and `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-06-22&exact=true` (no `view`), filtered to hardware `gb200`, framework `dynamo-sglang`, precision `fp8`, spec `none`, disagg `true`, isl/osl `8192/1024`, benchmark type `single_turn`, image `lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc`. 11 points, all produced by run <https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27653706015/attempts/1> (head SHA `de00324741775d575e6b71bf3e0d4de21cc9f54a`, PR #1810); logical curve snapshot id `2067` is distinct from that producer. Published evals (`GET /api/v1/evaluations`, same identity, date 2026-06-22): gsm8k `em_strict 0.9674` at conc 64 (1P1D TP4/TP4) and `em_strict 0.9674` at conc 4096 (8P1D DEP4/DEP16), both from run 27653706015.

**ZH:** 基线来自公开仪表盘数据，所有尝试均冻结使用同一基线（绝不重跑旧镜像）：查询如上，按 gb200 · dynamo-sglang · fp8 · spec none · disagg · 8192/1024 · single_turn · 旧镜像过滤。共 11 个点，全部由运行 27653706015（attempt 1，head SHA `de00324741775d575e6b71bf3e0d4de21cc9f54a`，PR #1810）产生；曲线快照 id `2067` 不是生产者 id。已发布评测（gsm8k，2026-06-22）：conc 64（1P1D）`em_strict 0.9674`，conc 4096（8P1D）`em_strict 0.9674`。

Baseline per-point metrics (published 2026-06-22) / 基线各点指标（发布日期 2026-06-22）:

| conc | topology / 拓扑 | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TTFT (ms) | median TPOT (ms) | median E2EL (s) | benchmark id |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 158.6 | 35.4 | 1140 | 5.77 | 6.61 | 426918 |
| 2 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 308.3 | 69.2 | 1178 | 5.90 | 6.71 | 426921 |
| 4 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 549.3 | 122.2 | 1169 | 6.63 | 7.27 | 426920 |
| 8 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 954.3 | 214.5 | 1214 | 7.67 | 8.42 | 426917 |
| 16 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 1610.6 | 356.8 | 1412 | 9.22 | 9.90 | 426916 |
| 32 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 2551.6 | 570.5 | 1538 | 11.75 | 12.44 | 426915 |
| 64 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 4094.4 | 908.3 | 1659 | 14.86 | 15.46 | 426919 |
| 128 | 1P1D P:TP4/EP1 D:TP4/EP1 (4+4 GPU) | 6431.1 | 1424.3 | 1848 | 19.12 | 19.55 | 426922 |
| 1024 | 4P1D P:TP4/EP4/DPA D:TP16/EP16/DPA (16+16 GPU) | 8948.0 | 1990.0 | 8929 | 21.48 | 28.68 | 426923 |
| 2048 | 8P1D P:TP4/EP4/DPA D:TP16/EP16/DPA (32+16 GPU) | 10841.1 | 3616.5 | 4816 | 27.56 | 30.36 | 426931 |
| 4096 | 8P1D P:TP4/EP4/DPA D:TP16/EP16/DPA (32+16 GPU) | 11422.6 | 3806.2 | 32745 | 28.20 | 59.25 | 426932 |

## Attempts / 尝试记录

| Attempt / 尝试 | Image / SHA | Run / 运行 | Benchmarks / 基准 | Evals / 评测 | Deltas vs baseline / 相对基线变化 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- | --- |
| Baseline (published 2026-06-22) / 基线（发布于 2026-06-22） | `lmsysorg/sglang:nightly-dev-cu13-20260608-303757cc` @ `de00324741775d575e6b71bf3e0d4de21cc9f54a` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27653706015/attempts/1 | 11/11 points published (conc 1–128 1P1D; 1024 4P1D; 2048, 4096 8P1D) | gsm8k em_strict 0.9674 (conc 64), 0.9674 (conc 4096) | — (reference) | Frozen public baseline / 冻结的公开基线 |
| 1 (initial update) / 第 1 次（初始更新） | `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e72886…` @ `0ce3b78ab315cf37c178d5f00c596fa7bf9ba2dc` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33983865337 (dispatched 2026-09-05T18:22:36Z, completed failure 19:03Z) | **FAILED** 0/11 points. 1P1D (nodes:2) benchmark failed; 4P1D (nodes:8) and 8P1D (nodes:12) benchmarks cancelled by fail-fast; `results_bmk/agg_bmk.json` = `[]` / **失败**，0/11 个点 | **FAILED**: 1P1D eval-only job failed the same way; 4P1D/8P1D evals cancelled / **失败** | N/A (no server became healthy; nothing to compare) / N/A（服务未启动，无法比较） | Every prefill and decode worker died at import: `ModuleNotFoundError: No module named 'sglang.srt.server_args_config_parser'` (server logs `watchtower-navy-cn03_prefill_w0.out`, `watchtower-navy-cn04_decode_w0.out`). The recipes installed Dynamo from source at `46520ca5` (ai-dynamo 1.2.0), replacing the image's bundled ai-dynamo 1.5.0.dev20260904; that old Dynamo imports a module SGLang moved under `utils` in sgl-project/sglang#36681 (in v0.5.18, gone in v0.5.19). Dynamo fixed the import in ai-dynamo/dynamo f3d0ed0f (2026-09-02) and b1c5147f (2026-09-03). Not a capacity or teardown symptom. / 所有 prefill/decode worker 在导入阶段失败：旧的源码安装 Dynamo 46520ca5 导入了 SGLang v0.5.19 已移除的模块。 |
| 2 (repair 1 of 3) / 第 2 次（第 1 次修复，共 3 次预算） | same image @ `fd71d273c69c2eac4be18b52509b974997684c7f` (recipes: `dynamo.install: false`, source pin `46520ca5` removed, image's bundled ai-dynamo 1.5.0.dev20260904 used) | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33986258530 (dispatched 2026-09-05T19:09:37Z, completed **success** 20:43Z) | **PASSED** 11/11 points in `results_bmk/agg_bmk.json`: 1P1D nodes:2 conc 1–128 (8), 4P1D nodes:8 conc 1024 (1), 8P1D nodes:12 conc 2048, 4096 (2); all with the new image / **通过**，11/11 个点 | **PASSED** 3/3 gsm8k (lm-eval, 5-shot, 1319/1319 samples): 1P1D conc 128 `em_strict 0.9651±0.0051`; 4P1D conc 1024 `em_strict 0.9674±0.0049`; 8P1D conc 4096 `em_strict 0.9682±0.0048` (baseline `0.9674` at conc 64 and 4096) / **通过** 3/3 | tput/GPU: 1P1D +14.4% … +45.5%, 4P1D +4.3%, 8P1D +8.2% / +10.3%. Median TPOT: −7.5% … −24.4% everywhere. Median TTFT: 1P1D −57% … −86%, **but 4P1D +39.8% (8.9 s → 12.5 s) and 8P1D +53.3% at conc 2048 (4.8 s → 7.4 s), +3.3% at conc 4096** (regressions reported, no threshold applied). Median E2EL −3.8% … −33.5%. Per-point table below. / 吞吐全部提升；TPOT 全部下降；宽 EP 拓扑的 TTFT 中位数回退（见下表）。 | Bundled Dynamo starts cleanly on v0.5.19; servers healthy on all three topologies. Power telemetry: valid for 1P1D and 4P1D points; **invalid for the two 8P1D points** (`power_valid=0`, aggregate_power_multinode: `power_artifacts_missing, invalid_benchmark_window`; `require-power` was false so the job passed) — a telemetry-lane issue, not an inference failure. / 8P1D 两点功耗遥测无效（power_artifacts_missing），不影响吞吐/延迟指标。 |



## Per-point deltas vs frozen baseline / 各点相对基线变化

**EN:** Attempt 2 (run 33986258530, SHA `fd71d273c…`) versus the published 2026-06-22 baseline (run 27653706015). Points are matched on prefill/decode worker count, TP, EP, concurrency, ISL/OSL (8192/1024) and dataset (sa-bench random, range ratio 0.8). Positive throughput deltas and negative latency deltas are improvements. Each cell compares one new run with one published run; run-to-run noise is not separately quantified.

**ZH:** 第 2 次尝试（运行 33986258530，SHA `fd71d273c…`）与 2026-06-22 发布基线（运行 27653706015）的对比；按 prefill/decode worker 数、TP、EP、并发、ISL/OSL 与数据集匹配。吞吐为正、延迟为负表示改进；每格为单次新运行与单次已发布运行的对比，未单独量化运行间噪声。

| conc | topology / 拓扑 | new tput/GPU (tok/s) | Δ vs baseline | new output tput/GPU | Δ | new median TTFT (ms) | Δ | new median TPOT (ms) | Δ | new median E2EL (s) | Δ |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 1P1D P:TP4/EP1 D:TP4/EP1 | 230.8 | +45.5% | 51.5 | +45.5% | 164 | -85.6% | 4.66 | -19.2% | 4.40 | -33.5% |
| 2 | 1P1D P:TP4/EP1 D:TP4/EP1 | 436.2 | +41.5% | 97.9 | +41.5% | 172 | -85.4% | 4.90 | -16.9% | 4.79 | -28.6% |
| 4 | 1P1D P:TP4/EP1 D:TP4/EP1 | 760.1 | +38.4% | 169.1 | +38.4% | 172 | -85.3% | 5.53 | -16.5% | 5.30 | -27.1% |
| 8 | 1P1D P:TP4/EP1 D:TP4/EP1 | 1265.6 | +32.6% | 284.5 | +32.6% | 179 | -85.3% | 6.61 | -13.9% | 6.39 | -24.1% |
| 16 | 1P1D P:TP4/EP1 D:TP4/EP1 | 2031.0 | +26.1% | 450.0 | +26.1% | 210 | -85.1% | 8.23 | -10.8% | 7.90 | -20.3% |
| 32 | 1P1D P:TP4/EP1 D:TP4/EP1 | 3100.4 | +21.5% | 693.3 | +21.5% | 308 | -80.0% | 10.65 | -9.4% | 10.24 | -17.7% |
| 64 | 1P1D P:TP4/EP1 D:TP4/EP1 | 4833.3 | +18.0% | 1072.2 | +18.0% | 397 | -76.1% | 13.73 | -7.6% | 13.10 | -15.3% |
| 128 | 1P1D P:TP4/EP1 D:TP4/EP1 | 7355.0 | +14.4% | 1628.9 | +14.4% | 796 | -57.0% | 17.70 | -7.5% | 17.00 | -13.1% |
| 1024 | 4P1D P:TP4/EP4 D:TP16/EP16 | 9334.8 | +4.3% | 2076.0 | +4.3% | 12479 | +39.8% | 16.24 | -24.4% | 27.60 | -3.8% |
| 2048 | 8P1D P:TP4/EP4 D:TP16/EP16 | 11958.8 | +10.3% | 3989.3 | +10.3% | 7384 | +53.3% | 22.39 | -18.8% | 27.92 | -8.0% |
| 4096 | 8P1D P:TP4/EP4 D:TP16/EP16 | 12358.7 | +8.2% | 4118.1 | +8.2% | 33818 | +3.3% | 22.57 | -20.0% | 54.83 | -7.5% |

**Eval detail / 评测详情:** baseline gsm8k `em_strict 0.9674` was published at conc 64 (1P1D) and conc 4096 (8P1D); the current matrix evaluates 1P1D at conc 128 (`eval-conc: 128`), 4P1D at conc 1024 and 8P1D at conc 4096, so the 1P1D eval concurrency differs from the published eval point and the 4P1D eval has no published counterpart. All new scores are within one stderr (≈0.005) of the baseline. / 基线 gsm8k 在 conc 64（1P1D）与 conc 4096（8P1D）发布；当前 1P1D 评测并发为 128，4P1D 评测无已发布对应点；所有新分数与基线差异均在一个标准误（≈0.005）以内。

**Regressions to note / 需关注的回退:** median TTFT rose on the wide-EP topologies (4P1D conc 1024 +39.8%, 8P1D conc 2048 +53.3%, conc 4096 +3.3%) while throughput and TPOT improved there; the wide-EP prefill runs with `disable-cuda-graph: true` and `chunked-prefill-size: 65536`, and Dynamo moved from 1.2.0 to 1.5.0.dev, so the TTFT shift may come from either SGLang v0.5.19 or the newer router/frontend. Reported as measured; no threshold is applied. / 宽 EP 拓扑 TTFT 中位数上升，同时吞吐与 TPOT 改善；原因可能来自 SGLang v0.5.19 或更新的 Dynamo，按实测报告，不设阈值。

**Power / 功耗:** 8P1D conc 2048 and 4096 rows have `power_valid=0` (`power_artifacts_missing, invalid_benchmark_window`); 1P1D and 4P1D rows are `power_valid=1`. Energy metrics for the two 8P1D points are therefore N/A. / 8P1D 两点功耗指标 N/A。

## Limitations / 限制

- **EN:** A green selected benchmark on the updated image proves this family runs and passes its default evals; it does not prove global repository checks pass (notably the perf-changelog gate described above), and it is not a full sweep. Per-point deltas compare a single new run against a single published run on the same topology/concurrency/dataset; run-to-run noise is not separately quantified. Unmatched, invalid or duplicate points are excluded from any improvement claim and reported as N/A with a reason.
- **ZH:** 更新镜像上的基准通过仅说明该配置可运行并通过默认评测，不代表仓库全局检查通过（尤其是上述 perf-changelog 检查），也不是完整 sweep。各点变化为单次新运行与单次已发布运行在相同拓扑/并发/数据集上的对比，未单独量化运行间噪声。无法匹配、无效或重复的点不计入任何改进结论，并以 N/A 及原因标注。

Klaud Cold session: `klaud-33982683946-daa7a1a5144e3543-ed613715f3bfca2a`. Runs are dispatched from `main` `e2e-tests.yml` with `klaud-run=true`, `fail-fast=true`, `inputs.ref` = the exact measured SHA.
