### PR TITLE
refactor: deduplicate benchmark internals / 重构：去除基准测试内部重复逻辑

### DIFF
--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -19,6 +19,9 @@ on:
       - "benchmarks/benchmark_lib.sh"
       - "configs/ci-priority.yaml"
       - "benchmarks/multi_node/amd_utils/job.slurm"
+      - "runners/launch_*.sh"
+      - "runners/slurm_utils.sh"
+      - "runners/test_slurm_utils.py"
       - "utils/ci_priority.py"
       - "utils/test_ci_priority.py"
       - "utils/find_reusable_sweep_run.py"
@@ -30,6 +33,7 @@ on:
       - "utils/evals/validate_scores.py"
       - "utils/evals/test_batched_eval.py"
       - "utils/evals/test_run_eval_dispatch.py"
+      - "utils/evals/_kimi_verifier_archive.py"
       - "utils/prepare_perf_changelog_merge.py"
       - "utils/recover_failed_ingest.py"
       - "utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py"
@@ -85,4 +89,5 @@ jobs:
             utils/test_collect_eval_results.py \
             utils/evals/test_batched_eval.py \
             utils/evals/test_run_eval_dispatch.py \
+            runners/test_slurm_utils.py \
             -v

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -504,14 +504,6 @@ append_command() {
     printf '\n' >> "$output_file"
 }
 
-# Persist an argv array in shell-replayable form.
-write_command() {
-    local output_file="$1"
-    shift
-    printf '%q ' "$@" | tee "$output_file"
-    printf '\n' | tee -a "$output_file"
-}
-
 # Run benchmark serving with standardized parameters
 # All parameters are required except --endpoint, --use-chat-template, --dsv4, and --trust-remote-code
 # Parameters:
@@ -1016,240 +1008,8 @@ _prepare_kimi_vendor_verifier() {
     }
 
     "${VENDOR_VERIFIER_PYTHON:-python3}" - \
-        "$repo_url" "$verifier_ref" "$expected_archive_sha256" "$checkout_dir" <<'PY' || prepare_rc=$?
-from hashlib import sha256
-from pathlib import Path
-import re
-import socket
-import sys
-import tarfile
-import tempfile
-import time
-from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlsplit, urlunsplit
-from urllib.request import Request, urlopen
-
-
-repo_url, verifier_ref, expected_archive_sha256, checkout_dir_arg = sys.argv[1:]
-checkout_dir = Path(checkout_dir_arg)
-stage = "derive the pinned archive URL"
-
-
-def archive_member_parts(name):
-    if not name or "\x00" in name or "\\" in name or name.startswith("/"):
-        raise ValueError(f"unsafe archive member path: {name!r}")
-    normalized = name.rstrip("/")
-    parts = normalized.split("/")
-    if not normalized or any(part in ("", ".", "..") for part in parts):
-        raise ValueError(f"unsafe archive member path: {name!r}")
-    return tuple(parts)
-
-
-try:
-    if not re.fullmatch(r"[0-9a-fA-F]{40}", verifier_ref):
-        raise ValueError(f"expected a 40-character commit SHA, got {verifier_ref!r}")
-    if not re.fullmatch(r"[0-9a-fA-F]{64}", expected_archive_sha256):
-        raise ValueError(
-            "expected a 64-character archive SHA256, got "
-            f"{expected_archive_sha256!r}"
-        )
-
-    parsed_repo_url = urlsplit(repo_url)
-    if parsed_repo_url.scheme not in ("http", "https") or not parsed_repo_url.netloc:
-        raise ValueError(f"unsupported repository URL: {repo_url!r}")
-    if parsed_repo_url.query or parsed_repo_url.fragment:
-        raise ValueError(f"repository URL must not contain a query or fragment: {repo_url!r}")
-    repo_path = parsed_repo_url.path.rstrip("/")
-    if repo_path.endswith(".git"):
-        repo_path = repo_path[:-4]
-    if not repo_path:
-        raise ValueError(f"repository URL has no repository path: {repo_url!r}")
-    archive_path = f"{repo_path}/archive/{quote(verifier_ref, safe='')}.tar.gz"
-    archive_url = urlunsplit(
-        (parsed_repo_url.scheme, parsed_repo_url.netloc, archive_path, "", "")
-    )
-
-    stage = f"download {archive_url}"
-    request = Request(
-        archive_url,
-        headers={"User-Agent": "InferenceX-Kimi-Vendor-Verifier"},
-    )
-    with tempfile.TemporaryFile() as archive_file:
-        downloaded = 0
-        for attempt in range(1, 4):
-            archive_file.seek(0)
-            archive_file.truncate()
-            downloaded = 0
-            digest = sha256()
-            deadline = time.monotonic() + 60
-            try:
-                with urlopen(request, timeout=60) as response:
-                    while True:
-                        remaining = deadline - time.monotonic()
-                        if remaining <= 0:
-                            raise TimeoutError(
-                                "archive download exceeded the 60-second deadline"
-                            )
-                        sock = getattr(getattr(response, "fp", None), "raw", None)
-                        sock = getattr(sock, "_sock", None)
-                        if sock is not None:
-                            sock.settimeout(max(0.001, remaining))
-                        try:
-                            chunk = response.read(1024 * 1024)
-                        except socket.timeout as error:
-                            raise TimeoutError(
-                                "archive download exceeded the 60-second deadline"
-                            ) from error
-                        if not chunk:
-                            break
-                        downloaded += len(chunk)
-                        if downloaded > 128 * 1024 * 1024:
-                            raise ValueError(
-                                "archive download exceeds the 128 MiB safety limit"
-                            )
-                        archive_file.write(chunk)
-                        digest.update(chunk)
-                break
-            except HTTPError as error:
-                if error.code not in (408, 429) and not 500 <= error.code < 600:
-                    raise
-                if attempt == 3:
-                    raise
-                print(
-                    f"WARN: Kimi-Vendor-Verifier archive download attempt "
-                    f"{attempt}/3 failed: {error}; retrying",
-                    file=sys.stderr,
-                )
-                time.sleep(attempt)
-            except (TimeoutError, URLError, ConnectionError) as error:
-                if attempt == 3:
-                    raise
-                print(
-                    f"WARN: Kimi-Vendor-Verifier archive download attempt "
-                    f"{attempt}/3 failed: {error}; retrying",
-                    file=sys.stderr,
-                )
-                time.sleep(attempt)
-        if downloaded == 0:
-            raise ValueError("downloaded archive is empty")
-        actual_archive_sha256 = digest.hexdigest()
-        if actual_archive_sha256 != expected_archive_sha256:
-            raise ValueError(
-                "Kimi-Vendor-Verifier archive SHA256 mismatch: expected "
-                f"{expected_archive_sha256}, got {actual_archive_sha256}"
-            )
-        archive_file.seek(0)
-
-        stage = "validate the downloaded archive"
-        required_files = {
-            "pyproject.toml",
-            "tests/conftest.py",
-            "tests/__init__.py",
-            "tests/tool_call_json_schema/conftest.py",
-            "tests/tool_call_json_schema/__init__.py",
-            "tests/tool_call_json_schema/test_tool_call_json_schema.py",
-            "tests/tool_call_json_schema/validator.py",
-            "testdata/walle_validator_cases/validator_cases/TestAdditionalProperties/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestAnyOf/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestBasicTypes/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestDefs/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestDescription/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestEnforcerCases/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestID/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestKeywordsValidation/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestNestedDefsDepth/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestNumberFormat/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestRangeConstraints/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestRefInProperties/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestReferences/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestRequired/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestSingleTypeInArray/valid.jsonl",
-            "testdata/walle_validator_cases/validator_cases/TestTypeLocation/valid.jsonl",
-        }
-        selected_files = {}
-        archive_roots = set()
-        member_count = 0
-        archive_size = 0
-        selected_size = 0
-
-        with tarfile.open(fileobj=archive_file, mode="r|gz") as archive:
-            for member in archive:
-                member_count += 1
-                if member_count > 100_000:
-                    raise ValueError("archive contains more than 100000 members")
-                if member.size < 0:
-                    raise ValueError(
-                        f"archive member has a negative size: {member.name!r}"
-                    )
-                archive_size += member.size
-                if archive_size > 512 * 1024 * 1024:
-                    raise ValueError("expanded archive exceeds the 512 MiB safety limit")
-
-                parts = archive_member_parts(member.name)
-                archive_roots.add(parts[0])
-                if len(archive_roots) > 1:
-                    roots = ", ".join(sorted(archive_roots))
-                    raise ValueError(f"archive has multiple roots: {roots}")
-                if not (member.isdir() or member.isfile()):
-                    raise ValueError(
-                        f"archive member has unsafe type: {member.name!r}"
-                    )
-                if len(parts) == 1:
-                    continue
-
-                relative_path = "/".join(parts[1:])
-                if relative_path not in required_files:
-                    continue
-                if relative_path in selected_files:
-                    raise ValueError(
-                        f"archive contains duplicate selected path: {relative_path!r}"
-                    )
-                if not member.isfile():
-                    raise ValueError(
-                        f"required path is not a regular file: {relative_path}"
-                    )
-                selected_size += member.size
-                if selected_size > 256 * 1024 * 1024:
-                    raise ValueError(
-                        "selected archive subset exceeds the 256 MiB safety limit"
-                    )
-                source = archive.extractfile(member)
-                if source is None:
-                    raise ValueError(f"could not read archive member: {member.name!r}")
-                with source:
-                    content = source.read(member.size + 1)
-                if len(content) != member.size:
-                    raise ValueError(
-                        f"archive member size mismatch: {member.name!r}"
-                    )
-                selected_files[relative_path] = content
-
-        if member_count == 0:
-            raise ValueError("archive contains no members")
-        if len(archive_roots) != 1:
-            raise ValueError("archive does not have exactly one root")
-        missing_files = sorted(required_files - selected_files.keys())
-        if missing_files:
-            raise ValueError(
-                "archive is missing required files: " + ", ".join(missing_files)
-            )
-
-        stage = "extract the verified archive subset"
-        if any(checkout_dir.iterdir()):
-            raise ValueError(f"checkout directory is not empty: {checkout_dir}")
-        for relative_path, content in selected_files.items():
-            destination = checkout_dir.joinpath(*relative_path.split("/"))
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            with destination.open("xb") as output:
-                output.write(content)
-except Exception as error:
-    print(
-        f"ERROR: failed to {stage} for Kimi-Vendor-Verifier "
-        f"at {verifier_ref}: {error}",
-        file=sys.stderr,
-    )
-    raise SystemExit(1)
-PY
+        "$repo_url" "$verifier_ref" "$expected_archive_sha256" "$checkout_dir" \
+        < "${INFERENCEX_REPO_ROOT}/utils/evals/_kimi_verifier_archive.py" || prepare_rc=$?
 
     if [ "$prepare_rc" -ne 0 ]; then
         if ! rm -rf "$checkout_dir"; then
@@ -1865,18 +1625,6 @@ _prepare_minimax_m3_full_runtime() {
     printf '%s\n' "$runtime_dir"
 }
 
-_write_minimax_m3_full_integration_error() {
-    local adapter_path="$1"
-    local model_name="$2"
-    local results_dir="$3"
-    local message="$4"
-
-    "${VENDOR_VERIFIER_PYTHON:-python3}" "$adapter_path" failure \
-        --model "$model_name" \
-        --output-dir "$results_dir" \
-        --message "$message"
-}
-
 _run_minimax_m3_full_eval() {
     local port="${PORT:-8888}"
     local results_dir="${EVAL_RESULT_DIR:-}"
@@ -1927,7 +1675,7 @@ _run_minimax_m3_full_eval() {
     if [ "$setup_rc" -ne 0 ]; then
         echo "ERROR: ${integration_error}" >&2
         local artifact_rc=0
-        _write_minimax_m3_full_integration_error \
+        _write_minimax_vendor_integration_error \
             "$adapter_path" "$model_name" "$results_dir" "$integration_error" \
             || artifact_rc=$?
         if [ "$artifact_rc" -ne 0 ]; then
@@ -1951,7 +1699,7 @@ _run_minimax_m3_full_eval() {
         && ! _has_eval_result "$results_dir" "results_minimax_vendor_full_"; then
         integration_error="MiniMax M3 full verifier failed with exit code ${eval_rc}"
         local artifact_rc=0
-        _write_minimax_m3_full_integration_error \
+        _write_minimax_vendor_integration_error \
             "$adapter_path" "$model_name" "$results_dir" "$integration_error" \
             || artifact_rc=$?
         if [ "$artifact_rc" -ne 0 ]; then

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/bash
 
+# shellcheck source=runners/slurm_utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/slurm_utils.sh"
+
 # Compatibility launcher for B200 Nscale configurations that have not yet
 # moved to the native srt-slurm path in launch_b200-nscale-slurm.sh.
 SLURM_PARTITION="${SLURM_PARTITION:-batch_1}"
@@ -463,48 +466,7 @@ EOF
     tar czf "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz" -C "$LOGS_DIR" .
 
     if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
-        # Find all result subdirectories
-        RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
-
-        if [ -z "$RESULT_SUBDIRS" ]; then
-            echo "Warning: No result subdirectories found in $LOGS_DIR"
-        else
-            # Process results from all configurations
-            for result_subdir in $RESULT_SUBDIRS; do
-                echo "Processing result subdirectory: $result_subdir"
-
-                # Extract configuration info from directory name
-                CONFIG_NAME=$(basename "$result_subdir")
-
-                # Find all result JSON files
-                RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
-
-                for result_file in $RESULT_FILES; do
-                    if [ -f "$result_file" ]; then
-                        # Extract metadata from filename
-                        # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
-                        filename=$(basename "$result_file")
-                        concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
-                        gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
-                        ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
-                        gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
-
-                        echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
-
-                        if [ -n "$ctx" ] && [ -n "$gen" ]; then
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
-                        else
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
-                        fi
-                        cp "$result_file" "$WORKSPACE_RESULT_FILE"
-
-                        echo "Copied result file to: $WORKSPACE_RESULT_FILE"
-                    fi
-                done
-            done
-        fi
-
-        echo "All result files processed"
+        copy_fixed_sequence_results "$LOGS_DIR" "$GITHUB_WORKSPACE" "$RESULT_FILENAME"
     else
         echo "EVAL_ONLY=true: Skipping benchmark result collection"
     fi

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/bash
 
+# shellcheck source=runners/slurm_utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/slurm_utils.sh"
+
 # Launcher for the B300 DSXE Slurm cluster (dsxe-sa-b300-prd0), runners run as sa-gha-runner.
 #
 # Every cluster-specific fact lives in this block. The rest of the file is generic:
@@ -358,48 +361,7 @@ cp -r "$LOGS_DIR" "$GITHUB_WORKSPACE/LOGS"
 tar czf "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz" -C "$LOGS_DIR" .
 
 if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
-    # Find all result subdirectories
-    RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
-
-    if [ -z "$RESULT_SUBDIRS" ]; then
-        echo "Warning: No result subdirectories found in $LOGS_DIR"
-    else
-        # Process results from all configurations
-        for result_subdir in $RESULT_SUBDIRS; do
-            echo "Processing result subdirectory: $result_subdir"
-
-            # Extract configuration info from directory name
-            CONFIG_NAME=$(basename "$result_subdir")
-
-            # Find all result JSON files
-            RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
-
-            for result_file in $RESULT_FILES; do
-                if [ -f "$result_file" ]; then
-                    # Extract metadata from filename
-                    # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
-                    filename=$(basename "$result_file")
-                    concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
-                    gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
-                    ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
-                    gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
-
-                    echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
-
-                    if [ -n "$ctx" ] && [ -n "$gen" ]; then
-                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
-                    else
-                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
-                    fi
-                    cp "$result_file" "$WORKSPACE_RESULT_FILE"
-
-                    echo "Copied result file to: $WORKSPACE_RESULT_FILE"
-                fi
-            done
-        done
-    fi
-
-    echo "All result files processed"
+    copy_fixed_sequence_results "$LOGS_DIR" "$GITHUB_WORKSPACE" "$RESULT_FILENAME"
 else
     echo "EVAL_ONLY=true: Skipping benchmark result collection"
 fi

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -656,48 +656,7 @@ if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
         exit 1
     fi
 
-    # Find all result subdirectories
-    RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
-
-    if [ -z "$RESULT_SUBDIRS" ]; then
-        echo "Warning: No result subdirectories found in $LOGS_DIR"
-    else
-        # Process results from all configurations
-        for result_subdir in $RESULT_SUBDIRS; do
-            echo "Processing result subdirectory: $result_subdir"
-
-            # Extract configuration info from directory name
-            CONFIG_NAME=$(basename "$result_subdir")
-
-            # Find all result JSON files
-            RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
-
-            for result_file in $RESULT_FILES; do
-                if [ -f "$result_file" ]; then
-                    # Extract metadata from filename
-                    # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
-                    filename=$(basename "$result_file")
-                    concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
-                    gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
-                    ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
-                    gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
-
-                    echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
-
-                    if [ -n "$ctx" ] && [ -n "$gen" ]; then
-                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
-                    else
-                        WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
-                    fi
-                    cp "$result_file" "$WORKSPACE_RESULT_FILE"
-
-                    echo "Copied result file to: $WORKSPACE_RESULT_FILE"
-                fi
-            done
-        done
-    fi
-
-    echo "All result files processed"
+    copy_fixed_sequence_results "$LOGS_DIR" "$GITHUB_WORKSPACE" "$RESULT_FILENAME"
 else
     echo "EVAL_ONLY=true: Skipping benchmark result collection"
 fi

--- a/runners/launch_h100-dgxc-slurm.sh
+++ b/runners/launch_h100-dgxc-slurm.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/bash
 set -e
 
+# shellcheck source=runners/slurm_utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/slurm_utils.sh"
+
 # System-specific configuration for H100 DGXC Slurm cluster
 SLURM_PARTITION="hpc-gpu-1"
 SLURM_ACCOUNT="customer"
@@ -216,48 +219,7 @@ EOF
     tar czf "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz" -C "$LOGS_DIR" .
 
     if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
-        # Find all result subdirectories
-        RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
-
-        if [ -z "$RESULT_SUBDIRS" ]; then
-            echo "Warning: No result subdirectories found in $LOGS_DIR"
-        else
-            # Process results from all configurations
-            for result_subdir in $RESULT_SUBDIRS; do
-                echo "Processing result subdirectory: $result_subdir"
-
-                # Extract configuration info from directory name
-                CONFIG_NAME=$(basename "$result_subdir")
-
-                # Find all result JSON files
-                RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
-
-                for result_file in $RESULT_FILES; do
-                    if [ -f "$result_file" ]; then
-                        # Extract metadata from filename
-                        # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
-                        filename=$(basename "$result_file")
-                        concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
-                        gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
-                        ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
-                        gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
-
-                        echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
-
-                        if [ -n "$ctx" ] && [ -n "$gen" ]; then
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
-                        else
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
-                        fi
-                        cp "$result_file" "$WORKSPACE_RESULT_FILE"
-
-                        echo "Copied result file to: $WORKSPACE_RESULT_FILE"
-                    fi
-                done
-            done
-        fi
-
-        echo "All result files processed"
+        copy_fixed_sequence_results "$LOGS_DIR" "$GITHUB_WORKSPACE" "$RESULT_FILENAME"
     else
         echo "EVAL_ONLY=true: Skipping benchmark result collection"
     fi

--- a/runners/launch_h200-dgxc-slurm.sh
+++ b/runners/launch_h200-dgxc-slurm.sh
@@ -390,48 +390,7 @@ EOF
     bundle_server_logs "$LOGS_DIR" "$GITHUB_WORKSPACE/multinode_server_logs.tar.gz"
 
     if [[ "${EVAL_ONLY:-false}" != "true" ]]; then
-        # Find all result subdirectories
-        RESULT_SUBDIRS=$(find "$LOGS_DIR" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
-
-        if [ -z "$RESULT_SUBDIRS" ]; then
-            echo "Warning: No result subdirectories found in $LOGS_DIR"
-        else
-            # Process results from all configurations
-            for result_subdir in $RESULT_SUBDIRS; do
-                echo "Processing result subdirectory: $result_subdir"
-
-                # Extract configuration info from directory name
-                CONFIG_NAME=$(basename "$result_subdir")
-
-                # Find all result JSON files
-                RESULT_FILES=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
-
-                for result_file in $RESULT_FILES; do
-                    if [ -f "$result_file" ]; then
-                        # Extract metadata from filename
-                        # Files may be "results_concurrency_N_gpus_G_ctx_C_gen_D.json" (disagg) or "results_concurrency_N_gpus_G.json" (non-disagg)
-                        filename=$(basename "$result_file")
-                        concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
-                        gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
-                        ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
-                        gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
-
-                        echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
-
-                        if [ -n "$ctx" ] && [ -n "$gen" ]; then
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
-                        else
-                            WORKSPACE_RESULT_FILE="$GITHUB_WORKSPACE/${RESULT_FILENAME}_${CONFIG_NAME}_conc${concurrency}_gpus_${gpus}.json"
-                        fi
-                        cp "$result_file" "$WORKSPACE_RESULT_FILE"
-
-                        echo "Copied result file to: $WORKSPACE_RESULT_FILE"
-                    fi
-                done
-            done
-        fi
-
-        echo "All result files processed"
+        copy_fixed_sequence_results "$LOGS_DIR" "$GITHUB_WORKSPACE" "$RESULT_FILENAME"
     else
         echo "EVAL_ONLY=true: Skipping benchmark result collection"
     fi

--- a/runners/slurm_utils.sh
+++ b/runners/slurm_utils.sh
@@ -63,6 +63,50 @@ copy_to_workspace() {
     echo "Copied $(basename "$source_file") to $destination_file"
 }
 
+# Preserve the legacy SRT filenames and the caller's shell error mode. Call
+# directly: testing this function's status would suppress errexit inside it.
+copy_fixed_sequence_results() {
+    local logs_dir="$1" workspace="$2" result_filename="$3"
+    local result_subdirs result_subdir result_files result_file config_name
+    local filename concurrency gpus ctx gen workspace_result_file
+
+    result_subdirs=$(find "$logs_dir" -maxdepth 1 -type d -name "*isl*osl*" 2>/dev/null)
+
+    if [ -z "$result_subdirs" ]; then
+        echo "Warning: No result subdirectories found in $logs_dir"
+    else
+        for result_subdir in $result_subdirs; do
+            echo "Processing result subdirectory: $result_subdir"
+            config_name=$(basename "$result_subdir")
+            result_files=$(find "$result_subdir" -name "results_concurrency_*.json" 2>/dev/null)
+
+            for result_file in $result_files; do
+                if [ -f "$result_file" ]; then
+                    # Both disaggregated (_ctx_C_gen_D) and aggregated names occur.
+                    filename=$(basename "$result_file")
+                    concurrency=$(echo "$filename" | sed -n 's/results_concurrency_\([0-9]*\)_gpus_.*/\1/p')
+                    gpus=$(echo "$filename" | sed -n 's/results_concurrency_[0-9]*_gpus_\([0-9][0-9]*\).*/\1/p')
+                    ctx=$(echo "$filename" | sed -n 's/.*_ctx_\([0-9]*\)_gen_.*/\1/p')
+                    gen=$(echo "$filename" | sed -n 's/.*_gen_\([0-9]*\)\.json/\1/p')
+
+                    echo "Processing concurrency $concurrency with $gpus GPUs (ctx: $ctx, gen: $gen): $result_file"
+
+                    if [ -n "$ctx" ] && [ -n "$gen" ]; then
+                        workspace_result_file="$workspace/${result_filename}_${config_name}_conc${concurrency}_gpus_${gpus}_ctx_${ctx}_gen_${gen}.json"
+                    else
+                        workspace_result_file="$workspace/${result_filename}_${config_name}_conc${concurrency}_gpus_${gpus}.json"
+                    fi
+                    cp "$result_file" "$workspace_result_file"
+
+                    echo "Copied result file to: $workspace_result_file"
+                fi
+            done
+        done
+    fi
+
+    echo "All result files processed"
+}
+
 copy_agentic_results() {
     local source_dir="$1"
     local workspace="$2"

--- a/runners/test_slurm_utils.py
+++ b/runners/test_slurm_utils.py
@@ -26,6 +26,86 @@ def run_bash(command: str, *args: Path | str) -> subprocess.CompletedProcess[str
     )
 
 
+def test_copy_fixed_sequence_results_preserves_names_contents_and_discovery(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    for relative, content in {
+        "isl128_osl256/nested/results_concurrency_16_gpus_8_ctx_128_gen_256.json": b'{"completed": 16}\n',
+        "isl32_osl64/results_concurrency_2_gpus_16.json": b'{"completed": 2}\n',
+        "isl32_osl64/server.json": b"ignored",
+        "unrelated/results_concurrency_4_gpus_8.json": b"ignored",
+        "results_concurrency_1_gpus_8.json": b"ignored",
+    }.items():
+        path = source / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+    result = run_bash(
+        'set -eo pipefail; source "$1"; copy_fixed_sequence_results "$2" "$3" run',
+        SLURM_UTILS,
+        source,
+        workspace,
+    )
+
+    assert result.returncode == 0, result.stderr
+    expected = {
+        "run_isl128_osl256_conc16_gpus_8_ctx_128_gen_256.json": b'{"completed": 16}\n',
+        "run_isl32_osl64_conc2_gpus_16.json": b'{"completed": 2}\n',
+    }
+    assert {path.name: path.read_bytes() for path in workspace.iterdir()} == expected
+    for name in expected:
+        assert f"Copied result file to: {workspace / name}\n" in result.stdout
+    assert result.stdout.endswith("All result files processed\n")
+
+
+def test_copy_fixed_sequence_results_allows_empty_discovery(tmp_path: Path) -> None:
+    result = run_bash(
+        'set -e; source "$1"; copy_fixed_sequence_results "$2" "$2" run',
+        SLURM_UTILS,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        f"Warning: No result subdirectories found in {tmp_path}\n"
+        "All result files processed\n"
+    )
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("errexit", [False, True])
+@pytest.mark.parametrize("failure", ["discovery", "copy"])
+def test_copy_fixed_sequence_results_preserves_caller_error_mode(
+    tmp_path: Path, errexit: bool, failure: str,
+) -> None:
+    source = tmp_path / "source"
+    if failure == "copy":
+        result_dir = source / "isl1_osl1"
+        result_dir.mkdir(parents=True)
+        (result_dir / "results_concurrency_1_gpus_8.json").write_text("{}\n")
+
+    result = run_bash(
+        f'set {"-e" if errexit else "+e"}; source "$1"; '
+        'copy_fixed_sequence_results "$2" "$3" run; echo continued',
+        SLURM_UTILS,
+        source,
+        tmp_path / "missing-workspace",
+    )
+
+    assert result.returncode == (1 if errexit else 0)
+    assert ("continued\n" in result.stdout) is not errexit
+    assert ("All result files processed\n" in result.stdout) is not errexit
+    if failure == "copy":
+        assert result.stderr
+        assert ("Copied result file to:" in result.stdout) is not errexit
+    else:
+        assert not result.stderr
+        assert ("No result subdirectories found" in result.stdout) is not errexit
+
+
 def test_copy_agentic_results_stages_only_matching_points(tmp_path: Path) -> None:
     source = tmp_path / "source"
     workspace = tmp_path / "workspace"

--- a/utils/evals/_kimi_verifier_archive.py
+++ b/utils/evals/_kimi_verifier_archive.py
@@ -1,0 +1,234 @@
+"""Internal pinned Kimi verifier archive preparation for benchmark_lib.sh."""
+
+from hashlib import sha256
+from pathlib import Path
+import re
+import socket
+import sys
+import tarfile
+import tempfile
+import time
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+repo_url, verifier_ref, expected_archive_sha256, checkout_dir_arg = sys.argv[1:]
+checkout_dir = Path(checkout_dir_arg)
+stage = "derive the pinned archive URL"
+
+
+def archive_member_parts(name):
+    if not name or "\x00" in name or "\\" in name or name.startswith("/"):
+        raise ValueError(f"unsafe archive member path: {name!r}")
+    normalized = name.rstrip("/")
+    parts = normalized.split("/")
+    if not normalized or any(part in ("", ".", "..") for part in parts):
+        raise ValueError(f"unsafe archive member path: {name!r}")
+    return tuple(parts)
+
+
+try:
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", verifier_ref):
+        raise ValueError(f"expected a 40-character commit SHA, got {verifier_ref!r}")
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", expected_archive_sha256):
+        raise ValueError(
+            "expected a 64-character archive SHA256, got "
+            f"{expected_archive_sha256!r}"
+        )
+
+    parsed_repo_url = urlsplit(repo_url)
+    if parsed_repo_url.scheme not in ("http", "https") or not parsed_repo_url.netloc:
+        raise ValueError(f"unsupported repository URL: {repo_url!r}")
+    if parsed_repo_url.query or parsed_repo_url.fragment:
+        raise ValueError(f"repository URL must not contain a query or fragment: {repo_url!r}")
+    repo_path = parsed_repo_url.path.rstrip("/")
+    if repo_path.endswith(".git"):
+        repo_path = repo_path[:-4]
+    if not repo_path:
+        raise ValueError(f"repository URL has no repository path: {repo_url!r}")
+    archive_path = f"{repo_path}/archive/{quote(verifier_ref, safe='')}.tar.gz"
+    archive_url = urlunsplit(
+        (parsed_repo_url.scheme, parsed_repo_url.netloc, archive_path, "", "")
+    )
+
+    stage = f"download {archive_url}"
+    request = Request(
+        archive_url,
+        headers={"User-Agent": "InferenceX-Kimi-Vendor-Verifier"},
+    )
+    with tempfile.TemporaryFile() as archive_file:
+        downloaded = 0
+        for attempt in range(1, 4):
+            archive_file.seek(0)
+            archive_file.truncate()
+            downloaded = 0
+            digest = sha256()
+            deadline = time.monotonic() + 60
+            try:
+                with urlopen(request, timeout=60) as response:
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise TimeoutError(
+                                "archive download exceeded the 60-second deadline"
+                            )
+                        sock = getattr(getattr(response, "fp", None), "raw", None)
+                        sock = getattr(sock, "_sock", None)
+                        if sock is not None:
+                            sock.settimeout(max(0.001, remaining))
+                        try:
+                            chunk = response.read(1024 * 1024)
+                        except socket.timeout as error:
+                            raise TimeoutError(
+                                "archive download exceeded the 60-second deadline"
+                            ) from error
+                        if not chunk:
+                            break
+                        downloaded += len(chunk)
+                        if downloaded > 128 * 1024 * 1024:
+                            raise ValueError(
+                                "archive download exceeds the 128 MiB safety limit"
+                            )
+                        archive_file.write(chunk)
+                        digest.update(chunk)
+                break
+            except HTTPError as error:
+                if error.code not in (408, 429) and not 500 <= error.code < 600:
+                    raise
+                if attempt == 3:
+                    raise
+                print(
+                    f"WARN: Kimi-Vendor-Verifier archive download attempt "
+                    f"{attempt}/3 failed: {error}; retrying",
+                    file=sys.stderr,
+                )
+                time.sleep(attempt)
+            except (TimeoutError, URLError, ConnectionError) as error:
+                if attempt == 3:
+                    raise
+                print(
+                    f"WARN: Kimi-Vendor-Verifier archive download attempt "
+                    f"{attempt}/3 failed: {error}; retrying",
+                    file=sys.stderr,
+                )
+                time.sleep(attempt)
+        if downloaded == 0:
+            raise ValueError("downloaded archive is empty")
+        actual_archive_sha256 = digest.hexdigest()
+        if actual_archive_sha256 != expected_archive_sha256:
+            raise ValueError(
+                "Kimi-Vendor-Verifier archive SHA256 mismatch: expected "
+                f"{expected_archive_sha256}, got {actual_archive_sha256}"
+            )
+        archive_file.seek(0)
+
+        stage = "validate the downloaded archive"
+        required_files = {
+            "pyproject.toml",
+            "tests/conftest.py",
+            "tests/__init__.py",
+            "tests/tool_call_json_schema/conftest.py",
+            "tests/tool_call_json_schema/__init__.py",
+            "tests/tool_call_json_schema/test_tool_call_json_schema.py",
+            "tests/tool_call_json_schema/validator.py",
+            "testdata/walle_validator_cases/validator_cases/TestAdditionalProperties/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestAnyOf/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestBasicTypes/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestDefs/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestDescription/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestEnforcerCases/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestID/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestKeywordsValidation/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestNestedDefsDepth/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestNumberFormat/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestRangeConstraints/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestRefInProperties/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestReferences/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestRequired/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestSingleTypeInArray/valid.jsonl",
+            "testdata/walle_validator_cases/validator_cases/TestTypeLocation/valid.jsonl",
+        }
+        selected_files = {}
+        archive_roots = set()
+        member_count = 0
+        archive_size = 0
+        selected_size = 0
+
+        with tarfile.open(fileobj=archive_file, mode="r|gz") as archive:
+            for member in archive:
+                member_count += 1
+                if member_count > 100_000:
+                    raise ValueError("archive contains more than 100000 members")
+                if member.size < 0:
+                    raise ValueError(
+                        f"archive member has a negative size: {member.name!r}"
+                    )
+                archive_size += member.size
+                if archive_size > 512 * 1024 * 1024:
+                    raise ValueError("expanded archive exceeds the 512 MiB safety limit")
+
+                parts = archive_member_parts(member.name)
+                archive_roots.add(parts[0])
+                if len(archive_roots) > 1:
+                    roots = ", ".join(sorted(archive_roots))
+                    raise ValueError(f"archive has multiple roots: {roots}")
+                if not (member.isdir() or member.isfile()):
+                    raise ValueError(
+                        f"archive member has unsafe type: {member.name!r}"
+                    )
+                if len(parts) == 1:
+                    continue
+
+                relative_path = "/".join(parts[1:])
+                if relative_path not in required_files:
+                    continue
+                if relative_path in selected_files:
+                    raise ValueError(
+                        f"archive contains duplicate selected path: {relative_path!r}"
+                    )
+                if not member.isfile():
+                    raise ValueError(
+                        f"required path is not a regular file: {relative_path}"
+                    )
+                selected_size += member.size
+                if selected_size > 256 * 1024 * 1024:
+                    raise ValueError(
+                        "selected archive subset exceeds the 256 MiB safety limit"
+                    )
+                source = archive.extractfile(member)
+                if source is None:
+                    raise ValueError(f"could not read archive member: {member.name!r}")
+                with source:
+                    content = source.read(member.size + 1)
+                if len(content) != member.size:
+                    raise ValueError(
+                        f"archive member size mismatch: {member.name!r}"
+                    )
+                selected_files[relative_path] = content
+
+        if member_count == 0:
+            raise ValueError("archive contains no members")
+        if len(archive_roots) != 1:
+            raise ValueError("archive does not have exactly one root")
+        missing_files = sorted(required_files - selected_files.keys())
+        if missing_files:
+            raise ValueError(
+                "archive is missing required files: " + ", ".join(missing_files)
+            )
+
+        stage = "extract the verified archive subset"
+        if any(checkout_dir.iterdir()):
+            raise ValueError(f"checkout directory is not empty: {checkout_dir}")
+        for relative_path, content in selected_files.items():
+            destination = checkout_dir.joinpath(*relative_path.split("/"))
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with destination.open("xb") as output:
+                output.write(content)
+except Exception as error:
+    print(
+        f"ERROR: failed to {stage} for Kimi-Vendor-Verifier "
+        f"at {verifier_ref}: {error}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -985,6 +985,7 @@ _prepare_kimi_vendor_verifier "$REPO_URL" "$VERIFIER_REF" "$ARCHIVE_SHA256"
                 "VERIFIER_REF": verifier_ref,
                 "ARCHIVE_SHA256": archive_sha256 or hashlib.sha256(payload).hexdigest(),
             },
+            cwd=tmp_path,
             text=True,
             capture_output=True,
         )

--- a/utils/matrix_logic/generate_sweep_configs.py
+++ b/utils/matrix_logic/generate_sweep_configs.py
@@ -487,18 +487,6 @@ def chunk_multinode_agentic_concurrencies(conc_values: list[int]) -> list[list[i
     return [conc_values[index:index + size] for index in range(0, len(conc_values), size)]
 
 
-def _freeze_matrix_value(value):
-    """Convert nested matrix values into hashable equivalents."""
-    if isinstance(value, dict):
-        return tuple(sorted(
-            (key, _freeze_matrix_value(item))
-            for key, item in value.items()
-        ))
-    if isinstance(value, list):
-        return tuple(_freeze_matrix_value(item) for item in value)
-    return value
-
-
 def _multinode_parallelism_key(entry: dict) -> tuple:
     """Identify a multi-node config independently of eval/concurrency fields.
 
@@ -520,7 +508,7 @@ def _multinode_parallelism_key(entry: dict) -> tuple:
         Fields.EVAL_SUITE.value,
     }
     return tuple(sorted(
-        (key, _freeze_matrix_value(value))
+        (key, freeze_config_value(value))
         for key, value in entry.items()
         if key not in ignored_fields
     ))
@@ -775,6 +763,89 @@ def mark_all_eval_entries(matrix_values: list[dict]) -> list[dict]:
     return expanded_entries
 
 
+def _concurrency_range(start: int, end: int, step: int) -> list[int]:
+    """Expand a validated positive range, including its end even after overshoot."""
+    values = []
+    while start <= end:
+        values.append(start)
+        if start == end:
+            break
+        start = min(start * step, end)
+    return values
+
+
+def _fixed_sequence_entries(
+    config: dict,
+    benchmark: dict,
+    sequence: dict,
+    conc_values: list[int],
+    runners: list[str],
+    runner_data: dict,
+) -> list[dict]:
+    """Build fixed-sequence rows after the command has selected runners and points.
+
+    Callers retain filtering and overrides; this owns row defaults, derived
+    identity, topology and validation for both full-sweep and test-config.
+    """
+    is_multinode = config.get(Fields.MULTINODE.value, False)
+    disagg = config.get(Fields.DISAGG.value, False)
+    isl, osl = sequence[Fields.ISL.value], sequence[Fields.OSL.value]
+    model_code = config[Fields.MODEL_PREFIX.value]
+    spec_decoding = benchmark.get(Fields.SPEC_DECODING.value, "none")
+    if is_multinode:
+        prefill, decode = multinode_worker_pair(benchmark, disagg)
+    else:
+        ep = benchmark.get(Fields.EP.value)
+        dp_attn = benchmark.get(Fields.DP_ATTN.value)
+
+    entries = []
+    # Multi-node rows carry the whole concurrency list; single-node rows carry
+    # one point. Keep point-major, runner-minor order for existing consumers.
+    for conc in [conc_values] if is_multinode else conc_values:
+        for runner in runners:
+            entry = {
+                Fields.IMAGE.value: config[Fields.IMAGE.value],
+                Fields.MODEL.value: config[Fields.MODEL.value],
+                Fields.MODEL_PREFIX.value: model_code,
+                Fields.PRECISION.value: config[Fields.PRECISION.value],
+                Fields.FRAMEWORK.value: config[Fields.FRAMEWORK.value],
+                Fields.RUNNER.value: runner,
+                Fields.ISL.value: isl,
+                Fields.OSL.value: osl,
+            }
+            if is_multinode:
+                entry.update({
+                    Fields.SPEC_DECODING.value: spec_decoding,
+                    Fields.PREFILL.value: prefill,
+                    Fields.DECODE.value: decode,
+                    Fields.CONC.value: conc,
+                    Fields.MAX_MODEL_LEN.value: isl + osl + 256,
+                })
+            else:
+                entry.update({
+                    Fields.TP.value: benchmark[Fields.TP.value],
+                    Fields.PP.value: benchmark.get(Fields.PP.value, 1),
+                    Fields.DCP_SIZE.value: benchmark.get(Fields.DCP_SIZE.value, 1),
+                    Fields.PCP_SIZE.value: benchmark.get(Fields.PCP_SIZE.value, 1),
+                    Fields.CONC.value: conc,
+                    Fields.MAX_MODEL_LEN.value: isl + osl + 256,
+                    Fields.EP.value: ep if ep is not None else 1,
+                    Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
+                    Fields.SPEC_DECODING.value: spec_decoding,
+                })
+            entry.update({
+                Fields.EXP_NAME.value: f"{model_code}_{seq_len_to_str(isl, osl)}",
+                Fields.DISAGG.value: disagg,
+                Fields.RUN_EVAL.value: False,
+            })
+            entry.update(component_metadata(benchmark, config))
+            if is_multinode:
+                add_multinode_node_count(
+                    entry, runner_data, benchmark.get(Fields.NUM_NODES.value))
+            entries.append(validate_matrix_entry(entry, is_multinode))
+    return entries
+
+
 def generate_full_sweep(args, all_config_data, runner_data):
     """Generate full sweep configurations with optional filtering.
 
@@ -873,12 +944,6 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     continue
 
                 if is_multinode:
-                    # Multinode configuration
-                    # spec_decoding defaults to "none" if not specified
-                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
-
-                    prefill, decode = multinode_worker_pair(bmk, disagg)
-
                     # Get concurrency values (can be list or range)
                     conc_list = bmk.get(Fields.CONC_LIST.value)
                     # If it's a list
@@ -888,15 +953,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                     else:
                         conc_start = bmk[Fields.CONC_START.value]
                         conc_end = bmk[Fields.CONC_END.value]
-                        conc_values = []
-                        conc = conc_start
-                        while conc <= conc_end:
-                            conc_values.append(conc)
-                            if conc == conc_end:
-                                break
-                            conc *= args.step_size
-                            if conc > conc_end:
-                                conc = conc_end
+                        conc_values = _concurrency_range(conc_start, conc_end, args.step_size)
 
                     # Apply min-conc filter if specified
                     if args.min_conc is not None:
@@ -919,46 +976,13 @@ def generate_full_sweep(args, all_config_data, runner_data):
                         else:
                             conc_values = filtered_conc
 
-                    seq_len_str = seq_len_to_str(isl, osl)
                     runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
-
-                    for runner_value in runners_for_entry:
-                        entry = {
-                            Fields.IMAGE.value: image,
-                            Fields.MODEL.value: model,
-                            Fields.MODEL_PREFIX.value: model_code,
-                            Fields.PRECISION.value: precision,
-                            Fields.FRAMEWORK.value: framework,
-                            Fields.RUNNER.value: runner_value,
-                            Fields.ISL.value: isl,
-                            Fields.OSL.value: osl,
-                            Fields.SPEC_DECODING.value: spec_decoding,
-                            Fields.PREFILL.value: prefill,
-                            Fields.DECODE.value: decode,
-                            Fields.CONC.value: conc_values,  # Pass the entire list for multinode
-                            Fields.MAX_MODEL_LEN.value: isl + osl + 256,
-                            Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                            Fields.DISAGG.value: disagg,
-                            Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
-                        }
-                        entry.update(component_metadata(bmk, val))
-                        add_multinode_node_count(
-                            entry,
-                            runner_data,
-                            bmk.get(Fields.NUM_NODES.value),
-                        )
-
-                        validate_matrix_entry(entry, is_multinode)
-                        matrix_values.append(entry)
+                    matrix_values.extend(_fixed_sequence_entries(
+                        val, bmk, seq_config, conc_values, runners_for_entry, runner_data))
                 else:
                     # Single-node configuration
                     tp = bmk[Fields.TP.value]
-                    pp = bmk.get(Fields.PP.value, 1)
-                    dcp_size = bmk.get(Fields.DCP_SIZE.value, 1)
-                    pcp_size = bmk.get(Fields.PCP_SIZE.value, 1)
                     ep = bmk.get(Fields.EP.value)
-                    dp_attn = bmk.get(Fields.DP_ATTN.value)
-                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
 
                     # Apply max-tp filter if specified
                     if args.max_tp is not None:
@@ -1023,52 +1047,12 @@ def generate_full_sweep(args, all_config_data, runner_data):
                             else:
                                 conc_end = min(conc_end, args.max_conc)
 
-                        conc_values = []
-                        conc = conc_start
-                        while conc <= conc_end:
-                            conc_values.append(conc)
-                            if conc == conc_end:
-                                break
-                            conc *= args.step_size
-                            if conc > conc_end:
-                                conc = conc_end
+                        conc_values = _concurrency_range(conc_start, conc_end, args.step_size)
 
-                    seq_len_str = seq_len_to_str(isl, osl)
                     runners_for_entry = runner_nodes_to_use if runner_nodes_to_use else [runner]
-
-                    for conc in conc_values:
-                        for runner_value in runners_for_entry:
-                            entry = {
-                                Fields.IMAGE.value: image,
-                                Fields.MODEL.value: model,
-                                Fields.MODEL_PREFIX.value: model_code,
-                                Fields.PRECISION.value: precision,
-                                Fields.FRAMEWORK.value: framework,
-                                Fields.RUNNER.value: runner_value,
-                                Fields.ISL.value: isl,
-                                Fields.OSL.value: osl,
-                                Fields.TP.value: tp,
-                                Fields.PP.value: pp,
-                                Fields.DCP_SIZE.value: dcp_size,
-                                Fields.PCP_SIZE.value: pcp_size,
-                                Fields.CONC.value: conc,
-                                Fields.MAX_MODEL_LEN.value: isl + osl + 256,
-                                Fields.EP.value: 1,  # Default
-                                Fields.DP_ATTN.value: False,  # Default
-                                Fields.SPEC_DECODING.value: spec_decoding,
-                                Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                                Fields.DISAGG.value: disagg,
-                                Fields.RUN_EVAL.value: False,  # Default, may be overridden by mark_eval_entries
-                            }
-
-                            if ep is not None:
-                                entry[Fields.EP.value] = ep
-                            if dp_attn is not None:
-                                entry[Fields.DP_ATTN.value] = dp_attn
-
-                            entry.update(component_metadata(bmk, val))
-                            validate_matrix_entry(entry, is_multinode)
-                            matrix_values.append(entry)
+                    matrix_values.extend(_fixed_sequence_entries(
+                        val, {**bmk, Fields.EP.value: ep}, seq_config,
+                        conc_values, runners_for_entry, runner_data))
 
         # ---- Agentic-coding scenarios ----
         agentic_configs = scenarios.get(Fields.AGENTIC_CODING.value, []) if (scenario_filter is None or 'agentic-coding' in scenario_filter) else []
@@ -1107,15 +1091,7 @@ def generate_full_sweep(args, all_config_data, runner_data):
                 else:
                     conc_start = bmk[Fields.CONC_START.value]
                     conc_end = bmk[Fields.CONC_END.value]
-                    conc_values = []
-                    conc = conc_start
-                    while conc <= conc_end:
-                        conc_values.append(conc)
-                        if conc == conc_end:
-                            break
-                        conc *= args.step_size
-                        if conc > conc_end:
-                            conc = conc_end
+                    conc_values = _concurrency_range(conc_start, conc_end, args.step_size)
 
                 # Apply conc filters
                 if args.min_conc is not None:
@@ -1263,122 +1239,20 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
             if seq_lens_filter and (isl, osl) not in seq_lens_filter:
                 continue
 
-            seq_len_str = seq_len_to_str(isl, osl)
-
             for bmk in seq_len_config[Fields.SEARCH_SPACE.value]:
-                if is_multinode:
-                    # Multinode config
-                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
-                    prefill, decode = multinode_worker_pair(bmk, disagg)
-
-                    # Get concurrency values
-                    if Fields.CONC_LIST.value in bmk:
-                        conc_values = bmk[Fields.CONC_LIST.value]
-                    else:
-                        conc_start = bmk[Fields.CONC_START.value]
-                        conc_end = bmk[Fields.CONC_END.value]
-                        conc_values = []
-                        conc = conc_start
-                        while conc <= conc_end:
-                            conc_values.append(conc)
-                            if conc == conc_end:
-                                break
-                            conc *= 2
-                            if conc > conc_end:
-                                conc = conc_end
-
-                    # Apply --conc filter if provided (only for test-config)
-                    if getattr(args, 'conc', None):
-                        conc_values = [c for c in conc_values if c in args.conc]
-                        if not conc_values:
-                            # No intersection with requested conc values; skip
-                            continue
-
-                    for runner_value in runners_for_entry:
-                        entry = {
-                            Fields.IMAGE.value: image,
-                            Fields.MODEL.value: model,
-                            Fields.MODEL_PREFIX.value: model_code,
-                            Fields.PRECISION.value: precision,
-                            Fields.FRAMEWORK.value: framework,
-                            Fields.RUNNER.value: runner_value,
-                            Fields.ISL.value: isl,
-                            Fields.OSL.value: osl,
-                            Fields.SPEC_DECODING.value: spec_decoding,
-                            Fields.PREFILL.value: prefill,
-                            Fields.DECODE.value: decode,
-                            Fields.CONC.value: conc_values,
-                            Fields.MAX_MODEL_LEN.value: isl + osl + 256,
-                            Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                            Fields.DISAGG.value: disagg,
-                            Fields.RUN_EVAL.value: False,
-                        }
-                        entry.update(component_metadata(bmk, val))
-                        add_multinode_node_count(
-                            entry,
-                            runner_data,
-                            bmk.get(Fields.NUM_NODES.value),
-                        )
-                        matrix_values.append(validate_matrix_entry(entry, is_multinode=True))
+                if Fields.CONC_LIST.value in bmk:
+                    conc_values = bmk[Fields.CONC_LIST.value]
                 else:
-                    # Single-node config
-                    tp = bmk[Fields.TP.value]
-                    pp = bmk.get(Fields.PP.value, 1)
-                    dcp_size = bmk.get(Fields.DCP_SIZE.value, 1)
-                    pcp_size = bmk.get(Fields.PCP_SIZE.value, 1)
-                    ep = bmk.get(Fields.EP.value)
-                    dp_attn = bmk.get(Fields.DP_ATTN.value)
-                    spec_decoding = bmk.get(Fields.SPEC_DECODING.value, "none")
+                    conc_values = _concurrency_range(
+                        bmk[Fields.CONC_START.value], bmk[Fields.CONC_END.value], 2)
 
-                    # Get concurrency values
-                    if Fields.CONC_LIST.value in bmk:
-                        conc_values = bmk[Fields.CONC_LIST.value]
-                    else:
-                        conc_start = bmk[Fields.CONC_START.value]
-                        conc_end = bmk[Fields.CONC_END.value]
-                        conc_values = []
-                        conc = conc_start
-                        while conc <= conc_end:
-                            conc_values.append(conc)
-                            if conc == conc_end:
-                                break
-                            conc *= 2
-                            if conc > conc_end:
-                                conc = conc_end
+                if getattr(args, 'conc', None):
+                    conc_values = [c for c in conc_values if c in args.conc]
+                    if not conc_values:
+                        continue
 
-                    # Apply --conc filter if provided (only for test-config)
-                    if getattr(args, 'conc', None):
-                        conc_values = [c for c in conc_values if c in args.conc]
-                        if not conc_values:
-                            # No intersection with requested conc values; skip
-                            continue
-
-                    for conc in conc_values:
-                        for runner_value in runners_for_entry:
-                            entry = {
-                                Fields.IMAGE.value: image,
-                                Fields.MODEL.value: model,
-                                Fields.MODEL_PREFIX.value: model_code,
-                                Fields.PRECISION.value: precision,
-                                Fields.FRAMEWORK.value: framework,
-                                Fields.RUNNER.value: runner_value,
-                                Fields.ISL.value: isl,
-                                Fields.OSL.value: osl,
-                                Fields.TP.value: tp,
-                                Fields.PP.value: pp,
-                                Fields.DCP_SIZE.value: dcp_size,
-                                Fields.PCP_SIZE.value: pcp_size,
-                                Fields.CONC.value: conc,
-                                Fields.MAX_MODEL_LEN.value: isl + osl + 256,
-                                Fields.EP.value: ep if ep is not None else 1,
-                                Fields.DP_ATTN.value: dp_attn if dp_attn is not None else False,
-                                Fields.SPEC_DECODING.value: spec_decoding,
-                                Fields.EXP_NAME.value: f"{model_code}_{seq_len_str}",
-                                Fields.DISAGG.value: disagg,
-                                Fields.RUN_EVAL.value: False,
-                            }
-                            entry.update(component_metadata(bmk, val))
-                            matrix_values.append(validate_matrix_entry(entry, is_multinode=False))
+                matrix_values.extend(_fixed_sequence_entries(
+                    val, bmk, seq_len_config, conc_values, runners_for_entry, runner_data))
 
         # ---- Agentic-coding scenarios ----
         agentic_configs = val[Fields.SCENARIOS.value].get(Fields.AGENTIC_CODING.value, []) if (scenario_filter is None or 'agentic-coding' in scenario_filter) else []
@@ -1411,15 +1285,7 @@ def generate_test_config_sweep(args, all_config_data, runner_data=None):
                 else:
                     conc_start = bmk[Fields.CONC_START.value]
                     conc_end = bmk[Fields.CONC_END.value]
-                    conc_values = []
-                    conc = conc_start
-                    while conc <= conc_end:
-                        conc_values.append(conc)
-                        if conc == conc_end:
-                            break
-                        conc *= 2
-                        if conc > conc_end:
-                            conc = conc_end
+                    conc_values = _concurrency_range(conc_start, conc_end, 2)
 
                 if getattr(args, 'conc', None):
                     conc_values = [c for c in conc_values if c in args.conc]


### PR DESCRIPTION
## Description / 说明

This first self-contained PR in the internal cleanup series removes duplicated matrix and result-collection logic while preserving existing caller and recipe interfaces.

这是内部清理系列的首个独立 PR：去除矩阵生成和结果收集中的重复逻辑，保持现有调用方式和 recipe 接口不变。

- Share fixed-sequence matrix row construction, concurrency-range expansion and nested-value freezing. / 统一固定序列长度矩阵行的构建、并发范围展开及嵌套值转换逻辑。
- Reuse one result collector across five Slurm launchers, preserving file selection, ordering and missing-result behavior. / 五个 Slurm launcher 共用结果收集函数，保留文件选择、顺序和结果缺失时的行为。
- Extract the Kimi archive verifier's unchanged Python body from Bash, remove duplicate helpers, and include helper/runner tests in CI coverage. / 将 Kimi 归档校验器的 Python 代码原样移出 Bash，删除重复辅助函数，并将相关辅助模块和 runner 测试纳入 CI。

Production code shrinks by 304 lines; the total change removes 218 lines net. Recipes, images, schemas and CLI options are unchanged.

生产代码减少 304 行，计入测试等改动后净减少 218 行。recipe、镜像、schema 和 CLI 选项均未改变。

**Validation / 验证**

- 405 tests passed: 280 matrix/changelog, 104 eval-dispatch and 21 runner tests. / 405 项测试通过：矩阵与 changelog 280 项、eval 调度 104 项、runner 21 项。
- 25 before/after CLI comparisons produced byte-identical matrix output across active-runner and all fixed-sequence cases; eight comparisons matched the old Git collector blocks against the shared collector. These comparison harnesses are temporary local artifacts. / 25 组改动前后的 CLI 对比覆盖有效 runner 和全部固定序列长度场景，矩阵输出逐字节一致；另有八组对比确认共享收集函数与 Git 基线中的原有代码块行为一致。对比脚本仅作为本地临时验证材料保存。
- Bash syntax, Python 3.10-compatible parsing and workflow YAML checks passed. / Bash 语法、Python 3.10 兼容解析及 workflow YAML 检查通过。

Unfiltered all-scenario generation still fails on both the baseline and this change because `cluster:b300-nv` hardware metadata is missing. No GPU smoke, full sweep or inference-engine eval was run; merge validation remains pending.

基线与本次改动在不筛选的全场景生成中均因缺少 `cluster:b300-nv` 硬件元数据而失败，该既有问题未改变。本次未执行 GPU smoke、完整 sweep 或推理引擎 eval；合并前验证尚未完成。

## Related Issue / 关联 Issue

None. / 无。

## Type of Change / 改动类型

- [ ] Bug fix / 缺陷修复
- [ ] New feature / 新功能
- [ ] Configuration change / 配置变更
- [ ] Documentation update / 文档更新
- [x] Other: internal refactor / 其他：内部重构

## Checklist / 检查清单

- [x] I have tested my changes locally. / 已完成本地测试。
- [x] Documentation reviewed; no update needed because existing interfaces and documented behavior are unchanged. / 已检查文档；现有接口及文档所述行为不变，无需更新。
- [ ] Performance changelog: N/A for this behavior-preserving internal refactor. No recipe or benchmark-performance behavior changes are intended; `perf-changelog.yaml` is untouched. / 性能 changelog：本次为保持行为不变的内部重构，不涉及 recipe 或基准测试性能行为调整；`perf-changelog.yaml` 未改动，因此不适用。
- [ ] Before merging via reuse, an authorized maintainer must post `/reuse-sweep-run` after a green full sweep with passing evals. Not completed for this draft. / 通过复用路径合并前，须在完整 sweep 和 eval 均通过后，由有权限的维护者发布 `/reuse-sweep-run`；此草稿尚未完成该步骤。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of matrix generation and artifact staging; Kimi verifier logic is relocated, not rewritten. Risk is mainly regression in result filename patterns or sweep matrix output if shared helpers diverge from the old copies.
> 
> **Overview**
> This PR **deduplicates internal benchmark and CI plumbing** without changing recipes, CLI options, or outward matrix contracts.
> 
> **Sweep matrix generation** centralizes fixed-sequence-length row building in `_fixed_sequence_entries` and concurrency expansion in `_concurrency_range`, reuses existing `freeze_config_value` for multinode grouping keys, and routes full-sweep and test-config paths through the shared helpers.
> 
> **Slurm launchers** (`launch_b200-nscale-compat`, `launch_b300-dsxe`, `launch_gb300-nv`, `launch_h100-dgxc-slurm`, `launch_h200-dgxc-slurm`) source `runners/slurm_utils.sh` and call **`copy_fixed_sequence_results`** instead of inlined find/copy loops, with new **`runners/test_slurm_utils.py`** coverage.
> 
> **Kimi vendor verifier** preparation moves from an inline heredoc in `benchmark_lib.sh` to **`utils/evals/_kimi_verifier_archive.py`** (same download/validate/extract logic). MiniMax full-eval failure reporting uses the shared **`_write_minimax_vendor_integration_error`** helper.
> 
> **Changelog-gate CI** watches the new runner/eval helper paths and runs `runners/test_slurm_utils.py` in the pytest job; eval dispatch tests set `cwd` for the archive script path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507393b740abb4c74dca5e73754b73a01dffc0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->