### PR TITLE
[Klaud Cold] Update dsr1-fp8-mi325x-sglang-mtp SGLang ROCm image to v0.5.19-rocm700-mi30x / 将 dsr1-fp8-mi325x-sglang-mtp 的 SGLang ROCm 镜像更新至 v0.5.19-rocm700-mi30x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1286,7 +1286,7 @@ dsv4-fp4-mi355x-atom-mtp:
       # works only because it's non-MTP (no draft KV layer). MTP stays tp8-only.
 
 dsr1-fp8-mi325x-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.19-rocm700-mi30x
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,9 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - dsr1-fp8-mi325x-sglang-mtp
+  description:
+    - "Update SGLang image from v0.5.12-rocm700-mi30x to v0.5.19-rocm700-mi30x"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2844


### PR DESCRIPTION
## Summary / 摘要

Klaud Cold image refresh for the master family `dsr1-fp8-mi325x-sglang-mtp` (`configs/amd-master.yaml`): update `image` from `lmsysorg/sglang:v0.5.12-rocm700-mi30x` to `lmsysorg/sglang:v0.5.19-rocm700-mi30x`, plus the required `perf-changelog.yaml` entry. Model, precision, topology (TP8/EP1), MTP speculative decoding, 8k/1k workload, benchmark script, and eval selection are unchanged. Only this family is touched; the non-MTP sibling `dsr1-fp8-mi325x-sglang` and all other families stay on their current images.

Klaud Cold 为主配置家族 `dsr1-fp8-mi325x-sglang-mtp`（`configs/amd-master.yaml`）刷新镜像：将 `image` 从 `lmsysorg/sglang:v0.5.12-rocm700-mi30x` 更新为 `lmsysorg/sglang:v0.5.19-rocm700-mi30x`，并追加必需的 `perf-changelog.yaml` 条目。模型、精度、拓扑（TP8/EP1）、MTP 投机解码、8k/1k 负载、基准脚本与评测选择均保持不变。仅改动该家族；非 MTP 兄弟家族 `dsr1-fp8-mi325x-sglang` 及其他家族保持原镜像。

## Candidate evidence / 候选证据

- Candidate id: `aac067bd5766d07d-d7346b01615deec4`; base SHA `e52162e5c4805ccf6933199034dbf2f7ba9f5b55`; branch `klaude/auto-aac067bd5766d07d-d7346b01615deec4`.
- Public observation (`/api/v1/latest-images`): dsr1 / mi325x / sglang / fp8 / mtp / single-node / 8192→1024 on `lmsysorg/sglang:v0.5.12-rocm700-mi30x`, published 2026-05-18. Release feed (`/api/v1/framework-releases`): sglang `v0.5.19`.
- Upstream verification: `lmsysorg/sglang:v0.5.19-rocm700-mi30x` exists on Docker Hub (linux/amd64, pushed 2026-09-04T21:28Z, digest `sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58`). It keeps the same ROCm 7.0 / MI30x (gfx942) base line as the current pin. Old image digest: `sha256:4548e936fd76e707184c449ed4720739220ca53734944e1d330c8c4c1c5215ed`. The image runs as shipped; no engine patches, wheel overlays, or script changes.
- Routing: `runner: mi325x` expands in `configs/runners.yaml` only to the `mi325x-amds_*` fleet; the single telemetry cluster `mi325x` passed `check-capacity` before edits, before branch/PR creation and before dispatch. Generated matrix (`test-config --config-files configs/amd-master.yaml --config-keys dsr1-fp8-mi325x-sglang-mtp`): 5 single-node points (conc 4/8/16/32/64, TP8 EP1, MTP), evals at conc 32 and 64; identical to base except `image`.
- Open-PR recheck before claiming the branch: no open PR modifies this key or `benchmarks/single_node/fixed_seq_len/dsr1_fp8_mi325x{,_mtp}.sh`.

## Published baseline (frozen) / 已发布基线（冻结）

Source: `GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-18&exact=true` filtered to hardware=mi325x, framework=sglang, model=dsr1, precision=fp8, spec_method=mtp, disagg=false, isl=8192, osl=1024, image=`lmsysorg/sglang:v0.5.12-rocm700-mi30x`; `GET /api/v1/workflow-info?date=2026-05-18`; `GET /api/v1/evaluations`. Producer run for every point: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26048239142/attempts/2 (PR #1500; curve snapshot id 1899 is not a producer id). Published date: **2026-05-18**.

| conc | benchmark id | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TTFT (s) | median TPOT (s) | median E2EL (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 4 | 412362 | 224.80 | 25.01 | 0.7110 | 0.01853 | 17.789 |
| 8 | 412360 | 381.95 | 42.94 | 0.4547 | 0.02130 | 21.038 |
| 16 | 412357 | 621.20 | 68.83 | 0.4439 | 0.02655 | 25.354 |
| 32 | 412361 | 842.61 | 94.23 | 0.4705 | 0.03997 | 37.805 |
| 64 | 412356 | 1027.76 | 114.02 | 0.4779 | 0.06736 | 62.961 |

Baseline evals (gsm8k, 2026-05-18, same producer run): conc 32 em_strict 0.9575 / em_flexible 0.9583; conc 64 em_strict 0.9575 / em_flexible 0.9568.

**Baseline comparability caveat / 基线可比性说明:** the retained baseline server log (`GET /api/v1/server-log-search?id=412356&q=EAGLE`, also `q=speculative_num_steps`) shows `speculative_algorithm=None`, `speculative_num_steps=None`, `mem_fraction_static=0.68` and `max_running_requests=None→4096`, i.e. the published "mtp" curve was served without speculative decoding and with the non-MTP launch flags (its metrics also match the non-MTP `dsr1-fp8-mi325x-sglang` curve of the same day within noise). The updated-image run below really ran EAGLE/MTP (accept length ≈2.0 on random benchmark traffic, ≈2.3–2.7 on gsm8k). The per-point deltas are therefore reported as **informational only** and are **not claimed as image improvements**; they mix the engine update with the MTP-on vs MTP-off difference. / 基线保留的服务端日志显示 `speculative_algorithm=None`（未启用投机解码，且为非 MTP 启动参数），而本次新镜像运行确实启用了 EAGLE/MTP。因此下列逐点变化仅供参考，**不作为镜像本身的性能提升声明**。

## Attempts / 尝试记录

| Attempt / 尝试 | Image / SHA | Run URLs | Benchmark / eval result / 基准与评测结果 | Per-point deltas vs baseline / 逐点相对基线变化 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- |
| Baseline (published 2026-05-18) / 基线（发布于 2026-05-18） | `lmsysorg/sglang:v0.5.12-rocm700-mi30x` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26048239142/attempts/2 | 5/5 points published; gsm8k conc32 em_strict 0.9575, conc64 em_strict 0.9575 | reference / 参考 | Published dashboard data, not rerun. Retained log shows speculative decoding was off (see caveat) / 公开面板数据，未重跑；日志显示未启用投机解码 |
| Update 1 / 更新 1 (targeted e2e, `klaud-run=true`, `fail-fast=true`) | `lmsysorg/sglang:v0.5.19-rocm700-mi30x` @ `97045041f5c0dbe62b2d1baef9b56e05b84a5958` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33991903593 | **success**: 5/5 benchmark points with non-empty `results_bmk/agg_bmk.json` (all `power_valid=1`); gsm8k (1319 samples) conc32 em_strict 0.9553 / flexible 0.9553 (baseline 0.9575 / 0.9583, Δ −0.2 pt); conc64 em_strict 0.9507 / flexible 0.9515 (baseline 0.9575 / 0.9568, Δ −0.7 / −0.5 pt, ≈1.2 SE) | See per-point table below (informational) / 见下表（仅供参考） | Image works as shipped. Engine notes: `SGLANG_ENABLE_SPEC_V2` is now a removed no-op (spec always runs the V2 worker); the engine now resets `max_running_requests` to 48 under speculative decoding, so the conc-64 point queues 16 requests server-side and its median TTFT rises to 13.85 s (**regression, reported not fixed**; recipe flags are out of Klaud scope) / 镜像可直接运行；新引擎在投机解码下将 max_running_requests 重置为 48，conc-64 点排队导致 TTFT 中位数升至 13.85 s（**回归，仅报告**） |
| Final full sweep (`full-sweep-enabled`) / 最终全量 sweep | `lmsysorg/sglang:v0.5.19-rocm700-mi30x` @ `1fceee6e753e4cf7959fee2e52bd46fcc276feec` (image + changelog) | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33993631221 (labeled event) and https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33993560455 (synchronize event) | **N/A — not executed**: both `run-sweep.yml` runs concluded `skipped` with every job skipped. `run-sweep.yml` gates `check-changelog`, `reuse-sweep-gate` and `setup` on `!github.event.pull_request.draft`, and this PR must stay a draft per Klaud Cold policy, so no GPU sweep ran on the PR head / **不适用 — 未执行**：两次 run-sweep 运行均为 skipped（所有作业跳过），因为该工作流要求 PR 非草稿，而 Klaud Cold 须保持草稿状态 | N/A (see result) | Blocked by workflow draft gating, not by the image. The `ready_for_review` event is a `run-sweep.yml` trigger, so a maintainer converting this draft to ready will start the labeled full sweep on the PR head; nothing else is needed from the recipe side. The perf-changelog entry was validated locally with `utils/validate_perf_changelog.py --base-ref e52162e5c --head-ref 1fceee6e7` (exit 0) / 受工作流草稿门控阻止，与镜像无关；维护者将 PR 转为 ready 后即会触发已加标签的全量 sweep |

### Update 1 per-point deltas vs frozen baseline (informational) / 更新 1 逐点变化（仅供参考）

Δ = (new − baseline) / baseline. Lower is better for TTFT/TPOT/E2EL. Matched per point on tp8 / ep1 / dp-attn off / isl 8192 / osl 1024 / concurrency.

| conc | new tput/GPU | Δ tput/GPU | new output tput/GPU | Δ output tput/GPU | new median TTFT s | Δ TTFT | new median TPOT s | Δ TPOT | new median E2EL s | Δ E2EL | power_valid |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 4 | 392.20 | +74.5% | 43.62 | +74.4% | 0.7377 | +3.8% | 0.01016 | -45.2% | 10.002 | -43.8% | 1 |
| 8 | 594.03 | +55.5% | 66.77 | +55.5% | 0.4908 | +7.9% | 0.01404 | -34.1% | 13.377 | -36.4% | 1 |
| 16 | 837.15 | +34.8% | 92.75 | +34.7% | 0.4600 | +3.6% | 0.02103 | -20.8% | 19.971 | -21.2% | 1 |
| 32 | 1023.81 | +21.5% | 114.48 | +21.5% | 0.5449 | +15.8% | 0.03431 | -14.1% | 32.076 | -15.2% | 1 |
| 64 | 1228.57 | +19.5% | 136.28 | +19.5% | 13.8537 | +2798.8% | 0.04418 | -34.4% | 53.458 | -15.1% | 1 |

Regressions to note / 需注意的回归: conc-64 median TTFT (0.48 s → 13.85 s, p99 37.9 s) from the engine's new default `max_running_requests=48` under speculative decoding; small TTFT increases at conc 8 and 32; gsm8k conc-64 exact-match −0.7 pt. No rejection threshold is applied.

## Limitations / 限制

- A green targeted benchmark proves the updated image serves this family's points and default evals; it does not prove global PR checks, CODEOWNER review, or other families pass. / 目标基准通过仅证明新镜像可运行该家族的点与默认评测，不代表全局检查、CODEOWNER 审核或其他家族通过。
- Baseline numbers are published dashboard data from 2026-05-18 served without speculative decoding (see caveat); deltas are indicative and no improvement is claimed. / 基线为 2026-05-18 未启用投机解码的公开数据；变化仅供参考，不声明性能提升。
- Raw artifacts remain on the e2e run; nothing was staged, reused, reviewed or merged by Klaud Cold. / 原始产物保留在 e2e 运行上；Klaud Cold 未执行暂存、复用、评审或合并。
