### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-mi325x-sglang-agentic-mtp SGLang ROCm image to v0.5.19-rocm720-mi30x-20260907

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -219,7 +219,7 @@ qwen3.5-fp8-mi355x-sglang-mtp:
 # peaks at c4, TP4/TEP4 at c40, and TP8/TEP8 at c64; the next point beyond each
 # knee is retained to document the throughput cliff.
 qwen3.5-fp8-mi325x-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi325x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,11 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp8-mi325x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang ROCm image from lmsysorg/sglang:v0.5.16-rocm720-mi30x (v0.5.16 release, ROCm 7.2, gfx942) to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907 (2026-09-07 ROCm 7.2 mi30x nightly, digest sha256:e5c773e5c53bbbb341f20584f92040be17b30f7518a2bbe1781f716cd6ea89e1; Docker Hub last pushed 2026-09-07T13:58:10Z), the same rocm720-mi30x nightly flavor the MI300X Qwen3.5 FP8 AgentX sibling already runs. benchmarks/single_node/agentic/qwen3.5_fp8_mi325x_mtp.sh is unchanged: AITER attention with unified attention and allreduce fusion, fp8 quantization and fp8_e4m3 KV, native EAGLE MTP with golden acceptance length 3.39; the TP2/EP2, TP4, TEP4, TP8, and TEP8 concurrency grids are unchanged. Same-day counterpart of the Qwen3.5 SGLang AgentX bumps on B200/H200/H100 (#2861, #2862, #2868, #2869)."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2870


### PR DESCRIPTION
## Summary
Update SGLang ROCm image for the MI325X Qwen3.5-397B-A17B FP8 AgentX MTP recipe from `lmsysorg/sglang:v0.5.16-rocm720-mi30x` (v0.5.16 release) to `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907` (2026-09-07 ROCm 7.2 mi30x nightly).

- Tag verified on Docker Hub: last pushed 2026-09-07T13:58:10Z, digest `sha256:e5c773e5c53bbbb341f20584f92040be17b30f7518a2bbe1781f716cd6ea89e1`.
- Same `rocm720-mi30x` nightly flavor the MI300X Qwen3.5 FP8 AgentX sibling already runs; image repo moves from `lmsysorg/sglang` (release tags) to `lmsysorg/sglang-rocm` (nightlies), as that sibling did.
- `benchmarks/single_node/agentic/qwen3.5_fp8_mi325x_mtp.sh` is unchanged and pins nothing image-specific: AITER attention + unified attention + allreduce fusion, fp8 quantization, fp8_e4m3 KV, native EAGLE MTP, golden AL 3.39. Concurrency grids unchanged.
- Same-day counterpart of the Qwen3.5 SGLang AgentX bumps on B200 (#2861, #2862), H200 (#2868), and H100 (#2869).

Recipes touched: `qwen3.5-fp8-mi325x-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:mi325x-amds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only image pin for a single benchmark recipe; no launch-script or search-space changes, though sweep results may shift with SGLang v0.5.19.
> 
> **Overview**
> Bumps the container image for **`qwen3.5-fp8-mi325x-sglang-agentic-mtp`** from the release tag `lmsysorg/sglang:v0.5.16-rocm720-mi30x` to the dated nightly `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907`, aligning with the MI300X AgentX sibling’s `sglang-rocm` nightly flavor.
> 
> Model, runner, **agentic-coding** scenario, and TP/EP/MTP concurrency grids are unchanged; only the pinned image moves. **`perf-changelog.yaml`** gains an entry for this config key (digest, parity with same-day Qwen3.5 AgentX bumps on NVIDIA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3729e06c63d6248e58ddd2eef34b43fbc603e695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->