### PR TITLE
[Klaud Cold] Add conc 10/12/14 to kimik3-fp4-b300-vllm-agentic-dspark and move it to cluster:b300-dsxe / 为 kimik3-fp4-b300-vllm-agentic-dspark 新增并发 10/12/14 并迁移至 cluster:b300-dsxe

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
@@ -5,7 +5,7 @@ set -x
 # Agentic trace replay for Kimi-K3 (MXFP4) on B300: TP8 x DCP8, TokenspeedMLA,
 # Mooncake as the external KV tier. Concurrency selects the arm:
 #   conc <= 8   DSpark level 7, golden AL 3.84
-#   conc 16     DSpark level 3, golden AL 3.00
+#   conc 10-16  DSpark level 3, golden AL 3.00
 #   conc >  16  no drafting
 # Keep the arms disjoint in concurrency: exp-name carries conc and spec but not
 # the arm, so a shared concurrency would collide.

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1489,7 +1489,7 @@ kimik3-fp4-b300-vllm-agentic-dspark:
   image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: vllm
   multinode: false
@@ -1502,9 +1502,9 @@ kimik3-fp4-b300-vllm-agentic-dspark:
       search-space:
       # TP8-only: a ~1.5 TB MXFP4 checkpoint does not fit below 8 GPUs.
       # One entry for every arm: the recipe drafts at DSpark 7 up to conc 8,
-      # DSpark 3 at conc 16, and not at all above. Keep the concurrencies
+      # DSpark 3 at conc 10-16, and not at all above. Keep the concurrencies
       # disjoint across arms so exp-names stay unique.
-      - { tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 70] }
+      - { tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [1, 2, 4, 8, 10, 12, 14, 16, 24, 32, 40, 48, 56, 70] }
 
 dsr1-fp8-b200-trt:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc14

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,12 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - kimik3-fp4-b300-vllm-agentic-dspark
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add concurrency 10, 12 and 14 to the TP8 x DCP8 Mooncake sweep, so the conc-list becomes [1, 2, 4, 8, 10, 12, 14, 16, 24, 32, 40, 48, 56, 70]. The new points fall in the recipe's existing conc 9-16 band and therefore draft with DSpark level 3 at the committed golden AL 3.00, the same arm as concurrency 16."
+    - "Repoint the runner from cluster:b300-nv, whose launcher and runner labels were retired in #2826, to cluster:b300-dsxe so the sweep can schedule."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2846


### PR DESCRIPTION
## Summary / 摘要

Adds concurrency 10, 12 and 14 to the `kimik3-fp4-b300-vllm-agentic-dspark` TP8 x DCP8 Mooncake sweep and repoints the config to the live B300 cluster.

为 `kimik3-fp4-b300-vllm-agentic-dspark` 的 TP8 x DCP8 Mooncake 扫描新增并发 10、12、14，并将该配置指向当前在线的 B300 集群。

## Changes / 变更

- `configs/nvidia-master.yaml`: conc-list `[1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 70]` -> `[1, 2, 4, 8, 10, 12, 14, 16, 24, 32, 40, 48, 56, 70]` on the `{ tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" } }` entry. Runner `cluster:b300-nv` -> `cluster:b300-dsxe`: the NV launcher and its runner labels were retired in #2826, so the sweep could not schedule on the old label.
- `benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh`: comment-only update of the arm table. No serve-flag or logic change. The new points fall in the existing `CONC <= 16` branch and draft with DSpark level 3 at the committed golden AL 3.00, the same arm as concurrency 16.
- `perf-changelog.yaml`: appended entry for `kimik3-fp4-b300-vllm-agentic-dspark`.

- `configs/nvidia-master.yaml`：在 `{ tp: 8, ep: 1, dcp-size: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" } }` 条目上，conc-list 从 `[1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 70]` 改为 `[1, 2, 4, 8, 10, 12, 14, 16, 24, 32, 40, 48, 56, 70]`。runner 从 `cluster:b300-nv` 改为 `cluster:b300-dsxe`：NV launcher 及其 runner 标签已在 #2826 退役，旧标签上的扫描无法调度。
- `benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh`：仅更新注释中的 arm 表，不改动 serve 参数或逻辑。新增的并发点落在现有 `CONC <= 16` 分支，以 DSpark level 3 和已提交的 golden AL 3.00 起草，与并发 16 同一 arm。
- `perf-changelog.yaml`：追加 `kimik3-fp4-b300-vllm-agentic-dspark` 条目。

## Validation / 验证

- `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD` passes.
- `generate_sweep_configs.py test-config --config-keys kimik3-fp4-b300-vllm-agentic-dspark` yields 14 rows on `cluster:b300-dsxe`, including `conc10`, `conc12` and `conc14`.
- Full sweep requested via the `full-sweep-enabled` label.

- `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD` 通过。
- `generate_sweep_configs.py test-config --config-keys kimik3-fp4-b300-vllm-agentic-dspark` 生成 14 行，全部在 `cluster:b300-dsxe` 上，包含 `conc10`、`conc12`、`conc14`。
- 通过 `full-sweep-enabled` 标签触发完整扫描。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark sweep and scheduling metadata only; no serving, auth, or runtime logic changes beyond comments.
> 
> **Overview**
> Extends the **kimik3-fp4-b300-vllm-agentic-dspark** agentic-coding sweep with mid-band concurrency points and points it at a schedulable B300 cluster.
> 
> The TP8 × DCP8 Mooncake entry in `configs/nvidia-master.yaml` now uses **conc-list** `[1, 2, 4, 8, 10, 12, 14, 16, 24, …, 70]` (adds **10, 12, 14**) and **runner** `cluster:b300-dsxe` instead of retired `cluster:b300-nv`. Comments in the config and `kimik3_fp4_b300_vllm_mtp.sh` describe the DSpark level-3 arm as **conc 10–16**; serve logic is unchanged and still maps `CONC <= 16` to DSpark level 3 / golden AL 3.00.
> 
> `perf-changelog.yaml` records the sweep expansion and runner repoint for this config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b7be407345e71efac7549caad38ab42c0d34e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->