### PR TITLE
[Klaud Cold] Refresh dsr1-fp4-gb300-dynamo-sglang SGLang image to v0.5.19-cu130-runtime (incompatible: upstream Dynamo 0.8.1 pin) / 将 dsr1-fp4-gb300-dynamo-sglang 的 SGLang 镜像更新至 v0.5.19-cu130-runtime（不兼容：上游固定 Dynamo 0.8.1）

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3219,7 +3219,7 @@ dsr1-fp4-gb300-dynamo-trt:
           ep: 16
           dp-attn: true
 dsr1-fp4-gb300-dynamo-sglang:
-  image: "lmsysorg/sglang:v0.5.8.post1-cu130-runtime"
+  image: "lmsysorg/sglang:v0.5.19-cu130-runtime@sha256:710bc11443a7b1807d69803386468101bcfced35f86bf8fe92a8209e05a2f052"
   model: nvidia/DeepSeek-R1-0528-NVFP4-v2
   model-prefix: dsr1
   runner: gb300


### PR DESCRIPTION
**Current status:** Closed without a GPU sweep. Confirmed image incompatibility: the upstream srt-slurm recipes this family runs pin Dynamo `0.8.1`, whose SGLang worker imports two SGLang modules that `lmsysorg/sglang:v0.5.19-cu130-runtime` no longer provides at those paths. No in-scope repair exists, so no benchmark was dispatched and no repair budget was used.

**Next step:** Manual review. Refreshing this family needs a Dynamo bump in the upstream NVIDIA/srt-slurm recipes (`recipes/gb300-fp4/8k1k/{low_latency,mid_curve,max_tpt}.yaml` on `sa-submission-q2-2026`) or checked-in recipes with a compatible Dynamo, mirroring the Qwen3.5 GB300 STP recipes (Dynamo `1.1.0` with SGLang `v0.5.14-cu130`). Both are outside Klaud Cold's edit scope. The candidate branch is retained so this exact image/release candidate is not re-selected.

Green targeted benchmarks would not prove that global PR checks pass; here none were run.

### Baseline (published 2026-02-12)
- Family: `dsr1-fp4-gb300-dynamo-sglang` in `configs/nvidia-master.yaml` (model `nvidia/DeepSeek-R1-0528-NVFP4-v2`, fp4, dynamo-sglang, disaggregated, spec-decoding none, 8k1k, single_turn). Runner `gb300` maps to `gb300-nv_0..2`, telemetry cluster `gb300-nv`.
- Old image on the published rows: `lmsysorg/sglang:v0.5.8.post1-cu130-runtime` (matches the master config at base `b51c65807`).
- Producer: run [21928999802 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21928999802/attempts/1), head SHA `3282fdeba5b7122a09dc191a486bca03433dc123` (PR #636). Curve snapshot `curve_workflow_run_id=283` is a logical snapshot id, not the producer.
- API queries: `GET /api/v1/workflow-info?date=2026-02-12`; `GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-12&exact=true` (no `view`), filtered to `hardware=gb300`, `framework=dynamo-sglang`, `precision=fp4`, `isl=8192`, `osl=1024`, `disagg=true`, `spec_method=none`. Result: 8 rows, one per recipe point (ids below). Time metrics are seconds in the API; TPOT is shown in ms.
- Published evals: N/A. No updated-image run exists to compare against, so eval baselines were not needed.

| id | Topology | Conc | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) | Updated image | Delta |
|---|---|---|---|---|---|---|---|---|---|
| 94540 | 1P(TP4/EP1)+4D(TP4/EP1) | 4 | 247.4 | 34.4 | 0.238 | 6.65 | 6.40 | N/A (not run) | N/A |
| 94542 | 1P(TP4/EP1)+4D(TP4/EP1) | 8 | 457.8 | 64.3 | 0.272 | 7.33 | 6.99 | N/A (not run) | N/A |
| 94539 | 1P(TP4/EP1)+4D(TP4/EP1) | 32 | 1374.7 | 192.1 | 0.618 | 9.17 | 9.09 | N/A (not run) | N/A |
| 94541 | 1P(TP4/EP1)+4D(TP4/EP1) | 64 | 2093.7 | 290.3 | 0.727 | 12.14 | 11.98 | N/A (not run) | N/A |
| 94559 | 6P(TP4/EP1)+1D(TP48/EP48/DP-attn) | 512 | 2653.3 | 442.2 | 3.390 | 12.95 | 15.14 | N/A (not run) | N/A |
| 94557 | 6P(TP4/EP1)+1D(TP48/EP48/DP-attn) | 2048 | 5028.8 | 838.8 | 32.029 | 13.26 | 44.28 | N/A (not run) | N/A |
| 94558 | 6P(TP4/EP1)+1D(TP48/EP48/DP-attn) | 4096 | 4594.4 | 765.5 | 80.427 | 13.59 | 92.94 | N/A (not run) | N/A |
| 94566 | 10P(TP4/EP1)+1D(TP32/EP32/DP-attn) | 2048 | 7120.5 | 1781.6 | 10.240 | 17.37 | 26.39 | N/A (not run) | N/A |

### Initial attempt
- Image: `lmsysorg/sglang:v0.5.19-cu130-runtime@sha256:710bc11443a7b1807d69803386468101bcfced35f86bf8fe92a8209e05a2f052` (Docker Hub manifest list, pushed 2026-09-04, amd64 + arm64, CUDA 13.0). Commit `d51e5344b80643754bdcad560097328bbcb90730`.
- Change: master `image` only. Model, precision, topology, concurrencies, evals, `nodes:N` demand (5 / 18 / 18) and `CONFIG_FILE` recipe references are unchanged; the regenerated `test-config` matrix differs from base only in `image`.
- Run: N/A. Not dispatched; the image was rejected as incompatible before any GPU use. Capacity check for `gb300-nv` passed (exit 0) before branch creation.
- Benchmark and eval results: N/A (not run). Per-point deltas: N/A (not run).
- Diagnosis (static, evidence-backed):
  - `runners/launch_gb300-nv.sh` handles `dsr1`+`fp4`+`dynamo-sglang` in its default branch: it clones NVIDIA/srt-slurm at `sa-submission-q2-2026` (`deb1dfd9934398664f92d194169c183e009da83b`) and runs the upstream recipes `recipes/gb300-fp4/8k1k/{low_latency,mid_curve,max_tpt}.yaml`. Those recipes set `dynamo.version: 0.8.1` and `model.container: "dynamo-sglang"`, and the launcher aliases `dynamo-sglang` to the master image's squash file. No in-repo srt-slurm YAML exists for this family.
  - srtctl runs `pip install ... ai-dynamo-runtime==0.8.1 ai-dynamo==0.8.1` inside the container and launches prefill/decode workers as `python -m dynamo.sglang` (frontend type `dynamo`).
  - Dynamo v0.8.1 `components/src/dynamo/sglang/request_handlers/handler_base.py:15` has the unconditional import `from sglang.srt.tracing import trace`. SGLang removed `python/sglang/srt/tracing/trace.py` at v0.5.10 (now `sglang/srt/observability/trace.py`); the v0.5.19 tree contains no `sglang/srt/tracing` package at all.
  - Dynamo v0.8.1 `components/src/dynamo/sglang/args.py:19` has the unconditional import `from sglang.srt.server_args_config_parser import ConfigArgumentMerger`. SGLang v0.5.19 moved that module to `sglang/srt/utils/server_args_config_parser.py`; the old path is gone.
  - Result: every prefill and decode worker would fail with `ImportError` at startup on v0.5.19 (and on any v0.5.10+ image for the first import). Fixing it requires either a newer Dynamo in the upstream recipe or patching Dynamo/SGLang inside the container, and shipped-image patches are prohibited.
  - Repository precedent agrees: GB300 dynamo-sglang families on newer SGLang pair it with newer Dynamo (Qwen3.5 GB300 FP4 STP: Dynamo `1.1.0` with `v0.5.14-cu130`; DSv4 GB300 pins a Dynamo source hash).
- Next step: manual review as described in the status summary. No repair attempted (0/5 used).

### Final full sweep
- N/A. Not started; no targeted attempt passed. No sweep label was applied.

---

**当前状态：** 未进行 GPU 扫描即关闭。已确认镜像不兼容：该配置族运行的上游 srt-slurm 配方固定 Dynamo `0.8.1`，其 SGLang worker 导入的两个 SGLang 模块在 `lmsysorg/sglang:v0.5.19-cu130-runtime` 中已不存在于原路径。范围内不存在可行修复，因此未派发任何基准测试，也未消耗修复预算。

**下一步：** 人工审查。刷新该配置族需要在上游 NVIDIA/srt-slurm 配方（`sa-submission-q2-2026` 分支的 `recipes/gb300-fp4/8k1k/{low_latency,mid_curve,max_tpt}.yaml`）中升级 Dynamo，或将配方入库并搭配兼容的 Dynamo（参照 Qwen3.5 GB300 STP 配方：Dynamo `1.1.0` 搭配 SGLang `v0.5.14-cu130`）。两者均超出 Klaud Cold 的修改范围。保留候选分支，以避免再次选中同一镜像/发布版本候选。

即便定向基准测试通过，也不能证明全局 PR 检查通过；本次未运行任何基准测试。

### 基线（发布日期 2026-02-12）
- 配置族：`configs/nvidia-master.yaml` 中的 `dsr1-fp4-gb300-dynamo-sglang`（模型 `nvidia/DeepSeek-R1-0528-NVFP4-v2`，fp4，dynamo-sglang，分离式，无投机解码，8k1k，single_turn）。runner `gb300` 映射到 `gb300-nv_0..2`，遥测集群 `gb300-nv`。
- 已发布数据的旧镜像：`lmsysorg/sglang:v0.5.8.post1-cu130-runtime`（与基线 `b51c65807` 处主配置一致）。
- 生产运行：[21928999802 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21928999802/attempts/1)，head SHA `3282fdeba5b7122a09dc191a486bca03433dc123`（PR #636）。`curve_workflow_run_id=283` 是逻辑曲线快照 ID，不是生产运行 ID。
- API 查询：`GET /api/v1/workflow-info?date=2026-02-12`；`GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-12&exact=true`（不带 `view`），过滤 `hardware=gb300`、`framework=dynamo-sglang`、`precision=fp4`、`isl=8192`、`osl=1024`、`disagg=true`、`spec_method=none`，得到 8 行，每个配方点一行（ID 见上表）。API 中时间指标单位为秒；TPOT 以毫秒显示。
- 已发布评测：N/A。没有更新镜像的运行可供比较，因此无需评测基线。

（数值对比见上方英文表格。）

### 初始尝试
- 镜像：`lmsysorg/sglang:v0.5.19-cu130-runtime@sha256:710bc11443a7b1807d69803386468101bcfced35f86bf8fe92a8209e05a2f052`（Docker Hub manifest list，2026-09-04 推送，amd64 + arm64，CUDA 13.0）。提交 `d51e5344b80643754bdcad560097328bbcb90730`。
- 变更：仅主配置 `image`。模型、精度、拓扑、并发、评测、`nodes:N` 需求（5 / 18 / 18）和 `CONFIG_FILE` 配方引用均未变；重新生成的 `test-config` 矩阵与基线仅在 `image` 上不同。
- 运行：N/A。未派发；镜像在使用任何 GPU 之前即被判定为不兼容。创建分支前 `gb300-nv` 容量检查通过（退出码 0）。
- 基准/评测结果：N/A（未运行）。逐点差值：N/A（未运行）。
- 诊断（静态、有证据支撑）：
  - `runners/launch_gb300-nv.sh` 在默认分支处理 `dsr1`+`fp4`+`dynamo-sglang`：克隆 NVIDIA/srt-slurm 的 `sa-submission-q2-2026`（`deb1dfd9934398664f92d194169c183e009da83b`），运行上游配方 `recipes/gb300-fp4/8k1k/{low_latency,mid_curve,max_tpt}.yaml`。这些配方设置 `dynamo.version: 0.8.1` 和 `model.container: "dynamo-sglang"`，启动器把 `dynamo-sglang` 别名指向主配置镜像的 squash 文件。本仓库中不存在该配置族的 srt-slurm YAML。
  - srtctl 在容器内执行 `pip install ... ai-dynamo-runtime==0.8.1 ai-dynamo==0.8.1`，并以 `python -m dynamo.sglang` 启动 prefill/decode worker（frontend 类型 `dynamo`）。
  - Dynamo v0.8.1 的 `components/src/dynamo/sglang/request_handlers/handler_base.py:15` 无条件导入 `from sglang.srt.tracing import trace`。SGLang 在 v0.5.10 移除了 `python/sglang/srt/tracing/trace.py`（现为 `sglang/srt/observability/trace.py`）；v0.5.19 源码树中完全没有 `sglang/srt/tracing` 包。
  - Dynamo v0.8.1 的 `components/src/dynamo/sglang/args.py:19` 无条件导入 `from sglang.srt.server_args_config_parser import ConfigArgumentMerger`。SGLang v0.5.19 将该模块移至 `sglang/srt/utils/server_args_config_parser.py`，旧路径已不存在。
  - 结论：在 v0.5.19 上每个 prefill 和 decode worker 都会在启动时抛出 `ImportError`（第一个导入在任何 v0.5.10+ 镜像上都会失败）。修复需要在上游配方中使用更新的 Dynamo，或在容器内修补 Dynamo/SGLang，而修补交付镜像是被禁止的。
  - 仓库先例一致：使用较新 SGLang 的 GB300 dynamo-sglang 配置族都搭配了更新的 Dynamo（Qwen3.5 GB300 FP4 STP：Dynamo `1.1.0` 搭配 `v0.5.14-cu130`；DSv4 GB300 固定 Dynamo 源码哈希）。
- 下一步：如状态摘要所述，转人工审查。未进行修复（已用 0/5）。

### 最终完整扫描
- N/A。未启动；没有通过的定向尝试。未添加任何扫描标签。
