### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-h100-sglang-agentic-mtp SGLang image to nightly-dev-cu13-20260907-30705c00

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7439,7 +7439,7 @@ qwen3.5-fp8-h200-sglang-agentic-hicache-mtp:
 
 
 qwen3.5-fp8-h100-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:h100-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,11 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp8-h100-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release) to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00; Docker Hub last pushed 2026-09-07T01:43:42Z). benchmarks/single_node/agentic/qwen3.5_fp8_h100_mtp.sh is unchanged: SGLANG_ENABLE_SPEC_V2 EAGLE MTP at 3 steps, golden acceptance length 3.39, flashinfer attention (sm_90) with allreduce fusion, fp8 quantization and fp8_e4m3 KV, HiCache kernel IO / page_first layout; the TP8/EP8 GPU-resident [1, 4, 8, 12, 16] and HiCache [4, 8, 12, 16] grids are unchanged. Same tag the Qwen3.5 SGLang AgentX recipes on B200 (#2861/#2862) and H200 (#2868) moved to. The non-MTP sibling qwen3.5-fp8-h100-sglang-agentic is not bumped: its agentic script was removed in #2561 and the arm is slated for retirement under MODELS.md."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2869


### PR DESCRIPTION
## Summary
Update SGLang image for the H100 Qwen3.5-397B-A17B FP8 AgentX MTP recipe from `lmsysorg/sglang:v0.5.16-cu130` (v0.5.16 release) to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00` (2026-09-07 cu13 dev nightly).

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`; tag commit sgl-project/sglang@30705c00.
- Same tag as the Qwen3.5 SGLang AgentX bumps on B200 (#2861, #2862) and H200 (#2868), so all Qwen3.5 SGLang AgentX curves share one SGLang commit.
- `benchmarks/single_node/agentic/qwen3.5_fp8_h100_mtp.sh` is unchanged and pins nothing image-specific: SPEC_V2 EAGLE MTP at 3 steps, golden AL 3.39, flashinfer attention (sm_90) + allreduce fusion, fp8 quantization, fp8_e4m3 KV, HiCache kernel IO / page_first. Concurrency grids unchanged.
- **Not bumped:** the non-MTP sibling `qwen3.5-fp8-h100-sglang-agentic` (still on v0.5.12-cu130). Its agentic script `qwen3.5_fp8_h100.sh` was removed in #2561, so the key cannot run today, and the arm is slated for retirement under MODELS.md. Flagged for cleanup rather than bumped.

Recipes touched: `qwen3.5-fp8-h100-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:h100-dgxc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and changelog-only image pin update for a single benchmark recipe; no application or infra code changes.
> 
> **Overview**
> Bumps the **H100** Qwen3.5 FP8 AgentX MTP recipe (`qwen3.5-fp8-h100-sglang-agentic-mtp`) from **`lmsysorg/sglang:v0.5.16-cu130`** to **`lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00`**, aligning with the same SGLang tag already used for Qwen3.5 AgentX on B200 and H200.
> 
> Adds a matching **`perf-changelog.yaml`** entry for the `agentic-coding` scenario. Benchmark script, search grids, and MTP/HiCache settings are unchanged; the non-MTP H100 agentic key is intentionally **not** updated (retirement path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75846b89436db220c5569b89a7c6610377daf867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->