### PR TITLE
refactor: simplify changelog orchestration and strengthen tests / 简化变更日志编排并强化测试

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -40,12 +40,28 @@ jobs:
           pip install -r .claude/requirements-mcp.txt
           mkdir -p /tmp/inferencemax-mcp
 
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          package-manager-cache: false
+
+      - name: Install Claude Code
+        id: claude-code
+        run: |
+          # The native installer can report success without creating its launcher.
+          npm install --prefix "$RUNNER_TEMP/claude-code" --no-audit --no-fund @anthropic-ai/claude-code@2.1.265
+          claude_path="$RUNNER_TEMP/claude-code/node_modules/.bin/claude"
+          "$claude_path" --version
+          echo "path=$claude_path" >> "$GITHUB_OUTPUT"
+
       - name: PR Review with Claude
         uses: anthropics/claude-code-action@v1
         env:
           INFERENCEMAX_ROOT: ${{ github.workspace }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          path_to_claude_code_executable: ${{ steps.claude-code.outputs.path }}
           trigger_phrase: "@pr-claude"
           track_progress: true
           allowed_bots: ''

--- a/docs/ci-procedures.md
+++ b/docs/ci-procedures.md
@@ -273,6 +273,8 @@ Watch the first canary or matrix failure, then classify it before rerunning:
 - **Policy/gate failure:** conflicting labels, invalid changelog, missing authorization, merge conflict, or ineligible artifacts. Correct the gate. GPU reruns will not fix it.
 - **Superseded run:** a later commit or recognized label change cancelled it through workflow concurrency. Monitor the replacement run rather than reviving stale evidence.
 
+The [`PR Review` workflow](../.github/workflows/claude-pr-review.yml) installs a pinned official Claude Code npm package and checks `claude --version` before passing its executable path to the review action. An installation or startup failure means the review did not run; it is not a review finding or a successful review. Check the installation step before retrying.
+
 ### Rerun safely
 
 Do not rerun an in-progress run blindly. A completed failed run can rerun only failed jobs and their dependents:

--- a/docs/ci-procedures_zh.md
+++ b/docs/ci-procedures_zh.md
@@ -265,6 +265,8 @@ gh api "/repos/SemiAnalysisAI/InferenceX/actions/runs/$RUN_ID" \
 - **策略/Gate 失败：** 标签冲突、Changelog 无效、缺少授权、合并冲突或产物不合格。修正 Gate；重跑 GPU 无法解决。
 - **已被取代的 Run：** 后续 Commit 或被识别的标签变更通过 Workflow Concurrency 将其取消。应监控替代 Run，不要复活过期证据。
 
+[`PR Review` Workflow](../.github/workflows/claude-pr-review.yml) 安装固定版本的官方 Claude Code npm 包，并在将可执行文件路径传给审阅 Action 前检查 `claude --version`。安装或启动失败表示审阅没有执行，既不是代码审阅发现的问题，也不代表审阅通过。重试前应先检查安装步骤。
+
 ### 安全重跑
 
 不要盲目重跑仍在执行的 Run。已结束的失败 Run 可以只重跑失败 Job 及其依赖项：

--- a/experimental/CollectiveX/tests/test_backends.py
+++ b/experimental/CollectiveX/tests/test_backends.py
@@ -149,7 +149,6 @@ class RoundtripStaging(unittest.TestCase):
         b = _StagingBackend(stage_device_work=True, fp8_consume="native")
         b.run_roundtrip(object(), staged="pre-materialised")
         self.assertEqual(b.calls, ["dispatch", "combine(pre-materialised)"])
-        self.assertNotIn("stage", b.calls)
 
     def test_an_unrecognised_consume_mode_fails_instead_of_silently_meaning_native(self):
         # The value is read at class-body evaluation, so a typo raises at import -- before
@@ -403,12 +402,15 @@ class TestSingleHandle(unittest.TestCase):
         """LL applies the gate in combine, so its weights wrapper must be cached: building one
         per timed combine puts a torch resolve and an np.asarray inside `time_us`."""
         ll = backend(ll=True)
+        ll._t = mock.Mock(side_effect=lambda value: types.SimpleNamespace(value=value))
         pa = problem(1)
         h = ll._ensure_handle(pa)
-        self.assertTrue(hasattr(h, "combine_weights_t"))
-        self.assertEqual(h.combine_weights_t, "w1")
+        first_weights = h.combine_weights_t
+        self.assertEqual(first_weights.value, "w1")
         # Re-entering the same problem reuses the handle and therefore the wrapper.
-        self.assertIs(ll._ensure_handle(pa).combine_weights_t, h.combine_weights_t)
+        ll._t.reset_mock()
+        self.assertIs(ll._ensure_handle(pa).combine_weights_t, first_weights)
+        ll._t.assert_not_called()
 
         ht = backend(ll=False)
         self.assertFalse(hasattr(ht._ensure_handle(problem(1)), "combine_weights_t"))

--- a/experimental/CollectiveX/tests/test_chain.py
+++ b/experimental/CollectiveX/tests/test_chain.py
@@ -228,16 +228,16 @@ class ChainedPairPeriod(unittest.TestCase):
                 self.assertEqual(ops_only(period), ["dispatch", "combine"] * iters)
                 # The staged cost is absent from the pair window, not merely from the trace.
                 for value in series["pair"]:
-                    self.assertAlmostEqual(value, (DISPATCH_MS + COMBINE_MS) * 1000.0)
+                    self.assertAlmostEqual(value, 8000.0)  # 3ms dispatch + 5ms combine
                 for value in series["start_to_start"]:
-                    self.assertAlmostEqual(value, (DISPATCH_MS + COMBINE_MS) * 1000.0)
+                    self.assertAlmostEqual(value, 8000.0)
                 for value in series["dispatch"]:
-                    self.assertAlmostEqual(value, DISPATCH_MS * 1000.0)
+                    self.assertAlmostEqual(value, 3000.0)
                 for value in series["combine"]:
-                    self.assertAlmostEqual(value, COMBINE_MS * 1000.0)
+                    self.assertAlmostEqual(value, 5000.0)
 
     def test_returns_one_sample_per_kept_iteration(self):
-        for iters, drop in ((8, 0), (8, 2), (6, 5)):
+        for iters, drop, kept, gaps in ((8, 0, 8, 7), (8, 2, 6, 5), (6, 5, 1, 0)):
             with self.subTest(iters=iters, drop=drop):
                 backend = _ChainBackend()
                 with trace_torch(backend.clock, backend.calls):
@@ -247,9 +247,9 @@ class ChainedPairPeriod(unittest.TestCase):
                     ["combine", "combined", "dispatch", "pair", "start_to_start"],
                 )
                 for key in ("pair", "dispatch", "combine"):
-                    self.assertEqual(len(series[key]), iters - drop)
+                    self.assertEqual(len(series[key]), kept)
                 # Start-to-start is a difference series: one fewer than the kept pairs.
-                self.assertEqual(len(series["start_to_start"]), max(iters - drop - 1, 0))
+                self.assertEqual(len(series["start_to_start"]), gaps)
 
     def test_the_dropped_iterations_are_the_head_of_each_chain(self):
         # `drop` discards pipeline fill, so it must cut the head of both chains -- the period
@@ -262,13 +262,11 @@ class ChainedPairPeriod(unittest.TestCase):
         )
         with trace_torch(backend.clock, backend.calls):
             series = backend.benchmark_chain(new_problem(), 0, iters, drop)
-        self.assertEqual(len(series["dispatch"]), iters - drop)
+        self.assertEqual(len(series["dispatch"]), 4)
         for value in series["dispatch"]:
-            self.assertAlmostEqual(value, DISPATCH_MS * 1000.0)
+            self.assertAlmostEqual(value, 3000.0)
         for value in series["pair"]:
-            self.assertAlmostEqual(
-                value, (DISPATCH_MS + STAGE_MS + COMBINE_MS) * 1000.0
-            )
+            self.assertAlmostEqual(value, 15000.0)  # 3ms dispatch + 7ms stage + 5ms combine
 
 
 class EventPlacement(unittest.TestCase):
@@ -362,7 +360,6 @@ class ChainComponentContract(unittest.TestCase):
 # ---- from test_run_sweep_chain.py -------------------------------------------------
 LADDER = [4, 8]
 CHAIN_ITERS, CHAIN_DROP, CHAIN_TRIALS = 8, 2, 2
-KEPT_PER_TRIAL = CHAIN_ITERS - CHAIN_DROP
 # What the stub backend reports for every chained iteration, distinct so a published number is
 # traceable to the op it came from; start_to_start sits a fixed GAP above the pair window.
 PAIR_US, DISPATCH_FLOOR_US, COMBINE_FLOOR_US = 50.0, 20.0, 25.0
@@ -733,7 +730,7 @@ class ChainedPublication(unittest.TestCase):
                 self.assertEqual(period["percentiles_us"]["p50"], PAIR_US)
                 self.assertEqual(period["origin"], "chained-median")
                 self.assertEqual(period["availability"], "measured")
-                self.assertEqual(period["sample_count"], KEPT_PER_TRIAL * CHAIN_TRIALS)
+                self.assertEqual(period["sample_count"], 12)  # six kept pairs in each of two trials
                 for op, expected in (
                     ("dispatch", DISPATCH_FLOOR_US), ("combine", COMBINE_FLOOR_US),
                 ):
@@ -843,40 +840,30 @@ class ChainOutputCheck(unittest.TestCase):
         # One table over the whole contract. The magnitude matters as much as the verdict: a
         # bare bool cost two wrong diagnoses of the same FP8 failures, because it cannot
         # separate a transport corruption from a tolerance too tight for an accumulator.
-        tol = ep_harness.COMBINE_REL_TOL
-        jitter = [value * (1.0 + tol / 2) for value in (1.0, -2.0)]
-        for label, chained, drained, ok, check in (
-            ("identical", [1.0, -3.5, 0.25], [1.0, -3.5, 0.25], True,
-             lambda e: self.assertEqual(e, 0.0)),
+        for label, chained, drained, ok, expected_error in (
+            ("identical", [1.0, -3.5, 0.25], [1.0, -3.5, 0.25], True, 0.0),
             # A rank that legitimately combined nothing under this routing.
-            ("empty", [], [], True, lambda e: self.assertEqual(e, 0.0)),
+            ("empty", [], [], True, 0.0),
             # Run-to-run jitter inside tolerance passes, and still reports its size -- a
             # magnitude creeping toward the gate is the early warning a bool cannot give.
-            ("jitter", jitter, [1.0, -2.0], True,
-             lambda e: self.assertAlmostEqual(e, tol / 2)),
+            ("jitter", [1.01, -2.02], [1.0, -2.0], True, 0.01),
             # The defect class this exists for lands orders of magnitude past tolerance.
-            ("corruption", [1.0, 2.0], [1.0, 4.0], False,
-             lambda e: self.assertGreater(e, 10 * tol)),
+            ("corruption", [1.0, 2.0], [1.0, 4.0], False, 0.5),
             # No elementwise error is defined across shapes; infinity stops a cross-rank MAX
             # reporting a small number for a structural mismatch.
-            ("shape", [1.0, 2.0], [1.0, 2.0, 3.0], False,
-             lambda e: self.assertEqual(e, float("inf"))),
+            ("shape", [1.0, 2.0], [1.0, 2.0, 3.0], False, float("inf")),
         ):
             with self.subTest(label):
                 got, error = ep_harness._chain_output_matches(_Vec(chained), _Vec(drained))
                 self.assertIs(got, ok)
-                check(error)
+                self.assertAlmostEqual(error, expected_error)
 
     def test_near_zero_elements_are_judged_against_the_magnitude_floor(self):
         # Relative error against a denominator of 1e-6 would be huge; the floor keeps
         # numerically-tiny elements from redding a healthy chain.
-        drained, chained = 1e-6, 1e-6 + 1e-4
-        self.assertGreater(
-            abs(chained - drained) / abs(drained), ep_harness.COMBINE_REL_TOL
-        )
-        self.assertTrue(
-            ep_harness._chain_output_matches(_Vec([chained]), _Vec([drained]))[0]
-        )
+        got, error = ep_harness._chain_output_matches(_Vec([0.000101]), _Vec([0.000001]))
+        self.assertTrue(got)
+        self.assertAlmostEqual(error, 0.005)  # 0.0001 difference under the 0.02 magnitude floor
 
 
 # ---- from test_summarize_headline.py ----------------------------------------------

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -21,16 +21,9 @@ from pathlib import Path
 
 import pytest
 
-from utils.agentic.aggregation.request_metrics import (
-    compute_request_metrics,
-    load_aggregate,
-    load_records,
-)
+from utils.agentic.aggregation.request_metrics import compute_request_metrics
 from utils.agentic.aggregation.process_agentic_result import _gpu_shape
-from utils.agentic.aggregation.server_metrics import (
-    compute_server_metrics,
-    load_server_metrics,
-)
+from utils.agentic.aggregation.server_metrics import compute_server_metrics
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -162,28 +155,6 @@ def _assert_stable_request_metrics_schema(agg: dict) -> None:
     assert set(request_metrics["tokens"]) == REQUEST_TOKEN_KEYS
     assert set(request_metrics["throughput"]) == REQUEST_THROUGHPUT_KEYS
     assert set(request_metrics["cache"]) == REQUEST_CACHE_KEYS
-
-
-def _flat_request_keys(result_dir: Path) -> set[str]:
-    artifact = result_dir / "aiperf_artifacts"
-    records = load_records(artifact / "profile_export.jsonl")
-    aggregate_path = artifact / "profile_export_aiperf.json"
-    aggregate = load_aggregate(aggregate_path) if aggregate_path.exists() else {}
-    flat, _ = compute_request_metrics(records, aggregate)
-    return set(flat)
-
-
-def _flat_server_keys(result_dir: Path, framework: str = "vllm") -> set[str]:
-    records = load_records(result_dir / "aiperf_artifacts" / "profile_export.jsonl")
-    server_metrics = load_server_metrics(
-        result_dir / "aiperf_artifacts" / "server_metrics_export.json"
-    )
-    flat, _, _ = compute_server_metrics(
-        server_metrics,
-        framework=framework,
-        records=records,
-    )
-    return set(flat)
 
 
 def _make_record(
@@ -377,8 +348,8 @@ def test_processor_emits_nested_request_and_server_metrics(tmp_path: Path):
     assert agg["recipe_fingerprint"] == "b" * 64
     missing = AGG_TOP_LEVEL_KEYS - set(agg.keys())
     assert not missing, f"agg JSON missing top-level keys: {sorted(missing)}"
-    assert not (_flat_request_keys(result_dir) & set(agg.keys()))
-    assert not (_flat_server_keys(result_dir) & set(agg.keys()))
+    assert "server_gpu_cache_hit_rate" not in agg
+    assert "total_prompt_tokens" not in agg
     _assert_stable_request_metrics_schema(agg)
     _assert_stable_server_metrics_schema(agg)
 
@@ -1138,7 +1109,6 @@ def test_processor_parses_real_server_metrics_schema(tmp_path: Path):
     assert agg["server_metrics"]["tokens"]["generation_total"] == 6789
     _assert_stable_server_metrics_schema(agg)
     assert agg["server_metrics"]["adapter"] == "vllm"
-    assert agg["server_metrics"]["cache"]["gpu_cache_hit_rate"] == pytest.approx(0.8)
 
 
 def test_processor_aggregates_across_multiple_series(tmp_path: Path):

--- a/utils/agentic/datasets/test_build_weka_hf_dataset.py
+++ b/utils/agentic/datasets/test_build_weka_hf_dataset.py
@@ -41,8 +41,6 @@ def test_filter_without_drops_preserves_overlapping_subagents_exactly() -> None:
     filtered = _filter_trace_256k(trace, cap=256_000)
 
     assert filtered == trace
-    child_a, child_b = filtered["requests"][1:]
-    assert child_b["t"] < child_a["t"] + child_a["duration_ms"] / 1000.0
 
 
 def test_filter_uses_uniform_shift_and_preserves_overlap() -> None:

--- a/utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py
+++ b/utils/changelog_gate_tests/test_prepare_perf_changelog_merge.py
@@ -76,7 +76,6 @@ def test_conflict_resolution_preserves_main_bytes_and_appends_pr_entry() -> None
 
     assert result.startswith(main)
     assert result[len(main):].startswith(b"\n- config-keys:")
-    assert b"  \n" in result[:len(main)]
     entries = parse_changelog(result, "result")
     assert [entry["config-keys"][0] for entry in entries] == [
         "base-config",

--- a/utils/evals/test_minimax_m3_full_eval.py
+++ b/utils/evals/test_minimax_m3_full_eval.py
@@ -174,8 +174,6 @@ def test_verifier_command_is_one_102_row_run_with_fixed_m3_settings(
         "--extra-body",
         '{"temperature":0,"top_p":1,"max_tokens":40960}',
     ]
-    assert "pass" not in " ".join(command).lower()
-    assert command.count("/runtime/source/sample.jsonl") == 1
 
 
 def test_projects_exactly_102_results_from_native_match_rate_without_rewriting_report(

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -256,9 +256,6 @@ run_kimi_vendor_eval() {
 run_lm_eval() {
     echo "DISPATCH=lm-eval SUITE=${EVAL_SUITE:-unset} COMPLETED=${EVAL_COMPLETED_SUITE:-unset}"
 }
-append_lm_eval_summary() {
-    echo "METADATA=${EVAL_COMPLETED_SUITE:-gsm8k}"
-}
 export EVAL_MAX_MODEL_LEN=16384
 export EVAL_CONCURRENT_REQUESTS=""
 export EVAL_ONLY=false
@@ -267,11 +264,9 @@ unset EVAL_SUITE
 export EVAL_FRAMEWORK=kimi-vendor
 run_eval --port 8888
 printf 'KIMI_COMPLETED=%s\n' "${EVAL_COMPLETED_SUITE:-unset}"
-append_lm_eval_summary
 export EVAL_FRAMEWORK=lm-eval
 run_eval --port 8888
 printf 'LM_COMPLETED=%s\n' "${EVAL_COMPLETED_SUITE:-unset}"
-append_lm_eval_summary
 printf 'FINAL_SUITE=%s\n' "${EVAL_SUITE-unset}"
 """
     result = subprocess.run(
@@ -285,10 +280,8 @@ printf 'FINAL_SUITE=%s\n' "${EVAL_SUITE-unset}"
     assert result.returncode == 0, result.stderr
     assert "DISPATCH=kimi-vendor SUITE=kimi_tool_call_schema" in result.stdout
     assert "KIMI_COMPLETED=kimi_tool_call_schema" in result.stdout
-    assert "METADATA=kimi_tool_call_schema" in result.stdout
     assert "DISPATCH=lm-eval SUITE=unset COMPLETED=unset" in result.stdout
     assert "LM_COMPLETED=unset" in result.stdout
-    assert "METADATA=gsm8k" in result.stdout
     assert "FINAL_SUITE=unset" in result.stdout
 
 
@@ -2013,14 +2006,19 @@ def test_modal_credentials_sanitizes_whitespace_contaminated_tokens(tmp_path):
     script = r"""
 source "$BENCHMARK_LIB" 2>/dev/null
 export SWEBENCH_USE_MODAL=true
-export MODAL_TOKEN_ID='ak-clean123'
-export MODAL_TOKEN_SECRET="$(printf 'as-dirty456\n')"
 _ensure_modal_credentials
-grep -q 'token_secret = "as-dirty456"' "$HOME/.modal.toml" || { echo FILE_DIRTY; exit 1; }
-[ "$MODAL_TOKEN_SECRET" = "as-dirty456" ] || { echo ENV_DIRTY; exit 1; }
+grep -q '^token_id = "ak-clean123"$' "$HOME/.modal.toml" || { echo ID_DIRTY; exit 1; }
+grep -q '^token_secret = "as-clean456"$' "$HOME/.modal.toml" || { echo FILE_DIRTY; exit 1; }
+[ "$MODAL_TOKEN_ID" = "ak-clean123" ] && [ "$MODAL_TOKEN_SECRET" = "as-clean456" ] || { echo ENV_DIRTY; exit 1; }
 echo SANITIZED_OK
 """
-    env = {**os.environ, "BENCHMARK_LIB": str(BENCHMARK_LIB), "HOME": str(home)}
+    env = {
+        **os.environ,
+        "BENCHMARK_LIB": str(BENCHMARK_LIB),
+        "HOME": str(home),
+        "MODAL_TOKEN_ID": " \t'ak-clean123'\r\n",
+        "MODAL_TOKEN_SECRET": ' \t"as-clean456"\r\n',
+    }
     res = subprocess.run(
         ["bash", "-c", script], env=env, text=True, capture_output=True
     )
@@ -2364,7 +2362,7 @@ def test_multinode_eval_artifact_names_are_bounded_and_distinct() -> None:
         conc_twin,
     ]
     names = [render(target) for target in variants]
-    assert len(names) == len(set(names)) == len(variants)
+    assert len(names) == len(set(names))
     assert all(name.startswith("eval_") and len(name.encode()) <= 256 for name in names)
 
 

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -1301,7 +1301,6 @@ class TestGenerateFullSweepSingleNode:
         )
         # 2 amd nodes (mi300x-amd_0, mi300x-amd_1), 1 conc value = 2 entries
         assert len(result) == 2
-        assert all("amd" in entry["runner"] for entry in result)
         runners = [entry["runner"] for entry in result]
         assert "mi300x-amd_0" in runners
         assert "mi300x-amd_1" in runners
@@ -1348,8 +1347,6 @@ class TestGenerateFullSweepMultiNode:
             sample_runner_config
         )
         entry = result[0]
-        assert "prefill" in entry
-        assert "decode" in entry
         assert entry["prefill"]["num-worker"] == 5
         assert entry["decode"]["num-worker"] == 1
         assert entry["disagg"] is True
@@ -1397,7 +1394,6 @@ class TestGenerateFullSweepMultiNode:
             sample_runner_config
         )
         entry = result[0]
-        assert isinstance(entry["conc"], list)
         assert entry["conc"] == [2150]
 
     def test_single_node_flag_skips_multinode(self, sample_multinode_config, sample_runner_config, full_sweep_args_single_node):
@@ -1460,7 +1456,6 @@ class TestGenerateFullSweepMultiNode:
         )
         # Only h200-cw_0 and h200-cw_1 match "cw" filter
         assert len(result) == 2
-        assert all("cw" in entry["runner"] for entry in result)
         runners = [entry["runner"] for entry in result]
         assert "h200-cw_0" in runners
         assert "h200-cw_1" in runners

--- a/utils/matrix_logic/test_validation.py
+++ b/utils/matrix_logic/test_validation.py
@@ -257,7 +257,7 @@ class TestWorkerConfig:
 
     @pytest.mark.parametrize("field", ["pp", "dcp-size", "pcp-size"])
     def test_worker_parallelism_fields_must_be_positive(self, field):
-        with pytest.raises(Exception, match="greater than 0"):
+        with pytest.raises(ValidationError, match="greater than 0"):
             WorkerConfig(**{
                 "num-worker": 2,
                 "tp": 4,
@@ -267,7 +267,7 @@ class TestWorkerConfig:
             })
 
     def test_worker_dcp_size_must_divide_tp(self):
-        with pytest.raises(Exception, match="must be divisible"):
+        with pytest.raises(ValidationError, match="must be divisible"):
             WorkerConfig(**{
                 "num-worker": 2,
                 "tp": 4,
@@ -278,7 +278,7 @@ class TestWorkerConfig:
 
     def test_worker_config_missing_required_field(self):
         """Missing required field should fail."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             WorkerConfig(**{
                 "num-worker": 2,
                 "tp": 4,
@@ -287,7 +287,7 @@ class TestWorkerConfig:
 
     def test_worker_config_extra_field_forbidden(self):
         """Extra fields should be forbidden."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             WorkerConfig(**{
                 "num-worker": 2,
                 "tp": 4,
@@ -328,25 +328,25 @@ class TestSingleNodeMatrixEntry:
     def test_invalid_spec_decoding(self, valid_single_node_matrix_entry):
         """Invalid spec decoding value should fail."""
         valid_single_node_matrix_entry["spec-decoding"] = "invalid"
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             SingleNodeMatrixEntry(**valid_single_node_matrix_entry)
 
     def test_missing_required_field(self, valid_single_node_matrix_entry):
         """Missing required field should fail validation."""
         del valid_single_node_matrix_entry["model"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             SingleNodeMatrixEntry(**valid_single_node_matrix_entry)
 
     def test_extra_field_forbidden(self, valid_single_node_matrix_entry):
         """Extra fields should be forbidden."""
         valid_single_node_matrix_entry["extra-field"] = "value"
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             SingleNodeMatrixEntry(**valid_single_node_matrix_entry)
 
     def test_disagg_requires_multinode(self, valid_single_node_matrix_entry):
         """Single-node matrix entries cannot enable disaggregation."""
         valid_single_node_matrix_entry["disagg"] = True
-        with pytest.raises(Exception, match="disagg"):
+        with pytest.raises(ValidationError, match="disagg"):
             SingleNodeMatrixEntry(**valid_single_node_matrix_entry)
 
 
@@ -415,7 +415,7 @@ class TestAgenticMatrixEntries:
         {"name": "vllm-router", "version": ""},
     ])
     def test_component_metadata_requires_exact_non_empty_fields(self, metadata):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "none",
@@ -425,7 +425,7 @@ class TestAgenticMatrixEntries:
 
     @pytest.mark.parametrize("value", ["", {"name": "nixl"}])
     def test_kv_p2p_transfer_requires_a_non_empty_name(self, value):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeSearchSpaceEntry(**{
                 "prefill": {
                     "num-worker": 1, "tp": 8, "ep": 1, "dp-attn": False,
@@ -449,7 +449,7 @@ class TestAgenticMatrixEntries:
         assert entry.kv_offload_backend.version == "0.5.1"
 
     def test_kv_offload_backend_rejects_unknown_metadata(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "dram",
@@ -458,7 +458,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_kv_offload_backend_rejects_image_as_version(self):
-        with pytest.raises(Exception, match="not an image reference"):
+        with pytest.raises(ValidationError, match="not an image reference"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "dram",
@@ -470,7 +470,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_kv_offload_backend_requires_dram_mode(self):
-        with pytest.raises(Exception, match="kv-offload-backend"):
+        with pytest.raises(ValidationError, match="kv-offload-backend"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "none",
@@ -479,7 +479,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_dram_kv_offload_requires_backend(self):
-        with pytest.raises(Exception, match="kv-offload-backend"):
+        with pytest.raises(ValidationError, match="kv-offload-backend"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "dram",
@@ -487,14 +487,14 @@ class TestAgenticMatrixEntries:
             })
 
     def test_single_node_agentic_requires_explicit_kv_offloading(self):
-        with pytest.raises(Exception, match="kv-offloading"):
+        with pytest.raises(ValidationError, match="kv-offloading"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "conc-list": [1, 2],
             })
 
     def test_dram_kv_offload_requires_dram_utilization(self):
-        with pytest.raises(Exception, match="dram-utilization"):
+        with pytest.raises(ValidationError, match="dram-utilization"):
             AgenticCodingConfig(**{
                 "search-space": [{
                     "tp": 4,
@@ -505,7 +505,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_agentic_search_space_rejects_total_cpu_dram_gb(self):
-        with pytest.raises(Exception, match="total-cpu-dram-gb"):
+        with pytest.raises(ValidationError, match="total-cpu-dram-gb"):
             AgenticCodingSearchSpaceEntry(**{
                 "tp": 8,
                 "kv-offloading": "dram",
@@ -527,7 +527,7 @@ class TestAgenticMatrixEntries:
         assert config.dram_utilization == 0.80
 
     def test_gpus_per_node_is_not_a_master_config_field(self):
-        with pytest.raises(Exception, match="gpus-per-node"):
+        with pytest.raises(ValidationError, match="gpus-per-node"):
             AgenticCodingConfig(**{
                 "dram-utilization": 0.80,
                 "gpus-per-node": 8,
@@ -540,7 +540,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_available_cpu_dram_is_not_a_master_config_field(self):
-        with pytest.raises(Exception, match="available-cpu-dram-mib"):
+        with pytest.raises(ValidationError, match="available-cpu-dram-mib"):
             AgenticCodingConfig(**{
                 "available-cpu-dram-mib": 2964436,
                 "dram-utilization": 0.80,
@@ -553,7 +553,7 @@ class TestAgenticMatrixEntries:
             })
 
     def test_duration_is_not_a_master_config_field(self):
-        with pytest.raises(Exception, match="duration"):
+        with pytest.raises(ValidationError, match="duration"):
             AgenticCodingConfig(**{
                 "duration": 1800,
                 "search-space": [{
@@ -594,7 +594,7 @@ class TestMultiNodeMatrixEntry:
     ):
         """Heterogeneous hardware metadata must identify both worker pools."""
         del valid_multinode_matrix_entry[missing_worker]["hardware"]
-        with pytest.raises(Exception, match="both.*prefill.*decode"):
+        with pytest.raises(ValidationError, match="both.*prefill.*decode"):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     def test_prefill_decode_worker_configs(self, valid_multinode_matrix_entry):
@@ -618,13 +618,13 @@ class TestMultiNodeMatrixEntry:
     def test_conc_must_be_list(self, valid_multinode_matrix_entry):
         """Conc must be a list for multinode."""
         valid_multinode_matrix_entry["conc"] = 2150  # Single int, not list
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     def test_node_count_is_required(self, valid_multinode_matrix_entry):
         """A multinode row cannot silently degrade to a one-node request."""
         del valid_multinode_matrix_entry["node-count"]
-        with pytest.raises(Exception, match="node-count"):
+        with pytest.raises(ValidationError, match="node-count"):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     @pytest.mark.parametrize("node_count", [0, -1, True, "2"])
@@ -633,19 +633,19 @@ class TestMultiNodeMatrixEntry:
     ):
         """Invalid node requests fail before reaching the reusable workflow."""
         valid_multinode_matrix_entry["node-count"] = node_count
-        with pytest.raises(Exception, match="node-count"):
+        with pytest.raises(ValidationError, match="node-count"):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     def test_missing_prefill(self, valid_multinode_matrix_entry):
         """Missing prefill should fail."""
         del valid_multinode_matrix_entry["prefill"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
     def test_missing_decode(self, valid_multinode_matrix_entry):
         """Missing decode should fail."""
         del valid_multinode_matrix_entry["decode"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeMatrixEntry(**valid_multinode_matrix_entry)
 
 
@@ -708,7 +708,7 @@ class TestSingleNodeSearchSpaceEntry:
         assert entry.conc_list == [4, 8, 16, 32, 64, 128]
 
     def test_pp_must_be_positive_integer(self):
-        with pytest.raises(Exception, match="greater than 0"):
+        with pytest.raises(ValidationError, match="greater than 0"):
             SingleNodeSearchSpaceEntry(**{
                 "tp": 4,
                 "pp": 0,
@@ -716,7 +716,7 @@ class TestSingleNodeSearchSpaceEntry:
             })
 
     def test_dcp_size_must_divide_tp(self):
-        with pytest.raises(Exception, match="must be divisible"):
+        with pytest.raises(ValidationError, match="must be divisible"):
             SingleNodeSearchSpaceEntry(**{
                 "tp": 8,
                 "dcp-size": 3,
@@ -726,7 +726,7 @@ class TestSingleNodeSearchSpaceEntry:
 
     def test_cannot_have_both_range_and_list(self):
         """Cannot specify both conc range and list."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             SingleNodeSearchSpaceEntry(**{
                 "tp": 4,
                 "conc-start": 4,
@@ -737,7 +737,7 @@ class TestSingleNodeSearchSpaceEntry:
 
     def test_must_have_range_or_list(self):
         """Must specify either conc range or list."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             SingleNodeSearchSpaceEntry(**{
                 "tp": 8,
             })
@@ -745,7 +745,7 @@ class TestSingleNodeSearchSpaceEntry:
 
     def test_conc_start_must_be_lte_conc_end(self):
         """conc-start must be <= conc-end."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             SingleNodeSearchSpaceEntry(**{
                 "tp": 8,
                 "conc-start": 64,
@@ -758,7 +758,7 @@ class TestSingleNodeSearchSpaceEntry:
         [(0, 4), (-1, 4), (1, 0)],
     )
     def test_conc_range_values_must_be_positive(self, conc_start, conc_end):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             SingleNodeSearchSpaceEntry(**{
                 "tp": 4,
                 "conc-start": conc_start,
@@ -769,7 +769,7 @@ class TestSingleNodeSearchSpaceEntry:
 
     def test_conc_list_values_must_be_positive(self):
         """conc-list values must be > 0."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             SingleNodeSearchSpaceEntry(**{
                 "tp": 4,
                 "conc-list": [4, 0, 16],
@@ -887,7 +887,7 @@ class TestMultiNodeSearchSpaceEntry:
 
     def test_missing_conc_specification(self):
         """Missing conc specification should fail."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeSearchSpaceEntry(**{
                 "prefill": {
                     "num-worker": 2,
@@ -986,19 +986,19 @@ class TestMasterConfigEntries:
         """Heterogeneous master configs must identify both worker pools."""
         search_entry = valid_multinode_master_config["scenarios"]["fixed-seq-len"][0]["search-space"][0]
         del search_entry["decode"]["hardware"]
-        with pytest.raises(Exception, match="both.*prefill.*decode"):
+        with pytest.raises(ValidationError, match="both.*prefill.*decode"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_single_node_cannot_have_multinode_true(self, valid_single_node_master_config):
         """Single node config must have multinode=False."""
         valid_single_node_master_config["multinode"] = True
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             SingleNodeMasterConfigEntry(**valid_single_node_master_config)
 
     def test_multinode_cannot_have_multinode_false(self, valid_multinode_master_config):
         """Multinode config must have multinode=True."""
         valid_multinode_master_config["multinode"] = False
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_single_node_rejects_kv_p2p_transfer(
@@ -1008,7 +1008,7 @@ class TestMasterConfigEntries:
         """P2P KV transfer is reserved for multinode configurations."""
         valid_single_node_master_config["kv-p2p-transfer"] = "nixl"
 
-        with pytest.raises(Exception, match="kv-p2p-transfer"):
+        with pytest.raises(ValidationError, match="kv-p2p-transfer"):
             SingleNodeMasterConfigEntry(**valid_single_node_master_config)
 
     def test_aggregated_multinode_allows_kv_p2p_transfer(
@@ -1047,7 +1047,7 @@ class TestMasterConfigEntries:
         )
         search_entry.pop("num-nodes")
 
-        with pytest.raises(Exception, match="disagg=false requires num-nodes"):
+        with pytest.raises(ValidationError, match="disagg=false requires num-nodes"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_aggregated_multinode_rejects_prefill_decode(
@@ -1057,7 +1057,7 @@ class TestMasterConfigEntries:
         """Aggregate master entries cannot model separate serving roles."""
         valid_multinode_master_config["disagg"] = False
 
-        with pytest.raises(Exception, match="disagg=false requires one worker"):
+        with pytest.raises(ValidationError, match="disagg=false requires one worker"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_disaggregated_multinode_rejects_num_nodes(
@@ -1070,7 +1070,7 @@ class TestMasterConfigEntries:
         ]["fixed-seq-len"][0]["search-space"][0]
         search_entry["num-nodes"] = 3
 
-        with pytest.raises(Exception, match="disagg=true.*num-nodes"):
+        with pytest.raises(ValidationError, match="disagg=true.*num-nodes"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     @pytest.mark.parametrize("num_nodes", [0, -1, True])
@@ -1085,12 +1085,12 @@ class TestMasterConfigEntries:
             num_nodes=num_nodes,
         )
 
-        with pytest.raises(Exception, match="num-nodes"):
+        with pytest.raises(ValidationError, match="num-nodes"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_component_metadata_rejects_image_as_version(self):
         """Component versions identify the component, not its container."""
-        with pytest.raises(Exception, match="not an image reference"):
+        with pytest.raises(ValidationError, match="not an image reference"):
             ComponentMetadata(
                 name="nixl",
                 version="image:vllm/vllm-openai:v0.23.0",
@@ -1113,7 +1113,7 @@ class TestMasterConfigEntries:
         ]["fixed-seq-len"][0]["search-space"]
         search_space[0][field] = value
 
-        with pytest.raises(Exception, match=f"{field} must be declared either"):
+        with pytest.raises(ValidationError, match=f"{field} must be declared either"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_component_metadata_allows_different_field_scopes(
@@ -1160,7 +1160,7 @@ class TestMasterConfigEntries:
         """A disaggregated config cannot omit KV transfer metadata."""
         valid_multinode_master_config.pop("kv-p2p-transfer")
 
-        with pytest.raises(Exception, match="disagg=true requires kv-p2p-transfer"):
+        with pytest.raises(ValidationError, match="disagg=true requires kv-p2p-transfer"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_disagg_accepts_kv_p2p_transfer_on_every_search_space_entry(
@@ -1195,13 +1195,13 @@ class TestMasterConfigEntries:
         search_space.append(copy.deepcopy(search_space[0]))
         search_space[0]["kv-p2p-transfer"] = "nixl"
 
-        with pytest.raises(Exception, match="disagg=true requires kv-p2p-transfer"):
+        with pytest.raises(ValidationError, match="disagg=true requires kv-p2p-transfer"):
             MultiNodeMasterConfigEntry(**valid_multinode_master_config)
 
     def test_disagg_requires_multinode(self, valid_single_node_master_config):
         """Single-node master configs cannot enable disaggregation."""
         valid_single_node_master_config["disagg"] = True
-        with pytest.raises(Exception, match="disagg"):
+        with pytest.raises(ValidationError, match="disagg"):
             SingleNodeMasterConfigEntry(**valid_single_node_master_config)
 
     def test_single_node_agentic_master_config_requires_cluster_runner(self):
@@ -1225,7 +1225,7 @@ class TestMasterConfigEntries:
             },
         }
 
-        with pytest.raises(Exception, match="Agentic master configs must use"):
+        with pytest.raises(ValidationError, match="Agentic master configs must use"):
             SingleNodeMasterConfigEntry(**config)
 
         config["runner"] = "cluster:b200-nscale"
@@ -1271,7 +1271,7 @@ class TestMasterConfigEntries:
             },
         }
 
-        with pytest.raises(Exception, match="Agentic master configs must use"):
+        with pytest.raises(ValidationError, match="Agentic master configs must use"):
             MultiNodeMasterConfigEntry(**config)
 
         config["runner"] = "cluster:b200-nscale"
@@ -1510,7 +1510,7 @@ class TestMultiNodeAgenticMatrixEntry:
     def test_node_count_is_required(self):
         row = dict(MULTINODE_AGENTIC_EVAL_ROW)
         del row["node-count"]
-        with pytest.raises(Exception, match="node-count"):
+        with pytest.raises(ValidationError, match="node-count"):
             MultiNodeAgenticMatrixEntry(**row)
 
     def test_validate_agentic_matrix_entry_dispatches_on_prefill_key(self):
@@ -1634,17 +1634,15 @@ hardware:
         assert len(result["labels"]["h100"]) == 2
 
     def test_load_runner_file_without_validation(self, tmp_path):
-        """Should load runner config file without validation when validate=False."""
+        """validate=False preserves parsed input that normal validation rejects."""
         runner_file = tmp_path / "runners.yaml"
-        runner_file.write_text("""
-labels:
-  h100:
-  - h100-node-0
-  - h100-node-1
-""")
-        result = load_runner_file(str(runner_file), validate=False)
-        assert "h100" in result["labels"]
-        assert len(result["labels"]["h100"]) == 2
+        runner_file.write_text("labels:\n  fixture-cluster: []\n")
+
+        assert load_runner_file(str(runner_file), validate=False) == {
+            "labels": {"fixture-cluster": []},
+        }
+        with pytest.raises(ValueError, match="cannot be an empty list"):
+            load_runner_file(str(runner_file))
 
     def test_nonexistent_runner_file(self):
         """Nonexistent runner file should raise error."""

--- a/utils/process_changelog.py
+++ b/utils/process_changelog.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
-from constants import GENERATE_SWEEPS_PY_SCRIPT, MASTER_CONFIGS
+from constants import GENERATE_SWEEPS_PY_SCRIPT, MASTER_CONFIGS, RUNNER_CONFIG
 from matrix_logic.generate_sweep_configs import (
     freeze_config_value,
     seq_len_to_str,
@@ -31,8 +31,6 @@ class GenerationInputs:
     config_files: list[str]
     generator_script: str
     runner_config: str
-
-
 
 
 def get_added_lines(base_ref: str, head_ref: str, filepath: str) -> str:
@@ -344,6 +342,59 @@ def validate_append_only_scope(
                 continue
 
 
+def group_unseen_scenarios(
+    config_keys: list[str],
+    scenarios: tuple[str, ...],
+    seen: dict[str, set[str]],
+) -> dict[tuple[str, ...], list[str]]:
+    """Claim unseen config/scenario pairs in canonical scenario and input-key order.
+
+    Benchmark and eval callers pass separate coverage maps; grouping one must
+    never suppress work in the other.
+    """
+    groups: dict[tuple[str, ...], list[str]] = defaultdict(list)
+    for config in config_keys:
+        unseen = tuple(
+            scenario for scenario in SCENARIO_TYPES
+            if scenario in scenarios and scenario not in seen[config]
+        )
+        if unseen:
+            seen[config].update(unseen)
+            groups[unseen].append(config)
+    return groups
+
+
+def generate_matrix(
+    config_keys: list[str],
+    flags: list[str],
+    inputs: GenerationInputs | None = None,
+) -> list[dict]:
+    """Run the selected generator in its own process and decode its matrix.
+
+    Explicit inputs include a runner override for current/historical benchmark
+    comparisons. Eval callers retain the generator's existing runner default.
+    Keep child-error diagnostics on stdout for compatibility with the CLI.
+    """
+    command = [
+        "python3",
+        inputs.generator_script if inputs else GENERATE_SWEEPS_PY_SCRIPT,
+        "test-config",
+        "--config-keys",
+        *config_keys,
+        "--config-files",
+        *(inputs.config_files if inputs else MASTER_CONFIGS),
+    ]
+    if inputs is not None:
+        command.extend(["--runner-config", inputs.runner_config])
+    command.extend(flags)
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr)
+        raise
+    return json.loads(result.stdout)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-ref", type=str, required=True)
@@ -404,6 +455,7 @@ def main():
     benchmark_scenarios_seen = defaultdict(set)
     eval_scenarios_seen = defaultdict(set)
 
+    head_inputs = GenerationInputs(MASTER_CONFIGS, GENERATE_SWEEPS_PY_SCRIPT, RUNNER_CONFIG)
     master_config = load_config_files(MASTER_CONFIGS)
     resolved_entries = []
     for entry in parsed_entries:
@@ -451,109 +503,30 @@ def main():
         )
 
         if not suppress_throughput:
-            # Generate benchmark entries (no evals)
-            benchmark_groups = defaultdict(list)
-            for config in all_configs:
-                unseen_scenarios = tuple(
-                    scenario for scenario in SCENARIO_TYPES
-                    if (
-                        scenario in entry_scenarios
-                        and scenario not in benchmark_scenarios_seen[config]
-                    )
-                )
-                if unseen_scenarios:
-                    benchmark_scenarios_seen[config].update(unseen_scenarios)
-                    benchmark_groups[unseen_scenarios].append(config)
-
+            benchmark_groups = group_unseen_scenarios(
+                all_configs, entry_scenarios, benchmark_scenarios_seen)
             for scenarios, benchmark_configs in benchmark_groups.items():
-                head_cmd = [
-                    "python3",
-                    GENERATE_SWEEPS_PY_SCRIPT,
-                    "test-config",
-                    "--config-keys",
-                    *benchmark_configs,
-                    "--config-files",
-                    *MASTER_CONFIGS,
-                    "--runner-config",
-                    "configs/runners.yaml",
-                    "--no-evals",
-                ]
+                flags = ["--no-evals"]
                 if scenarios != SCENARIO_TYPES:
-                    head_cmd.extend(["--scenario-type", *scenarios])
-                try:
-                    result = subprocess.run(
-                        head_cmd,
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    )
-                    head_results = json.loads(result.stdout)
-                    if entry.append_only:
-                        base_cmd = head_cmd.copy()
-                        base_cmd[1] = base_inputs.generator_script
-                        config_files_index = base_cmd.index("--config-files") + 1
-                        base_cmd[
-                            config_files_index:config_files_index + len(MASTER_CONFIGS)
-                        ] = base_inputs.config_files
-                        runner_config_index = base_cmd.index("--runner-config") + 1
-                        base_cmd[runner_config_index] = base_inputs.runner_config
-                        base_result = subprocess.run(
-                            base_cmd,
-                            capture_output=True,
-                            text=True,
-                            check=True,
-                        )
-                        head_results = append_only_delta(
-                            json.loads(base_result.stdout), head_results
-                        )
-                except subprocess.CalledProcessError as e:
-                    print(e.stderr)
-                    raise
+                    flags.extend(["--scenario-type", *scenarios])
+                head_results = generate_matrix(benchmark_configs, flags, head_inputs)
+                if entry.append_only:
+                    assert base_inputs is not None
+                    base_results = generate_matrix(benchmark_configs, flags, base_inputs)
+                    head_results = append_only_delta(base_results, head_results)
                 all_benchmark_results.extend(head_results)
 
         if entry.append_only:
             continue
 
-        eval_groups = defaultdict(list)
-        for config in all_configs:
-            unseen_scenarios = tuple(
-                scenario for scenario in SCENARIO_TYPES
-                if (
-                    scenario in entry_scenarios
-                    and scenario not in eval_scenarios_seen[config]
-                )
-            )
-            if unseen_scenarios:
-                eval_scenarios_seen[config].update(unseen_scenarios)
-                eval_groups[unseen_scenarios].append(config)
-
+        eval_groups = group_unseen_scenarios(
+            all_configs, entry_scenarios, eval_scenarios_seen)
         for scenarios, eval_configs in eval_groups.items():
-            eval_flags = ["--evals-only"]
+            flags = ["--evals-only"]
             if expand_all_evals:
-                eval_flags.append("--all-evals")
-            base_cmd = [
-                "python3",
-                GENERATE_SWEEPS_PY_SCRIPT,
-                "test-config",
-                "--config-keys",
-                *eval_configs,
-                "--config-files",
-                *MASTER_CONFIGS,
-                *eval_flags,
-                "--scenario-type",
-                *scenarios,
-            ]
-            try:
-                eval_result = subprocess.run(
-                    base_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-            except subprocess.CalledProcessError as e:
-                print(e.stderr)
-                raise
-            entry_eval_results = json.loads(eval_result.stdout)
+                flags.append("--all-evals")
+            flags.extend(["--scenario-type", *scenarios])
+            entry_eval_results = generate_matrix(eval_configs, flags)
             entry_eval_results = filter_eval_rows_by_prefill_ep(
                 entry_eval_results, entry.eval_min_prefill_ep
             )

--- a/utils/test_find_reusable_sweep_run.py
+++ b/utils/test_find_reusable_sweep_run.py
@@ -36,27 +36,6 @@ def test_find_reuse_authorization_uses_latest_allowed_comment(monkeypatch) -> No
     ) == (True, 333)
 
 
-def test_find_reuse_authorization_accepts_command_without_run_id(monkeypatch) -> None:
-    def fake_paginated_github_api(*args, **kwargs):
-        return [
-            {
-                "created_at": "2026-05-13T00:00:00Z",
-                "author_association": "OWNER",
-                "body": "/reuse-sweep-run",
-            },
-        ]
-
-    monkeypatch.setattr(reuse, "paginated_github_api", fake_paginated_github_api)
-
-    assert reuse.find_reuse_authorization(
-        "SemiAnalysisAI/InferenceX",
-        1321,
-        "token",
-        "/reuse-sweep-run",
-        {"OWNER", "MEMBER", "COLLABORATOR"},
-    ) == (True, None)
-
-
 def test_find_reuse_authorization_lets_newer_no_arg_unpin_older_pin(monkeypatch) -> None:
     def fake_paginated_github_api(*args, **kwargs):
         return [

--- a/utils/test_process_changelog.py
+++ b/utils/test_process_changelog.py
@@ -6,6 +6,8 @@ import sys
 from contextlib import nullcontext
 from types import SimpleNamespace
 
+import pytest
+
 import process_changelog
 from matrix_logic.generate_sweep_configs import generate_test_config_sweep
 from matrix_logic.validation import validate_master_config
@@ -433,9 +435,11 @@ def test_append_only_scope_allows_range_to_list_expansion():
     )
 
 
+@pytest.mark.parametrize("trim", [False, True])
 def test_append_only_main_runs_only_added_points_and_skips_evals(
     monkeypatch,
     capsys,
+    trim,
 ):
     added_yaml = """
 - config-keys:
@@ -477,7 +481,7 @@ def test_append_only_main_runs_only_added_points_and_skips_evals(
         "process_changelog.py",
         "--base-ref", "base",
         "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
+        "--changelog-file", "perf-changelog.yaml", *(["--trim-conc"] if trim else []),
     ])
 
     process_changelog.main()
@@ -492,290 +496,6 @@ def test_append_only_main_runs_only_added_points_and_skips_evals(
     assert commands[1][1] == "base-generate-sweep-configs.py"
     assert commands[0][commands[0].index("--runner-config") + 1] == "configs/runners.yaml"
     assert commands[1][commands[1].index("--runner-config") + 1] == "base-runners.yaml"
-
-
-def test_all_evals_skips_benchmarks_and_uses_all_evals_generator_flag(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Run every eval configuration
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-  all-evals: true
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 1
-    assert "--all-evals" in commands[0]
-    assert "--evals-only" in commands[0]
-    assert "--no-evals" not in commands[0]
-    assert _scenario_values(commands[0]) == ["fixed-seq-len", "agentic-coding"]
-
-    output = json.loads(capsys.readouterr().out)
-    assert output["changelog_metadata"]["entries"][0]["all-evals"] is True
-
-
-def test_regular_changelog_entry_keeps_benchmark_and_subset_eval_commands(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Run benchmarks and selected evals
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 2
-    assert "--no-evals" in commands[0]
-    assert "--evals-only" in commands[1]
-    assert "--all-evals" not in commands[1]
-    assert _scenario_values(commands[1]) == ["fixed-seq-len", "agentic-coding"]
-    json.loads(capsys.readouterr().out)
-
-
-def test_cli_all_evals_expands_evals_and_preserves_benchmarks(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Run every eval configuration through a PR label
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-        "--all-evals",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 2
-    assert "--no-evals" in commands[0]
-    assert "--all-evals" not in commands[0]
-    assert "--all-evals" in commands[1]
-    assert "--evals-only" in commands[1]
-    assert _scenario_values(commands[1]) == ["fixed-seq-len", "agentic-coding"]
-    json.loads(capsys.readouterr().out)
-
-
-def test_cli_all_evals_expands_evals_only_entry_without_benchmarks(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Expand an eval-only entry through a PR label
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-  evals-only: true
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-        "--all-evals",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 1
-    assert "--all-evals" in commands[0]
-    assert "--evals-only" in commands[0]
-    assert "--no-evals" not in commands[0]
-    json.loads(capsys.readouterr().out)
-
-
-def test_cli_evals_only_suppresses_benchmarks_and_keeps_default_subset(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Run only the default eval subset through a PR label
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-        "--evals-only",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 1
-    assert "--evals-only" in commands[0]
-    assert "--all-evals" not in commands[0]
-    assert "--no-evals" not in commands[0]
-    assert _scenario_values(commands[0]) == ["fixed-seq-len", "agentic-coding"]
-    json.loads(capsys.readouterr().out)
-
-
-def test_cli_eval_modifiers_compose_as_all_evals_without_benchmarks(
-    monkeypatch,
-    capsys,
-):
-    added_yaml = """
-- config-keys:
-    - test-config
-  description:
-    - Run every eval and no throughput through PR labels
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/1
-"""
-    commands = []
-
-    monkeypatch.setattr(
-        process_changelog,
-        "get_added_lines",
-        lambda *_: added_yaml,
-    )
-    monkeypatch.setattr(
-        process_changelog,
-        "load_config_files",
-        lambda _: {"test-config": {}},
-    )
-
-    def fake_run(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(stdout="[]")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(sys, "argv", [
-        "process_changelog.py",
-        "--base-ref", "base",
-        "--head-ref", "head",
-        "--changelog-file", "perf-changelog.yaml",
-        "--all-evals",
-        "--evals-only",
-    ])
-
-    process_changelog.main()
-
-    assert len(commands) == 1
-    assert "--evals-only" in commands[0]
-    assert "--all-evals" in commands[0]
-    assert "--no-evals" not in commands[0]
-    json.loads(capsys.readouterr().out)
 
 
 def test_cli_evals_only_generates_agentic_eval(
@@ -1167,3 +887,156 @@ def test_eval_rows_split_into_multinode_fixed_and_agentic_buckets(
     assert [r["exp-name"] for r in output["multinode_agentic_evals"]] == ["multinode_agentic_eval"]
     assert output["evals"] == []
     assert output["agentic_evals"] == []
+
+
+@pytest.fixture
+def changelog_run(monkeypatch, capsys):
+    """Exercise main and final validation; replace only Git/config/subprocess I/O."""
+    def run(entries, cli_flags=(), generated=None, master=None):
+        entries = [{"config-keys": ["config-a"], "description": ["Controlled change"],
+                    "pr-link": "https://github.com/SemiAnalysisAI/InferenceX/pull/1",
+                    **entry} for entry in entries]
+        commands = []
+        monkeypatch.setattr(process_changelog, "get_added_lines", lambda *_: json.dumps(entries))
+        monkeypatch.setattr(process_changelog, "load_config_files",
+                            lambda _: master if master is not None else {"config-b": {}, "config-a": {}})
+        monkeypatch.setattr(sys, "argv", ["process_changelog.py", "--base-ref", "base",
+                            "--head-ref", "head", "--changelog-file", "perf-changelog.yaml", *cli_flags])
+
+        def generate(command, **kwargs):
+            commands.append(command)
+            result = generated(command) if generated else []
+            if isinstance(result, subprocess.CalledProcessError):
+                if kwargs.get("check"):
+                    raise result
+                result = []
+            return SimpleNamespace(stdout=result if isinstance(result, str) else json.dumps(result))
+
+        monkeypatch.setattr(subprocess, "run", generate)
+        process_changelog.main()
+        return json.loads(capsys.readouterr().out), commands
+    return run
+
+
+# The table is the contract: CLI expansion preserves throughput, whereas an
+# entry requesting all evals is eval-only. Trimming affects throughput alone.
+@pytest.mark.parametrize("cli_flags,expected_modes", [
+    ([], ("benchmark-subset", "subset", "all", "all")),
+    (["--all-evals"], ("benchmark-all", "all", "all", "all")),
+    (["--evals-only"], ("subset", "subset", "all", "all")),
+    (["--all-evals", "--evals-only"], ("all", "all", "all", "all")),
+])
+@pytest.mark.parametrize("entry_flags,mode_index", [
+    ({}, 0), ({"evals-only": True}, 1), ({"all-evals": True}, 2),
+    ({"all-evals": True, "evals-only": True}, 3),
+])
+@pytest.mark.parametrize("trim", [False, True])
+def test_cli_entry_mode_truth_table(changelog_run, cli_flags, expected_modes, entry_flags, mode_index, trim):
+    def generate(command):
+        concs = [8, 4] if "--no-evals" in command or "--all-evals" in command else [4]
+        return [_fixed_matrix_row(conc) for conc in concs]
+
+    output, commands = changelog_run([entry_flags], cli_flags + (["--trim-conc"] if trim else []), generate)
+    mode = expected_modes[mode_index]
+    expected_benchmarks = ([4] if trim else [8, 4]) if mode.startswith("benchmark-") else []
+    assert [row["conc"] for row in output["single_node"].get("8k1k", [])] == expected_benchmarks
+    assert [row["conc"] for row in output["evals"]] == ([8, 4] if mode.endswith("all") else [4])
+    assert ["--no-evals" in command for command in commands] == (
+        [True, False] if mode.startswith("benchmark-") else [False])
+    assert ("--all-evals" in commands[-1]) == mode.endswith("all")
+    assert "--evals-only" in commands[-1]
+    assert _scenario_values(commands[-1]) == ["fixed-seq-len", "agentic-coding"]
+    if mode.startswith("benchmark-"):
+        assert "--all-evals" not in commands[0]
+    assert output["changelog_metadata"]["base_ref"] == "base"
+    for flag, value in entry_flags.items():
+        assert output["changelog_metadata"]["entries"][0][flag] is value
+
+
+def test_overlapping_wildcard_scenarios_keep_priority_and_group_order(changelog_run):
+    entries = [
+        {"scenario-type": ["fixed-seq-len"]},
+        {"config-keys": ["config-*", "config-a"], "scenario-type": ["agentic-coding", "fixed-seq-len"]},
+        {"config-keys": ["config-b"], "all-evals": True, "scenario-type": ["agentic-coding"]},
+        {"config-keys": ["config-*"], "evals-only": True, "scenario-type": ["fixed-seq-len"]},
+    ]
+    _, commands = changelog_run(entries)
+    trace = [("benchmark" if "--no-evals" in c else "all" if "--all-evals" in c else "subset",
+              c[c.index("--config-keys") + 1:c.index("--config-files")], _scenario_values(c))
+             for c in commands]
+    assert trace == [
+        ("all", ["config-b"], ["agentic-coding"]),
+        ("benchmark", ["config-a"], ["fixed-seq-len"]),
+        ("subset", ["config-a"], ["fixed-seq-len"]),
+        ("benchmark", ["config-b"], []),
+        ("benchmark", ["config-a"], ["agentic-coding"]),
+        ("subset", ["config-b"], ["fixed-seq-len"]),
+        ("subset", ["config-a"], ["agentic-coding"]),
+    ]
+
+
+@pytest.mark.parametrize("cli_flags", [["--all-evals"], ["--evals-only"], ["--all-evals", "--evals-only"]])
+@pytest.mark.parametrize("trim", [False, True])
+def test_append_only_rejects_cli_eval_modifiers_before_generation(changelog_run, cli_flags, trim):
+    with pytest.raises(ValueError, match="append-only sweeps cannot use"):
+        changelog_run([{"append-only": True}], cli_flags + (["--trim-conc"] if trim else []),
+                      lambda _: pytest.fail("invalid sweep must not invoke the generator"))
+
+
+@pytest.mark.parametrize("entries", [
+    [{"append-only": True}, {}],
+    [{"append-only": True, "all-evals": True}],
+    [{"append-only": True, "evals-only": True}],
+    [{"append-only": True, "eval-min-prefill-ep": 2}],
+])
+def test_append_only_rejects_mixed_or_entry_eval_modes(changelog_run, entries):
+    with pytest.raises(ValueError, match="append-only"):
+        changelog_run(entries, generated=lambda _: pytest.fail("invalid sweep must not invoke the generator"))
+
+
+@pytest.mark.parametrize("stage", ["--no-evals", "--evals-only", "append-head", "append-base"])
+@pytest.mark.parametrize("failure", ["exit", "json"])
+def test_generator_failure_never_publishes_partial_matrix(changelog_run, monkeypatch, capsys, stage, failure):
+    error = subprocess.CalledProcessError(23, ["generator"], stderr="controlled generator failure")
+    append = stage.startswith("append-")
+    if append:
+        monkeypatch.setattr(process_changelog, "generation_inputs_at_ref", lambda _: nullcontext(
+            process_changelog.GenerationInputs(["base-config"], "base-generator", "base-runners")))
+
+    def generate(command):
+        revision_stage = "append-base" if command[1] == "base-generator" else "append-head"
+        if stage in command or (append and stage == revision_stage):
+            return error if failure == "exit" else "not-json"
+        return [_fixed_matrix_row(4), _fixed_matrix_row(8)]
+
+    with pytest.raises(subprocess.CalledProcessError if failure == "exit" else json.JSONDecodeError) as caught:
+        changelog_run([{"append-only": append}], generated=generate)
+    if failure == "exit":
+        assert caught.value is error
+    assert capsys.readouterr().out == ("controlled generator failure\n" if failure == "exit" else "")
+
+
+@pytest.mark.parametrize("keys,message", [
+    (["config-a", "missing"], "not found"),
+    (["config-a", "missing-*"], "No config keys matched"),
+])
+def test_invalid_key_after_valid_key_rejects_entire_selection(changelog_run, keys, message):
+    with pytest.raises(ValueError, match=message):
+        changelog_run([{"config-keys": keys}], generated=lambda _: pytest.fail("keys must resolve before generation"))
+
+
+@pytest.mark.parametrize("threshold,expected", [
+    (None, ["single", "default", "low", "high", "null", "invalid"]),
+    (1, ["single", "default", "low", "high"]),
+    (2, ["single", "low", "high"]),
+    (4, ["single"]),
+])
+def test_eval_prefill_ep_filter_preserves_single_node_and_order(threshold, expected):
+    rows = [
+        {"label": "single"}, {"label": "default", "prefill": {}},
+        {"label": "low", "prefill": {"ep": 2}},
+        {"label": "high", "prefill": {"ep": "3"}},
+        {"label": "null", "prefill": {"ep": None}},
+        {"label": "invalid", "prefill": {"ep": "bad"}},
+    ]
+    assert [row["label"] for row in process_changelog.filter_eval_rows_by_prefill_ep(rows, threshold)] == expected

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -357,24 +357,6 @@ class TestCalculations:
         output_data = json.loads(result.stdout)
         assert output_data["custom_metric"] == pytest.approx(0.5)
 
-    def test_tpot_to_interactivity_conversion(self, tmp_path, single_node_env_vars):
-        """Test that tpot fields are converted to interactivity."""
-        benchmark_result = {
-            "model_id": "test-model",
-            "max_concurrency": 8,
-            "total_token_throughput": 1000.0,
-            "output_throughput": 800.0,
-            "tpot_p50_ms": 20.0,  # Should become intvty_p50 = 50
-            "tpot_p99_ms": 50.0,  # Should become intvty_p99 = 20
-        }
-
-        result = run_script(tmp_path, single_node_env_vars, benchmark_result)
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
-
-        output_data = json.loads(result.stdout)
-        assert output_data["intvty_p50"] == pytest.approx(50.0)
-        assert output_data["intvty_p99"] == pytest.approx(20.0)
-
     def test_throughput_per_gpu_single_node(self, tmp_path, single_node_env_vars):
         """PP and PCP expand the GPU denominator while DCP remains metadata."""
         benchmark_result = {
@@ -564,22 +546,6 @@ class TestEdgeCases:
         assert output_data["osl"] == 1024
         assert isinstance(output_data["isl"], int)
         assert isinstance(output_data["osl"], int)
-
-    def test_conc_from_benchmark_result(self, tmp_path, single_node_env_vars):
-        """Test that conc is read from benchmark result max_concurrency."""
-        benchmark_result = {
-            "model_id": "test-model",
-            "max_concurrency": 128,
-            "total_token_throughput": 5000.0,
-            "output_throughput": 4000.0,
-        }
-
-        result = run_script(tmp_path, single_node_env_vars, benchmark_result)
-        assert result.returncode == 0, f"Script failed: {result.stderr}"
-
-        output_data = json.loads(result.stdout)
-        assert output_data["conc"] == 128
-
 
 # =============================================================================
 # Integration: power aggregation patches the agg JSON

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -338,24 +338,7 @@ def write_agentic_artifacts(
     (root / f"agentic_{result_name}").mkdir()
 
 
-def test_eval_validation_requires_raw_result_dirs_not_eval_debug_dirs(
-    tmp_path: Path,
-) -> None:
-    write_eval_aggregate(
-        tmp_path,
-        [single_eval_result(32), single_eval_result(64)],
-    )
-
-    (tmp_path / "eval_server_logs_gptoss_8k1k_runner").mkdir()
-    (tmp_path / "eval_gpu_metrics_gptoss_8k1k_runner").mkdir()
-    write_raw_eval_artifact(tmp_path, 32)
-
-    errors = validate_eval_artifacts(tmp_path)
-
-    assert any("unexpected" in error for error in errors)
-
-
-def test_eval_validation_accepts_matching_legacy_artifacts_without_suite(
+def test_eval_validation_accepts_legacy_results_alongside_debug_artifacts(
     tmp_path: Path,
 ) -> None:
     write_eval_aggregate(
@@ -368,6 +351,8 @@ def test_eval_validation_accepts_matching_legacy_artifacts_without_suite(
         64,
         physical_runner="h100-dgxc-slurm_01",
     )
+    (tmp_path / "eval_server_logs_fixture").mkdir()
+    (tmp_path / "eval_gpu_metrics_fixture").mkdir()
 
     assert validate_eval_artifacts(tmp_path) == []
 


### PR DESCRIPTION
## Description

`process_changelog.py` duplicated scenario grouping and generator command/subprocess handling across benchmark, eval, and historical-input paths. Share those operations while preserving selection precedence, ordering, runner defaults, subprocess isolation, JSON output, and existing failure behavior. Existing CLI and recipe interfaces remain compatible.

The test cleanup removes duplicate cases and self-confirming expectations, fixes ineffective credential/cache/validation checks, uses independently worked numeric expectations, and narrows 50 broad exception assertions. The combined patch removes 259 lines overall, including 27 production lines.

The Claude review workflow now installs and verifies the official npm executable before starting the action. Its native installer failed twice with a missing launcher, preventing review. The English and Chinese CI guides document this failure mode.

## Related Issue

Second internal cleanup in the series, following [#2897](https://github.com/SemiAnalysisAI/InferenceX/pull/2897).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Configuration change
- [x] Documentation update
- [x] Other: internal refactor and test-quality cleanup

## Validation

```sh
python3 -m pytest utils/ runners/ experimental/CollectiveX/tests/ -q -o addopts= --tb=short --durations=5
```

- Full local suite: **1,085 passed + 219 subtests, zero skips, 40.38 seconds** with Python 3.12, pytest, Pydantic, PyYAML, packaging, CPU torch, and Matplotlib.
- The same **86 changelog behavior tests** pass against the original and refactored implementations. Coverage includes all 32 CLI/entry eval-flag and trim combinations, scenario overlap/priority, append-only restrictions, and generator failures.
- **80 real CLI/Git comparisons** against `df23daa71616fd76313e63739fe4a60fc75f2d5f`: 47 successful outputs match byte-for-byte; 33 rejected cases match exit status and diagnostics after normalizing traceback locations/source excerpts and random historical temporary-directory names. Both versions leave temporary directories empty after process exit. These are controlled cases, not proof over arbitrary inputs or within-process cleanup timing.
- Four isolated negative controls confirm the strengthened tests reject missing token sanitization, recreated cached wrappers, ignored `validate=False`, and debug folders treated as eval results. The original token/cache tests passed their deliberately broken implementations.
- Audited all 38 Python test files; removed four additional redundant cases during the wider audit. `git diff --check` passes.

The 86 regression cases and test-quality changes are included in this PR. The one-off differential harness, raw comparison outputs, and negative-control evidence were retained locally. On `fff9eb6e4`, matrix, result-processing, CollectiveX, and CodeQL checks pass, and Cursor Bugbot found no issues. The official npm executable starts both locally and on the Linux CI runner; `actionlint` passes. The PR Review action intentionally skips reviews when its workflow differs from `main`, so its green job verifies installation only. The independent [Claude Code Review](https://github.com/SemiAnalysisAI/InferenceX/runs/102273170044) completed with zero findings. No GPU sweep was run.

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [ ] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

The intended internal refactor preserves benchmark behavior, so no performance-changelog entry is needed. Reuse authorization has not been posted; no benchmark sweep reuse is claimed.

## 中文说明

`process_changelog.py` 在 benchmark、eval 和历史输入路径中重复实现了场景分组及生成器命令、子进程处理。本次共用这些操作，保留选择优先级、顺序、runner 默认值、子进程隔离、JSON 输出及现有失败行为，保持 CLI 和配方接口兼容。

测试清理删除重复用例和自我验证式预期值，修复实际未覆盖目标行为的凭据、缓存和验证测试，使用独立手算的数值预期，并将 50 处宽泛异常断言收紧为明确异常类型。整个改动净减少 259 行，其中生产代码减少 27 行。Claude 审阅 Workflow 改为安装并验证官方 npm 可执行文件后再启动 Action。原生安装程序连续两次未创建启动器，导致审阅无法执行；中英文 CI 指南已补充此类故障的说明。

这是继 [#2897](https://github.com/SemiAnalysisAI/InferenceX/pull/2897) 之后的第二批内部清理，类型为内部重构和测试质量改进。

验证命令与结果：

```sh
python3 -m pytest utils/ runners/ experimental/CollectiveX/tests/ -q -o addopts= --tb=short --durations=5
```

- 使用 Python 3.12、pytest、Pydantic、PyYAML、packaging、CPU torch 和 Matplotlib，完整本地测试 **1,085 个通过，另有 219 个子测试通过，零跳过，耗时 40.38 秒**。
- 同一组 **86 个变更日志行为测试**在原实现和重构实现上均通过，覆盖 CLI 与条目级 eval 标志及裁剪的全部 32 种组合、场景重叠与优先级、append-only 限制和生成器失败。
- 相对 `df23daa71616fd76313e63739fe4a60fc75f2d5f` 执行 **80 个真实 CLI/Git 对比**：47 个成功输出逐字节一致；33 个拒绝案例在归一化 traceback 位置、源码摘录及历史临时目录随机名称后，退出码和诊断一致。两版进程退出后的临时目录均为空。这些是受控案例，不代表对任意输入或进程内清理时机的完整证明。
- 四个隔离反例确认强化后的测试能够发现：遗漏 token 清理、重复创建缓存包装对象、忽略 `validate=False`、将调试目录识别为 eval 结果。原有 token 和缓存测试在故意破坏实现后仍会通过。
- 已审查全部 38 个 Python 测试文件；广泛审查阶段额外删除四个重复用例。`git diff --check` 通过。

86 个回归用例和测试质量改动包含在本 PR 中；一次性差异对比脚本、原始输出及反例证据保留在本地。在 `fff9eb6e4` 上，矩阵、结果处理、CollectiveX 和 CodeQL 检查均已通过，Cursor Bugbot 未发现问题。官方 npm 可执行文件已在本地和 Linux CI runner 上成功启动，`actionlint` 通过。PR Review Action 会跳过 Workflow 与 `main` 不同的审阅，因此该绿色 Job 仅证明安装成功；独立的 [Claude Code Review](https://github.com/SemiAnalysisAI/InferenceX/runs/102273170044) 已完成，未发现问题。未执行 GPU sweep。

本次内部重构保持 benchmark 行为不变，因此无需新增性能变更日志。尚未发布复用授权，也不声明复用了 benchmark sweep。
