### PR TITLE
WIP DNM - Qwen b200 sgl fp8 v2 

### DIFF
--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
@@ -41,7 +41,6 @@ PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.
 --kv-cache-dtype fp8_e4m3 \
 --mamba-ssm-dtype bfloat16 \
 --attention-backend trtllm_mha \
---moe-runner-backend flashinfer_trtllm \
 --flashinfer-allreduce-fusion-backend auto \
 --cuda-graph-max-bs-decode $CONC \
 --max-prefill-tokens 8192 \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
@@ -35,6 +35,7 @@ set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 --expert-parallel-size=$EP_SIZE \
+--enable-symm-mem \
 --disable-radix-cache \
 --quantization fp8 \
 --kv-cache-dtype fp8_e4m3 \

--- a/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
+++ b/benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_b200.sh
@@ -35,16 +35,16 @@ set -x
 PYTHONNOUSERSITE=1 python3 -m sglang.launch_server --model-path=$MODEL --host=0.0.0.0 --port=$PORT \
 --trust-remote-code \
 --tensor-parallel-size=$TP --data-parallel-size=1 --expert-parallel-size=$EP_SIZE \
---enable-symm-mem \
 --disable-radix-cache \
 --quantization fp8 \
 --kv-cache-dtype fp8_e4m3 \
 --mamba-ssm-dtype bfloat16 \
 --attention-backend trtllm_mha \
 --moe-runner-backend flashinfer_trtllm \
---cuda-graph-max-bs $CONC \
---max-prefill-tokens 16384 \
---chunked-prefill-size 16384 \
+--flashinfer-allreduce-fusion-backend auto \
+--cuda-graph-max-bs-decode $CONC \
+--max-prefill-tokens 8192 \
+--chunked-prefill-size 8192 \
 --mem-fraction-static 0.8 \
 --stream-interval 50 \
 --scheduler-recv-interval $( [[ $CONC -gt 4 ]] && echo 30 || echo 10 ) \

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1200,7 +1200,7 @@ dsv4-fp4-b300-sglang-mtp:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 32, spec-decoding: mtp }
 
 qwen3.5-fp8-b200-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6917,4 +6917,4 @@
     - "Update the SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130."
     - "Reduce max-prefill-tokens and chunked-prefill-size from 16384 to 8192 to activate the validated FlashInfer GDN prefill path on B200."
     - "Enable symmetric memory alongside FlashInfer all-reduce fusion to measure the combined path and migrate cuda-graph-max-bs to the canonical cuda-graph-max-bs-decode flag."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2858

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6910,3 +6910,11 @@
   description:
     - "Repin the image from vllm/vllm-openai-rocm:nightly-311b3513af33bc29b4acb2fde2e9313e5e9966a0 to the 2026-09-05 ROCm nightly (nightly-e962733e08d10f7ca65dac4df99e116460b8b174, digest sha256:511755968434e26da590c3398f1e8a6399be4416226d5779ce92fb0655811a9c). Docker Hub last pushed it at 2026-09-05T05:27:09Z and the tag commit is vllm-project/vllm@e962733e."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2841
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang
+  description:
+    - "Update the SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130."
+    - "Reduce max-prefill-tokens and chunked-prefill-size from 16384 to 8192 to activate the validated FlashInfer GDN prefill path on B200."
+    - "Use FlashInfer all-reduce fusion instead of symmetric memory and migrate cuda-graph-max-bs to the canonical cuda-graph-max-bs-decode flag."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6916,5 +6916,5 @@
   description:
     - "Update the SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130."
     - "Reduce max-prefill-tokens and chunked-prefill-size from 16384 to 8192 to activate the validated FlashInfer GDN prefill path on B200."
-    - "Use FlashInfer all-reduce fusion instead of symmetric memory and migrate cuda-graph-max-bs to the canonical cuda-graph-max-bs-decode flag."
+    - "Enable symmetric memory alongside FlashInfer all-reduce fusion to measure the combined path and migrate cuda-graph-max-bs to the canonical cuda-graph-max-bs-decode flag."
   pr-link: TBD


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Benchmark and container pin updates only; no application auth, data, or production serving logic changes.
> 
> **Overview**
> Updates the **qwen3.5-fp8-b200-sglang** benchmark to **SGLang v0.5.19** (`lmsysorg/sglang:v0.5.19-cu130`) and aligns the B200 launch script with the validated FlashInfer GDN prefill setup.
> 
> The server flags drop **`--moe-runner-backend flashinfer_trtllm`**, add **`--flashinfer-allreduce-fusion-backend auto`** (with existing symmetric memory), and move decode CUDA graphs from **`--cuda-graph-max-bs`** to **`--cuda-graph-max-bs-decode`**. **max-prefill-tokens** and **chunked-prefill-size** are halved from **16384 → 8192** to hit the intended prefill path. **perf-changelog.yaml** records the config change for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e26b6a7a815f1db165d39dc675a1bf70ea244c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->