### PR TITLE
chore(dsv4): rerun GB300 TRT-LLM AgentX / 重新运行 GB300 TRT-LLM AgentX 配置

### DIFF
--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2891
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp
@@ -6964,4 +6964,4 @@
     - agentic-coding
   description:
     - "Re-run the GB300 Dynamo TensorRT-LLM AgentX configuration to verify KV offload environment propagation."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2891

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2891
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6958,3 +6958,10 @@
     - "Expand the TP8 and TP4/EP1 sweep coverage through concurrency 640."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2866
   
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-trt-agentx
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Re-run the GB300 Dynamo TensorRT-LLM AgentX configuration to verify KV offload environment propagation."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Description

Re-run the existing DeepSeek V4 GB300 Dynamo TensorRT-LLM AgentX configuration to verify KV offload environment propagation. This PR changes only the performance changelog; the benchmark configuration and recipes are unchanged.

## 中文说明

重新运行现有的 DeepSeek V4 GB300 Dynamo TensorRT-LLM AgentX 配置，以验证 KV 卸载环境变量的传递。本 PR 仅更新性能变更日志，不修改基准测试配置或配方。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Configuration change
- [ ] Documentation update
- [x] Other: configuration rerun

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change with no recipe or runtime configuration edits.
> 
> **Overview**
> Documents a **configuration rerun** in `perf-changelog.yaml` for `dsv4-fp4-gb300-dynamo-trt-agentx` under the **agentic-coding** scenario.
> 
> The entry records re-executing the existing DeepSeek V4 GB300 Dynamo TensorRT-LLM AgentX setup to confirm **KV offload environment variables** propagate correctly. **No benchmark recipes or config files are modified** in this PR—only the changelog at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dcd29b2f88d50b6354280e37bdb3084bba274d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->