### PR TITLE
Optimize GLM-5.2-MXFP4 SGLang Agentic Performance on MI355X

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -91,9 +91,9 @@ if agentic_kv_offload_enabled; then
         # env-var override for maximum throughput on nodes with >4 TB DRAM.
         HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
     fi
-    # write_through_selective skips DRAM writes for non-reusable KV blocks,
-    # reducing host-bus traffic without affecting the cache hit rate.
-    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through_selective}"
+    # Keep write_through as the validated baseline. Override
+    # HICACHE_WRITE_POLICY explicitly for selective-write experiments.
+    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through}"
     HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-direct}"
     HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
     case "$KV_OFFLOAD_BACKEND" in

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1708,7 +1708,7 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
 #     c6 and c8 removed after sweep validation: dominated by TP4/EP4 arm.
 # SA selects the Pareto-optimal arm per concurrency point.
 glm5.2-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907
   model: amd/GLM-5.2-MXFP4
   model-prefix: glm5.2
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6969,3 +6969,13 @@
     - "Use SGLang's current W4A4 MegaMoE and DP LM-head flags for DP-attention instead of the deprecated MegaMoE environment variables."
     - "Resolve draft-model jobs through the existing B200 SGLang speculative recipe and the staged DeepSeek-V4-Pro-0813 checkpoint."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2821
+
+- config-keys:
+    - glm5.2-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907."
+    - "Pick up our recent SGLang main-branch optimizations for GLM-5.2-MXFP4 serving."
+    - "Restore HiCache write_through as the default write policy to optimize GLM-5.2-MXFP4 output interactivity and per-GPU throughput in the MI355X AgentX configuration."
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6978,4 +6978,4 @@
     - "Update the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907."
     - "Pick up our recent SGLang main-branch optimizations for GLM-5.2-MXFP4 serving."
     - "Restore HiCache write_through as the default write policy to optimize GLM-5.2-MXFP4 output interactivity and per-GPU throughput in the MI355X AgentX configuration."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2887


### PR DESCRIPTION
## Summary

- Update the GLM-5.2-MXFP4 MI355X AgentX SGLang image from v0.5.16 to v0.5.19.
- Pick up recent SGLang main-branch optimizations.
- Restore `write_through` as the default HiCache write policy.

## Benchmark Results

Test configuration: MI355X, TP4/EP4, MTP, HiCache DRAM offload, 3600-second AgentX profiling.

| Concurrency | P90 Interactivity | Throughput per Chip |
|---|---:|---:|
| 10 | 66.92 tokens/s/user | 13,002.49 tokens/s/GPU |
| 12 | 57.87 tokens/s/user | 12,340.00 tokens/s/GPU |

Concurrency 10 provides the best balance of output interactivity and per-GPU throughput.

## Validation

- Both benchmark runs completed successfully with no profiling request errors.
- Bash syntax, YAML parsing, and targeted matrix generation passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and config-only changes (container pin and HiCache default); no auth or core application logic.
> 
> **Overview**
> Updates the **glm5.2-fp4-mi355x-sglang-agentic-mtp** recipe to **SGLang ROCm v0.5.19** (`20260907`) from v0.5.16, picking up recent main-branch GLM-5.2-MXFP4 serving work.
> 
> In **`glm5.2_fp4_mi355x_sglang_mtp.sh`**, the default **HiCache** write policy switches from **`write_through_selective`** back to **`write_through`** as the validated baseline for AgentX interactivity and per-GPU throughput; **`HICACHE_WRITE_POLICY`** can still be set explicitly for selective-write experiments.
> 
> **`perf-changelog.yaml`** documents the image bump and write-policy change for this config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5361b955f8451e45f23b23a9fdc4533c35898628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->