### PR TITLE
[waiting for NVIDIA to sweep & pass CI on this PR] perf(qwen3.5): update B300 FP8 SGLang tuning

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b300.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b300.sh
@@ -45,7 +45,6 @@ set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL_PATH --served-model-name $MODEL --host 0.0.0.0 --port $PORT \
 --trust-remote-code \
 --tensor-parallel-size $TP --data-parallel-size 1 --expert-parallel-size $EP_SIZE \
---enable-symm-mem \
 --disable-radix-cache \
 --quantization fp8 \
 --kv-cache-dtype fp8_e4m3 \
@@ -53,10 +52,11 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path $MODEL_PATH --se
 --attention-backend trtllm_mha \
 --mm-attention-backend triton_attn \
 --moe-runner-backend flashinfer_trtllm \
---cuda-graph-max-bs $CONC \
+--flashinfer-allreduce-fusion-backend auto \
+--cuda-graph-max-bs-decode $CONC \
 --max-running-requests $CONC \
---max-prefill-tokens 16384 \
---chunked-prefill-size 16384 \
+--max-prefill-tokens 8192 \
+--chunked-prefill-size 8192 \
 --mem-fraction-static 0.8 \
 --stream-interval 50 \
 --scheduler-recv-interval 10 \

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1297,10 +1297,10 @@ qwen3.5-fp8-b300-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 qwen3.5-fp8-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: b300
+  runner: cluster:b300-dsxe
   precision: fp8
   framework: sglang
   multinode: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6910,3 +6910,11 @@
   description:
     - "Repin the image from vllm/vllm-openai-rocm:nightly-311b3513af33bc29b4acb2fde2e9313e5e9966a0 to the 2026-09-05 ROCm nightly (nightly-e962733e08d10f7ca65dac4df99e116460b8b174, digest sha256:511755968434e26da590c3398f1e8a6399be4416226d5779ce92fb0655811a9c). Docker Hub last pushed it at 2026-09-05T05:27:09Z and the tag commit is vllm-project/vllm@e962733e."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2841
+
+- config-keys:
+    - qwen3.5-fp8-b300-sglang
+  description:
+    - "Update the SGLang image from lmsysorg/sglang:v0.5.12-cu130 to lmsysorg/sglang:v0.5.19-cu130 and route the benchmark to cluster:b300-dsxe."
+    - "Reduce max-prefill-tokens and chunked-prefill-size from 16384 to 8192 to activate the FlashInfer GDN prefill path on Blackwell."
+    - "Use FlashInfer all-reduce fusion instead of symmetric memory and migrate cuda-graph-max-bs to the canonical cuda-graph-max-bs-decode flag."
+  pr-link: TBD


### PR DESCRIPTION
Update the non-MTP 8k/1k recipe to SGLang v0.5.19, activate the 8K FlashInfer GDN prefill path, and route it to the replacement B300 DSXE cluster. Use FlashInfer all-reduce fusion instead of symmetric memory and migrate the CUDA graph batch-size flag to its canonical name.

将非 MTP 8k/1k 配方更新至 SGLang v0.5.19，启用 8K FlashInfer GDN 预填充路径，并将其路由到新的 B300 DSXE 集群。使用 FlashInfer 全归约融合替代对称内存，并将 CUDA Graph 批大小参数迁移到规范名称。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only tuning (SGLang flags, image pin, and runner label); no application auth, data, or serving API logic changes.
> 
> **Overview**
> Updates the **qwen3.5-fp8-b300-sglang** fixed-seq-len recipe for the 8k ISL / 1k OSL benchmark.
> 
> **Infra & image:** Pins SGLang to `lmsysorg/sglang:v0.5.19-cu130` (from v0.5.12) and moves the job from runner `b300` to **`cluster:b300-dsxe`**.
> 
> **Launch flags in `qwen3.5_fp8_b300.sh`:** Drops `--enable-symm-mem` and adds **`--flashinfer-allreduce-fusion-backend auto`**. Replaces deprecated **`--cuda-graph-max-bs`** with **`--cuda-graph-max-bs-decode`**. Lowers **`--max-prefill-tokens`** and **`--chunked-prefill-size`** from 16384 to **8192** so the FlashInfer GDN prefill path is used on Blackwell.
> 
> **Changelog:** Documents the image, cluster, prefill, and all-reduce/CUDA-graph flag changes in `perf-changelog.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3417585c07f98e8f6ef2714cc0626f610d71cb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->