### PR TITLE
[AMD] Update qwen3.5-fp4-mi355x-sglang-agentic-mtp SGLang ROCm image to v0.5.19-rocm720-mi35x-20260908 / 升级 qwen3.5-fp4-mi355x-sglang-agentic-mtp 的 SGLang ROCm 镜像至 v0.5.19-rocm720-mi35x-20260908

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -361,7 +361,7 @@ qwen3.5-fp4-mi355x-sglang-mtp:
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
 
 qwen3.5-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: cluster:mi355x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6969,3 +6969,11 @@
     - "Use SGLang's current W4A4 MegaMoE and DP LM-head flags for DP-attention instead of the deprecated MegaMoE environment variables."
     - "Resolve draft-model jobs through the existing B200 SGLang speculative recipe and the staged DeepSeek-V4-Pro-0813 checkpoint."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2821
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Bump the SGLang ROCm image from lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2904


### PR DESCRIPTION
## Summary / 摘要

Update the SGLang ROCm image for the Qwen3.5 MXFP4 MI355X AgentX recipe from `lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829` to `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908`.

将 Qwen3.5 MXFP4 MI355X AgentX 配方使用的 SGLang ROCm 镜像从 `lmsysorg/sglang-rocm:v0.5.18-rocm720-mi35x-20260829` 升级到 `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908`。

Recipes touched / 涉及的配方: `qwen3.5-fp4-mi355x-sglang-agentic-mtp`

The target tag was verified to exist on Docker Hub under `lmsysorg/sglang-rocm` (HTTP 200). Note that the ROCm-suffixed tag does not exist under `lmsysorg/sglang`.

目标镜像标签已确认存在于 Docker Hub 的 `lmsysorg/sglang-rocm` 仓库（HTTP 200）。请注意，该 ROCm 后缀标签在 `lmsysorg/sglang` 仓库下并不存在。

## Test plan / 测试计划

- [ ] The `full-sweep-fail-fast` sweep passes. / `full-sweep-fail-fast` 全量 sweep 通过。