### PR TITLE
perf(sglang): use DSpark6 for B300 DSV4 AgentX / B300 DSV4 AgentX 使用 DSpark6

### DIFF
--- a/benchmarks/single_node/agentic/dsv4_fp4_b300_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv4_fp4_b300_sglang_mtp.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 set -x
 
-# Agentic trace replay for DeepSeek-V4-Pro FP4 on B300 with native EAGLE MTP.
+# Agentic trace replay for DeepSeek-V4-Pro-0813 FP4 on B300 with DSpark K=6.
 # Throughput uses the committed golden synthetic AL; eval retains real target
 # verification.
 #
@@ -122,12 +122,14 @@ if [ "$DP_ATTENTION" = "true" ]; then
         --enable-prefill-delayer
         --prefill-decode-interval 20
         --enable-dp-attention
+        --enable-dp-lm-head
         --enable-dp-attention-local-control-broadcast
         --incremental-streaming-output
         --stream-interval 20
         --dist-init-addr "127.0.0.1:$((PORT + 2000))"
         --ep-size "$EP_SIZE"
         --moe-a2a-backend megamoe
+        --enable-w4a4-mxfp4-megamoe
         --enable-deepseek-v4-fp4-indexer
         --disable-flashinfer-autotune
     )
@@ -149,6 +151,8 @@ if [ "$DP_ATTENTION" = "true" ]; then
             MEM_FRACTION_STATIC=0.88
         elif [ "$CONC" -ge 256 ]; then
             MEM_FRACTION_STATIC=0.9
+        elif [ "$CONC" -eq 128 ] || [ "$CONC" -eq 64 ] || [ "$CONC" -eq 32 ]; then
+            MEM_FRACTION_STATIC=0.90
         fi
     else
         # DEP4 is squeezed from both sides: weights occupy ~90% of each GPU when
@@ -156,8 +160,7 @@ if [ "$DP_ATTENTION" = "true" ]; then
         # below ~0.902 (no KV left), while megamoe still needs its ~7 GB
         # workspace above the static budget. 0.95 leaves only ~11 GB free -- the
         # same margin that OOM'd a rank at DEP8 conc 256 -- so use 0.93, which
-        # gives the ~16 GB that DEP8 conc 128 runs with at the same per-rank load
-        # (max-running-requests/dp = 32 in both cases).
+        # leaves approximately 16 GB for the MegaMoE workspace.
         MEM_FRACTION_STATIC=0.93
     fi
     # --chunked-prefill-size is a GLOBAL budget: server_args.py divides it by
@@ -194,7 +197,7 @@ CUDA_GRAPH_MAX_BS=$((CONC * 4))
 CUDA_GRAPH_ARGS=(--cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS")
 SWA_FULL_TOKENS_RATIO=0.1
 if [ "$DP_ATTENTION" = "true" ]; then
-    # Decode graphs must cover the padded MTP batch across all DP ranks, which
+    # Decode graphs must cover the padded speculative batch across all DP ranks, which
     # exceeds CONC; capping at 64 would fall back to eager decode.
     CUDA_GRAPH_ARGS=(--cuda-graph-max-bs-decode 544)
     SWA_FULL_TOKENS_RATIO=0.075
@@ -219,18 +222,12 @@ export SGLANG_OPT_USE_JIT_INDEXER_METADATA=1
 export SGLANG_OPT_USE_TOPK_V2=1
 export SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2=1
 if [ "$DP_ATTENTION" = "true" ]; then
-    # MegaMoE's FP4/MXF4 activation path is opt-in -- both flags default False,
-    # so --moe-a2a-backend megamoe alone runs a different kernel than the one
-    # measured. DG_USE_FP4_ACTS / DG_USE_MXF4_KIND are forwarded to DeepGEMM
-    # automatically from these two.
-    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1
-    export SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND=1
     # Must cover the per-rank prefill budget (8192) or startup raises; the
     # extra 128 is headroom over the exact-fit boundary.
     export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=8320
 fi
 if [ "${EVAL_ONLY}" != "true" ]; then
-    export SGLANG_SIMULATE_ACC_LEN=2.49
+    export SGLANG_SIMULATE_ACC_LEN=3.77
     export SGLANG_SIMULATE_ACC_METHOD=match-expected
     export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
 fi
@@ -261,10 +258,11 @@ SGLANG_CMD=(
     --reasoning-parser deepseek-v4
     --chat-template "$SCRIPT_DIR/../chat_templates/deepseek_v4_thinking.jinja"
     --watchdog-timeout 1800
-    --speculative-algorithm EAGLE
-    --speculative-num-steps 3
+    --speculative-algorithm DSPARK
+    --speculative-dspark-block-size 6
+    --speculative-num-steps 1
     --speculative-eagle-topk 1
-    --speculative-num-draft-tokens 4
+    --speculative-num-draft-tokens 7
     "${MODEL_ARGS[@]}"
     "${METRICS_ARGS[@]}"
     "${CACHE_ARGS[@]}"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1155,10 +1155,10 @@ dsv4-fp4-b300-sglang:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 4096, conc-end: 4096 }
 
 dsv4-fp4-b300-sglang-agentic-hicache-mtp:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260827-20621aa1
-  model: deepseek-ai/DeepSeek-V4-Pro
+  image: lmsysorg/sglang:nightly-dev-20260901-07c8f729
+  model: deepseek-ai/DeepSeek-V4-Pro-0813
   model-prefix: dsv4
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: sglang
   multinode: false
@@ -1166,10 +1166,10 @@ dsv4-fp4-b300-sglang-agentic-hicache-mtp:
     agentic-coding:
     - dram-utilization: 0.95
       search-space:
-      - { tp: 8, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 4, 8, 16, 32] }
-      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, spec-decoding: mtp, conc-list: [32, 256, 384, 512, 576], router: { name: sglang-router, version: "0.3.2" } }
+      - { tp: 8, kv-offloading: none, spec-decoding: draft_model, conc-list: [1, 4, 8, 16, 32] }
+      - { tp: 8, ep: 8, dp-attn: true, kv-offloading: dram, kv-offload-backend: { name: hicache }, spec-decoding: draft_model, conc-list: [32, 64, 128, 256, 384, 512, 576], router: { name: sglang-router, version: "0.3.2" } }
 
-  # DeepSeek-V4-Pro on B300 with EAGLE/MTP speculative decoding. Recipe is
+  # DeepSeek-V4-Pro-0813 on B300 with DSpark speculative decoding. Recipe is
   # selected inside benchmarks/single_node/dsv4_fp4_b300_sglang_mtp.sh by
   # DP_ATTENTION:
   #   dp-attn: false -> TP-only + flashinfer_mxfp4 + chunked-prefill 8192
@@ -1178,7 +1178,8 @@ dsv4-fp4-b300-sglang-agentic-hicache-mtp:
   #                     + chunked-prefill 65536 + mem-fraction 0.90
   #                     + swa-full-tokens-ratio 0.075
   #                     + prefill-decode-interval 20
-  # Both paths share EAGLE (3,1,4) and max-running-requests 2*CONC.
+  # Both paths share DSpark K=6 (1 step, 7 draft tokens) and
+  # max-running-requests 2*CONC.
 dsv4-fp4-b300-sglang-mtp:
   image: lmsysorg/sglang:nightly-dev-cu13-20260610-f332e526
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,15 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - dsv4-fp4-b300-sglang-agentic-hicache-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Replace the B300 DeepSeek-V4-Pro AgentX native EAGLE/MTP serving path with DSpark block size 6 on the DeepSeek-V4-Pro-0813 checkpoint."
+    - "Use one speculative step, seven draft tokens, and thinking-on golden synthetic acceptance length 3.77 for throughput; eval retains real DSpark verification."
+    - "Run on the AWS B300 DSXE cluster with the nightly-dev-20260901-07c8f729 image and route draft-model jobs through the existing speculative benchmark script."
+    - "Use the current W4A4 MegaMoE and DP LM-head flags for DP attention, and reserve additional MegaMoE workspace at high concurrency."
+    - "Mount a writable Hugging Face and Xet cache for AgentX trace downloads."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2849
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp
@@ -6913,4 +6913,4 @@
     - "Run on the AWS B300 DSXE cluster with the nightly-dev-20260901-07c8f729 image and route draft-model jobs through the existing speculative benchmark script."
     - "Use the current W4A4 MegaMoE and DP LM-head flags for DP attention, and reserve additional MegaMoE workspace at high concurrency."
     - "Mount a writable Hugging Face and Xet cache for AgentX trace downloads."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2849

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2849
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -432,9 +432,15 @@ done
 find . -name '.nfs*' -delete 2>/dev/null || true
 
 else
-    # HF_HUB_CACHE is set to help with dataset download inside the container
-    # for eval jobs.
-    export HF_HUB_CACHE="$HOME/.cache/huggingface"
+    # AgentX trace datasets need a writable persistent cache. Keep the host and
+    # container paths separate so the cache remains valid with
+    # --no-container-mount-home.
+    HF_CACHE_HOST_DIR="${B300_HF_CACHE_HOST_DIR:-$HOME/.cache/huggingface}"
+    HF_CACHE_CONTAINER_DIR="${B300_HF_CACHE_CONTAINER_DIR:-/hf_hub_cache}"
+    mkdir -p "$HF_CACHE_HOST_DIR/hub" "$HF_CACHE_HOST_DIR/xet"
+    export HF_HOME="$HF_CACHE_CONTAINER_DIR"
+    export HF_HUB_CACHE="$HF_CACHE_CONTAINER_DIR/hub"
+    export HF_XET_CACHE="$HF_CACHE_CONTAINER_DIR/xet"
 
     # MODEL stays the HF id for the client; MODEL_PATH is where the server reads
     # weights. Only the root holding MODEL_PATH is mounted -- mounting both roots
@@ -449,7 +455,7 @@ else
     export MODEL_PATH="${MODEL_MOUNT_DIR}/${MODEL_BASENAME}"
 
     SQUASH_FILE="$SQUASH_DIR/$(echo "$IMAGE" | sed 's/[\/:@#]/_/g').sqsh"
-    SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" ]] && printf '_mtp' || printf '')
+    SPEC_SUFFIX=$([[ "$SPEC_DECODING" == "mtp" || "$SPEC_DECODING" == "draft_model" ]] && printf '_mtp' || printf '')
     # Prefer a framework-tagged script (e.g. dsv4_fp4_b300_sglang.sh); fall back to
     # the untagged historical name for scripts that haven't been retagged yet.
     BENCH_BASE="benchmarks/single_node/${SCENARIO_SUBDIR}${EXP_NAME%%_*}_${PRECISION}_b300"
@@ -499,6 +505,7 @@ else
     CONTAINER_MOUNTS=(
         "$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR"
         "$MODEL_MOUNT_DIR:$MODEL_MOUNT_DIR"
+        "$HF_CACHE_HOST_DIR:$HF_CACHE_CONTAINER_DIR"
     )
     CONTAINER_MOUNTS_ARG=$(IFS=,; printf '%s' "${CONTAINER_MOUNTS[*]}")
 

--- a/runners/test_slurm_utils.py
+++ b/runners/test_slurm_utils.py
@@ -432,3 +432,16 @@ def test_eval_only_acceptance_rewrite_allows_non_speculative_recipe(
 
     assert result.returncode == 0, result.stderr
     assert recipe.read_text() == original
+
+
+def test_b300_dsxe_draft_model_uses_speculative_script_and_writable_hf_cache() -> None:
+    launcher = (REPO_ROOT / "runners/launch_b300-dsxe.sh").read_text()
+
+    assert (
+        '[[ "$SPEC_DECODING" == "mtp" || "$SPEC_DECODING" == "draft_model" ]]'
+        in launcher
+    )
+    assert 'export HF_HOME="$HF_CACHE_CONTAINER_DIR"' in launcher
+    assert 'export HF_HUB_CACHE="$HF_CACHE_CONTAINER_DIR/hub"' in launcher
+    assert 'export HF_XET_CACHE="$HF_CACHE_CONTAINER_DIR/xet"' in launcher
+    assert '"$HF_CACHE_HOST_DIR:$HF_CACHE_CONTAINER_DIR"' in launcher

--- a/utils/agentic/aggregation/test_power_lifecycle.py
+++ b/utils/agentic/aggregation/test_power_lifecycle.py
@@ -233,10 +233,21 @@ run_agentic_replay_and_write_outputs {str(result_dir)!r}
     )
     try:
         # The monitor starts before the production signal traps are installed.
-        # Wait for replay so the signal actually exercises those traps.
+        # Wait until fake_replay has replaced its shell with sleep so signaling
+        # cannot race between the readiness write and exec.
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:
-            if event_log.exists() and "replay-ready" in event_log.read_text().splitlines():
+            replay_ready = (
+                event_log.exists()
+                and "replay-ready" in event_log.read_text().splitlines()
+            )
+            replay_running = subprocess.run(
+                ["pgrep", "-g", str(proc.pid), "-x", "sleep"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            ).returncode == 0
+            if replay_ready and replay_running:
                 break
             time.sleep(0.01)
         else:


### PR DESCRIPTION
## Summary

- move the B300 DSV4 SGLang AgentX config to DeepSeek-V4-Pro-0813 with DSpark block size 6
- use the AWS `cluster:b300-dsxe` runner and current W4A4 MegaMoE/DP LM-head flags
- retain the tuned AgentX concurrency and memory tiers, including `mem-fraction-static=0.90` at DEP8 c32/c64/c128
- route draft-model jobs through the speculative script and mount a writable Hugging Face/Xet cache

## Validation

- generated the 12-point AgentX throughput matrix plus eval selection
- 74 launcher and changelog tests passed
- shell syntax and changelog validation passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live benchmark serving flags, GPU memory budgets, and cluster runner mounts where mis-tuning can OOM or skew throughput matrices, but no auth or production user-data paths.
> 
> **Overview**
> **Moves the B300 AgentX DeepSeek-V4 FP4 SGLang recipe from native EAGLE/MTP to DSpark block size 6** on checkpoint `DeepSeek-V4-Pro-0813`, with throughput golden acceptance length **3.77** (was 2.49) while eval still uses real verification.
> 
> The agentic benchmark script now passes **`--speculative-algorithm DSPARK`**, one step, seven draft tokens, plus **`--enable-dp-lm-head`** and **`--enable-w4a4-mxfp4-megamoe`** under DP attention; DeepGEMM MegaMoE FP4 env toggles are dropped in favor of the CLI flag. **Memory tiers** add `mem-fraction-static=0.90` for DEP8 at concurrency 32/64/128 to leave MegaMoE workspace headroom.
> 
> **`nvidia-master`** retargets `dsv4-fp4-b300-sglang-agentic-hicache-mtp` to the **20260901** nightly image, **`cluster:b300-dsxe`**, `spec-decoding: draft_model`, and an expanded DP+hicache concurrency sweep. **`launch_b300-dsxe.sh`** mounts a **writable Hugging Face/Xet cache** and treats **`draft_model`** like **`mtp`** for the `*_sglang_mtp.sh` script suffix; a launcher test locks that in.
> 
> A small **agentic power-lifecycle test** fix waits until replay has **`exec`**’d into `sleep` before sending signals, avoiding a readiness race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b183c404730898e152b907a2afc0c4c84262b3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->