### PR TITLE
[Klaud Cold] Update dsv4-fp4-b300-dynamo-sglang SGLang image to v0.5.19-cu130 (digest-pinned) and refresh the Dynamo pin / 将 dsv4-fp4-b300-dynamo-sglang 的 SGLang 镜像更新为 v0.5.19-cu130（按 digest 固定）并刷新 Dynamo 提交

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-1p1d-dep4-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-1p1d-dep4-dep8.yaml
@@ -2,11 +2,11 @@ name: "disagg-b300-1p1d-dep4-dep8"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:
-  hash: "41882ae9b07232eed4850fb1daf8c958abb2556a"
+  hash: "b1c5147f6c9eb036d98e0e25e2a980375f491e78"
   install: true
 
 sbatch_directives:
@@ -46,8 +46,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -69,8 +67,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "1280"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -99,6 +95,7 @@ backend:
 
       enable-dp-attention: true
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "prefill"
@@ -118,6 +115,7 @@ backend:
       stream-interval: 60
 
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-1p1d-tp4-tp4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-1p1d-tp4-tp4.yaml
@@ -2,11 +2,11 @@ name: "disagg-b300-1p1d-tp4-tp4"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:
-  hash: "41882ae9b07232eed4850fb1daf8c958abb2556a"
+  hash: "b1c5147f6c9eb036d98e0e25e2a980375f491e78"
   install: true
 
 sbatch_directives:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-2p1d-dep4-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-2p1d-dep4-dep8.yaml
@@ -2,11 +2,11 @@ name: "disagg-b300-2p1d-dep4-dep8"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:
-  hash: "41882ae9b07232eed4850fb1daf8c958abb2556a"
+  hash: "b1c5147f6c9eb036d98e0e25e2a980375f491e78"
   install: true
 
 sbatch_directives:
@@ -46,8 +46,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -69,8 +67,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "1280"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -99,6 +95,7 @@ backend:
 
       enable-dp-attention: true
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "prefill"
@@ -118,6 +115,7 @@ backend:
       stream-interval: 60
 
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-4p1d-dep4-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-4p1d-dep4-dep8.yaml
@@ -2,11 +2,11 @@ name: "disagg-b300-4p1d-dep4-dep8"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:
-  hash: "41882ae9b07232eed4850fb1daf8c958abb2556a"
+  hash: "b1c5147f6c9eb036d98e0e25e2a980375f491e78"
   install: true
 
 sbatch_directives:
@@ -46,8 +46,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -69,8 +67,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "1280"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -99,6 +95,7 @@ backend:
 
       enable-dp-attention: true
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "prefill"
@@ -118,6 +115,7 @@ backend:
       stream-interval: 60
 
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-6p1d-dep4-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-6p1d-dep4-dep8.yaml
@@ -2,11 +2,11 @@ name: "disagg-b300-6p1d-dep4-dep8"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:
-  hash: "41882ae9b07232eed4850fb1daf8c958abb2556a"
+  hash: "b1c5147f6c9eb036d98e0e25e2a980375f491e78"
   install: true
 
 sbatch_directives:
@@ -46,8 +46,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "8192"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -69,8 +67,6 @@ backend:
     SGLANG_DSV4_REASONING_EFFORT: "max"
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT: "1"
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK: "1280"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS: "1"
-    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND: "1"
     SGLANG_OPT_USE_ONLINE_COMPRESS: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_CUMEM_ENABLE: "1"
@@ -99,6 +95,7 @@ backend:
 
       enable-dp-attention: true
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "prefill"
@@ -118,6 +115,7 @@ backend:
       stream-interval: 60
 
       moe-a2a-backend: "megamoe"
+      enable-w4a4-mxfp4-megamoe: true
       moe-dense-tp-size: 1
 
       disaggregation-mode: "decode"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -5233,7 +5233,7 @@ dsv4-fp4-b300-dynamo-vllm:
 # runners/launch_b300-nv.sh. Prefill workers are TP4/DEP4 (two workers per
 # 8-GPU B300 node); the decode worker is a single DEP8 node.
 dsv4-fp4-b300-dynamo-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: b300


### PR DESCRIPTION
## Summary / 摘要

Refresh the `dsv4-fp4-b300-dynamo-sglang` family (DeepSeek-V4-Pro FP4, B300, Dynamo + SGLang disaggregated, 8k/1k, no speculative decoding) from the removed nightly `lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4` to the digest-pinned release `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, matching the public framework release `sglang v0.5.19`.

将 `dsv4-fp4-b300-dynamo-sglang` 系列（DeepSeek-V4-Pro FP4、B300、Dynamo + SGLang 分离式部署、8k/1k、无投机解码）的镜像从已被删除的 nightly `lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4` 更新为按 digest 固定的正式版 `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，与公开的框架版本 `sglang v0.5.19` 一致。

**Files / 文件**

- `configs/nvidia-master.yaml`: `dsv4-fp4-b300-dynamo-sglang.image` (one line).
- `benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b300-{1p1d-tp4-tp4,1p1d-dep4-dep8,2p1d-dep4-dep8,4p1d-dep4-dep8,6p1d-dep4-dep8}.yaml`: `model.container` equals the master image; `dynamo.hash` bumped from `41882ae9b07232eed4850fb1daf8c958abb2556a` (2026-07-14) to `b1c5147f6c9eb036d98e0e25e2a980375f491e78` (2026-09-03); the four DEP recipes replace the deprecated `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS` / `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND` env vars with `enable-w4a4-mxfp4-megamoe: true` on prefill and decode.
- No other family, script, launcher or workflow is touched. Model, precision, topology, concurrency list, workloads, resources and recipe references are unchanged. Only these five recipes reference the family's `CONFIG_FILE` paths; the `-mtp` sibling uses separate `*-mtp.yaml` recipes and is untouched.
- 未改动其他系列、脚本、启动器或工作流。模型、精度、拓扑、并发列表、负载、资源和配方引用保持不变。只有这五个配方被该系列的 `CONFIG_FILE` 引用；`-mtp` 兄弟系列使用独立的 `*-mtp.yaml` 配方，未做改动。

## Why these exact changes / 变更依据

- **Old tag is gone.** Docker Hub returns no manifest for `lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4` (dated nightlies are cleaned up), so the family can no longer be reproduced from its pinned image. / 旧标签已不存在：Docker Hub 已无 `nightly-dev-cu13-20260721-8905cbd4` 的 manifest（带日期的 nightly 会被清理），该系列已无法从其固定镜像复现。
- **Same image lineage.** `v0.5.19-cu130` (pushed 2026-09-04, tag commit `59f20bff`) is built by `release-docker.yml` with the same Dockerfile target (`framework_final`), `CUDA_VERSION=13.0.3`, `BUILD_TYPE=all` and `INSTALL_FLASHINFER_JIT_CACHE=1` as the `nightly-dev-cu13-*` images from `release-docker-dev.yml`; only the source commit differs. The `@sha256` pin follows the existing `dsv4-fp4-gb300-dynamo-sglang` recipes, and the B300 launcher already normalises `@` in squash-file names. / 镜像谱系一致：`v0.5.19-cu130` 与 `nightly-dev-cu13-*` 使用同一 Dockerfile target、CUDA 13.0.3 与构建参数，仅源码提交不同；`@sha256` 固定方式沿用现有 `dsv4-fp4-gb300-dynamo-sglang` 配方。
- **Dynamo pin must move with SGLang.** SGLang v0.5.19 contains sgl-project/sglang#35907 (constructing `ServerArgs` no longer resolves it), #36255, #36972 (`server_args.get_model_config()` / `use_mla_backend()` removed) and the `ConfigArgumentMerger` move to `sglang.srt.utils.server_args_config_parser`. Dynamo `41882ae9` (2026-07-14) predates all of them; ai-dynamo/dynamo#13905, #14054 and #14234 add the compatibility shims, and `b1c5147f6c9e` (2026-09-03) is the first commit containing all three. srt-slurm still builds Dynamo from this pinned commit at run time, as before; no engine or container patching is involved. / Dynamo 提交必须随 SGLang 更新：v0.5.19 包含 #35907、#36255、#36972 以及 `ConfigArgumentMerger` 模块迁移，旧 Dynamo 提交早于这些改动；dynamo#13905、#14054、#14234 提供兼容层，`b1c5147f6c9e` 是同时包含三者的首个提交。srt-slurm 仍按原有方式从该提交构建 Dynamo，不涉及引擎或容器补丁。
- **MegaMoE FP4 activations.** sgl-project/sglang#35918 (in v0.5.19) turned `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS` / `_USE_MXF4_KIND` into warn-only `_DeprecatedEnv` entries; `mega_moe.py` now selects `mxf4xmxf4` only from `--enable-w4a4-mxfp4-megamoe`. The flag is added to both prefill and decode of the four `megamoe` recipes so the recipe keeps its FP4-activation path instead of silently falling back to FP8 activations (see #2878 for the single-node sibling). `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK` and every other env var used by the recipes are still live in v0.5.19 `environ.py`. / sgl-project/sglang#35918 已将上述两个环境变量改为仅告警，FP4 激活路径只能通过 `--enable-w4a4-mxfp4-megamoe` 选择；四个 `megamoe` 配方的 prefill 与 decode 均加入该标志以保持原行为。其余环境变量在 v0.5.19 中仍然有效。

## Local checks / 本地检查

- `generate_sweep_configs.py test-config --config-files configs/nvidia-master.yaml --config-keys dsv4-fp4-b300-dynamo-sglang`: same five matrix rows, `node-count` 2/2/2/3/4 unchanged, only `image` differs from base.
- `generate_sweep_configs.py full-sweep --config-files configs/nvidia-master.yaml --framework dynamo-sglang`: exit 0.
- `pytest utils/matrix_logic/test_generate_sweep_configs.py utils/test_gb300_power_official_contract.py`: 121 passed.
- `srtctl dry-run -f <recipe>` for all five recipes with the dcgm-power srt-slurm fork pinned by `runners/launch_b300-dsxe.sh`: exit 0.
- Capacity check (`python -m utils.klaud check-capacity --cluster b300-dsxe`) passed before edits and before each dispatch.

## Baseline / 基线（published 2026-07-30 / 发布日期 2026-07-30）

Source: `GET /api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-07-30&exact=true`, filtered to `hardware=b300`, `framework=dynamo-sglang`, `precision=fp4`, `spec_method=none`, `isl=8192`, `osl=1024`, `benchmark_type=single_turn`, image `lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4`. All eight points come from producer run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30431262611/attempts/1 (`Run Sweep - feat: add DSV4 FP4 B300 Dynamo-SGLang STP configuration`, from `GET /api/v1/workflow-info?date=2026-07-30`); logical curve snapshot id 2240 is not a producer id. Time metrics are seconds.

| conc / 并发 | topology / 拓扑 | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TTFT (s) | median TPOT (s) | median E2EL (s) | median interactivity (tok/s/user) | benchmark id |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 1P x TP4/EP1 + 1D x TP4/EP1 (4+4 GPUs) | 105.7 | 23.6 | 0.319 | 0.0102 | 9.70 | 97.7 | 438001 |
| 8 | 1P x TP4/EP1 + 1D x TP4/EP1 (4+4 GPUs) | 629.2 | 141.5 | 0.368 | 0.0130 | 12.63 | 76.7 | 438003 |
| 16 | 1P x TP4/EP1 + 1D x TP4/EP1 (4+4 GPUs) | 1091.7 | 241.9 | 0.578 | 0.0150 | 14.51 | 66.5 | 438000 |
| 32 | 1P x TP4/EP1 + 1D x TP4/EP1 (4+4 GPUs) | 1786.7 | 399.6 | 0.886 | 0.0178 | 17.56 | 56.3 | 438002 |
| 256 | 1P x TP4/EP4/DP-attn + 1D x TP8/EP8/DP-attn (4+8 GPUs) | 5051.4 | 842.1 | 11.162 | 0.0238 | 32.80 | 42.0 | 438004 |
| 768 | 2P x TP4/EP4/DP-attn + 1D x TP8/EP8/DP-attn (8+8 GPUs) | 7702.0 | 1710.8 | 21.938 | 0.0286 | 47.89 | 34.9 | 437998 |
| 2048 | 4P x TP4/EP4/DP-attn + 1D x TP8/EP8/DP-attn (16+8 GPUs) | 10243.4 | 3417.6 | 28.569 | 0.0377 | 63.19 | 26.5 | 437999 |
| 3072 | 6P x TP4/EP4/DP-attn + 1D x TP8/EP8/DP-attn (24+8 GPUs) | 11212.4 | 4983.0 | 21.867 | 0.0463 | 63.95 | 21.6 | 438005 |

**Published evaluations for the baseline run / 基线运行的已发布评测**（`GET /api/v1/evaluations`, filtered to the same identity and producer run）:

| task / 任务 | conc / 并发 | topology / 拓扑 | metrics / 指标 | eval id |
| --- | --- | --- | --- | --- |
| gsm8k | 32 | 1P TP4/EP1 + 1D TP4/EP1 | em_flexible=0.9674, em_flexible_se=0.0049, em_strict=0.9682, em_strict_se=0.0048, n_eff=1319 | 9030 |
| gsm8k | 256 | 1P TP4/EP4 + 1D TP8/EP8 | em_flexible=0.9659, em_flexible_se=0.0050, em_strict=0.9659, em_strict_se=0.0050, n_eff=1319 | 9031 |
| gsm8k | 768 | 2P TP4/EP4 + 1D TP8/EP8 | em_flexible=0.9666, em_flexible_se=0.0049, em_strict=0.9674, em_strict_se=0.0049, n_eff=1319 | 9027 |
| gsm8k | 2048 | 4P TP4/EP4 + 1D TP8/EP8 | em_flexible=0.9644, em_flexible_se=0.0051, em_strict=0.9644, em_strict_se=0.0051, n_eff=1319 | 9028 |
| gsm8k | 3072 | 6P TP4/EP4 + 1D TP8/EP8 | em_flexible=0.9674, em_flexible_se=0.0049, em_strict=0.9674, em_strict_se=0.0049, n_eff=1319 | 9029 |

## Attempts / 尝试记录

| Attempt / 尝试 | Image / SHA | Run | Benchmarks / 基准 | Evals / 评测 | Δ vs baseline (per point) / 相对基线差异 | Diagnosis / 诊断 |
| --- | --- | --- | --- | --- | --- | --- |
| Baseline (published 2026-07-30) / 基线 | `lmsysorg/sglang:nightly-dev-cu13-20260721-8905cbd4` (Dynamo `41882ae9`) | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30431262611 | 8/8 points published (table above) | see evaluation table above / 见上方评测表 | — | Reference only; the old image is never rerun. / 仅作参考，不重跑旧镜像。 |
| Attempt 1 (initial update) / 尝试 1（首次更新） | `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e72886…` (Dynamo `b1c5147f`) @ `001e9af8413ed8d323b3cd0dd9e5e3925069e308` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34281233059 (`e2e-tests.yml` from `main`, `inputs.ref` = measured SHA, `klaud-run=true`, `fail-fast=true`) | **failed**: 0/5 matrix rows measured. c768 (2P DEP4 + 1D DEP8) failed; TP4x1D c1x8x16x32, c256, c2048, c3072 cancelled by fail-fast before finishing. `results_bmk` artifact is empty (142 bytes). | **failed**: 0/5 eval rows. TP4x1D eval-only job failed; the other four eval-only jobs cancelled by fail-fast. `eval_results_all` is empty. | N/A: no measured points (infrastructure failure before the server became healthy). / 无可比较数据（服务器健康前即因基础设施故障中止）。 | Both failing jobs (Slurm jobs 958 and 961) landed on nodes `dsxe-sa-b300-prd0-gpu-00` + `gpu-01`. On `gpu-01` the decode worker and frontend containers aborted at start: `pyxis: --container-mounts: source path does not exist: /scratch/models/DeepSeek-V4-Pro` (node-local staged weights missing on that node). The prefill workers on `gpu-00` started normally with the new image and began the pinned Dynamo source build before being killed by the teardown. Not attributable to the image, Dynamo pin or recipe flags. / 两次失败的作业都落在 `gpu-00`+`gpu-01`，`gpu-01` 缺少节点本地模型目录 `/scratch/models/DeepSeek-V4-Pro`，decode 与 frontend 容器无法挂载而启动失败；`gpu-00` 上的 prefill 使用新镜像正常启动。与镜像、Dynamo 提交或配方标志无关。 |
| Attempt 2 (repair 1: retry, no code change) / 尝试 2（修复 1：重试，无代码改动） | same image and Dynamo pin @ `001e9af8413ed8d323b3cd0dd9e5e3925069e308` | https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34283344876 (`e2e-tests.yml` from `main`, `inputs.ref` = measured SHA, `klaud-run=true`, `fail-fast=true`) | **failed**: 0/5 matrix rows measured. c768 (2P DEP4 + 1D DEP8) failed; TP4x1D c1x8x16x32, c256, c2048, c3072 cancelled by fail-fast. `results_bmk` empty (142 bytes). | **failed**: 0/5 eval rows. c2048 eval-only job failed; the other four eval-only jobs cancelled by fail-fast. `eval_results_all` empty. | N/A: no measured points (same infrastructure failure). / 无可比较数据（同一基础设施故障）。 | Same root cause as attempt 1, now on two nodes. Slurm job 963 (c768) again allocated `gpu-00`+`gpu-01` and the `gpu-01` decode/frontend containers failed with `pyxis: --container-mounts: source path does not exist: /scratch/models/DeepSeek-V4-Pro`. Slurm job 969 (c2048 eval-only, head node `dsxe-sa-b300-prd0-gpu-11`) failed even earlier in `srtctl` with `FileNotFoundError: Model path does not exist: /scratch/models/DeepSeek-V4-Pro`. The launcher documents `/scratch/models` as node-local NVMe with the same layout on every compute node; at least `gpu-01` and `gpu-11` currently lack the DeepSeek-V4-Pro directory. Not attributable to the image, Dynamo pin or recipe flags. / 与尝试 1 同一根因，且出现在两个节点：作业 963 再次分到 `gpu-00`+`gpu-01`，`gpu-01` 容器挂载失败；作业 969（c2048 仅评测，头节点 `gpu-11`）在 `srtctl` 阶段即报 `Model path does not exist: /scratch/models/DeepSeek-V4-Pro`。至少 `gpu-01` 与 `gpu-11` 缺少节点本地的 DeepSeek-V4-Pro 权重目录。与镜像、Dynamo 提交或配方标志无关。 |

## Status / 状态

**Stopped: the same failure occurred twice without progress (repair budget used: 1 of 3).** Both targeted attempts died before any SGLang server became healthy because `/scratch/models/DeepSeek-V4-Pro` is missing on at least two `b300-dsxe` compute nodes (`dsxe-sa-b300-prd0-gpu-01`, `dsxe-sa-b300-prd0-gpu-11`). That is cluster weight staging, outside the scope of an image refresh, so no further GPU attempts were made. Both e2e runs (34281233059, 34283344876) are confirmed terminal; every matrix job is failed or cancelled, and the collection jobs completed with empty artifacts.

**已停止：同一故障连续出现两次且无进展（已使用修复次数：1/3）。** 两次目标尝试都在任何 SGLang 服务器就绪之前中止，原因是 `b300-dsxe` 至少两个计算节点（`gpu-01`、`gpu-11`）缺少 `/scratch/models/DeepSeek-V4-Pro`。这属于集群权重预置问题，超出镜像刷新范围，因此不再消耗 GPU。两个 e2e 运行（34281233059、34283344876）均已确认结束；所有矩阵作业为失败或已取消，收集作业完成但产物为空。

- No `perf-changelog.yaml` entry was appended and the PR stays a draft without a sweep label, because no updated-image attempt has passed yet. / 由于尚无通过的目标尝试，未追加 `perf-changelog.yaml` 条目，PR 保持草稿且未加 sweep 标签。
- The change itself is ready to re-test once the node-local weights are restored (or the affected nodes are drained): re-dispatch `e2e-tests.yml` with `test-config --config-files configs/nvidia-master.yaml --config-keys dsv4-fp4-b300-dynamo-sglang` at this SHA. The prefill containers on `gpu-00` started with the new image and began the pinned Dynamo source build before teardown, so the image pull and container start are known to work. / 节点本地权重恢复（或问题节点被下线）后即可重新测试：在此 SHA 上重新分发上述 `e2e-tests.yml` 命令。`gpu-00` 上的 prefill 容器已使用新镜像启动并开始构建固定的 Dynamo 源码，说明镜像拉取与容器启动正常。
- Image-level compatibility (Dynamo `b1c5147f` vs SGLang v0.5.19 API, `--enable-w4a4-mxfp4-megamoe`) has not been exercised on GPU in this PR; it is supported by the source-level evidence above only. / 镜像层面的兼容性（Dynamo 与 SGLang v0.5.19 的 API、`--enable-w4a4-mxfp4-megamoe`）尚未在 GPU 上实际验证，目前仅有上述源码层面的证据。

## Limitations / 局限性

- A green targeted benchmark proves this family runs on the new image; it does not prove that every global repository check passes. / 目标基准通过只能证明该系列可在新镜像上运行，不能证明所有全局检查都通过。
- Deltas are computed only for points whose topology, concurrency and dataset match the published baseline; unmatched or invalid points are excluded from any improvement claim. / 差异只对拓扑、并发和数据集与基线一致的点计算；不匹配或无效的点不计入改进结论。
- Performance improvements are best effort; regressions are reported, not used as a rejection threshold. / 性能提升为尽力而为；回退会如实报告，不作为拒绝阈值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
