### PR TITLE
[Klaud Cold] Update dsv4-fp4-b200-dynamo-sglang SGLang image to v0.5.19-cu130 / 将 dsv4-fp4-b200-dynamo-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p1d-dep8-dep8-c512"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-tp8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-dep8-tp8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p1d-dep8-tp8-4-c64"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-tp8-tp8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p1d-tp8-tp8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p1d-tp8-tp8-c1"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p2d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p2d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p2d-dep8-dep8-c256"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p4d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p4d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p4d-dep8-dep8-c256"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p4d-dep8-tp8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-1p4d-dep8-tp8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-1p4d-dep8-tp8-c64"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-3p2d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-3p2d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-3p2d-dep8-dep8-c2048"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-4p2d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-4p2d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-4p2d-dep8-dep8-c4096"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-5p2d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-5p2d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-5p2d-dep8-dep8-c6144"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-6p2d-dep8-dep8.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-6p2d-dep8-dep8.yaml
@@ -3,7 +3,7 @@ name: "disagg-b200-6p2d-dep8-dep8-c8192"
 
 model:
   path: "deepseek-v4-pro"
-  container: "lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp4"
 
 dynamo:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -4682,7 +4682,7 @@ dsv4-fp4-gb200-dynamo-vllm-mtp2-nosynthetic:
 
 # DSV4 B200 disaggregated Dynamo SGLang STP configuration.
 dsv4-fp4-b200-dynamo-sglang:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:b200-nscale


### PR DESCRIPTION
## Status / 状态

**Current status:** Deferred for capacity. The image change was committed and this draft PR opened, but the mandatory `check-capacity --cluster b200-nscale` recheck run immediately before the first targeted dispatch failed twice (2026-09-09T02:30:01Z and 02:30:18Z), after passing at branch-creation time. No benchmark or eval run was dispatched, so no GPU time was used and there are no owned runs to cancel.
**Next step:** None in this session. Per the Klaud Cold capacity rule the PR is returned to draft (it never left draft), closed, and its remote branch deleted so a later auto-sweep can reselect this candidate when `b200-nscale` is eligible again. No recovery is awaited or promised.

Green targeted benchmarks and default evals do not prove that global repository checks pass.

## Change / 变更

- Family: `configs/nvidia-master.yaml:dsv4-fp4-b200-dynamo-sglang` (DeepSeek-V4-Pro FP4, B200, Dynamo + SGLang, disaggregated, 8k/1k, no speculative decoding, runner `cluster:b200-nscale`).
- Image: `lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729` → `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9` in the master entry and its ten referenced `benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-*.yaml` recipes (`model.container` equals the master `image`).
- Unchanged: model, precision, topology, Dynamo revision `86f84b94`, NIXL KV transfer, workloads, resources, environment flags and recipe references. The generated matrix differs from `main` only in the image (10 recipes, 12 concurrency points, node counts 2/2/2/5/3/5/5/6/7/8).

## Supporting evidence / 支持证据

- Public observation: `latest-images` reports `dsv4` / `b200` / `dynamo-sglang` / `fp4` / `spec_method=none` / disagg / 8192-1024 on `lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729`, dated 2026-09-01; `framework-releases` reports SGLang `v0.5.19`.
- Compatibility: the `sgl-project/sglang` tag `v0.5.19` (commit `59f20bff`, released 2026-09-05) is 631 commits ahead of and contains the nightly commit `f825d729`, so the release is a superset of the code currently pinned. Docker Hub tag `v0.5.19-cu130` (CUDA 13.0, linux/amd64 + arm64) was pushed 2026-09-04 and is pinned by its manifest-list digest. Digest-pinned `lmsysorg/sglang:<tag>@sha256:...` images already have published Dynamo-SGLang results on GB200/GB300 (`v0.5.14-cu130@sha256:5027e95b…`), so the reference form is proven on srt-slurm.
- No open PR modifies the ten B200 DeepSeek-V4 8k/1k recipes or the family key in `configs/nvidia-master.yaml` (rechecked immediately before the branch was claimed; PR #2623's removal of the same tag is in the GB300 agentic families only).
- Local checks: YAML parses; `generate_sweep_configs.py test-config --config-keys dsv4-fp4-b200-dynamo-sglang` output is identical to `main` except the image; `utils/matrix_logic` `test_validation.py` + `test_generate_sweep_configs.py` pass (291 tests).

## Baseline (published 2026-09-01) / 基线（发布于 2026-09-01）

- Source: `GET /api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-09-01&exact=true` (no `view`) and `GET /api/v1/workflow-info?date=2026-09-01`; `GET /api/v1/evaluations?model=DeepSeek-V4-Pro` filtered to the same identity.
- Identity verified on all 12 rows: `dsv4` / `b200` / `dynamo-sglang` / `fp4` / `spec_method=none` / disagg / multinode / 8192-1024 / `single_turn` / image `lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729` / router `dynamo-router@86f84b94` / KV `nixl`.
- Producer (all 12 points and 9 evals): run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33447526958 (attempt 1, "Run Sweep - Add DSV4 B200 disaggregated Dynamo SGLang STP configuration", PR #2560, head SHA `a430c17bab40fe1bf9c6e94d8b69c3d032dd0143`, created 2026-08-31T22:43Z). `curve_workflow_run_id=2391` is a logical curve snapshot, not the producer.
- Baseline published points (per-GPU throughput = `tput_per_gpu` total tok/s/GPU; output = `output_tput_per_gpu`; latencies in seconds):

| conc | topology (P×TP/EP → D×TP/EP) | GPUs | tput/GPU | out tput/GPU | mean TPOT | mean TTFT | mean E2E |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 1×TP8 → 1×TP8 | 16 | 52.67 | 11.77 | 0.0097 | 0.868 | 9.88 |
| 32 | 1×DEP8 → 1×TP8 | 16 | 1049.89 | 234.81 | 0.0146 | 1.634 | 15.12 |
| 64 | 1×DEP8 → 1×TP8 | 16 | 1719.59 | 381.55 | 0.0179 | 2.138 | 18.57 |
| 64 | 1×DEP8 → 4×TP8 | 40 | 927.70 | 128.65 | 0.0120 | 2.613 | 13.68 |
| 256 | 1×DEP8 → 1×DEP8 | 16 | 4539.28 | 1009.02 | 0.0252 | 4.807 | 28.00 |
| 256 | 1×DEP8 → 2×DEP8 | 24 | 3268.09 | 544.84 | 0.0223 | 5.406 | 25.96 |
| 256 | 1×DEP8 → 4×DEP8 | 40 | 2029.05 | 281.89 | 0.0202 | 6.460 | 25.08 |
| 512 | 1×DEP8 → 1×DEP8 | 16 | 6402.47 | 1422.76 | 0.0268 | 14.093 | 38.81 |
| 2048 | 3×DEP8 → 2×DEP8 | 40 | 7717.78 | 2145.78 | 0.0316 | 21.706 | 50.80 |
| 4096 | 4×DEP8 → 2×DEP8 | 48 | 8667.01 | 2888.37 | 0.0357 | 42.404 | 75.25 |
| 6144 | 5×DEP8 → 2×DEP8 | 56 | 9332.22 | 3628.30 | 0.0382 | 54.472 | 89.64 |
| 8192 | 6×DEP8 → 2×DEP8 | 64 | 9733.98 | 4325.50 | 0.0432 | 60.463 | 100.24 |

- Baseline published evals (gsm8k, n_eff 1319, same producer run): em_strict 0.964–0.969 across conc 64 (1×DEP8→1×TP8 and 1×DEP8→4×TP8), 256 (1×DEP8→2×DEP8, 1×DEP8→4×DEP8), 512, 2048, 4096, 6144, 8192. No published eval for conc 1, 32 or the 1×DEP8→1×DEP8 conc 256 point.

## Initial attempt / 初始尝试

- Image/commit: `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e72886…` at commit `d0a00ef89457fea20fbf9f94da0ff6f06a9d3d38`.
- Run: none. Outcome: **cancelled before dispatch (capacity deferral)**. The `check-capacity --cluster b200-nscale` recheck required immediately before dispatch exited non-zero twice at 2026-09-09T02:30Z; the same check had passed before edits and branch creation a few minutes earlier.
- Changes: image refresh only (see Change).
- Benchmark/eval results: N/A (never dispatched).
- Deltas vs baseline: N/A (never dispatched).
- Diagnosis / next step: no image-related finding; the image was never exercised. Candidate released for a later auto-sweep retry.

## Repairs / 修复

- None used (0/5). The repair budget was not consumed because no attempt ran.

## Final full sweep / 最终完整 sweep

- Not started. No `perf-changelog.yaml` entry was appended, no sweep label was applied, and the PR never left draft.

---

## 状态

**当前状态：** 因容量原因推迟。镜像变更已提交并创建了本草稿 PR，但在首次定向派发前必须执行的 `check-capacity --cluster b200-nscale` 复查连续两次失败（2026-09-09T02:30:01Z 与 02:30:18Z），而该检查在创建分支时曾通过。未派发任何基准或评测运行，因此未使用 GPU 时间，也没有需要取消的运行。
**下一步：** 本会话内无后续操作。按照 Klaud Cold 容量规则，PR 保持草稿状态（从未转为 ready）、关闭，并删除其远程分支，以便 `b200-nscale` 恢复可用后由后续 auto-sweep 重新选择该候选。不等待也不承诺恢复。

定向基准测试与默认评测通过并不证明仓库的全局检查通过。

## 变更

- 系列：`configs/nvidia-master.yaml:dsv4-fp4-b200-dynamo-sglang`（DeepSeek-V4-Pro FP4、B200、Dynamo + SGLang、分离式、8k/1k、无投机解码，runner `cluster:b200-nscale`）。
- 镜像：`lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729` → `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，同时更新主配置条目及其引用的十个 `benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/8k1k/disagg-b200-*.yaml` 配方（`model.container` 与主配置 `image` 一致）。
- 未变更：模型、精度、拓扑、Dynamo 版本 `86f84b94`、NIXL KV 传输、负载、资源、环境变量与配方引用。生成的矩阵与 `main` 仅镜像不同（10 个配方、12 个并发点，节点数 2/2/2/5/3/5/5/6/7/8）。

## 支持证据

- 公开观测：`latest-images` 报告 `dsv4` / `b200` / `dynamo-sglang` / `fp4` / `spec_method=none` / 分离式 / 8192-1024 使用 `lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729`，日期 2026-09-01；`framework-releases` 报告 SGLang `v0.5.19`。
- 兼容性：`sgl-project/sglang` 标签 `v0.5.19`（提交 `59f20bff`，2026-09-05 发布）领先 nightly 提交 `f825d729` 631 个提交且包含该提交，因此该发布版是当前所固定代码的超集。Docker Hub 标签 `v0.5.19-cu130`（CUDA 13.0，linux/amd64 + arm64）于 2026-09-04 推送，并按 manifest-list 摘要固定。按摘要固定的 `lmsysorg/sglang:<tag>@sha256:...` 镜像已在 GB200/GB300 上有公开发布的 Dynamo-SGLang 结果（`v0.5.14-cu130@sha256:5027e95b…`），该引用形式在 srt-slurm 上已被验证。
- 没有任何开放 PR 修改这十个 B200 DeepSeek-V4 8k/1k 配方或 `configs/nvidia-master.yaml` 中的该系列键（在占用分支前已再次核查；PR #2623 删除同一标签的位置仅在 GB300 agentic 系列中）。
- 本地检查：YAML 可解析；`generate_sweep_configs.py test-config --config-keys dsv4-fp4-b200-dynamo-sglang` 的输出与 `main` 仅镜像不同；`utils/matrix_logic` 的 `test_validation.py` + `test_generate_sweep_configs.py` 通过（291 个测试）。

## 基线（发布于 2026-09-01）

- 来源：`GET /api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-09-01&exact=true`（无 `view`）与 `GET /api/v1/workflow-info?date=2026-09-01`；`GET /api/v1/evaluations?model=DeepSeek-V4-Pro` 按同一身份过滤。
- 12 行数据均已核对身份：`dsv4` / `b200` / `dynamo-sglang` / `fp4` / `spec_method=none` / 分离式 / 多节点 / 8192-1024 / `single_turn` / 镜像 `lmsysorg/sglang:nightly-dev-cu13-20260821-f825d729` / 路由 `dynamo-router@86f84b94` / KV `nixl`。
- 生产者（全部 12 个点与 9 项评测）：运行 https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33447526958（attempt 1，PR #2560，head SHA `a430c17bab40fe1bf9c6e94d8b69c3d032dd0143`，创建于 2026-08-31T22:43Z）。`curve_workflow_run_id=2391` 是逻辑曲线快照，不是生产者。
- 基线公开数据点见上方英文表格（每 GPU 吞吐 = `tput_per_gpu`，输出吞吐 = `output_tput_per_gpu`，延迟单位为秒）。
- 基线公开评测（gsm8k，n_eff 1319，同一生产者运行）：em_strict 0.964–0.969，覆盖并发 64（1×DEP8→1×TP8 与 1×DEP8→4×TP8）、256（1×DEP8→2×DEP8、1×DEP8→4×DEP8）、512、2048、4096、6144、8192。并发 1、32 以及 1×DEP8→1×DEP8 的并发 256 点没有公开评测。

## 初始尝试

- 镜像/提交：`lmsysorg/sglang:v0.5.19-cu130@sha256:d6e72886…`，提交 `d0a00ef89457fea20fbf9f94da0ff6f06a9d3d38`。
- 运行：无。结果：**派发前取消（容量推迟）**。派发前必须执行的 `check-capacity --cluster b200-nscale` 复查于 2026-09-09T02:30Z 连续两次返回非零；几分钟前在编辑与创建分支之前该检查曾通过。
- 变更：仅镜像刷新（见“变更”）。
- 基准/评测结果：N/A（从未派发）。
- 相对基线的差异：N/A（从未派发）。
- 诊断/下一步：没有与镜像相关的发现；镜像从未被实际运行。候选已释放，供后续 auto-sweep 重试。

## 修复

- 未使用（0/5）。由于没有任何尝试运行，修复预算未被消耗。

## 最终完整 sweep

- 未开始。未追加 `perf-changelog.yaml` 条目，未应用任何 sweep 标签，PR 从未离开草稿状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
