### PR TITLE
chore(ci): update and SHA-pin latest GitHub Actions / 更新 GitHub Actions 并固定到最新版本 SHA

### DIFF
--- a/.github/workflows/benchmark-multinode-tmpl.yml
+++ b/.github/workflows/benchmark-multinode-tmpl.yml
@@ -399,7 +399,7 @@ jobs:
             done
           fi
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0

--- a/.github/workflows/benchmark-tmpl.yml
+++ b/.github/workflows/benchmark-tmpl.yml
@@ -331,7 +331,7 @@ jobs:
             done
           fi
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,7 +31,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
           mkdir -p /tmp/inferencemax-mcp
 
       - name: PR Review with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
         env:
           INFERENCEMAX_ROOT: ${{ github.workspace }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.CLAUDE_PAT }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
           GITHUB_TOKEN: ${{ secrets.CLAUDE_PAT }}

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -206,7 +206,7 @@ jobs:
       # files. Check out the trusted default branch; all PR content is read
       # read-only via the GitHub API (gh / MCP), never from the working tree.
       - name: Checkout repository (trusted default branch only)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch }}
@@ -239,7 +239,7 @@ jobs:
           wc -c /tmp/codeowner-signoff-verify-prompt.md
 
       - name: Verify sign-off with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
           GITHUB_TOKEN: ${{ secrets.CLAUDE_PAT }}

--- a/.github/workflows/collect-evals.yml
+++ b/.github/workflows/collect-evals.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0

--- a/.github/workflows/collect-results.yml
+++ b/.github/workflows/collect-results.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0

--- a/.github/workflows/collectivex-sweep.yml
+++ b/.github/workflows/collectivex-sweep.yml
@@ -49,9 +49,9 @@ jobs:
       n: ${{ steps.gen.outputs.n }}
       priority: ${{ steps.score.outputs.priority }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { clean: true, persist-credentials: false }
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - id: score
         run: |
           scored=$(printf '%s' '[{"runner":"collectivex","framework":"collectivex"}]' |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -211,7 +211,7 @@ jobs:
         steps:
             - name: Checkout code (ref)
               if: ${{ inputs.ref && inputs.ref != '' }}
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 ref: ${{ inputs.ref }}
                 fetch-depth: 0
@@ -219,18 +219,18 @@ jobs:
 
             - name: Checkout code (default)
               if: ${{ !inputs.ref || inputs.ref == '' }}
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 ref: ${{ github.sha }}
             - name: Checkout priority scheduler tooling
               if: ${{ inputs.ref && inputs.ref != '' }}
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 ref: ${{ github.workflow_sha }}
                 path: .ci-priority
                 persist-credentials: false
 
-            - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+            - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
             - id: get-jobs
               env:
                   PR_LABELS: ${{ inputs.pr-labels-json || toJson(github.event.pull_request.labels.*.name) }}
@@ -762,7 +762,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
 
         steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.REPO_PAT }}
                   fetch-depth: 0

--- a/.github/workflows/klaud-candidate.yml
+++ b/.github/workflows/klaud-candidate.yml
@@ -61,7 +61,7 @@ jobs:
           echo "KLAUD_STARTED_AT=$started_at" >> "$GITHUB_ENV"
       - name: Let Klaud Cold own the candidate PR
         id: claude
-        uses: anthropics/claude-code-action@d75b94d5ad426cb8546e6628b6f5f19b84e5cce1
+        uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
           KLAUD_DASHBOARD_API_KEY: ${{ secrets.KLAUD_DASHBOARD_API_KEY }}

--- a/.github/workflows/klaud-plan.yml
+++ b/.github/workflows/klaud-plan.yml
@@ -46,7 +46,7 @@ jobs:
         id: review
         if: steps.prepare.outputs.has_candidates == 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@d75b94d5ad426cb8546e6628b6f5f19b84e5cce1
+        uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
         env:
           GH_TOKEN: ${{ github.token }}
           KLAUD_EVIDENCE: ${{ runner.temp }}/klaud

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -46,18 +46,18 @@ jobs:
       count: ${{ steps.filter.outputs.count }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Checkout priority scheduler tooling
         if: ${{ inputs.ref && inputs.ref != '' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
           path: .ci-priority
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - id: gen
         name: Generate matrix via script
         run: |
@@ -206,7 +206,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.sha }}
@@ -301,7 +301,7 @@ jobs:
 
       - name: Checkout storage repo
         if: ${{ steps.run.outputs.trace != '' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: SemiAnalysisAI/InferenceX-trace-storage
           path: storage

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -89,7 +89,7 @@ jobs:
                   fi
 
             - name: Checkout code
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 
@@ -149,7 +149,7 @@ jobs:
             skip-pr-sweep: ${{ steps.gate.outputs.skip-pr-sweep }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Check for reusable sweep authorization
               id: gate
@@ -230,18 +230,18 @@ jobs:
             reuse-source-head-sha: ${{ steps.setup.outputs.reuse-source-head-sha }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   fetch-depth: 0
 
-            - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+            - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
             - name: Classify priority criteria
               id: classify
               if: >-
                   vars.PRIORITY_SCHEDULER_ENABLED == 'true' &&
                   github.event_name == 'pull_request'
               continue-on-error: true
-              uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1.0.174
+              uses: anthropics/claude-code-action@0d0e0876d3eaa933f45dc692f7a4312c83caf36f # v1.0.218
               with:
                   github_token: ${{ github.token }}
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -1002,7 +1002,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.REPO_PAT }}
 
         steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                   token: ${{ secrets.REPO_PAT }}
                   fetch-depth: 0
@@ -1040,7 +1040,7 @@ jobs:
             DATABASE_URL: ${{ secrets.NEON_PROD_RO_URL }}
 
         steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Download results artifacts
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/speedbench-al.yml
+++ b/.github/workflows/speedbench-al.yml
@@ -109,9 +109,9 @@ jobs:
       priority: ${{ steps.score.outputs.priority }}
       queue-token: ${{ steps.score.outputs.queue-token }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { clean: true, persist-credentials: false }
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - id: score
         env:
           RUNNER: ${{ inputs.runner }}
@@ -195,7 +195,7 @@ jobs:
           # matrix from a previous run is never picked up as this job's output.
           rm -rf "${{ github.workspace }}/speedbench_results" 2>/dev/null || true
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.REPO_PAT }}
           fetch-depth: 0

--- a/.github/workflows/test-changelog-gate.yml
+++ b/.github/workflows/test-changelog-gate.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-collectivex.yml
+++ b/.github/workflows/test-collectivex.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/test-matrix-logic.yml
+++ b/.github/workflows/test-matrix-logic.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/test-process-result.yml
+++ b/.github/workflows/test-process-result.yml
@@ -50,7 +50,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
Update 38 action references across 18 workflows so all 91 external action references use full commit SHAs matching the latest stable versions verified on September 8, 2026.

- `actions/checkout`: v7.0.0 → v7.0.1 (`3d3c42e5aac5ba805825da76410c181273ba90b1`).
- `astral-sh/setup-uv`: v9.0.0 → v10.0.1 (`20cfd1bf945f4377ade1205e4dbc17946fc9a30d`).
- `anthropics/claude-code-action`: v1.0.174, v1.0.216, and floating v1 → v1.0.218 (`0d0e0876d3eaa933f45dc692f7a4312c83caf36f`).
- Replace all four floating action references and correct the stale checkout version comment. The other four action dependencies are already current and SHA-pinned.

Validation: upstream GitHub releases and tag SHAs checked; all workflow YAML parses; structural comparison confirms only action references changed; `git diff --check` passes. Actionlint with shellcheck/pyflakes disabled reports the same two baseline findings: required `run-eval` input with a default in `benchmark-tmpl.yml:92`, and an empty string in `collectivex-sweep.yml:38`. No GitHub Actions runs have been validated yet.

Compatibility: setup-uv v10 disables automatic caching for `pull_request_target`, `workflow_run`, and `release` events. Retain the upstream defaults.

## 中文说明

更新 18 个工作流中的 38 处 Action 引用，使全部 91 处外部 Action 引用均固定到完整提交 SHA，对应于 2026 年 9 月 8 日核实的最新稳定版本。

- `actions/checkout`：从 v7.0.0 升级至 v7.0.1，固定到上述 SHA。
- `astral-sh/setup-uv`：从 v9.0.0 升级至 v10.0.1，固定到上述 SHA。
- `anthropics/claude-code-action`：将 v1.0.174、v1.0.216 和浮动标签 v1 统一升级至 v1.0.218，固定到上述 SHA。
- 替换全部 4 处浮动标签引用，并修正 checkout 的过期版本注释。其余 4 个 Action 依赖已是最新版本，且已固定到 SHA。

验证：已核对上游 GitHub 发布版本及标签对应的 SHA；所有工作流 YAML 均可解析；结构对比确认仅修改了 Action 引用；`git diff --check` 通过。禁用 shellcheck/pyflakes 后，actionlint 仍仅报告原有的两项问题：`benchmark-tmpl.yml:92` 中必填的 `run-eval` 输入同时设置了默认值，以及 `collectivex-sweep.yml:38` 中的空字符串。尚未验证 GitHub Actions 运行结果。

兼容性：setup-uv v10 在 `pull_request_target`、`workflow_run` 和 `release` 事件中默认禁用自动缓存，本次保留上游默认行为。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide CI surface area and privileged Claude/sign-off workflows depend on the new action versions; setup-uv v10 may change caching behavior on certain triggers until runs are validated.
> 
> **Overview**
> This PR **only changes third-party Action references** in 18 workflow files—no benchmark logic, scripts, or job structure.
> 
> **`actions/checkout`** moves from v7.0.0 to **v7.0.1** (commit `3d3c42e…`) everywhere it appears, including benchmark templates, e2e/sweep/profile flows, artifact collection, and tests. **`collectivex-sweep`** also drops a stale v5.0.0 comment in favor of the same v7.0.1 pin.
> 
> **`astral-sh/setup-uv`** is bumped **v9.0.0 → v10.0.1** in e2e matrix generation, profile, collectivex setup, speedbench, run-sweep priority classification, and Klaud plan/candidate jobs.
> 
> **`anthropics/claude-code-action`** is unified on **v1.0.218** (`0d0e0876…`), replacing older SHAs, floating `@v1`, and tag-only `@v7.0.0`-style checkout in Claude PR review, interactive Claude, CODEOWNER sign-off verify, Klaud plan/candidate, and sweep priority classification.
> 
> Floating tags are eliminated in favor of full SHAs for supply-chain consistency. **Note:** setup-uv v10’s default is to skip auto-caching on some event types; this PR keeps upstream defaults as documented in the PR body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6308bcbc5650e33205610caf50ca2ab5ab9dffa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->