### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-b300-sglang-agentic-mtp SGLang image to nightly-dev-cu13-20260907-30705c00 and move to cluster:b300-dsxe

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7217,10 +7217,10 @@ qwen3.5-fp8-b300-sglang-agentic-mtp:
       - { tp: 2, ep: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [32, 34, 36, 38, 40, 44, 48, 52, 56] }
 
 qwen3.5-fp4-b300-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: sglang
   multinode: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6921,3 +6921,12 @@
     - "Pick up the latest automatic ROCm DeepSeek-V4 optimizations, including fused mHC post/pre plus RMSNorm, gfx950 C4A top-k dispatch, fused C4 compressor GEMMs, fused SWA q/kv RMSNorm plus q FP8 quantization, and medium-batch cooperative top-k tuning."
     - "Keep the existing VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1, and --moe-backend aiter settings, and explicitly add VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 plus VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4 to both STP and MTP paths. The current checkpoint's shared-expert path does not satisfy the latest vLLM fusion conditions, so that fusion flag self-disables while preserving recipe parity."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2792
+
+- config-keys:
+    - qwen3.5-fp4-b300-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (v0.5.16 release) to lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, digest sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007, tag commit sgl-project/sglang@30705c00; Docker Hub last pushed 2026-09-07T01:43:42Z), the same tag the Qwen3.5 SGLang AgentX recipes on B200/H200/H100 moved to in #2861/#2862/#2868/#2869. benchmarks/single_node/agentic/qwen3.5_fp4_b300_sglang_mtp.sh is unchanged: modelopt_fp4 quantization, fp8_e4m3 KV, trtllm_mha attention, flashinfer_trtllm MoE runner, native NEXTN MTP with golden AL 3.39; the TP4 and TP2/EP2 grids are unchanged. The qwen3.5-fp4-b300-sglang-agentic-power-ab key is deliberately not bumped: it is a controlled FP8/FP4 power matrix that requires an identical SGLang build across both precisions."
+    - "Move the recipe from the retired cluster:b300-nv fleet (launcher and runner labels removed in #2826) to cluster:b300-dsxe so the sweep has a runner to schedule on. The runner change means this is not an append-only bump: the whole curve reruns on DSXE."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2882


### PR DESCRIPTION
## Summary
Update the SGLang image for `qwen3.5-fp4-b300-sglang-agentic-mtp` from `lmsysorg/sglang:v0.5.16-cu130` to `lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00`, and move the recipe from the retired `cluster:b300-nv` runner to `cluster:b300-dsxe`.

- Tag verified on Docker Hub: last pushed 2026-09-07T01:43:42Z, digest `sha256:19b8fa1223cc339c1eae7a5b703f1a8c2543b5b119155bf3d7efaef18f77f007`; same tag as the other Qwen3.5 SGLang AgentX bumps.
- **Not bumped:** `qwen3.5-fp4-b300-sglang-agentic-power-ab`, a controlled FP8/FP4 power matrix pinned to one SGLang build across both precisions.
- **Runner:** `cluster:b300-nv` was retired in #2826 (launcher and runner labels removed), so a sweep on it can never be scheduled. Repointed to `cluster:b300-dsxe`, the same move #2829 makes for the GLM-5.2 FP4 B300 sibling. Because the runner changed this is not an append-only bump; the whole curve reruns on DSXE.
- Recipe script and concurrency grid unchanged.

Recipes touched: `qwen3.5-fp4-b300-sglang-agentic-mtp`

## Test plan
- [ ] full-sweep-enabled sweep passes on cluster:b300-dsxe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark config and changelog only; no application code, though runner migration invalidates prior B300-NV curves for this key.
> 
> **Overview**
> Updates **`qwen3.5-fp4-b300-sglang-agentic-mtp`** to use SGLang **`nightly-dev-cu13-20260907-30705c00`** instead of **`v0.5.16-cu130`**, aligning with the other Qwen3.5 SGLang AgentX B200/H200/H100 bumps.
> 
> The recipe **runner** moves from retired **`cluster:b300-nv`** to **`cluster:b300-dsxe`** so agentic-coding sweeps can schedule again; that forces a full curve rerun on DSXE, not an append-only image bump. **`qwen3.5-fp4-b300-sglang-agentic-power-ab`** stays on the old image so FP8/FP4 power A/B stays on one build.
> 
> **`perf-changelog.yaml`** documents the image, runner, and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d9e08e722e24386f3085a1a0a3437ed56e38b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->