### PR TITLE
fix(evals): preserve single-node DP attention metadata / 修复单节点评测的 DP attention 元数据

### DIFF
--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -29,6 +29,7 @@ on:
       - "utils/test_collect_eval_results.py"
       - "utils/evals/validate_scores.py"
       - "utils/evals/test_batched_eval.py"
+      - "utils/evals/test_run_eval_dispatch.py"
       - "utils/prepare_perf_changelog_merge.py"
       - "utils/recover_failed_ingest.py"
       - "utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py"
@@ -83,4 +84,5 @@ jobs:
             utils/test_process_changelog.py \
             utils/test_collect_eval_results.py \
             utils/evals/test_batched_eval.py \
+            utils/evals/test_run_eval_dispatch.py \
             -v

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -2267,7 +2267,12 @@ _write_lm_eval_meta_json() {
     local batch_metadata="${2:-}"
     local metadata_conc="${3:-${CONC:-1}}"
 
-    bridge_disagg_eval_metadata
+    # Single-node jobs already export TP/EP/DP_ATTENTION. The disaggregated
+    # bridge defaults missing per-phase DP flags to false, so applying it to
+    # single-node jobs would overwrite their actual DP-attention setting.
+    if [ "${IS_MULTINODE:-false}" = "true" ]; then
+        bridge_disagg_eval_metadata
+    fi
 
     local model_name="${MODEL_NAME:-$MODEL}"
     local is_multinode_json="false"

--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -102,6 +102,16 @@ InferenceX-app treats routing fields as columns or config dimensions and stores 
 
 Each eval upload is named `eval_<EXP_NAME>_<RESULT_FILENAME>`. Its current allowed payload includes `meta_env.json`, `results*.json`, sample JSONL, predictions, SWE-bench reports, and trajectory files. The collector uses only the metadata and lm-eval result JSON for aggregate rows.
 
+The shared eval metadata writer preserves single-node `DP_ATTENTION` and uses it
+as the default for both `prefill_dp_attention` and `decode_dp_attention`. Only
+`IS_MULTINODE=true` jobs bridge the separate prefill/decode environment variables;
+those jobs may have different DP-attention settings on each side. The collector
+does not reconstruct topology from artifact names or server logs. Older artifacts
+affected by the unconditional bridge can report `false` for a single-node
+DP-attention eval. Fixing the writer does not repair those artifacts or existing
+database rows: verify the original job configuration and server logs before
+correcting metadata, regenerating aggregates, and re-ingesting affected results.
+
 [`utils/collect_eval_results.py`](../utils/collect_eval_results.py) applies these rules:
 
 1. An eval set is a root or immediate child directory containing `meta_env.json`.

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -102,6 +102,15 @@ InferenceX-app 将路由字段作为列或配置维度，并把数值测量存�
 
 每个评测上传名为 `eval_<EXP_NAME>_<RESULT_FILENAME>`。当前允许的载荷包括 `meta_env.json`、`results*.json`、样本 JSONL、预测、SWE-bench 报告和轨迹文件。收集器只使用元数据和 lm-eval 结果 JSON 来生成聚合记录。
 
+共享评测元数据写入器保留单节点的 `DP_ATTENTION`，并将其作为
+`prefill_dp_attention` 和 `decode_dp_attention` 的默认值。只有
+`IS_MULTINODE=true` 的任务才会转换独立的 prefill/decode 环境变量；
+这类任务两侧的 DP attention 设置可以不同。收集器不会根据工件名称或
+服务端日志重建拓扑。受旧版无条件转换逻辑影响的历史工件，可能将实际启用
+DP attention 的单节点评测记录为 `false`。修复写入器不会修复这些工件或
+已有数据库记录：应先核实原始任务配置和服务端日志，再更正元数据、重新生成
+聚合结果并重新摄取受影响的数据。
+
 [`utils/collect_eval_results.py`](../utils/collect_eval_results.py) 执行以下规则：
 
 1. 评测集是包含 `meta_env.json` 的根目录或一级子目录。

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -1489,11 +1489,44 @@ append_lm_eval_summary >/dev/null
         "CONC": "7",
         "KV_OFFLOADING": "none",
     }
-    for key in ("EVAL_COMPLETED_SUITE", "EVAL_SUITE", "EVAL_TASKS_DIR"):
+    for key in (
+        "EVAL_COMPLETED_SUITE", "EVAL_SUITE", "EVAL_TASKS_DIR",
+        "IS_MULTINODE", "DP_ATTENTION",
+        "PREFILL_DP_ATTN", "PREFILL_DP_ATTENTION", "PREFILL_ENABLE_DP",
+        "DECODE_DP_ATTN", "DECODE_DP_ATTENTION", "DECODE_ENABLE_DP",
+    ):
         env.pop(key, None)
     env.update(overrides)
     subprocess.run(["bash", "-c", script], env=env, check=True)
     return json.loads((work_dir / "meta_env.json").read_text())
+
+
+@pytest.mark.parametrize("dp_attention, expected", [("true", True), ("false", False)])
+def test_summary_preserves_single_node_dp_attention(
+    tmp_path: Path, dp_attention: str, expected: bool,
+) -> None:
+    meta = _summary_metadata(
+        tmp_path, IS_MULTINODE="false", TP="8", EP_SIZE="8",
+        DP_ATTENTION=dp_attention,
+    )
+    assert meta["dp_attention"] is expected
+    assert meta["prefill_dp_attention"] is expected
+    assert meta["decode_dp_attention"] is expected
+    assert meta["tp"] == 8
+    assert meta["ep"] == 8
+
+
+def test_summary_preserves_asymmetric_multinode_dp_attention(tmp_path: Path) -> None:
+    meta = _summary_metadata(
+        tmp_path, IS_MULTINODE="true", DP_ATTENTION="false",
+        PREFILL_TP="4", PREFILL_EP="4", DECODE_TP="8", DECODE_EP="8",
+        PREFILL_DP_ATTN="true", DECODE_DP_ATTN="false",
+    )
+    assert meta["dp_attention"] is True
+    assert meta["prefill_dp_attention"] is True
+    assert meta["decode_dp_attention"] is False
+    assert meta["prefill_tp"] == 4
+    assert meta["decode_tp"] == 8
 
 
 def test_summary_stages_bfcl_upstream_archive_before_cleanup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem / 问题

Single-node evals with `DP_ATTENTION=true` were recorded as `false` in `meta_env.json` and the collected eval rows. `_write_lm_eval_meta_json` unconditionally called the disaggregated-topology bridge, whose missing prefill/decode DP variables default to false and overwrite the single-node setting. In #2821, the eval server and matching AgentX throughput artifact report DP attention enabled, while `eval_results_all` reports it disabled. The app uses these metadata fields to identify the evaluated configuration.

启用 `DP_ATTENTION=true` 的单节点评测，在 `meta_env.json` 和聚合评测记录中被错误标记为 `false`。`_write_lm_eval_meta_json` 无条件调用分离式拓扑转换函数；缺失的 prefill/decode DP 变量默认为 false，覆盖了单节点设置。在 #2821 中，评测服务端和对应的 AgentX 吞吐工件都表明 DP attention 已启用，但 `eval_results_all` 却标记为禁用。应用会使用这些元数据字段确定评测对应的配置。

## Change / 修改

Only bridge prefill/decode topology when `IS_MULTINODE=true`. Single-node eval metadata preserves `DP_ATTENTION`, including the existing defaults for the prefill/decode fields. Add regression coverage through the real summary writer for enabled/disabled single-node DP attention and asymmetric multinode DP attention, and run the dispatch tests in CI. Update the English and Chinese ingestion guide.

仅在 `IS_MULTINODE=true` 时转换 prefill/decode 拓扑。单节点评测元数据保留 `DP_ATTENTION`，包括 prefill/decode 字段原有的默认取值。通过真实的摘要写入函数，覆盖单节点 DP attention 启用/禁用及多节点两侧设置不同的回归场景，并将评测调度测试加入 CI。同步更新中英文摄取指南。

## Validation / 验证

- The enabled-DP regression fails against the original writer (`False is True`) and passes with the fix.
- All 340 tests in the updated Test Changelog Gate workflow command pass locally, including eval dispatch, batching, collection, reuse, and changelog validation.
- Bash syntax, workflow YAML parsing, and `git diff --check` pass.
- This changes metadata serialization after evaluation; no recipe, serving command, or performance setting changes. No GPU sweep was run.

- 启用 DP 的回归测试在原始写入器上失败（`False is True`），修复后通过。
- 更新后的 Test Changelog Gate 工作流命令中的全部 340 项测试在本地通过，涵盖评测调度、批量评测、收集、复用和 changelog 校验。
- Bash 语法、工作流 YAML 解析和 `git diff --check` 均通过。
- 本次仅修复评测后的元数据序列化，不修改 recipe、服务启动命令或性能参数；未运行 GPU sweep。

## Historical results / 历史结果

The faulty bridge was introduced in #2309 and predates #2821. This fix affects future metadata generation; it does not repair previously uploaded artifacts or persisted database rows. A separate repair must verify original job/server evidence, correct affected metadata, regenerate aggregates, and re-ingest the results. Do not treat #2821's existing eval configuration metadata as repaired by this PR.

错误的转换逻辑由 #2309 引入，早于 #2821。本修复作用于后续元数据生成，不会修复已经上传的工件或已有数据库记录。历史数据需要单独核实原始任务与服务端证据，更正受影响的元数据、重新生成聚合结果并重新摄取。本 PR 不代表 #2821 现有评测配置元数据已经修复。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata serialization only after eval runs; no serving, recipe, or runtime behavior changes. Wrong topology labels in old uploads remain until a separate re-ingest.
> 
> **Overview**
> Fixes incorrect **`dp_attention`** (and matching prefill/decode fields) on single-node evals when **`DP_ATTENTION=true`**. **`_write_lm_eval_meta_json`** in **`benchmark_lib.sh`** no longer always runs **`bridge_disagg_eval_metadata`**; that bridge runs only when **`IS_MULTINODE=true`**, so missing per-phase DP env vars no longer default to **false** and overwrite the single-node setting in **`meta_env.json`** and downstream **`eval_results_all`** rows.
> 
> Adds regression tests via the real summary writer (single-node on/off, asymmetric multinode) in **`test_run_eval_dispatch.py`**, wires that module into the **Test Changelog Gate** workflow, and documents the writer behavior plus that **historical artifacts and DB rows are not backfilled** in the English and Chinese ingestion guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ba9869c6ecaa4d1c47318f69c847d601330642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->