### PR TITLE
fix(runners): include all ten MI355X runners

### DIFF
--- a/configs/runners.yaml
+++ b/configs/runners.yaml
@@ -95,6 +95,7 @@ labels:
     - mi355x-amds_06
     - mi355x-amds_07
     - mi355x-amds_08
+    - mi355x-amds_09
   gb200:
     - gb200-nv_0
     - gb200-nv_1
@@ -243,6 +244,7 @@ labels:
     - mi355x-amds_06
     - mi355x-amds_07
     - mi355x-amds_08
+    - mi355x-amds_09
 hardware:
   cluster:h100-dgxc:
     available-cpu-dram-mib: 2_063_837


### PR DESCRIPTION
The MI355X cluster has ten online GitHub runners, but both runner inventories list only `_00` through `_08`. Add `mi355x-amds_09` to `mi355x` and `cluster:mi355x-amds` so repository configuration matches the live pool.

Validation: runner configuration schema passes; both lists exactly match the GitHub API inventory; 11 existing runner configuration tests pass. Nodes 31 and 37 passed GPU, container, and eight-link RDMA smoke checks, joined the ten-node compute partition, and received production Slurm job 42723. The deployed dashboard collector exclusions were separately removed and telemetry now reports ten nodes and 80 GPUs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inventory-only YAML update with no auth, data, or runtime logic changes; misconfiguration risk is limited to job routing if the runner name were wrong.
> 
> **Overview**
> Adds **`mi355x-amds_09`** to the **`mi355x`** label list and **`cluster:mi355x-amds`** cluster inventory in `configs/runners.yaml`, bringing both entries from nine runners (`_00`–`_08`) to ten so repo config matches the live GitHub Actions pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceffec395d24f31745de83475c33de08b2c6cab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->