### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-gb300-dynamo-sglang SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp4-gb300-dynamo-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_lowlat_0.yaml
@@ -14,7 +14,7 @@ model:
   precision: "fp4"
 
 dynamo:
-  version: "1.1.0"
+  version: "1.5.0.dev20260908"
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_0.yaml
@@ -15,7 +15,7 @@ model:
   precision: "fp4"
 
 dynamo:
-  version: "1.1.0"
+  version: "1.5.0.dev20260908"
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_1.yaml
@@ -15,7 +15,7 @@ model:
   precision: "fp4"
 
 dynamo:
-  version: "1.1.0"
+  version: "1.5.0.dev20260908"
 
 frontend:
   type: dynamo

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/8k1k_stp_maxtpt_2.yaml
@@ -15,7 +15,7 @@ model:
   precision: "fp4"
 
 dynamo:
-  version: "1.1.0"
+  version: "1.5.0.dev20260908"
 
 frontend:
   type: dynamo

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6443,7 +6443,7 @@ qwen3.5-fp8-h100-sglang-mtp:
 
     # ---------- 1k1k high-throughput (wide-EP TP=32 decode) ----------
 qwen3.5-fp4-gb300-dynamo-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
   model-prefix: qwen3.5
   runner: gb300

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6449,7 +6449,7 @@ qwen3.5-fp4-gb300-dynamo-sglang:
   runner: gb300
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "1.1.0" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260908" }
   multinode: true
   disagg: true
   scenarios:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -6969,3 +6969,11 @@
     - "Use SGLang's current W4A4 MegaMoE and DP LM-head flags for DP-attention instead of the deprecated MegaMoE environment variables."
     - "Resolve draft-model jobs through the existing B200 SGLang speculative recipe and the staged DeepSeek-V4-Pro-0813 checkpoint."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2821
+
+- config-keys:
+    - qwen3.5-fp4-gb300-dynamo-sglang
+  description:
+    - "Bump the Qwen3.5 FP4 GB300 disaggregated Dynamo-SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130."
+    - "Pin Dynamo 1.5.0.dev20260908 in the four 8k1k STP recipes (and the family's router metadata) because Dynamo 1.1.0 imports sglang.srt.server_args_config_parser, which sglang v0.5.19 moved to sglang.srt.utils.server_args_config_parser; no stable Dynamo release carries the compat shim yet."
+    - "Model, topology, concurrency lists, workloads and recipe references are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2909


### PR DESCRIPTION
## Status / 状态

**Current status:** **Stopped — final full sweep failed on a confirmed CI-infrastructure blocker that is outside this PR's edit scope.** The image refresh itself works: Repair 1/5's targeted run passed 4/4 benchmark points and 4/4 gsm8k evals with +8.3% to +15.6% throughput per GPU versus the 2026-08-10 baseline. In the labeled sweep (https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946) the 1P1D benchmark completed but result processing crashed with `OSError: [Errno 36] File name too long` because the shared multinode template appends `_recipe-<fingerprint>` to the result filename, pushing this family's 1P1D (`conc1x4x8x16x32x64x256`) aggregate name to 256 bytes (NAME_MAX is 255); the 5P1D and 6P1D benchmark jobs failed when pyxis could not pull the `nginx` frontend image from Docker Hub (anonymous pull, error 23). No in-scope change can shorten the generated filename, so the sweep cannot pass for this family until the shared template/result-processing code is fixed. Disposition: sweep run cancelled, label removed, PR returned to draft and closed, remote branch deleted so the candidate can be retried after the shared fix lands. Repairs used: 1 of 5.

Family: `configs/nvidia-master.yaml:qwen3.5-fp4-gb300-dynamo-sglang` (Qwen3.5-397B-A17B NVFP4-V2, GB300, dynamo-sglang, disaggregated, 8k1k, no speculative decoding). Target cluster: `gb300-nv` (runner `gb300` → `gb300-nv_0/1/2` in `configs/runners.yaml`).

Change: `image: lmsysorg/sglang:v0.5.14-cu130` → `lmsysorg/sglang:v0.5.19-cu130`; recipes' `dynamo.version` and the family's `router.version` `1.1.0` → `1.5.0.dev20260908` (Repair 1, see below) (Docker Hub manifest digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, pushed 2026-09-04, linux/arm64 present; release `v0.5.19` published 2026-09-05). The four srt-slurm recipes under `benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/` keep `container: "dynamo-sglang"`, which `runners/launch_gb300-nv.sh` maps to the master image's squash file, so no recipe edit is needed. Matrix generation at base and head differs only in `image` (4 points, node counts 2/9/10/11, evals enabled). Every recipe server flag exists in v0.5.19 (`--mamba-scheduler-strategy` remains a deprecated alias of `--mamba-radix-cache-strategy`, as in v0.5.14).

Green targeted benchmarks do not prove that global PR checks pass.

## Baseline (published 2026-08-10)

- Source: public API `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-10&exact=true` (no `view`), filtered to hardware `gb300`, framework `dynamo-sglang`, precision `fp4`, spec `none`, disagg, 8192/1024, `single_turn`; `GET /api/v1/workflow-info?date=2026-08-10`; `GET /api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-08-10`.
- Old image verified on every point: `lmsysorg/sglang:v0.5.14-cu130`. Producer run for all 10 points: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29473335540/attempts/1 (head SHA `7df19b5b7abd238d7663cce15bffeaa8891ad065`, PR #2238). Logical curve snapshot id 2289 is not a producer id.
- Dataset/workload: fixed-seq-len 8k1k, random-range-ratio 0.8 (sa-bench), router dynamo-router 1.1.0.

| Point (P/D topology, kv) | conc | tput/GPU (tok/s) | median TTFT (s) | median TPOT (s) | median E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 1P TP4 / 1D TP4, mooncake | 1 | 242.87 | 0.381 | 0.00417 | 4.27 |
| 1P TP4 / 1D TP4, mooncake | 4 | 806.75 | 0.418 | 0.00486 | 5.00 |
| 1P TP4 / 1D TP4, mooncake | 8 | 1344.60 | 0.724 | 0.00567 | 5.98 |
| 1P TP4 / 1D TP4, mooncake | 16 | 2292.35 | 0.745 | 0.00672 | 6.93 |
| 1P TP4 / 1D TP4, mooncake | 32 | 3629.11 | 0.889 | 0.00849 | 8.72 |
| 1P TP4 / 1D TP4, mooncake | 64 | 5745.02 | 1.034 | 0.01077 | 10.99 |
| 1P TP4 / 1D TP4, mooncake | 256 | 9091.45 | 15.103 | 0.01383 | 28.01 |
| 5P DEP4 / 1D DEP16, nixl | 2048 | 15626.02 | 12.200 | 0.01688 | 27.87 |
| 6P DEP4 / 1D DEP16, mooncake | 5120 | 17301.32 | 40.608 | 0.01900 | 57.85 |
| 7P DEP4 / 1D DEP16, mooncake | 5120 | 18370.36 | 27.722 | 0.02154 | 47.60 |

- Published evals (gsm8k, n=1319, same producer run): 1P/1D conc 256 em_strict 0.9659 / em_flexible 0.9606; 5P1D conc 2048 0.9674 / 0.9560; 6P1D conc 5120 0.9666 / 0.9530; 7P1D conc 5120 0.9682 / 0.9530.

## Initial attempt

- Image/commit: `lmsysorg/sglang:v0.5.19-cu130`, commit `ebde675f2fa4519650be9c0349d12c9d75694bfa`.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34303559979 (dispatched 2026-09-09T02:31:33Z from `main`, `inputs.ref=ebde675f2fa4519650be9c0349d12c9d75694bfa`, `fail-fast=true`, `klaud-run=true`). Outcome: **failure** at 02:43 UTC.
- Changes: master image bump only.
- Benchmark/eval results: N/A (1P1D benchmark and 1P1D eval jobs failed in "Launch multi-node job script" before serving; fail-fast cancelled the 5P1D/6P1D/7P1D benchmark and eval jobs). Empty `results_bmk`/`eval_results_all` artifacts.
- Deltas vs baseline: N/A (no measurements).
- Diagnosis (first server error, prefill worker on srtctl job 29041): `ModuleNotFoundError: No module named 'sglang.srt.server_args_config_parser'` raised from `dynamo/sglang/args.py` after "Dynamo 1.1.0 installed". sglang v0.5.19 moved that module to `sglang.srt.utils.server_args_config_parser` (sgl-project/sglang#36681; the old path exists in v0.5.14–v0.5.18). Dynamo v1.1.0 through v1.4.2 (and `release/1.4.2`) still import the old path; the fix (ai-dynamo/dynamo#14054, #14234) is only on `main` and in the `1.5.0.dev*` PyPI nightlies; backport PR #14064 was closed. The v0.5.19 squash image itself imported fine.
- Next step: Repair 1 — pin a Dynamo build that carries the compat shim.

## Repair 1/5

- Image/commit: `lmsysorg/sglang:v0.5.19-cu130`, commit `30fbdb6a38ad300d4618dcdfefa467ef0fd69a86`.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34304865256 (dispatched 2026-09-09T02:51:26Z from `main`, `inputs.ref=30fbdb6a38ad300d4618dcdfefa467ef0fd69a86`, `fail-fast=true`, `klaud-run=true`).
- Changes: `dynamo.version` `"1.1.0"` → `"1.5.0.dev20260908"` in the four referenced recipes (`8k1k_stp_lowlat_0/maxtpt_0/maxtpt_1/maxtpt_2.yaml`); `router.version` `"1.1.0"` → `"1.5.0.dev20260908"` in the family's master entry so published router metadata matches the installed Dynamo. The srt-slurm producer installs `ai-dynamo-runtime==V ai-dynamo==V` from PyPI without the sglang extra, so the container's sglang stays v0.5.19. The `ai_dynamo-1.5.0.dev20260908` wheel contains `dynamo/sglang/_compat.py` importing `sglang.srt.utils.server_args_config_parser`; every other `sglang.srt` module it imports exists in the v0.5.19 tree (multimodal encode-server imports are try/except-guarded). `ai-dynamo-runtime` ships a `cp310-abi3 manylinux_2_28_aarch64` wheel.
- Outcome: **success** (run completed 2026-09-09 05:27 UTC). All 4 multi-node benchmark jobs and all 4 eval-only jobs succeeded; `results_bmk/agg_bmk.json` has 10 rows, every row `image: lmsysorg/sglang:v0.5.19-cu130`; `eval_results_all/agg_eval_all.json` has 4 entries.
- Eval results (gsm8k, n=1319, strict / flexible; baseline in parentheses): 1P1D conc 256 0.9697 / 0.9621 (0.9659 / 0.9606); 5P1D conc 2048 0.9659 / 0.9598 (0.9674 / 0.9560); 6P1D conc 5120 0.9636 / 0.9530 (0.9666 / 0.9530); 7P1D conc 5120 0.9659 / 0.9575 (0.9682 / 0.9530). All within ±0.5 pt of baseline (SE ≈ 0.005).
- Deltas vs baseline (per point, new vs published 2026-08-10; same topology, concurrency and 8k1k dataset; throughput = `tput_per_gpu`):

| conc | tput/GPU new vs base (Δ) | median TTFT new vs base (Δ) | median TPOT new vs base (Δ) | median E2E new vs base (Δ) |
| --- | --- | --- | --- | --- |
| 1 | 279.61 vs 242.87 (+15.1%) | 0.150 vs 0.381 s (−60.6%) | 3.84 vs 4.17 ms (−8.1%) | 3.63 vs 4.27 s (−15.1%) |
| 4 | 916.30 vs 806.75 (+13.6%) | 0.183 vs 0.418 s (−56.2%) | 4.57 vs 4.86 ms (−6.0%) | 4.40 vs 5.00 s (−12.0%) |
| 8 | 1554.42 vs 1344.60 (+15.6%) | 0.195 vs 0.724 s (−73.1%) | 5.31 vs 5.67 ms (−6.3%) | 5.19 vs 5.98 s (−13.2%) |
| 16 | 2595.83 vs 2292.35 (+13.2%) | 0.230 vs 0.745 s (−69.2%) | 6.30 vs 6.72 ms (−6.3%) | 6.15 vs 6.93 s (−11.2%) |
| 32 | 4049.07 vs 3629.11 (+11.6%) | 0.333 vs 0.889 s (−62.5%) | 8.07 vs 8.49 ms (−5.0%) | 7.84 vs 8.72 s (−10.1%) |
| 64 | 6347.02 vs 5745.02 (+10.5%) | 0.407 vs 1.034 s (−60.6%) | 10.34 vs 10.77 ms (−4.1%) | 9.96 vs 10.99 s (−9.4%) |
| 256 | 9847.69 vs 9091.45 (+8.3%) | 13.694 vs 15.103 s (−9.3%) | 13.48 vs 13.83 ms (−2.5%) | 26.09 vs 28.01 s (−6.8%) |

  Wide-EP points (prefill DEP4 workers / 1 decode DEP16 worker):

| Point | conc | tput/GPU new vs base (Δ) | median TTFT new vs base (Δ) | median TPOT new vs base (Δ) | median E2E new vs base (Δ) |
| --- | --- | --- | --- | --- | --- |
| 5P1D, nixl | 2048 | 17654.45 vs 15626.02 (+13.0%) | 9.474 vs 12.200 s (−22.3%) | 17.07 vs 16.88 ms (+1.1%, regression) | 25.39 vs 27.87 s (−8.9%) |
| 6P1D, mooncake | 5120 | 19273.44 vs 17301.32 (+11.4%) | 35.541 vs 40.608 s (−12.5%) | 18.67 vs 19.00 ms (−1.7%) | 52.98 vs 57.85 s (−8.4%) |
| 7P1D, mooncake | 5120 | 20282.71 vs 18370.36 (+10.4%) | 24.590 vs 27.722 s (−11.3%) | 22.07 vs 21.54 ms (+2.5%, regression) | 45.09 vs 47.60 s (−5.3%) |

  All 10 points matched a baseline point; none excluded. Single-run measurements, no repeat; the two TPOT regressions are small and reported, not gated.
- Next step: append the `perf-changelog.yaml` entry and start the final full sweep.

## Final full sweep

- Image/commit: `lmsysorg/sglang:v0.5.19-cu130`, head `278090e154fbbca8b653b284c51c56b40add9534` (adds the `perf-changelog.yaml` entry; validator `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD` passed locally, prior bytes preserved).
- Transition: capacity check on `gb300-nv` passed at 05:28 UTC; PR marked ready; `full-sweep-enabled` applied as the sole sweep label.
- Runs on the exact head: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946 (active; triggered by the `full-sweep-enabled` label event; `check-changelog` passed, `setup` running). https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315043758 and https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044003 (ready-for-review events) were cancelled by the sweep concurrency group before any benchmark job ran.
- Result: **failure** (run cancelled by Klaud Cold after the failures below made success impossible; job states at cancellation are listed under "Terminal states").
- Job outcomes: 7P1D c5120 benchmark **success** (05:54–06:35 UTC); 1P1D eval and 7P1D eval **success**; 1P1D c1–256 benchmark **failure** (06:04 UTC); 5P1D c2048 benchmark **failure** (06:44 UTC); 6P1D c5120 benchmark **failure** (06:54 UTC); 5P1D eval was in progress and 6P1D eval queued when the run was cancelled.
- Diagnosis 1 (1P1D benchmark, deterministic, out of scope): the srtctl sweep itself finished ("Benchmark completed successfully", 7/7 concurrencies, all requests completed, power telemetry `publication_valid: true`). The `Process result` step then failed in `utils/process_result.py` with `OSError: [Errno 36] File name too long: 'agg_qwen3.5_8k1k_fp4_dynamo-sglang_prefill-tp4-…-nw1_decode-tp4-…-nw1_disagg-true_spec-none_conc1x4x8x16x32x64x256_gb300-nv_00_recipe-0190dba4907b78b3_sa-bench_isl_8192_osl_1024_conc16_gpus_8_ctx_4_gen_4.json'` (256 bytes; the matching `power_validation_…` name is 269 bytes; Linux NAME_MAX is 255). `benchmark-multinode-tmpl.yml` appends `_recipe-${RECIPE_FINGERPRINT:0:16}` to `RESULT_FILENAME` whenever `run-sweep.yml` supplies a recipe fingerprint (since #2613, 2026-08-14); the manual `e2e-tests.yml` path passes no fingerprint, which is why the identical point produced a 232-byte name and passed in the targeted run. The published baseline predates the fingerprint suffix and no sweep has published this family since, so every labeled sweep of this family's 1P1D point will hit this regardless of image. Fixing it requires shared template/result-processing changes, which this PR must not touch.
- Diagnosis 2 (5P1D and 6P1D benchmarks, infrastructure flake, out of scope): both jobs died 6–7 minutes after submission when the `nginx` frontend container failed to start: `pyxis: importing docker image: nginx … Authenticating with user: <anonymous> … Fetching image manifest list … pyxis: child … failed with error code: 23 … failed to import docker image`. The recipes' `frontend.nginx_container: nginx` is pulled from Docker Hub by pyxis on the head node; the same pull succeeded for the 1P1D and 7P1D sweep jobs and for all four jobs of the targeted run, so this is a registry/network failure, not an image or recipe defect.
- Next step: none within scope. Recommended follow-up for maintainers: shorten the generated multinode result filename (e.g. truncate/hash the `conc…` list or the `_recipe-` suffix) or move the `nginx` frontend to the pre-imported squash alias, then let the planner retry this candidate.
- Terminal states (confirmed 2026-09-09 07:2x UTC): sweep run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946 → **cancelled** (jobs: 1P1D/5P1D/6P1D benchmark failure, 7P1D benchmark success, 1P1D/5P1D/7P1D eval success, 6P1D eval cancelled; no unfinished jobs). Owned e2e runs: 34303559979 failure (initial attempt), 34304865256 success (Repair 1); both completed with no unfinished jobs.

---

## 状态

**当前状态：** **已停止 —— 最终全量 sweep 因已确认的 CI 基础设施阻塞而失败，该问题超出本 PR 的编辑范围。** 镜像更新本身可用：修复 1/5 的定向运行通过了 4/4 个基准点与 4/4 个 gsm8k 评测，每 GPU 吞吐相对 2026-08-10 基线提升 +8.3% 至 +15.6%。在带标签的 sweep（https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946）中，1P1D 基准已跑完，但结果处理因 `OSError: [Errno 36] File name too long` 崩溃：共享的多节点模板会在结果文件名后追加 `_recipe-<fingerprint>`，使该配置族 1P1D（`conc1x4x8x16x32x64x256`）的聚合文件名达到 256 字节（NAME_MAX 为 255）；5P1D 与 6P1D 基准作业则因 pyxis 无法从 Docker Hub 拉取 `nginx` 前端镜像（匿名拉取，错误码 23）而失败。范围内没有任何改动能缩短生成的文件名，因此在共享模板/结果处理代码修复之前，该配置族的 sweep 无法通过。处置：取消 sweep 运行、移除标签、PR 转回草稿并关闭、删除远程分支，以便共享修复落地后可重试该候选。已用修复次数：1/5。

配置族：`configs/nvidia-master.yaml:qwen3.5-fp4-gb300-dynamo-sglang`（Qwen3.5-397B-A17B NVFP4-V2，GB300，dynamo-sglang，分离式，8k1k，无投机解码）。目标集群：`gb300-nv`（`configs/runners.yaml` 中 runner `gb300` → `gb300-nv_0/1/2`）。

变更：`image: lmsysorg/sglang:v0.5.14-cu130` → `lmsysorg/sglang:v0.5.19-cu130`；配方的 `dynamo.version` 与配置族的 `router.version` `1.1.0` → `1.5.0.dev20260908`（修复 1，见下文）（Docker Hub 清单摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，2026-09-04 推送，包含 linux/arm64；`v0.5.19` 发布于 2026-09-05）。`benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb300-fp4/8k1k/disagg/stp/` 下的四个 srt-slurm 配方继续使用 `container: "dynamo-sglang"` 别名，`runners/launch_gb300-nv.sh` 会将其映射到主配置镜像的 squash 文件，因此无需修改配方。基线与头部提交生成的矩阵仅 `image` 字段不同（4 个点，节点数 2/9/10/11，启用评测）。配方中的所有服务端参数在 v0.5.19 中均存在（`--mamba-scheduler-strategy` 与 v0.5.14 一样仍是 `--mamba-radix-cache-strategy` 的弃用别名）。

定向基准测试通过并不代表全局 PR 检查通过。

## 基线（发布日期 2026-08-10）

- 来源：公开 API `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-10&exact=true`（不带 `view`），筛选硬件 `gb300`、框架 `dynamo-sglang`、精度 `fp4`、投机解码 `none`、分离式、8192/1024、`single_turn`；`GET /api/v1/workflow-info?date=2026-08-10`；`GET /api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-08-10`。
- 每个点均已核实旧镜像：`lmsysorg/sglang:v0.5.14-cu130`。全部 10 个点的生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29473335540/attempts/1（头部 SHA `7df19b5b7abd238d7663cce15bffeaa8891ad065`，PR #2238）。逻辑曲线快照 id 2289 不是生产运行 id。
- 数据集/负载：固定序列长度 8k1k，random-range-ratio 0.8（sa-bench），路由器 dynamo-router 1.1.0。

| 点（P/D 拓扑，kv） | 并发 | 每 GPU 吞吐 (tok/s) | 中位 TTFT (s) | 中位 TPOT (s) | 中位 E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 1P TP4 / 1D TP4，mooncake | 1 | 242.87 | 0.381 | 0.00417 | 4.27 |
| 1P TP4 / 1D TP4，mooncake | 4 | 806.75 | 0.418 | 0.00486 | 5.00 |
| 1P TP4 / 1D TP4，mooncake | 8 | 1344.60 | 0.724 | 0.00567 | 5.98 |
| 1P TP4 / 1D TP4，mooncake | 16 | 2292.35 | 0.745 | 0.00672 | 6.93 |
| 1P TP4 / 1D TP4，mooncake | 32 | 3629.11 | 0.889 | 0.00849 | 8.72 |
| 1P TP4 / 1D TP4，mooncake | 64 | 5745.02 | 1.034 | 0.01077 | 10.99 |
| 1P TP4 / 1D TP4，mooncake | 256 | 9091.45 | 15.103 | 0.01383 | 28.01 |
| 5P DEP4 / 1D DEP16，nixl | 2048 | 15626.02 | 12.200 | 0.01688 | 27.87 |
| 6P DEP4 / 1D DEP16，mooncake | 5120 | 17301.32 | 40.608 | 0.01900 | 57.85 |
| 7P DEP4 / 1D DEP16，mooncake | 5120 | 18370.36 | 27.722 | 0.02154 | 47.60 |

- 已发布评测（gsm8k，n=1319，同一生产运行）：1P/1D 并发 256 em_strict 0.9659 / em_flexible 0.9606；5P1D 并发 2048 0.9674 / 0.9560；6P1D 并发 5120 0.9666 / 0.9530；7P1D 并发 5120 0.9682 / 0.9530。

## 初始尝试

- 镜像/提交：`lmsysorg/sglang:v0.5.19-cu130`，提交 `ebde675f2fa4519650be9c0349d12c9d75694bfa`。
- 运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34303559979（2026-09-09T02:31:33Z 从 `main` 派发，`inputs.ref=ebde675f2fa4519650be9c0349d12c9d75694bfa`，`fail-fast=true`，`klaud-run=true`）。结果：**失败**（02:43 UTC）。
- 变更：仅更新主配置镜像。
- 基准/评测结果：N/A（1P1D 基准与 1P1D 评测作业在“Launch multi-node job script”步骤、服务启动前失败；fail-fast 取消了 5P1D/6P1D/7P1D 的基准与评测作业）。`results_bmk`/`eval_results_all` 产物为空。
- 相对基线的差异：N/A（无测量结果）。
- 诊断（首个服务端错误，srtctl 作业 29041 的 prefill worker）：在“Dynamo 1.1.0 installed”之后，`dynamo/sglang/args.py` 抛出 `ModuleNotFoundError: No module named 'sglang.srt.server_args_config_parser'`。sglang v0.5.19 已将该模块移至 `sglang.srt.utils.server_args_config_parser`（sgl-project/sglang#36681；旧路径存在于 v0.5.14–v0.5.18）。Dynamo v1.1.0 至 v1.4.2（及 `release/1.4.2`）仍导入旧路径；修复（ai-dynamo/dynamo#14054、#14234）仅在 `main` 分支及 PyPI 的 `1.5.0.dev*` 每日构建中；回移 PR #14064 已关闭。v0.5.19 squash 镜像本身可正常导入。
- 下一步：修复 1 —— 固定包含兼容层的 Dynamo 构建。

## 修复 1/5

- 镜像/提交：`lmsysorg/sglang:v0.5.19-cu130`，提交 `30fbdb6a38ad300d4618dcdfefa467ef0fd69a86`。
- 运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34304865256（2026-09-09T02:51:26Z 从 `main` 派发，`inputs.ref=30fbdb6a38ad300d4618dcdfefa467ef0fd69a86`，`fail-fast=true`，`klaud-run=true`）。
- 变更：四个被引用配方（`8k1k_stp_lowlat_0/maxtpt_0/maxtpt_1/maxtpt_2.yaml`）的 `dynamo.version` `"1.1.0"` → `"1.5.0.dev20260908"`；配置族主配置条目的 `router.version` `"1.1.0"` → `"1.5.0.dev20260908"`，使发布的路由器元数据与实际安装的 Dynamo 一致。srt-slurm 生产端从 PyPI 安装 `ai-dynamo-runtime==V ai-dynamo==V`（不带 sglang extra），容器内 sglang 保持 v0.5.19。`ai_dynamo-1.5.0.dev20260908` wheel 包含导入 `sglang.srt.utils.server_args_config_parser` 的 `dynamo/sglang/_compat.py`；其导入的其他所有 `sglang.srt` 模块均存在于 v0.5.19 源码树中（多模态 encode-server 导入有 try/except 保护）。`ai-dynamo-runtime` 提供 `cp310-abi3 manylinux_2_28_aarch64` wheel。
- 结果：**成功**（运行于 2026-09-09 05:27 UTC 完成）。全部 4 个多节点基准作业与 4 个仅评测作业均成功；`results_bmk/agg_bmk.json` 共 10 行，每行 `image: lmsysorg/sglang:v0.5.19-cu130`；`eval_results_all/agg_eval_all.json` 共 4 条。
- 评测结果（gsm8k，n=1319，strict / flexible；括号内为基线）：1P1D 并发 256 0.9697 / 0.9621（0.9659 / 0.9606）；5P1D 并发 2048 0.9659 / 0.9598（0.9674 / 0.9560）；6P1D 并发 5120 0.9636 / 0.9530（0.9666 / 0.9530）；7P1D 并发 5120 0.9659 / 0.9575（0.9682 / 0.9530）。均在基线 ±0.5 个百分点内（标准误约 0.005）。
- 相对基线的差异（逐点，新值 vs 2026-08-10 发布值；拓扑、并发与 8k1k 数据集相同；吞吐为 `tput_per_gpu`）：

| 并发 | 每 GPU 吞吐 新 vs 基线（Δ） | 中位 TTFT 新 vs 基线（Δ） | 中位 TPOT 新 vs 基线（Δ） | 中位 E2E 新 vs 基线（Δ） |
| --- | --- | --- | --- | --- |
| 1 | 279.61 vs 242.87（+15.1%） | 0.150 vs 0.381 s（−60.6%） | 3.84 vs 4.17 ms（−8.1%） | 3.63 vs 4.27 s（−15.1%） |
| 4 | 916.30 vs 806.75（+13.6%） | 0.183 vs 0.418 s（−56.2%） | 4.57 vs 4.86 ms（−6.0%） | 4.40 vs 5.00 s（−12.0%） |
| 8 | 1554.42 vs 1344.60（+15.6%） | 0.195 vs 0.724 s（−73.1%） | 5.31 vs 5.67 ms（−6.3%） | 5.19 vs 5.98 s（−13.2%） |
| 16 | 2595.83 vs 2292.35（+13.2%） | 0.230 vs 0.745 s（−69.2%） | 6.30 vs 6.72 ms（−6.3%） | 6.15 vs 6.93 s（−11.2%） |
| 32 | 4049.07 vs 3629.11（+11.6%） | 0.333 vs 0.889 s（−62.5%） | 8.07 vs 8.49 ms（−5.0%） | 7.84 vs 8.72 s（−10.1%） |
| 64 | 6347.02 vs 5745.02（+10.5%） | 0.407 vs 1.034 s（−60.6%） | 10.34 vs 10.77 ms（−4.1%） | 9.96 vs 10.99 s（−9.4%） |
| 256 | 9847.69 vs 9091.45（+8.3%） | 13.694 vs 15.103 s（−9.3%） | 13.48 vs 13.83 ms（−2.5%） | 26.09 vs 28.01 s（−6.8%） |

  宽 EP 点（prefill DEP4 worker / 1 个 decode DEP16 worker）：

| 点 | 并发 | 每 GPU 吞吐 新 vs 基线（Δ） | 中位 TTFT 新 vs 基线（Δ） | 中位 TPOT 新 vs 基线（Δ） | 中位 E2E 新 vs 基线（Δ） |
| --- | --- | --- | --- | --- | --- |
| 5P1D，nixl | 2048 | 17654.45 vs 15626.02（+13.0%） | 9.474 vs 12.200 s（−22.3%） | 17.07 vs 16.88 ms（+1.1%，回退） | 25.39 vs 27.87 s（−8.9%） |
| 6P1D，mooncake | 5120 | 19273.44 vs 17301.32（+11.4%） | 35.541 vs 40.608 s（−12.5%） | 18.67 vs 19.00 ms（−1.7%） | 52.98 vs 57.85 s（−8.4%） |
| 7P1D，mooncake | 5120 | 20282.71 vs 18370.36（+10.4%） | 24.590 vs 27.722 s（−11.3%） | 22.07 vs 21.54 ms（+2.5%，回退） | 45.09 vs 47.60 s（−5.3%） |

  全部 10 个点均匹配到基线点；无排除项。均为单次测量、未重复；两处 TPOT 轻微回退仅作报告，不设门限。
- 下一步：追加 `perf-changelog.yaml` 条目并启动最终全量 sweep。

## 最终全量 sweep

- 镜像/提交：`lmsysorg/sglang:v0.5.19-cu130`，头部 `278090e154fbbca8b653b284c51c56b40add9534`（新增 `perf-changelog.yaml` 条目；本地 `utils/validate_perf_changelog.py --base-ref origin/main --head-ref HEAD` 校验通过，既有字节完整保留）。
- 转换：05:28 UTC `gb300-nv` 容量检查通过；PR 标记为 ready；添加 `full-sweep-enabled` 作为唯一 sweep 标签。
- 精确头部上的运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946（活动运行；由 `full-sweep-enabled` 标签事件触发；`check-changelog` 已通过，`setup` 运行中）。https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315043758 与 https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044003（ready-for-review 事件）在任何基准作业运行前即被 sweep 并发组取消。
- 结果：**失败**（在下列失败使成功不再可能后，由 Klaud Cold 取消运行；取消时的作业状态见“终态”）。
- 作业结果：7P1D c5120 基准**成功**（05:54–06:35 UTC）；1P1D 与 7P1D 评测**成功**；1P1D c1–256 基准**失败**（06:04 UTC）；5P1D c2048 基准**失败**（06:44 UTC）；6P1D c5120 基准**失败**（06:54 UTC）；取消时 5P1D 评测正在运行、6P1D 评测排队中。
- 诊断 1（1P1D 基准，确定性，超出范围）：srtctl sweep 本身已完成（“Benchmark completed successfully”，7/7 个并发、所有请求完成，功耗遥测 `publication_valid: true`）。随后 `Process result` 步骤在 `utils/process_result.py` 中因 `OSError: [Errno 36] File name too long: 'agg_qwen3.5_8k1k_fp4_dynamo-sglang_prefill-tp4-…-nw1_decode-tp4-…-nw1_disagg-true_spec-none_conc1x4x8x16x32x64x256_gb300-nv_00_recipe-0190dba4907b78b3_sa-bench_isl_8192_osl_1024_conc16_gpus_8_ctx_4_gen_4.json'` 失败（256 字节；对应的 `power_validation_…` 文件名为 269 字节；Linux NAME_MAX 为 255）。只要 `run-sweep.yml` 提供配方指纹（自 #2613，2026-08-14 起），`benchmark-multinode-tmpl.yml` 就会在 `RESULT_FILENAME` 后追加 `_recipe-${RECIPE_FINGERPRINT:0:16}`；手动 `e2e-tests.yml` 路径不传指纹，因此同一点在定向运行中生成 232 字节的文件名并通过。已发布基线早于指纹后缀的引入，此后该配置族没有任何 sweep 发布过数据，因此无论镜像如何，该配置族 1P1D 点在任何带标签的 sweep 中都会触发此问题。修复需要改动共享模板/结果处理代码，本 PR 不得触碰。
- 诊断 2（5P1D 与 6P1D 基准，基础设施抖动，超出范围）：两个作业在提交后 6–7 分钟因 `nginx` 前端容器无法启动而终止：`pyxis: importing docker image: nginx … Authenticating with user: <anonymous> … Fetching image manifest list … pyxis: child … failed with error code: 23 … failed to import docker image`。配方的 `frontend.nginx_container: nginx` 由头节点上的 pyxis 从 Docker Hub 拉取；同样的拉取在 1P1D、7P1D sweep 作业及定向运行的全部四个作业中均成功，因此这是镜像仓库/网络故障，而非镜像或配方缺陷。
- 下一步：范围内无可行操作。建议维护者：缩短生成的多节点结果文件名（例如截断/哈希 `conc…` 列表或 `_recipe-` 后缀），或将 `nginx` 前端改用预导入的 squash 别名，然后让规划器重试该候选。
- 终态（2026-09-09 07:2x UTC 确认）：sweep 运行 https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34315044946 → **已取消**（作业：1P1D/5P1D/6P1D 基准失败，7P1D 基准成功，1P1D/5P1D/7P1D 评测成功，6P1D 评测已取消；无未完成作业）。自有 e2e 运行：34303559979 失败（初始尝试）、34304865256 成功（修复 1）；均已完成且无未完成作业。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
