### PR TITLE
[Klaud Cold] Update minimaxm3-fp8-h200-vllm-agentic-mtp vLLM image to nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7529,7 +7529,7 @@ minimaxm3-fp8-h100-vllm-agentic-mtp:
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [6, 8] }
 
 minimaxm3-fp8-h200-vllm-agentic-mtp:
-  image: vllm/vllm-openai:v0.27.1
+  image: vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: cluster:h200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,11 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - minimaxm3-fp8-h200-vllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update vLLM image from vllm/vllm-openai:v0.27.1 (v0.27.1 release) to vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36 (2026-09-07 upstream nightly, digest sha256:254eebf919e8b7b0d530d97fccc606c36f380ff6724d64bc190951bec1aee838, tag commit vllm-project/vllm@d9105ea8; Docker Hub last pushed 2026-09-07T06:16:01Z), the same tag the B200 MiniMax-M3 AgentX recipe moved to in #2860 and the ROCm counterpart of the MI325X/MI300X bumps in #2872/#2873. benchmarks/single_node/agentic/minimaxm3_fp8_h200_mtp.sh is unchanged: TRITON_ATTN attention, fp8 KV, EAGLE3 with the Inferact MiniMax-M3 EAGLE3-GQA draft pinned to FLASH_ATTN and the committed golden synthetic acceptance length 2.78, Mooncake 0.3.11.post1 DRAM offload on the host-tier arm; the resident TP8 c1/c2/c4/c6/c8/c10 and Mooncake DRAM offload c12/c14 grid is unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2875


### PR DESCRIPTION
## Summary
Update vLLM image for the H200 MiniMax-M3 MXFP8 AgentX EAGLE3 recipe from `vllm/vllm-openai:v0.27.1` (v0.27.1 release) to `vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36` (2026-09-07 upstream nightly).

- Tag verified on Docker Hub: last pushed 2026-09-07T06:16:01Z, digest `sha256:254eebf919e8b7b0d530d97fccc606c36f380ff6724d64bc190951bec1aee838`; tag commit vllm-project/vllm@d9105ea8, the same tag the B200 MiniMax-M3 AgentX recipe moved to in #2860.
- `benchmarks/single_node/agentic/minimaxm3_fp8_h200_mtp.sh` is unchanged and pins nothing image-specific: TRITON_ATTN attention, fp8 KV, EAGLE3 with the Inferact EAGLE3-GQA draft on FLASH_ATTN, golden synthetic AL 2.78, Mooncake 0.3.11.post1 on the DRAM-offload arm. Grid unchanged: resident TP8 c1/c2/c4/c6/c8/c10 and Mooncake DRAM offload c12/c14.

Recipes touched: `minimaxm3-fp8-h200-vllm-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:h200-dgxc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only swaps a pinned container image and documents it in the perf changelog; no script or search-space changes.
> 
> **Overview**
> Updates the **`minimaxm3-fp8-h200-vllm-agentic-mtp`** recipe to use **`vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36`** instead of **`vllm/vllm-openai:v0.27.1`**, aligning the H200 AgentX EAGLE3 run with the same upstream nightly already used on B200 (#2860) and related ROCm bumps.
> 
> Adds a **`perf-changelog.yaml`** entry for the **`agentic-coding`** scenario. Benchmark script, Mooncake offload settings, and the TP8 concurrency grid are **unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd1898085343b37705babf27285d01344f5e983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->