### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-b200-sglang-agentic-mtp SGLang image to nightly-dev-cu13-20260907-30705c00

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7548,7 +7548,7 @@ minimaxm3-fp8-h200-vllm-agentic-mtp:
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [12, 14] }
 
 qwen3.5-fp4-b200-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,11 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp4-b200-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release, cu130) to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00). Docker Hub last pushed the tag at 2026-09-07T01:43:42Z. Engine flags (modelopt_fp4, trtllm_mha, flashinfer_trtllm), NEXTN MTP settings, golden acceptance length 3.39, and the TP2/TP4 concurrency and HiCache grids are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2862


### PR DESCRIPTION
## Summary
Update SGLang image for the Qwen3.5-397B-A17B NVFP4 B200 AgentX MTP recipe from `lmsysorg/sglang:v0.5.16-cu130` (v0.5.16 release) to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` (2026-09-07 cu13 dev nightly).

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`
- Tag commit: sgl-project/sglang@30705c00 ("[Deepseek V4] Keep fp32 routing weights in the mxfp4 trtllm MoE")
- Same target tag as the FP8 sibling bump in #2861; follows the repo's `nightly-dev-cu13-<date>-<hash>` convention, matching the current cu130 pin.
- Recipe script, modelopt_fp4 / trtllm_mha / flashinfer_trtllm flags, NEXTN MTP settings, golden AL 3.39, and the TP2/TP4 concurrency and HiCache grids are unchanged; image-only bump.

Recipes touched: `qwen3.5-fp4-b200-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:b200-nscale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark config and changelog only; behavior change is limited to the pinned SGLang container for one recipe, with no auth or production runtime impact.
> 
> **Overview**
> **Updates the `qwen3.5-fp4-b200-sglang-agentic-mtp` benchmark recipe** to use `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` instead of `lmsysorg/sglang:v0.5.16-cu130` (cu13 dev nightly vs prior release pin). Engine flags, NEXTN MTP settings, golden acceptance length, and TP2/TP4 concurrency / HiCache search grids are left as-is.
> 
> Adds a matching **perf-changelog** entry for the `agentic-coding` scenario documenting the image digest, tag commit, and unchanged recipe parameters.
> 
> The same config hunk also **drops `dram-utilization: 0.80`** from the `minimaxm3-fp8-h200-vllm-agentic-mtp` agentic-coding sweep block immediately above the Qwen recipe (not called out in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a43cbe293beac46da5720ff7bced01e4a2af63f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->