### PR TITLE
update vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf to 728d3ad

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1485,8 +1485,8 @@ kimik3-fp4-b300-vllm-agentic-dspark:
   # and EVAL_ONLY switches to real block verification.
   #
   # The image carries the Kimi-K3 DCP, DSpark-under-DCP and Mooncake-hybrid
-  # changes (vllm-project/vllm agentx-k3 @ 5894fdf).
-  image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf
+  # changes (vllm-project/vllm agentx-k3 @ 728d3ad).
+  image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-728d3ad
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
   runner: cluster:b300-nv


### PR DESCRIPTION
The docker `docker.io/vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf` was deleted, need to update. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only image tag swap for one benchmark recipe; no application logic changes.
> 
> **Overview**
> Replaces the deleted **`vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf`** image with **`...-728d3ad`** for the **`kimik3-fp4-b300-vllm-agentic-dspark`** recipe in `configs/nvidia-master.yaml`.
> 
> The inline comment is updated to point at **vllm-project/vllm agentx-k3 @ 728d3ad** so the documented commit matches the new nightly tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4463c22eeba800bd21d68b3b073e6d713d858eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->