### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-h200-sglang-agentic-mtp (+hicache-mtp) SGLang image to nightly-dev-cu13-20260907-30705c00

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7388,7 +7388,7 @@ qwen3.5-fp8-h100-sglang-agentic:
 # fixed-seq-len H200 MTP entry already runs conc 4-128 at TP8/EP8 versus H100's
 # 4-32, so the GPU-resident arm extends to 24 and HiCache to 48.
 qwen3.5-fp8-h200-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:h200-dgxc
@@ -7424,7 +7424,7 @@ qwen3.8next-fp8-h200-sglang-agentic-mtp:
 # H200 AgentX MTP frontier with DRAM HiCache. This is intentionally an MTP-only
 # submission; the model's non-speculative AgentX arm is not included.
 qwen3.5-fp8-h200-sglang-agentic-hicache-mtp:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260815-a5ba081f
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:h200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,12 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-agentic-mtp
+    - qwen3.5-fp8-h200-sglang-agentic-hicache-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00; Docker Hub last pushed 2026-09-07T01:43:42Z) for both H200 Qwen3.5 FP8 SGLang AgentX MTP recipes: qwen3.5-fp8-h200-sglang-agentic-mtp from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release) and qwen3.5-fp8-h200-sglang-agentic-hicache-mtp from lmsysorg/sglang:nightly-dev-cu13-20260815-a5ba081f (2026-08-15 nightly). Both route to benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh, which is unchanged: SGLANG_ENABLE_SPEC_V2 EAGLE MTP at 3 steps, golden acceptance length 3.39, flashinfer attention with allreduce fusion, fp8 quantization and fp8_e4m3 KV, HiCache kernel IO / page_first layout. Concurrency grids unchanged. Same tag the B200 Qwen3.5 FP8/FP4 SGLang AgentX recipes moved to in #2861/#2862."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2868


### PR DESCRIPTION
## Summary
Update SGLang image for both H200 Qwen3.5-397B-A17B FP8 AgentX MTP recipes to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` (2026-09-07 cu13 dev nightly).

| Recipe | From | To |
|---|---|---|
| `qwen3.5-fp8-h200-sglang-agentic-mtp` | `lmsysorg/sglang:v0.5.16-cu130` (v0.5.16 release) | `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` |
| `qwen3.5-fp8-h200-sglang-agentic-hicache-mtp` | `lmsysorg/sglang:nightly-dev-cu13-20260815-a5ba081f` (2026-08-15 nightly) | `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` |

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`; tag commit sgl-project/sglang@30705c00.
- Both keys are one recipe family (same model, precision, SKU, engine) and share `benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh`, which is unchanged and pins nothing image-specific: SPEC_V2 EAGLE MTP at 3 steps, golden AL 3.39, flashinfer attention + allreduce fusion, fp8 quantization, fp8_e4m3 KV, HiCache kernel IO / page_first layout.
- Concurrency grids unchanged. Same tag as the B200 Qwen3.5 SGLang bumps (#2861, #2862), so the Qwen3.5 SGLang AgentX curves on H200 and B200 share one SGLang commit.

Recipes touched: `qwen3.5-fp8-h200-sglang-agentic-mtp`, `qwen3.5-fp8-h200-sglang-agentic-hicache-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:h200-dgxc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Docker image pin updates for benchmark recipes; no application logic, auth, or runtime code changes.
> 
> **Overview**
> Both H200 **Qwen3.5 FP8 SGLang AgentX MTP** recipe keys in `nvidia-master.yaml` now pin **`lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00`** instead of older tags: **`qwen3.5-fp8-h200-sglang-agentic-mtp`** moves off **`v0.5.16-cu130`**, and **`qwen3.5-fp8-h200-sglang-agentic-hicache-mtp`** off the **2026-08-15** nightly.
> 
> **Search spaces, scenarios, and the shared benchmark script** (`benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh`) are **unchanged**—only the container image moves, aligned with the B200 Qwen3.5 SGLang bumps in prior PRs. A matching **`perf-changelog.yaml`** entry documents the tag, digest, and scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb832a32a4df76517ffcc1bf5572e76f3fb74c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->