### PR TITLE
[AMD][DSV4] Repin MI355X vLLM entries to the nightly shipping FHMoE

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1202,7 +1202,7 @@ dsv4-fp4-mi355x-sglang-mtp:
 # gpu-mem-util=0.6. TP8 sweeps conc 4-64; DEP8 has a single conc=64
 # probe to validate the ROCm DP+EP path.
 dsv4-fp4-mi355x-vllm:
-  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
+  image: vllm/vllm-openai-rocm:nightly-de69e821b7c834bcf1ec96325ec8c410ac183680
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1225,7 +1225,7 @@ dsv4-fp4-mi355x-vllm:
 # above ~conc32 (-37% @ conc32). Image reuses the base entry's v0.22.0 ROCm
 # build, which already contains the MTP commit.
 dsv4-fp4-mi355x-vllm-mtp:
-  image: vllm/vllm-openai-rocm:nightly-09663abde0f50944a8d5ea30120666024b503faa
+  image: vllm/vllm-openai-rocm:nightly-de69e821b7c834bcf1ec96325ec8c410ac183680
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: mi355x
@@ -1316,7 +1316,7 @@ qwen3.5-fp8-mi325x-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
 dsv4-fp4-mi355x-vllm-agentic-mtp:
-  image: vllm/vllm-openai-rocm:nightly-311b3513af33bc29b4acb2fde2e9313e5e9966a0
+  image: vllm/vllm-openai-rocm:nightly-de69e821b7c834bcf1ec96325ec8c410ac183680
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6902,3 +6902,16 @@
     - "Lower mem-fraction-static from 0.89 to 0.86 on every arm: TP4, TP8 and TP8 with DP attention. swa-full-tokens-ratio becomes per-arm: 0.10 on the tensor-parallel arms as before, 0.15 under DP attention."
     - "Drop concurrency 2 and 10 from the TP4 arm, leaving [1, 4, 8], and drop concurrency 16 from the TP8 hicache arm, leaving [32, 48]. Concurrency 16 remains on the TP8 no-offload arm."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2800
+
+- config-keys:
+    - dsv4-fp4-mi355x-vllm
+    - dsv4-fp4-mi355x-vllm-mtp
+    - dsv4-fp4-mi355x-vllm-agentic-mtp
+  scenario-type:
+    - fixed-seq-len
+    - agentic-coding
+  description:
+    - "Repin all three DSv4 MI355X vLLM entries to the first ROCm nightly that ships vllm-project/vllm#53161 (vllm-project/vllm@de69e821), which fuses the DeepSeek-V4 native-FP8 shared expert into the MXFP4 routed-expert AITER kernel (FHMoE)."
+    - "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 was already exported by the AgentX script and is added to the 8K/1K STP and MTP scripts by #2792, but on every nightly before de69e821 the request was inert: vLLM's eligibility check rejected this mixed FP4+FP8 checkpoint and the fusion self-disabled at startup. #53161 is what makes the flag take effect."
+    - "Fusion eligibility is gated on gfx950, tensor parallelism 8, data parallelism 1, no expert parallelism and no EPLB, --moe-backend aiter, BF16 model dtype, and the DeepSeek-V4 block-128 FP8 shared-expert quantization config. All three entries satisfy it; the AgentX DP-attention arm does not and keeps the unfused path."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/PENDING


### PR DESCRIPTION
## What

Repins the three DSv4 MI355X vLLM entries — `dsv4-fp4-mi355x-vllm` (8K/1K STP), `dsv4-fp4-mi355x-vllm-mtp` (8K/1K MTP), and `dsv4-fp4-mi355x-vllm-agentic-mtp` (AgentX) — to the first ROCm nightly that ships [vllm-project/vllm#53161](https://github.com/vllm-project/vllm/pull/53161) (merged as `de69e821`), which fuses the DeepSeek-V4 native-FP8 shared expert into the MXFP4 routed-expert AITER kernel (FHMoE).

## Why this is not a duplicate

- **[#2792](https://github.com/SemiAnalysisAI/InferenceX/pull/2792)** adds `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` to the two 8K/1K scripts and pins the Sep-1 `nightly-7c5dc571`. This PR deliberately does **not** touch those scripts — the export belongs there. It is materially different: it moves the image to a build where that export actually does something.
- **[#2841](https://github.com/SemiAnalysisAI/InferenceX/pull/2841)** bumps only the AgentX image, to `nightly-e962733e`, which also predates `de69e821`.

The env var alone was never sufficient. On every nightly before `de69e821`, vLLM's eligibility check rejected this mixed FP4+FP8 checkpoint and the fusion self-disabled at startup, which is exactly what #2792's changelog and the `vllm-project/recipes` DSv4-Pro caveat currently describe. #53161 is the piece that makes the flag take effect.

## Eligibility

vLLM gates the fused path on gfx950, TP8, DP1, no expert parallelism, no EPLB, `--moe-backend aiter`, BF16 dtype, and the DeepSeek-V4 block-128 FP8 shared-expert quant config. All three entries satisfy this. The AgentX DP-attention arm (TP1/DP8) does not and keeps the unfused path — no change in behaviour there.

## Blocking on

**The image tag is intentionally a `nightly-TBD` placeholder.** `de69e821` was the tip of vLLM `main` when this was written; the newest published nightly is `nightly-1970f3ed` (2026-09-06 05:31 UTC), which predates it. Before this leaves draft:

- [ ] Confirm the next nightly contains `de69e821` and replace `nightly-TBD` with the published sha (3 places in `configs/amd-master.yaml`, 1 note in `perf-changelog.yaml`)
- [ ] Land #2792 first (or absorb its two export lines here if it stalls)
- [ ] Run the 8K/1K STP + MTP sweeps and the AgentX sweep on the new image
- [ ] Confirm from the server log that the fused path is actually selected, not silently self-disabled
- [ ] Fill in `pr-link: .../PENDING` in `perf-changelog.yaml`

## Testing

No benchmark has been run on this image because it does not exist yet. Local validation only:

```
python3 utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD
# Validated perf-changelog.yaml: final newline present and matrix generated
```

Supporting local measurements on a source build of the FHMoE branch (TP8 AgentX, MI355X, pure TP, synthetic AL 2.49) are promising but are **not** a validation of this image: c1 1,417, c4 2,628, c8 4,699, c32 14,178 tok/s/GPU, versus the reference run [32082871496](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32082871496) at 1,143 / 2,251 / 4,112 / 12,939. That delta also carries three weeks of unrelated vLLM changes and should not be read as the FHMoE effect on its own.

> AI assistance was used to prepare this PR. Numbers, eligibility conditions, and duplicate checks were verified against the linked runs and source before submission.

