### PR TITLE
Optimize GLM-5.2-MXFP4 SGLang Agentic Performance on MI355X

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -91,9 +91,9 @@ if agentic_kv_offload_enabled; then
         # env-var override for maximum throughput on nodes with >4 TB DRAM.
         HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
     fi
-    # write_through_selective skips DRAM writes for non-reusable KV blocks,
-    # reducing host-bus traffic without affecting the cache hit rate.
-    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through_selective}"
+    # Keep write_through as the validated baseline. Override
+    # HICACHE_WRITE_POLICY explicitly for selective-write experiments.
+    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through}"
     HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-direct}"
     HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
     case "$KV_OFFLOAD_BACKEND" in

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1708,7 +1708,7 @@ minimaxm3-fp4-mi355x-vllm-agentic-mtp:
 #     c6 and c8 removed after sweep validation: dominated by TP4/EP4 arm.
 # SA selects the Pareto-optimal arm per concurrency point.
 glm5.2-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907
   model: amd/GLM-5.2-MXFP4
   model-prefix: glm5.2
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6956,4 +6956,4 @@
     - "Update the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907."
     - "Pick up our recent SGLang main-branch optimizations for GLM-5.2-MXFP4 serving."
     - "Restore HiCache write_through as the default write policy to optimize GLM-5.2-MXFP4 output interactivity and per-GPU throughput in the MI355X AgentX configuration."
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2887

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6956,7 +6956,7 @@
     - "Update the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907."
     - "Pick up our recent SGLang main-branch optimizations for GLM-5.2-MXFP4 serving."
     - "Restore HiCache write_through as the default write policy to optimize GLM-5.2-MXFP4 output interactivity and per-GPU throughput in the MI355X AgentX configuration."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2887
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2890
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6947,3 +6947,13 @@
     - "Update vLLM ROCm image from vllm/vllm-openai-rocm:v0.27.1 (v0.27.1 release) to vllm/vllm-openai-rocm:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36 (2026-09-07 upstream ROCm nightly, digest sha256:74d4a95f3ae672ecddf9acb7296917def82d9eca51687fa2862ae72b03ff1907, tag commit vllm-project/vllm@d9105ea8; Docker Hub last pushed 2026-09-07T05:26:48Z). benchmarks/single_node/agentic/minimaxm3_fp8_mi300x_mtp.sh is unchanged: TRITON_ATTN attention, fp8 KV, block-size 128, EAGLE3 speculative decoding with the Inferact MiniMax-M3 EAGLE3-GQA draft and the committed golden synthetic acceptance length, minimax_m3 tool-call and reasoning parsers; the search space is unchanged. The upstream commit-pinned ROCm nightly is the same vllm commit the B200 MiniMax-M3 AgentX recipe moved to in #2860. Note that vllm-openai-rocm commit-nightly tags have expired from Docker Hub within days in the past; node squash caches keep merged configs running, but a re-pin to a durable tag may be needed later."
     - "Add --compilation-config cudagraph_mode=FULL_DECODE_ONLY to the serve command. The upstream nightly does not torch-compile MiniMaxM3SparseForConditionalGeneration, so with VLLM_USE_BREAKABLE_CUDAGRAPH=0 the default FULL_AND_PIECEWISE mode aborts at engine init with piecewise CUDA graphs unavailable (first sweep, run 34174124043, eval cell); full decode-only graphs are what the MI355X MiniMax-M3 sibling runs on its nightly (#2825)."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2873
+
+- config-keys:
+    - glm5.2-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260728 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260907."
+    - "Pick up our recent SGLang main-branch optimizations for GLM-5.2-MXFP4 serving."
+    - "Restore HiCache write_through as the default write policy to optimize GLM-5.2-MXFP4 output interactivity and per-GPU throughput in the MI355X AgentX configuration."
+  pr-link: TBD


### PR DESCRIPTION
## Summary

- Update the GLM-5.2-MXFP4 MI355X AgentX SGLang image from v0.5.16 to v0.5.19.
- Pick up recent SGLang main-branch optimizations.
- Restore `write_through` as the default HiCache write policy.
- Merge the latest `main` and preserve both concurrent performance-changelog entries.

Supersedes #2887.

## Benchmark Results

Test configuration: MI355X, TP4/EP4, MTP, HiCache DRAM offload, 3600-second AgentX profiling.

| Concurrency | P90 Interactivity | Throughput per Chip |
|---|---:|---:|
| 10 | 66.92 tokens/s/user | 13,002.49 tokens/s/GPU |
| 12 | 57.87 tokens/s/user | 12,340.00 tokens/s/GPU |

Concurrency 10 provides the best balance of output interactivity and per-GPU throughput.

## Validation

- Both benchmark runs completed successfully with no profiling request errors.
- Bash syntax, YAML parsing, and targeted matrix generation passed.
- The resolved `perf-changelog.yaml` parses successfully after merging `main`.

Made with [Cursor](https://cursor.com)