### PR TITLE
perf(agentx): tune Kimi-K3 MI355X C1 DSpark depth

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_mi355x_mtp.sh
@@ -263,7 +263,7 @@ case "$CONC" in
     # No KV offload; the working set fits in HBM.
     1)
         SYNTHETIC_ACCEPT_LEN=3.75
-        SPEC_NUM_TOKENS=6
+        SPEC_NUM_TOKENS=3
         GPU_MEM_UTIL=0.9
         MAX_NUM_BATCHED_TOKENS=16384
         ;;

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,12 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - kimik3-fp4-mi355x-vllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "At concurrency 1 only, reduce the Kimi-K3 MI355X vLLM DSpark draft depth from 6 to 3 speculative tokens."
+    - "Keep synthetic_acceptance_length=3.75 and every non-C1 recipe setting and concurrency point unchanged; the smaller draft removes three positions that the synthetic acceptance curve always rejects and automatically reduces the maximum decode graph size from 14 to 8 rows."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2845


### PR DESCRIPTION
## Description

Follow-up to #2810. At AgentX concurrency 1 only, change the Kimi-K3 MI355X vLLM DSpark operating point from:

- `num_speculative_tokens=6`, `synthetic_acceptance_length=3.75`

to:

- `num_speculative_tokens=3`, `synthetic_acceptance_length=3.00`

The acceptance value is the committed K=3 golden value in `golden_al_distribution/kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml`. With `max_num_seqs=2`, the derived maximum decode graph size decreases from 14 to 8 rows.

Everything else from #2810 is unchanged, including TP8/DCP1/EP1, no KV offload, GPU memory utilization 0.9, maximum 16,384 batched tokens, FP8 KV cache, image, trace settings, and all non-C1 branches.

### Validation status

A previous exploratory 900-second result used K=3 with synthetic AL=3.75. That pairing does not follow the committed golden curve, so its 139.108889 tokens/s/user result is excluded from evidence for this PR.

Fresh validation is pending on the corrected K=3 / AL=3.00 head and will report:

- canonical 3,600-second AgentX P90 interactivity and P90 TPOT
- total and output throughput per GPU
- full 1,319-example GSM8K strict exact-match score
- complete request/error accounting, provenance, runtime health, and teardown

No vLLM or AITER kernel patch is part of this change.

## 中文说明

这是 #2810 的后续优化。仅在 AgentX 并发 1 时，将 Kimi-K3 MI355X vLLM DSpark 从 K=6、合成 AL=3.75 调整为 K=3、合成 AL=3.00。AL=3.00 是仓库 golden curve 中 K=3 对应的标准值。`max_num_seqs=2` 时，最大解码图规模从 14 行降至 8 行。

#2810 的其余配置以及所有非 C1 分支均保持不变。此前 K=3 / AL=3.75 的 900 秒探索结果不符合 golden curve，因此不作为本 PR 的性能证据。当前正在基于修正后的 K=3 / AL=3.00 配置重新执行 3,600 秒 AgentX 和完整 GSM8K 验证。

## Related Issue

Follow-up to #2810.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] I appended a new entry to the physical end of `perf-changelog.yaml` and did not edit historical entries
- [ ] Before merging via reuse, an authorized maintainer has commented `/reuse-sweep-run` after a final green full sweep with evals