### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-b300-sglang-agentic-mtp SGLang image to nightly-dev-cu13-20260907-30705c00 and move to cluster:b300-dsxe

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7201,10 +7201,10 @@ qwen3.5-fp4-gb300-dynamo-sglang-agentic-disagg:
 
     # ---------- 1k1k high-throughput (wide-EP decode, EAGLE MTP) ----------
 qwen3.5-fp8-b300-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp8
   framework: sglang
   multinode: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,12 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp8-b300-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release) to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00; Docker Hub last pushed 2026-09-07T01:43:42Z), the same tag the Qwen3.5 SGLang AgentX recipes on B200/H200/H100 moved to in #2861/#2862/#2868/#2869. benchmarks/single_node/agentic/qwen3.5_fp8_b300_sglang_mtp.sh is unchanged: fp8 quantization, fp8_e4m3 KV, trtllm_mha attention, flashinfer_trtllm MoE runner, native NEXTN MTP with golden AL 3.39; the TP4 and TP2/EP2 grids are unchanged. The qwen3.5-fp8-b300-sglang-agentic-power-ab key is deliberately not bumped: it is a controlled FP8/FP4 power matrix that requires an identical SGLang build across both precisions."
+    - "Move the recipe from the retired cluster:b300-nv fleet (launcher and runner labels removed in #2826) to cluster:b300-dsxe so the sweep has a runner to schedule on. The runner change means this is not an append-only bump: the whole curve reruns on DSXE."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2881


### PR DESCRIPTION
## Summary
Update the SGLang image for `qwen3.5-fp8-b300-sglang-agentic-mtp` from `lmsysorg/sglang:v0.5.16-cu130` to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00`, and move the recipe from the retired `cluster:b300-nv` runner to `cluster:b300-dsxe`.

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`; same tag as the other Qwen3.5 SGLang AgentX bumps (#2861, #2862, #2868, #2869).
- **Not bumped:** `qwen3.5-fp8-b300-sglang-agentic-power-ab`, a controlled FP8/FP4 power matrix pinned to one SGLang build across both precisions.
- **Runner:** `cluster:b300-nv` was retired in #2826 (launcher and runner labels removed), so a sweep on it can never be scheduled. Repointed to `cluster:b300-dsxe`, the same move #2829 makes for the GLM-5.2 FP4 B300 sibling. Because the runner changed this is not an append-only bump; the whole curve reruns on DSXE.
- Recipe script and concurrency grid unchanged.

Recipes touched: `qwen3.5-fp8-b300-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:b300-dsxe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark recipe and changelog only; no application runtime or security paths. Main operational note is non-comparable perf history across the fleet move.
> 
> **Overview**
> Updates **`qwen3.5-fp8-b300-sglang-agentic-mtp`** in `nvidia-master.yaml`: SGLang moves from **`v0.5.16-cu130`** to **`nightly-dev-cu13-20260907-30705c00`** (aligned with other Qwen3.5 SGLang AgentX image bumps), and the runner switches from retired **`cluster:b300-nv`** to **`cluster:b300-dsxe`** so sweeps can schedule again.
> 
> Adds a matching **`perf-changelog.yaml`** entry noting unchanged TP/EP grids and script settings, that **`qwen3.5-fp8-b300-sglang-agentic-power-ab`** stays pinned for cross-precision parity, and that the runner change forces a full curve rerun on DSXE (not append-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847e9dd2e27899fcefa42a2add3cd09aca46ce75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->