### PR TITLE
Add Kimi K3 B300 1P3D EFA config

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-b300-1p3d-dcp8-dcp8-dspark4-mooncake-c32-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-b300-1p3d-dcp8-dcp8-dspark4-mooncake-c32-agentic.yaml
@@ -1,0 +1,228 @@
+# Kimi-K3 B300 disaggregated, agentic coding.
+#
+# Mirrors the 1P3D/c32 point from PR 2814, adapted for AWS EFA. NIXL carries
+# P-to-D GPU KV traffic through its LIBFABRIC backend. The ordinary CUDA
+# allocator and DMA-BUF are required because cuMem/VMM-backed KV buffers fail
+# EFA reads with EINVAL on this stack.
+#
+# Mooncake is intentionally instantiated only by the prefill worker. Its large
+# host store uses TCP locally and is not registered with EFA; decode workers use
+# NIXL only and therefore contribute no CPU memory to the Mooncake pool.
+
+name: kimi-k3-vllm-disagg-b300-1p3d-dcp8-dcp8-dspark4-mooncake-c32-agentic
+model:
+  path: moonshotai/Kimi-K3
+  container: vllm/vllm-openai:nightly-dev-x86_64-cu13-3696c77
+  precision: fp4
+dynamo:
+  hash: ba83080ecd31c1ce918559e576d3c5bc9e092ff1
+  install: true
+health_check:
+  max_attempts: 720
+  interval_seconds: 10
+resources:
+  gpu_type: b300
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 3
+  prefill_workers: 1
+  decode_workers: 3
+  gpus_per_prefill: 8
+  gpus_per_decode: 8
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: least-loaded
+    router-session-affinity-ttl-secs: 900
+  env:
+    DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS: '3600'
+    DYN_TOKENIZER_CACHE_BYTES: '8589934592'
+    PYTHONPYCACHEPREFIX: /tmp/vllm-pycache-kimi-k3
+backend:
+  type: vllm
+  connector: null
+  dp_launch_mode: per_node
+  kv_events_config:
+    prefill: true
+  mooncake_kv_store:
+    master_extra_args:
+    - --default_kv_lease_ttl=60000
+    - --eviction_high_watermark_ratio=0.95
+    - --eviction_ratio=0.10
+    store_config:
+      metadata_server: P2PHANDSHAKE
+      global_segment_size: 281GB
+      local_buffer_size: 4GB
+      protocol: tcp
+      device_name: ''
+      mode: embedded
+      enable_offload: false
+  prefill_environment:
+    VLLM_USE_DIRECT_DCP_A2A: '1'
+    VLLM_USE_DIRECT_DCP_Q_GATHER: '1'
+    VLLM_USE_DIRECT_DCP_KV_GATHER: '1'
+    VLLM_ALLREDUCE_USE_FLASHINFER: '1'
+    VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: '0'
+    DYN_REQUEST_PLANE: tcp
+    ETCD_LEASE_TTL: '600'
+    VLLM_ENGINE_READY_TIMEOUT_S: '3600'
+    VLLM_RPC_TIMEOUT: '600000'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    VLLM_USE_NCCL_SYMM_MEM: '0'
+    NCCL_CUMEM_ENABLE: '1'
+    NCCL_MNNVL_ENABLE: '0'
+    NCCL_NVLS_ENABLE: '1'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_USE_V2_MODEL_RUNNER: '1'
+    VLLM_USE_RUST_FRONTEND: '1'
+    VLLM_MOONCAKE_LOAD_RECV_THREADS: '4'
+    MC_SLICE_SIZE: '1048576'
+    VLLM_CONNECTOR_PREFETCH_DEPTH: '8'
+    VLLM_CONNECTOR_PREFETCH_KV_CAP: '0.65'
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: '1800'
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: '0'
+    NCCL_P2P_LEVEL: NVL
+    MC_ENABLE_DEST_DEVICE_AFFINITY: '1'
+    WITH_NVIDIA_PEERMEM: '0'
+    NCCL_NET_PLUGIN: none
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_RCACHE_MAX_UNRELEASED: '1024'
+    UCX_TCP_AF_PRIO: inet
+    FI_PROVIDER: efa
+    FI_EFA_USE_DEVICE_RDMA: '1'
+    FI_EFA_ENABLE_SHM_TRANSFER: '0'
+    FI_EFA_ENABLE_SHM: '0'
+    FI_EFA_USE_HUGE_PAGE: '0'
+    FI_HMEM: cuda
+    FI_HMEM_CUDA_ENABLE_XFER: '1'
+    FI_HMEM_CUDA_USE_DMABUF: '1'
+    VLLM_SSM_CONV_STATE_LAYOUT: DS
+    DG_JIT_CACHE_DIR: /tmp/dg-cache-kimi-k3-gb300-pd-dspark-mooncake-{job_id}
+    PYTHONHASHSEED: '42'
+    PYTHONNOUSERSITE: '1'
+    PYTHONUNBUFFERED: '1'
+    PYTHONPATH: /nixl_overlay/lib/python3/dist-packages
+    LD_LIBRARY_PATH: /nixl_overlay/lib/x86_64-linux-gnu:/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/efa_system_libs:/efa_system_libs/libibverbs:/usr/local/cuda/lib64:/usr/local/nvidia/lib64
+    IBV_DRIVERS_PATH: /efa_system_libs/libibverbs
+    NIXL_PLUGIN_DIR: /nixl_overlay/lib/x86_64-linux-gnu/plugins
+    TORCH_CUDA_ARCH_LIST: '10.0'
+    MC_STORE_CLIENT_METRIC: '1'
+    MC_STORE_CLIENT_METRIC_INTERVAL: '5'
+    MC_TE_METRIC: '0'
+  decode_environment:
+    VLLM_USE_DIRECT_DCP_A2A: '1'
+    VLLM_USE_DIRECT_DCP_Q_GATHER: '1'
+    VLLM_USE_DIRECT_DCP_KV_GATHER: '1'
+    VLLM_ALLREDUCE_USE_FLASHINFER: '1'
+    VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: '0'
+    DYN_REQUEST_PLANE: tcp
+    ETCD_LEASE_TTL: '600'
+    VLLM_ENGINE_READY_TIMEOUT_S: '3600'
+    VLLM_RPC_TIMEOUT: '600000'
+    TILELANG_CLEANUP_TEMP_FILES: '1'
+    VLLM_USE_NCCL_SYMM_MEM: '0'
+    NCCL_CUMEM_ENABLE: '1'
+    NCCL_MNNVL_ENABLE: '0'
+    NCCL_NVLS_ENABLE: '1'
+    VLLM_SERVER_DEV_MODE: '1'
+    VLLM_USE_V2_MODEL_RUNNER: '1'
+    VLLM_USE_RUST_FRONTEND: '1'
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: '1800'
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: '0'
+    NCCL_P2P_LEVEL: NVL
+    WITH_NVIDIA_PEERMEM: '0'
+    NCCL_NET_PLUGIN: none
+    UCX_MEMTYPE_CACHE: n
+    UCX_MEMTYPE_REG_WHOLE: n
+    UCX_RCACHE_MAX_UNRELEASED: '1024'
+    UCX_TCP_AF_PRIO: inet
+    FI_PROVIDER: efa
+    FI_EFA_USE_DEVICE_RDMA: '1'
+    FI_EFA_ENABLE_SHM_TRANSFER: '0'
+    FI_EFA_ENABLE_SHM: '0'
+    FI_EFA_USE_HUGE_PAGE: '0'
+    FI_HMEM: cuda
+    FI_HMEM_CUDA_ENABLE_XFER: '1'
+    FI_HMEM_CUDA_USE_DMABUF: '1'
+    VLLM_SSM_CONV_STATE_LAYOUT: DS
+    DG_JIT_CACHE_DIR: /tmp/dg-cache-kimi-k3-gb300-pd-dspark-mooncake-{job_id}
+    PYTHONHASHSEED: '42'
+    PYTHONNOUSERSITE: '1'
+    PYTHONUNBUFFERED: '1'
+    PYTHONPATH: /nixl_overlay/lib/python3/dist-packages
+    LD_LIBRARY_PATH: /nixl_overlay/lib/x86_64-linux-gnu:/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/efa_system_libs:/efa_system_libs/libibverbs:/usr/local/cuda/lib64:/usr/local/nvidia/lib64
+    IBV_DRIVERS_PATH: /efa_system_libs/libibverbs
+    NIXL_PLUGIN_DIR: /nixl_overlay/lib/x86_64-linux-gnu/plugins
+    TORCH_CUDA_ARCH_LIST: '10.0'
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector":"MultiConnector","kv_role":"kv_both","kv_load_failure_policy":"recompute","kv_connector_extra_config":{"connectors":[{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"backends":["LIBFABRIC"],"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}},{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both","kv_load_failure_policy":"recompute","kv_connector_extra_config":{"load_async":true,"lookup_async":true,"compact_group_io":true,"max_load_batch_keys":2,"enable_cross_layers_blocks":false,"enable_offload":false}}]}}'
+      served-model-name: moonshotai/Kimi-K3
+      prefix-match-unit: 128
+      load-format: fastsafetensors
+      kv-cache-dtype: fp8
+      gpu-memory-utilization: 0.94
+      tensor-parallel-size: 8
+      decode-context-parallel-size: 8
+      dcp-comm-backend: a2a
+      enable-cumem-allocator: false
+      trust-remote-code: true
+      max-cudagraph-capture-size: 512
+      stream-interval: 10
+      language-model-only: true
+      attention-backend: TOKENSPEED_MLA
+      attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}'
+      speculative-config: '{"model":"Inferact/Kimi-K3-DSpark","attention_backend":"TOKENSPEED_MLA","method":"dspark","num_speculative_tokens":4,"rejection_sample_method":"block","draft_sample_method":"probabilistic"}'
+      enable-prefix-caching: true
+    decode:
+      kv-transfer-config: '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"backends":["LIBFABRIC"],"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}}'
+      served-model-name: moonshotai/Kimi-K3
+      prefix-match-unit: 128
+      load-format: fastsafetensors
+      kv-cache-dtype: fp8
+      gpu-memory-utilization: 0.94
+      tensor-parallel-size: 8
+      decode-context-parallel-size: 8
+      dcp-comm-backend: a2a
+      enable-cumem-allocator: false
+      trust-remote-code: true
+      max-cudagraph-capture-size: 512
+      stream-interval: 10
+      language-model-only: true
+      attention-backend: TOKENSPEED_MLA
+      attention-config: '{"mla_prefill_backend": "TRTLLM_RAGGED", "use_prefill_query_quantization": true}'
+      speculative-config: '{"model":"Inferact/Kimi-K3-DSpark","attention_backend":"TOKENSPEED_MLA","method":"dspark","num_speculative_tokens":4,"rejection_sample_method":"block","draft_sample_method":"probabilistic"}'
+      enable-prefix-caching: true
+sbatch_directives:
+  cpus-per-task: '72'
+  mem: '0'
+  comment: '''{"OccupiedIdleGPUsJobReaper":{"exemptIdleTimeMins":"60","reason":"model_loading","description":"Very large model will take extra loading time."}}'''
+srun_options:
+  mem: '0'
+  container-remap-root: ''
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+identity:
+  model:
+    repo: moonshotai/Kimi-K3
+  container:
+    image: vllm/vllm-openai:nightly-dev-x86_64-cu13-3696c77
+  frameworks:
+    dynamo: ba83080ecd31c1ce918559e576d3c5bc9e092ff1

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9772,6 +9772,39 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-mooncake-dcp8-agg:
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb300-dcp8-nospec-mooncake-agentic.yaml"
 
+# Kimi-K3 1P3D AgentX point from PR 2814, adapted to the B300 DSXE EFA
+# fabric. Decode workers use NIXL only; Mooncake host storage is prefill-only.
+kimik3-fp4-b300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg-1p3d-efa-prefill-store:
+  image: vllm/vllm-openai:nightly-dev-x86_64-cu13-3696c77
+  model: moonshotai/Kimi-K3
+  model-prefix: kimik3
+  runner: cluster:b300-dsxe
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "ba83080ecd31c1ce918559e576d3c5bc9e092ff1" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.75
+      search-space:
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }
+        conc-list: [32]
+        prefill:
+          num-worker: 1
+          tp: 8
+          dcp-size: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=3.36"
+          - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/disagg-b300-1p3d-dcp8-dcp8-dspark4-mooncake-c32-agentic.yaml"
+        decode: { num-worker: 3, tp: 8, dcp-size: 8, ep: 1, dp-attn: false }
+
 
 # Kimi-K3 MXFP4 B200 aggregated vLLM (TP8 x PP2, 2 nodes / 16 GPUs), agentic
 # coding. The native MXFP4 checkpoint (2.8T total params, ~1.4TB weights) does

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,12 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - kimik3-fp4-b300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg-1p3d-efa-prefill-store
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add the Kimi-K3 B300 1P3D AgentX configuration from PR 2814 with NIXL LIBFABRIC transfers over AWS EFA."
+    - "Disable vLLM cuMem KV allocation, use DMA-BUF for EFA, and keep the Mooncake host-memory pool on prefill only."
+  pr-link: XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6910,4 +6910,4 @@
   description:
     - "Add the Kimi-K3 B300 1P3D AgentX configuration from PR 2814 with NIXL LIBFABRIC transfers over AWS EFA."
     - "Disable vLLM cuMem KV allocation, use DMA-BUF for EFA, and keep the Mooncake host-memory pool on prefill only."
-  pr-link: XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2848

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -205,6 +205,17 @@ NGINX_SQUASH_FILE="$SQUASH_DIR/$(echo "$NGINX_IMAGE" | sed 's/[\/:@#]/_/g').sqsh
 import_squash_image "$IMAGE" "$SQUASH_FILE"
 import_squash_image "$NGINX_IMAGE" "$NGINX_SQUASH_FILE"
 
+# The Kimi-K3 EFA recipe uses NIXL's optional LIBFABRIC backend, which is not
+# present in its pinned vLLM image. Build a version-matched overlay once and
+# share it across runs and compute nodes.
+USES_EFA_NIXL=0
+if [[ -n "${_RECIPE_SRC:-}" ]] && grep -q '"LIBFABRIC"' "$_RECIPE_SRC"; then
+    USES_EFA_NIXL=1
+    EFA_NIXL_CACHE_ROOT="${B300_EFA_NIXL_CACHE_ROOT:-/data/home/sa-gha-runner/efa-nixl-1.3.2-efa-1.47.0}"
+    "$GITHUB_WORKSPACE/runners/setup_b300_efa_nixl.sh" \
+        "$SQUASH_FILE" "$EFA_NIXL_CACHE_ROOT" "$SLURM_ACCOUNT" "$SLURM_PARTITION"
+fi
+
 if [[ "$USES_DCGM_POWER" == "1" ]]; then
     DCGM_EXPORTER_IMAGE="nvcr.io/nvidia/k8s/dcgm-exporter:4.6.0-4.8.3-distroless"
     # enroot resolves bare paths against Docker Hub; nvcr.io pulls need the registry# form
@@ -247,6 +258,14 @@ EOF
     if [[ "$USES_DCGM_POWER" == "1" ]]; then
         printf '  dcgm-exporter: "%s"\n' "$DCGM_EXPORTER_SQSH"
     fi
+    if [[ "$USES_EFA_NIXL" == "1" ]]; then
+        cat <<EOF
+default_mounts:
+  "${EFA_NIXL_CACHE_ROOT}/nixl": /nixl_overlay
+  "${EFA_NIXL_CACHE_ROOT}/efa": /opt/amazon/efa
+  "${EFA_NIXL_CACHE_ROOT}/efa-system-libs": /efa_system_libs
+EOF
+    fi
     echo "use_exclusive_sbatch_directive: true"
 } > srtslurm.yaml
 
@@ -277,10 +296,8 @@ fi
 
 # Override the job name in the recipe with the runner name.
 sed -i "s/^name:.*/name: \"${RUNNER_NAME}\"/" "$CONFIG_PATH"
-if [[ "${EVAL_ONLY:-false}" == "true" ]]; then
-    python3 "$GITHUB_WORKSPACE/runners/inject_synthetic_acceptance.py" \
-        "$CONFIG_PATH" "$FRAMEWORK" || exit 1
-fi
+python3 "$GITHUB_WORKSPACE/runners/inject_synthetic_acceptance.py" \
+    "$CONFIG_PATH" "$FRAMEWORK" || exit 1
 
 # Weights live on node-local MODEL_ROOT, which this login host cannot stat, so
 # srtctl's preflight model.path check is always skipped. Runtime loading still

--- a/runners/setup_b300_efa_nixl.sh
+++ b/runners/setup_b300_efa_nixl.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Build the userspace pieces missing from the Kimi-K3 vLLM image for NIXL over
+# AWS EFA. The result is cached on storage shared by every B300 DSXE node.
+
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 <container.sqsh> <cache-root> <slurm-account> <slurm-partition>" >&2
+    exit 2
+fi
+
+CONTAINER_IMAGE=$1
+CACHE_ROOT=$2
+SLURM_ACCOUNT=$3
+SLURM_PARTITION=$4
+NIXL_VERSION=1.3.2
+EFA_VERSION=1.47.0
+READY_FILE="$CACHE_ROOT/.ready-nixl-${NIXL_VERSION}-efa-${EFA_VERSION}"
+LOCK_FILE="$CACHE_ROOT.lock"
+
+mkdir -p "$(dirname "$CACHE_ROOT")"
+exec 9>"$LOCK_FILE"
+flock -w 7200 9
+
+if [[ -f "$READY_FILE" ]]; then
+    exit 0
+fi
+
+rm -rf "$CACHE_ROOT"
+mkdir -p \
+    "$CACHE_ROOT/nixl" \
+    "$CACHE_ROOT/efa" \
+    "$CACHE_ROOT/efa-system-libs"
+
+srun -N 1 -n 1 \
+    -A "$SLURM_ACCOUNT" \
+    -p "$SLURM_PARTITION" \
+    --time=60 \
+    --container-image="$CONTAINER_IMAGE" \
+    --container-remap-root \
+    --container-mounts="$CACHE_ROOT/nixl:/nixl_out,$CACHE_ROOT/efa:/opt/amazon/efa,$CACHE_ROOT/efa-system-libs:/efa_system_libs" \
+    bash -lc "
+        set -euo pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y --no-install-recommends \
+            ca-certificates curl environment-modules tcl pkg-config \
+            libhwloc-dev libnuma-dev libibverbs-dev librdmacm-dev rdma-core \
+            ibverbs-providers libnl-3-200 libnl-route-3-200 pybind11-dev
+
+        cd /tmp
+        curl -fsSLO https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz
+        tar xzf aws-efa-installer-${EFA_VERSION}.tar.gz
+        cd aws-efa-installer
+        ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify
+
+        cp -L /usr/lib/x86_64-linux-gnu/libefa.so.1 /efa_system_libs/libefa.so.1
+        cp -L /usr/lib/x86_64-linux-gnu/librdmacm.so.1 /efa_system_libs/librdmacm.so.1
+        cp -L /usr/lib/x86_64-linux-gnu/libibverbs.so.1 /efa_system_libs/libibverbs.so.1
+        cp -L /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /efa_system_libs/libmlx5.so.1
+        cp -a /usr/lib/x86_64-linux-gnu/libibverbs /efa_system_libs/
+
+        cd /tmp
+        curl -fsSL https://github.com/ai-dynamo/nixl/archive/refs/tags/v${NIXL_VERSION}.tar.gz \
+            -o nixl-${NIXL_VERSION}.tar.gz
+        tar xzf nixl-${NIXL_VERSION}.tar.gz
+        python3 -m pip install --disable-pip-version-check --target=/tmp/nixl-build-tools meson ninja
+        export PATH=/tmp/nixl-build-tools/bin:\"\$PATH\"
+        export PYTHONPATH=/tmp/nixl-build-tools
+        export LD_LIBRARY_PATH=/opt/amazon/efa/lib:/efa_system_libs:/usr/local/cuda/lib64:/usr/local/lib
+        export IBV_DRIVERS_PATH=/efa_system_libs/libibverbs
+        export PKG_CONFIG_PATH=/opt/amazon/efa/lib/pkgconfig
+        mkdir -p /tmp/nixl-build-bin /tmp/nixl-build
+        printf '#!/bin/sh\\nexit 0\\n' >/tmp/nixl-build-bin/git
+        chmod +x /tmp/nixl-build-bin/git
+        export PATH=/tmp/nixl-build-bin:\"\$PATH\"
+        meson setup /tmp/nixl-build /tmp/nixl-${NIXL_VERSION} \
+            --prefix=/nixl_out \
+            --buildtype=release \
+            -Denable_plugins=LIBFABRIC \
+            -Dlibfabric_path=/opt/amazon/efa \
+            -Dbuild_tests=false \
+            -Dbuild_examples=false \
+            -Dnixl_cuda_arch_list=100
+        meson compile -C /tmp/nixl-build -j 32
+        meson install -C /tmp/nixl-build
+        mkdir -p /nixl_out/lib/x86_64-linux-gnu
+        cp -a /usr/lib/x86_64-linux-gnu/libhwloc.so.15* /nixl_out/lib/x86_64-linux-gnu/
+
+        test -f /nixl_out/lib/x86_64-linux-gnu/plugins/libplugin_LIBFABRIC.so
+        /opt/amazon/efa/bin/fi_info -p efa -t FI_EP_RDM >/dev/null
+    "
+
+touch "$READY_FILE"


### PR DESCRIPTION
[by Codex]

Mirrors the 1P3D/c32 Kimi-K3 AgentX configuration from #2814 for the AWS B300 DSXE runner.

- sends P-to-D GPU KV through NIXL LIBFABRIC over EFA with DMA-BUF and the ordinary CUDA allocator
- builds and caches the pinned NIXL 1.3.2 / AWS EFA 1.47.0 userspace overlay on first use
- instantiates Mooncake only on prefill, so decode CPU memory is not registered in the Mooncake pool
- retains the prefill Mooncake store over local TCP and adds only the 1P3D concurrency-32 sweep point

Validated with the repository matrix/changelog tools and an srt-slurm v1.0.87 dry-run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the B300 DSXE launch path for LIBFABRIC recipes and broadens synthetic-acceptance injection to all B300 runs, not eval-only; risk is confined to benchmark infrastructure rather than production serving.
> 
> **Overview**
> Adds a **Kimi-K3 B300 disaggregated (1 prefill / 3 decode) agentic-coding** benchmark point at concurrency 32, mirroring the AgentX 1P3D setup from PR 2814 for **AWS EFA**: prefill-to-decode GPU KV uses **NIXL over LIBFABRIC**, with **cuMem disabled** and **DMA-BUF** so EFA transfers work; **Mooncake host KV stays on prefill only** (decode is NIXL-only).
> 
> Registers the scenario in `nvidia-master.yaml` (`kimik3-fp4-b300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg-1p3d-efa-prefill-store`) and documents it in `perf-changelog.yaml`.
> 
> Extends the **B300 DSXE launcher** to detect recipes that reference `"LIBFABRIC"`, run a new **`setup_b300_efa_nixl.sh`** once to cache NIXL 1.3.2 + EFA 1.47.0 userspace, and mount that overlay into srt-slurm jobs. Also **always runs** `inject_synthetic_acceptance.py` on B300 launches (previously only when `EVAL_ONLY=true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0e5b7bb03d047d1ebf68649a0703ed855d4773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->