### PR TITLE
fix(runners): detect unhealthy B300 Lustre clients

### DIFF
--- a/KLAUD_DEBUG.md
+++ b/KLAUD_DEBUG.md
@@ -178,6 +178,45 @@ Doesn't survive controller reboots. For permanent removal, a SLURM admin should 
 
 ---
 
+## 5.7 B300 DSXE: Lustre client eviction before image import
+
+**Symptom:** `launch_b300-dsxe.sh` hangs at `exec 9>...sqsh.lock`, or fails
+there with `Input/output error`. No model server has started. In run
+[34177497130](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34177497130),
+Slurm jobs 837 and 838 waited over 100 minutes in `ptlrpc_set_wait` before
+`flock` was invoked. Fresh shared-file writes and existing image reads also
+failed from compute nodes; the login node could read and write the same storage.
+
+**Diagnosis:** inspect local client state from `/tmp`, without first reading a
+script or opening a log on `/data`:
+
+```bash
+lctl get_param 'osc.*.import' 'mdc.*.import' | grep -E 'name:|state:'
+```
+
+Compute clients showed `EVICTED`, `CONNECTING`, or `IDLE` instead of `FULL`.
+On 2026-09-08, a six-MiB write/read probe striped across all three OSTs failed
+or timed out on all nine idle nodes tested: 00, 07, 09, 10, and 13–17. A
+single-file read succeeded on node 13 while its OST0000 connection was broken;
+one successful read is therefore insufficient to declare a node healthy.
+
+**Recovery:** a cluster administrator must diagnose and restore Lustre
+connectivity, then verify client state and shared read/write/fsync across all
+OSTs before rerunning benchmarks. `cjquilici` can switch to `sa-gha-runner`, but
+neither account had root access for repairing mounts or clients. Do not bypass
+this with a different model image or assume an idle Slurm node is healthy.
+
+**Launcher protection:** `b300_lustre_preflight.sh` checks local client state
+before the import opens its lock and before single-node Pyxis startup. It waits
+up to 30 seconds for clients to reach `FULL`, then fails with node/client
+diagnostics. Both checks start in `/tmp` and receive their code through the
+Slurm command, so they do not need a working shared filesystem to load it.
+Import jobs use `RUNNER_NAME` so normal workflow cleanup can cancel them, and
+request 16 CPUs/64 GiB instead of the partition's default whole-node memory.
+`SALLOC_EXCLUDE` applies to imports as well as benchmark allocations.
+
+---
+
 ## 6. Docker image tag gotchas
 
 **Don't invent a "release" tag pattern from a date-suffixed nightly.** `lmsysorg/sglang-rocm:v0.5.12-rocm720-mi35x` does **not** exist. Only the dated `v0.5.12-rocm720-mi35x-20260517` does. All MI355X `sglang-rocm:rocm720` tags follow the dated-nightly pattern.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,6 +81,17 @@ Classify queue/allocation failures before reading server logs:
 
 [`KLAUD_DEBUG.md` §5](../KLAUD_DEBUG.md#5-cluster-infrastructure-amd-mi355x--mi300x--mi325x) lists known AMD node, Docker socket, disk, and port incidents. Treat named-node state as historical until current node evidence confirms it.
 
+### B300 DSXE shared-storage hangs
+
+An import blocked on `*.sqsh.lock` can be a Lustre I/O failure before `flock`
+even starts. Inspect `lctl get_param 'osc.*.import' 'mdc.*.import'` from
+node-local `/tmp`; login-node access does not prove compute-node health.
+The B300 launcher checks that clients reach `FULL` before importing images or
+starting a single-node Pyxis container, and names import jobs after the runner
+so workflow cleanup can cancel them. A failed check requires cluster storage
+repair before retrying. See [the B300 incident](../KLAUD_DEBUG.md#57-b300-dsxe-lustre-client-eviction-before-image-import)
+for the observed failure and recovery evidence.
+
 ### AMD root-owned workspace files
 
 The signature is checkout cleanup failing with `EACCES` on `benchmark_logs/logs/slurm_job-*`. Root-running Slurm containers may leave root-owned directories when cancellation skips teardown, blocking every later job on that runner. The prevention contract in [`CONTRIBUTING.md`](../CONTRIBUTING.md#amd-cluster-never-leave-root-owned-files-in-runner-workspaces) is:

--- a/docs/troubleshooting_zh.md
+++ b/docs/troubleshooting_zh.md
@@ -81,6 +81,17 @@ Setup 阶段的删除错误通常意味着陈旧分支或改变空白的合并�
 
 [`KLAUD_DEBUG.md` §5](../KLAUD_DEBUG.md#5-cluster-infrastructure-amd-mi355x--mi300x--mi325x) 列出了已知 AMD 节点、Docker socket、磁盘和端口事故。除非当前节点证据再次确认，否则应把其中点名的节点状态视为历史记录。
 
+### B300 DSXE 共享存储挂起
+
+镜像导入阻塞在 `*.sqsh.lock` 时，可能是 Lustre I/O 故障，甚至还未执行
+`flock`。从节点本地 `/tmp` 执行
+`lctl get_param 'osc.*.import' 'mdc.*.import'` 检查客户端状态；登录节点能访问
+共享存储并不代表计算节点正常。B300 启动器会在导入镜像或启动单节点 Pyxis
+容器前检查客户端是否进入 `FULL` 状态，并用运行器名称命名导入作业，确保
+工作流清理步骤能取消这些作业。检查失败时，必须先修复集群存储再重试。
+具体故障现象和恢复验证要求见
+[B300 事故记录](../KLAUD_DEBUG.md#57-b300-dsxe-lustre-client-eviction-before-image-import)。
+
 ### AMD root 属主工作区文件
 
 其特征是 checkout 清理在 `benchmark_logs/logs/slurm_job-*` 上因 `EACCES` 失败。以 root 运行的 Slurm 容器在取消导致 teardown 跳过时可能遗留 root 属主目录，阻塞该运行器上所有后续任务。[`CONTRIBUTING.md`](../CONTRIBUTING.md#amd-cluster-never-leave-root-owned-files-in-runner-workspaces) 中的预防契约是：

--- a/runners/b300_lustre_preflight.sh
+++ b/runners/b300_lustre_preflight.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+# Run from node-local /tmp, before opening anything on /data. This function is
+# sent in the srun command so an unhealthy client need not read a shared script.
+check_b300_lustre() {
+    local imports states
+    local deadline=$((SECONDS + ${LUSTRE_PREFLIGHT_TIMEOUT:-30}))
+
+    while :; do
+        if ! imports=$(timeout --kill-after=2 10 lctl get_param \
+            'osc.*.import' 'mdc.*.import' 2>&1); then
+            echo "Error: cannot inspect Lustre clients on $(hostname): $imports" >&2
+            return 1
+        fi
+        states=$(awk '/^[[:space:]]*state:/ { print $2 }' <<< "$imports")
+        if [[ -n "$states" ]] && ! grep -qv '^FULL$' <<< "$states"; then
+            return 0
+        fi
+        if (( SECONDS >= deadline )); then
+            echo "Error: Lustre clients are not ready on $(hostname); refusing shared-filesystem I/O." >&2
+            awk '/^[[:space:]]*(name|state):/' <<< "$imports" >&2
+            echo "A cluster administrator must restore Lustre connectivity before retrying." >&2
+            return 1
+        fi
+        echo "Waiting for Lustre clients on $(hostname) to reconnect..." >&2
+        sleep 5
+    done
+}

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -8,6 +8,9 @@
 SLURM_PARTITION="batch_1"
 SLURM_ACCOUNT="benchmark"
 
+source "$(dirname "${BASH_SOURCE[0]}")/b300_lustre_preflight.sh" || exit 1
+LUSTRE_PREFLIGHT="$(declare -f check_b300_lustre); check_b300_lustre"
+
 # enroot squash images. Must be on storage every compute node mounts and writable
 # by the runner user (/data/squash is root-owned, hence the per-user default).
 SQUASH_DIR="/data/home/sa-gha-runner/squash"
@@ -93,9 +96,19 @@ import_squash_image() {
         return 0
     fi
 
-    srun -N 1 -A "$SLURM_ACCOUNT" -p "$SLURM_PARTITION" \
-        --time="${ENROOT_IMPORT_TIME_LIMIT:-120}" bash -c "
+    local import_args=(
+        -N 1 -n 1 -c 16 --mem=64G
+        -A "$SLURM_ACCOUNT" -p "$SLURM_PARTITION"
+        --job-name="${RUNNER_NAME:?RUNNER_NAME must be set}"
+        --chdir=/tmp
+        --time="${ENROOT_IMPORT_TIME_LIMIT:-120}"
+    )
+    if [[ -n "${SALLOC_EXCLUDE:-}" ]]; then
+        import_args+=(--exclude="$SALLOC_EXCLUDE")
+    fi
+    srun "${import_args[@]}" bash -c "
         set -euo pipefail
+        $LUSTRE_PREFLIGHT || exit 1
         exec 9>\"$lock\"
         flock -w 3600 9
         if unsquashfs -l \"$sqsh\" > /dev/null 2>&1; then
@@ -493,8 +506,13 @@ else
     if [[ -n "${SALLOC_EXCLUDE:-}" ]]; then
         SALLOC_ARGS+=(--exclude="$SALLOC_EXCLUDE")
     fi
-    salloc "${SALLOC_ARGS[@]}"
+    salloc "${SALLOC_ARGS[@]}" || exit 1
     JOB_ID=$(squeue --name="$RUNNER_NAME" -u "$USER" -h -o %A | head -n1)
+
+    # Check outside Pyxis: its image/workspace reads can block in the kernel
+    # before the container starts, even when the login-node image probe passed.
+    srun --jobid="$JOB_ID" --chdir=/tmp \
+        bash -c "$LUSTRE_PREFLIGHT" || exit 1
 
     CONTAINER_MOUNTS=(
         "$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR"

--- a/utils/test_b300_lustre_preflight.py
+++ b/utils/test_b300_lustre_preflight.py
@@ -1,0 +1,126 @@
+"""Exercise B300 storage checks before import or container I/O."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT = ROOT / "runners/b300_lustre_preflight.sh"
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text("#!/bin/bash\n" + body)
+    path.chmod(0o755)
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict[str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # macOS has no GNU timeout. Only lctl is mocked here; the live Slurm check
+    # exercises the real timeout command on Linux.
+    executable(bin_dir / "timeout", 'shift 2\nexec "$@"\n')
+    executable(
+        bin_dir / "lctl",
+        'printf "%s\\n" "$IMPORTS"\nexit "${LCTL_STATUS:-0}"\n',
+    )
+    return {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "LUSTRE_PREFLIGHT_TIMEOUT": "0",
+        "IMPORTS": "    name: test-OST0000\n    state: FULL\n"
+        "    name: test-MDT0000\n    state: FULL\n",
+    }
+
+
+@pytest.mark.parametrize("state", ["FULL", "EVICTED", "CONNECTING", "IDLE"])
+def test_all_clients_must_be_connected(env: dict[str, str], state: str) -> None:
+    env["IMPORTS"] += f"    name: test-OST0001\n    state: {state}\n"
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; check_b300_lustre', "bash", str(PREFLIGHT)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    assert (result.returncode == 0) == (state == "FULL")
+    if state != "FULL":
+        assert "test-OST0001" in result.stderr
+        assert "refusing shared-filesystem I/O" in result.stderr
+
+
+@pytest.mark.parametrize("output,status", [("", "0"), ("permission denied", "1")])
+def test_missing_client_evidence_fails_closed(
+    env: dict[str, str], output: str, status: str,
+) -> None:
+    env.update(IMPORTS=output, LCTL_STATUS=status)
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; check_b300_lustre', "bash", str(PREFLIGHT)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    assert result.returncode == 1
+    assert "Error:" in result.stderr
+
+
+def test_client_can_recover_during_grace_period(
+    tmp_path: Path, env: dict[str, str],
+) -> None:
+    marker = tmp_path / "checked"
+    env.update(LUSTRE_PREFLIGHT_TIMEOUT="30", CHECK_MARKER=str(marker))
+    executable(
+        tmp_path / "bin/lctl",
+        'if [[ -e "$CHECK_MARKER" ]]; then\n'
+        '  printf "    state: FULL\\n"\n'
+        'else\n'
+        '  touch "$CHECK_MARKER"\n'
+        '  printf "    state: CONNECTING\\n"\n'
+        'fi\n',
+    )
+    executable(tmp_path / "bin/sleep", "exit 0\n")
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; check_b300_lustre', "bash", str(PREFLIGHT)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    assert result.returncode == 0
+    assert "Waiting for Lustre clients" in result.stderr
+
+
+@pytest.mark.parametrize("state", ["FULL", "EVICTED"])
+def test_import_checks_storage_before_opening_lock(
+    tmp_path: Path, env: dict[str, str], state: str,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    env.update(
+        IMPORTS=f"    name: test-OST0000\n    state: {state}\n",
+        SRUN_LOG=str(tmp_path / "srun.log"),
+    )
+    executable(
+        bin_dir / "srun",
+        'printf "%s\\n" "$@" > "$SRUN_LOG"\n'
+        'while [[ "$1" != bash ]]; do shift; done\nexec "$@"\n',
+    )
+    executable(bin_dir / "unsquashfs", '[[ -s "$2" ]]\n')
+    executable(bin_dir / "flock", 'exit 0\n')
+    executable(bin_dir / "enroot", 'printf valid-image > "$3"\n')
+    launcher = (ROOT / "runners/launch_b300-dsxe.sh").read_text()
+    start = launcher.index("import_squash_image() {")
+    end = launcher.index('\nif [[ "$IS_MULTINODE"', start)
+    script = (
+        'source "$1"\n'
+        'LUSTRE_PREFLIGHT="$(declare -f check_b300_lustre); check_b300_lustre"\n'
+        'SLURM_ACCOUNT=benchmark\nSLURM_PARTITION=batch_1\n'
+        'RUNNER_NAME=b300-test_01\nSALLOC_EXCLUDE=bad-node\n'
+        + launcher[start:end]
+        + '\nimport_squash_image example/test:tag "$2"\n'
+    )
+    squash = tmp_path / "test.sqsh"
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(PREFLIGHT), str(squash)],
+        env=env, capture_output=True, text=True, timeout=5,
+    )
+    args = (tmp_path / "srun.log").read_text().splitlines()
+    assert "--job-name=b300-test_01" in args
+    assert "--chdir=/tmp" in args
+    assert "--exclude=bad-node" in args
+    assert (result.returncode == 0) == (state == "FULL"), result.stderr
+    assert squash.exists() == (state == "FULL")
+    assert squash.with_suffix(".sqsh.lock").exists() == (state == "FULL")


### PR DESCRIPTION
The new B300 DSXE jobs hang before model startup because compute-node Lustre clients are evicted or stuck reconnecting. In [run 34177497130](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34177497130), Slurm jobs 837/838 spent over 100 minutes opening the shared image lock, before reaching `flock`. Fresh shared-file reads/writes also failed; this is not an SGLang startup failure.

This change checks Lustre client state from node-local `/tmp` before image-import I/O and before single-node Pyxis startup. It gives reconnecting clients a short grace period, then fails with diagnostics. Import allocations now use the runner name so existing workflow cleanup can cancel them, request 16 CPUs/64 GiB instead of defaulting to one CPU and whole-node memory, and honor `SALLOC_EXCLUDE`.

Validation:

- Nine targeted tests pass, including unhealthy/missing client state, recovery during the grace period, and refusing import before opening the shared lock.
- Bash syntax checks, ShellCheck for the new helper, and `git diff --check` pass.
- The helper passes on the login node. Live Slurm validation job 890 on gpu-00 exited 1 after 10 seconds, rather than entering shared-file I/O.
- Six-MiB read/write/fsync probes across all three OSTs failed or timed out on all nine idle nodes tested (00, 07, 09, 10, 13–17).

**Still blocked on infrastructure:** this PR detects the failure; it does not repair Lustre. Both available accounts lack root privileges. A cluster administrator must restore client connectivity and verify shared read/write/fsync across all OSTs before end-to-end benchmarks can be validated. The reported run was canceled and its jobs 837/838 were released. No benchmark recipe, model, or image was changed.
