### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-b200-sglang-agentic-mtp SGLang image to nightly-dev-cu13-20260907-30705c00

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1216,7 +1216,7 @@ qwen3.5-fp8-b200-sglang:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp8-b200-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,11 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release, cu130) to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00). Docker Hub last pushed the tag at 2026-09-07T01:43:42Z. Engine flags, NEXTN MTP settings, golden acceptance length 3.39, and the TP4/TP8 concurrency and HiCache grids are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2861


### PR DESCRIPTION
## Summary
Update SGLang image for the Qwen3.5-397B-A17B FP8 B200 AgentX MTP recipe from `lmsysorg/sglang:v0.5.16-cu130` (v0.5.16 release) to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` (2026-09-07 cu13 dev nightly).

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`
- Tag commit: sgl-project/sglang@30705c00 ("[Deepseek V4] Keep fp32 routing weights in the mxfp4 trtllm MoE")
- Follows the repo's `nightly-dev-cu13-<date>-<hash>` convention used by the other B200/B300 SGLang recipes, matching the current cu130 pin.
- Recipe script, NEXTN MTP settings, golden AL 3.39, and the TP4/TP8 concurrency and HiCache grids are unchanged; image-only bump.

Recipes touched: `qwen3.5-fp8-b200-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:b200-nscale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark recipe pin and changelog only; no runtime code, auth, or serving logic changes.
> 
> **Overview**
> **Image-only** update for the `qwen3.5-fp8-b200-sglang-agentic-mtp` recipe on `cluster:b200-nscale`: the SGLang container moves from **`lmsysorg/sglang:v0.5.16-cu130`** to **`lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00`**, matching the repo’s `nightly-dev-cu13-<date>-<hash>` pattern used by other B200 SGLang configs.
> 
> `perf-changelog.yaml` adds an **agentic-coding** entry for this config key (digest, tag commit, and note that engine flags, NEXTN MTP, golden acceptance length, and TP/HiCache search grids are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0125efa9cc3ccfedc386ba94a5cbb71f2e004b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->