### PR TITLE
[Klaud Cold] kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg: vLLM v0.28.0 image refresh rejected as incompatible / 拒绝 vLLM v0.28.0 镜像刷新（镜像不兼容）

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p1d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p1d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
@@ -2,14 +2,14 @@ name: "kimi-k3-vllm-disagg-gb300-1p1d-dcp8-dcp8-dspark4-mooncake-agentic"
 
 model:
   path: "moonshotai/Kimi-K3"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "moonshotai/Kimi-K3"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+    image: "vllm/vllm-openai:v0.28.0"
   frameworks:
     dynamo: "ba83080ecd31c1ce918559e576d3c5bc9e092ff1"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p2d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p2d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
@@ -2,14 +2,14 @@ name: "kimi-k3-vllm-disagg-gb300-1p2d-dcp8-dcp8-dspark4-mooncake-agentic"
 
 model:
   path: "moonshotai/Kimi-K3"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "moonshotai/Kimi-K3"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+    image: "vllm/vllm-openai:v0.28.0"
   frameworks:
     dynamo: "ba83080ecd31c1ce918559e576d3c5bc9e092ff1"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p3d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p3d-dcp8-dcp8-dspark4-mooncake-agentic.yaml
@@ -2,14 +2,14 @@ name: "kimi-k3-vllm-disagg-gb300-1p3d-dcp8-dcp8-dspark4-mooncake-agentic"
 
 model:
   path: "moonshotai/Kimi-K3"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "moonshotai/Kimi-K3"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+    image: "vllm/vllm-openai:v0.28.0"
   frameworks:
     dynamo: "ba83080ecd31c1ce918559e576d3c5bc9e092ff1"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p3d-dcp8-dcp8-dspark7-mooncake-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic/disagg-gb300-1p3d-dcp8-dcp8-dspark7-mooncake-agentic.yaml
@@ -2,14 +2,14 @@ name: "kimi-k3-vllm-disagg-gb300-1p3d-dcp8-dcp8-dspark7-mooncake-agentic"
 
 model:
   path: "moonshotai/Kimi-K3"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "moonshotai/Kimi-K3"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77"
+    image: "vllm/vllm-openai:v0.28.0"
   frameworks:
     dynamo: "ba83080ecd31c1ce918559e576d3c5bc9e092ff1"
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9639,7 +9639,7 @@ qwen3.5-fp8-gb200-dynamo-sglang-mtp:
 # Kimi-K3 GB300 points on the measured global p90-ITL Pareto front. Each
 # DCP8 worker spans two 4-GPU nodes.
 kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg:
-  image: vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77
+  image: vllm/vllm-openai:v0.28.0
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
   runner: cluster:gb300-nv


### PR DESCRIPTION
**Current status:** Closed without GPU dispatch. The candidate replacement image `vllm/vllm-openai:v0.28.0` cannot run this recipe as shipped: two startup validation checks in vLLM v0.28.0 reject this family's exact configuration (DSpark speculative decoding with decode context parallelism, and the Mooncake store connector with DCP on a hybrid-attention model). Making it run would require engine patches, which Klaud Cold must not apply. Repairs used: 0/5.
**Next step:** None automated. The PR is closed and the branch is retained so this exact candidate (source image `nightly-dev-arm64-cu13-3696c77`, release hint `v0.28.0`) is not re-selected. A refresh to an official vLLM main nightly is possible but unverified and needs manual review (see notes under Initial attempt).

Candidate `8a7f400957397734-3497b7e4d3d23ff5`, family `configs/nvidia-master.yaml:kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg`, runner `cluster:gb300-nv` (telemetry cluster `gb300-nv`, capacity checks passed before edits and before branch creation). Review reasons: `unstable-image`, `release-string-mismatch`. Green benchmarks alone do not prove that the repository's global checks pass.

## Baseline (published 2026-09-04)

- Queries: `GET /api/v1/benchmarks?model=Kimi-K3&date=2026-09-04&exact=true` (22 rows, 9 match hardware `gb300`, framework `dynamo-vllm`, precision `fp4`, spec `mtp`, `disagg=true`, `agentic_traces`); `GET /api/v1/workflow-info?date=2026-09-04&benchmarkType=agentic_traces`; `GET /api/v1/evaluations` filtered to the same identity.
- Identity verified on every row: image `vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77`, `kv_offloading=dram`, `kv_offload_backend=mooncake 0.3.12.post1`, `kv_p2p_transfer=nixl`, router `dynamo-router` `ba83080ecd31c1ce918559e576d3c5bc9e092ff1`, prefill/decode TP 8, DCP 8, PCP 1, `allocated_cpu_dram_gb=160`.
- Producer: run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33701025625/attempts/3 (head SHA `f6984c117827245de7c26ea6496e661dd2e41985`, started 2026-09-04T20:04:55Z); changelog entry from PR #2811 (base `c355f549ad06ae06675411fea1537ad589f41db7`, head `cf08a54b17ef5fafcea1989d72383649a1e5c872`). Curve snapshot id `2403` is a database snapshot id, not a producer id.
- Published points (all 9 recipe points present; throughput in tokens/s, latency in ms/s):

| Topology | Conc | Total tput/GPU | Output tput/GPU | p90 ITL (ms) | Mean TTFT (s) | Requests |
| --- | --- | --- | --- | --- | --- | --- |
| 1P1D DCP8/DCP8 (16 GPUs) | 48 | 11848.95 | 81.87 | 15.96 | 8.04 | 4719 |
| 1P1D DCP8/DCP8 (16 GPUs) | 52 | 11637.41 | 85.99 | 16.58 | 11.01 | 4950 |
| 1P1D DCP8/DCP8 (16 GPUs) | 56 | 11670.40 | 88.02 | 17.06 | 15.58 | 5021 |
| 1P2D DCP8/DCP8 (24 GPUs) | 32 | 7729.49 | 48.20 | 9.58 | 3.31 | 4067 |
| 1P2D DCP8/DCP8 (24 GPUs) | 48 | 9599.17 | 65.91 | 11.38 | 5.96 | 5515 |
| 1P2D DCP8/DCP8 (24 GPUs) | 64 | 9100.94 | 71.83 | 12.79 | 20.26 | 6104 |
| 1P3D DCP8/DCP8 DSpark7 (32 GPUs) | 1 | 510.33 | 3.86 | 4.06 | 1.66 | 240 |
| 1P3D DCP8/DCP8 (32 GPUs) | 32 | 6075.55 | 37.26 | 7.05 | 3.65 | 4174 |
| 1P3D DCP8/DCP8 (32 GPUs) | 48 | 7681.22 | 51.87 | 8.79 | 6.07 | 5820 |

- Published evals: `gsm8k` for all 9 points from the same run, exact-match scores 0.9651 to 0.9719 (n_eff 1319 each).

## Initial attempt

- Image: `vllm/vllm-openai:v0.28.0` (Docker Hub manifest list `sha256:61fc8a896b0a4fbbbdc063bc4b0dbc25ce98e02b5050c24aeb7830ac02039b14`, arm64 image `sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce`, `CUDA_VERSION=13.0.2`, `TORCH_CUDA_ARCH_LIST` includes 10.0, build commit `2cf0a6915ce544dc493a0990f2ea38d81601128a`, published 2026-08-26). Commit `62e6de632b30499bfcd4c9b5c9361987ac6bfc91` on this branch changes only the family image and the four referenced, unshared recipe YAMLs (`model.container` and `identity.container.image`).
- Local checks: `test-config` matrix generation for the family produces the same 9 points as the base SHA with only `image` changed (`nodes` 4/4/4/6/6/6/8/8/8, evals and all points preserved); the four recipes' container fields equal the master image.
- Run: N/A. No `e2e-tests.yml` run was dispatched because the image was confirmed incompatible from its shipped source before any GPU use.
- Diagnosis (confirmed, from the vLLM `v0.28.0` tag, commit `2cf0a691`):
  1. `vllm/config/speculative.py` lines 1049-1057 raise `ValueError("MLA DSpark does not currently support decode context parallelism; set decode_context_parallel_size=1.")` when `method == "dspark"`, the draft architectures contain `K3DSparkModel`, and `decode_context_parallel_size > 1`. This recipe uses `speculative-config` method `dspark` with draft `Inferact/Kimi-K3-DSpark` (HF config architectures `["K3DSparkModel"]`) and `decode-context-parallel-size: 8` on prefill and decode. The check was removed upstream by `[Spec decode] Support Kimi-K3 DCP with DSpark (#52188)` (`d1e3eee6f`, 2026-08-17), which is not contained in `v0.28.0`.
  2. `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py` lines 119-127 raise `ValueError("MooncakeStoreConnector does not support: PCP/DCP > 1 (pcp=1, dcp=8) with hybrid attention")` when the KV cache has more than one group and `pcp * dcp > 1`. Kimi-K3 is a hybrid KDA + MLA model and the recipe's `kv-transfer-config` uses `MooncakeStoreConnector` with DCP 8. The restriction was lifted upstream by vllm-project/vllm#53324 (merged 2026-08-29), also not in `v0.28.0`.
  3. `git compare v0.28.0...3696c772` reports `diverged` (428 commits ahead, 13 behind). The 428 commits include `Support kimi k3 nvfp4 checkpoint (#53132)`, `[Kimi-K3] support DCP partial prefix cache hit (#50493)` and `[KV Connector] Add decode offloading to Mooncake Store consumers (#52466)`.
- Benchmark/eval results: N/A (not run). Per-point deltas versus baseline: N/A (no measurement).
- Notes for manual review (not attempted): the current image is a locally built dev image (OCI labels `build.commit=unknown`, `build.pipeline=local`) of vLLM commit `3696c772`, which is not on vLLM `main` (32 dev-only commits, including `[KV Connector] Support MooncakeStore with hybrid DCP prefix caching`, `[Kimi K3] Add FlashInfer NVFP4 MegaMoE support`, `Add compact group-specific Mooncake values`, `Mitigate Mooncake load timeouts with sub-batching`, `Retry Mooncake puts under transient pressure`). Official main nightlies such as `vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2` (2026-09-09, arm64, `CUDA_VERSION=13.0.2`) no longer contain either rejection and `TOKENSPEED_MLA` declares DSpark DCP support there, but the recipe's Mooncake extra-config keys `compact_group_io` and `max_load_batch_keys` have no counterpart on `main` and several dev-only Mooncake/KDA fixes are unmerged. Compatibility of a main nightly is therefore uncertain; it was not dispatched because a targeted run plus the required final sweep would not complete within this session's job limit.
- Next step: stop. Confirmed image incompatibility for `v0.28.0`; the branch is retained to block this exact candidate while allowing a changed source image or release to be selected.

## Final full sweep

- N/A. Not reached; no sweep label was applied and the PR stays draft and closed.

---

**当前状态：** 未调度 GPU 即关闭。候选替换镜像 `vllm/vllm-openai:v0.28.0` 无法按原样运行本配方：vLLM v0.28.0 的两处启动校验会拒绝本系列的精确配置（DSpark 投机解码搭配 decode context parallelism，以及混合注意力模型上启用 DCP 的 Mooncake store connector）。要使其运行必须修补推理引擎，Klaud Cold 不得这样做。已用修复次数：0/5。
**下一步：** 无自动化步骤。PR 已关闭并保留分支，以免该精确候选（源镜像 `nightly-dev-arm64-cu13-3696c77`、发布提示 `v0.28.0`）被再次选中。改用 vLLM main 官方 nightly 的刷新在理论上可行，但未经验证，需要人工评估（见"初次尝试"中的说明）。

候选 `8a7f400957397734-3497b7e4d3d23ff5`，系列 `configs/nvidia-master.yaml:kimik3-fp4-gb300-dynamo-vllm-agentic-dspark-mooncake-dcp8-disagg`，运行器 `cluster:gb300-nv`（遥测集群 `gb300-nv`，编辑前与建分支前的容量检查均通过）。评审原因：`unstable-image`、`release-string-mismatch`。基准测试通过本身不能证明仓库的全局检查通过。

## 基线（发布日期 2026-09-04）

- 查询：`GET /api/v1/benchmarks?model=Kimi-K3&date=2026-09-04&exact=true`（22 行，其中 9 行匹配硬件 `gb300`、框架 `dynamo-vllm`、精度 `fp4`、投机 `mtp`、`disagg=true`、`agentic_traces`）；`GET /api/v1/workflow-info?date=2026-09-04&benchmarkType=agentic_traces`；`GET /api/v1/evaluations` 并按同一身份过滤。
- 每行均已核对身份：镜像 `vllm/vllm-openai:nightly-dev-arm64-cu13-3696c77`，`kv_offloading=dram`，`kv_offload_backend=mooncake 0.3.12.post1`，`kv_p2p_transfer=nixl`，路由器 `dynamo-router` `ba83080ecd31c1ce918559e576d3c5bc9e092ff1`，prefill/decode TP 8、DCP 8、PCP 1，`allocated_cpu_dram_gb=160`。
- 生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33701025625/attempts/3（head SHA `f6984c117827245de7c26ea6496e661dd2e41985`，开始于 2026-09-04T20:04:55Z）；changelog 条目来自 PR #2811（base `c355f549ad06ae06675411fea1537ad589f41db7`，head `cf08a54b17ef5fafcea1989d72383649a1e5c872`）。曲线快照 id `2403` 是数据库快照 id，不是生产运行 id。
- 已发布数据点（全部 9 个配方点均存在；吞吐单位 tokens/s，延迟单位 ms/s）：

| 拓扑 | 并发 | 总吞吐/GPU | 输出吞吐/GPU | p90 ITL (ms) | 平均 TTFT (s) | 请求数 |
| --- | --- | --- | --- | --- | --- | --- |
| 1P1D DCP8/DCP8（16 GPU） | 48 | 11848.95 | 81.87 | 15.96 | 8.04 | 4719 |
| 1P1D DCP8/DCP8（16 GPU） | 52 | 11637.41 | 85.99 | 16.58 | 11.01 | 4950 |
| 1P1D DCP8/DCP8（16 GPU） | 56 | 11670.40 | 88.02 | 17.06 | 15.58 | 5021 |
| 1P2D DCP8/DCP8（24 GPU） | 32 | 7729.49 | 48.20 | 9.58 | 3.31 | 4067 |
| 1P2D DCP8/DCP8（24 GPU） | 48 | 9599.17 | 65.91 | 11.38 | 5.96 | 5515 |
| 1P2D DCP8/DCP8（24 GPU） | 64 | 9100.94 | 71.83 | 12.79 | 20.26 | 6104 |
| 1P3D DCP8/DCP8 DSpark7（32 GPU） | 1 | 510.33 | 3.86 | 4.06 | 1.66 | 240 |
| 1P3D DCP8/DCP8（32 GPU） | 32 | 6075.55 | 37.26 | 7.05 | 3.65 | 4174 |
| 1P3D DCP8/DCP8（32 GPU） | 48 | 7681.22 | 51.87 | 8.79 | 6.07 | 5820 |

- 已发布评测：同一运行中 9 个点均有 `gsm8k`，exact-match 得分 0.9651 至 0.9719（每项 n_eff 1319）。

## 初次尝试

- 镜像：`vllm/vllm-openai:v0.28.0`（Docker Hub manifest list `sha256:61fc8a896b0a4fbbbdc063bc4b0dbc25ce98e02b5050c24aeb7830ac02039b14`，arm64 镜像 `sha256:2a7cde230b59f3ce6cab33dd245ba6bee41aa87b38c9fe84f966ff24016813ce`，`CUDA_VERSION=13.0.2`，`TORCH_CUDA_ARCH_LIST` 含 10.0，构建提交 `2cf0a6915ce544dc493a0990f2ea38d81601128a`，发布于 2026-08-26）。本分支提交 `62e6de632b30499bfcd4c9b5c9361987ac6bfc91` 仅修改该系列镜像以及四个被引用且未共享的配方 YAML（`model.container` 与 `identity.container.image`）。
- 本地检查：对该系列运行 `test-config` 矩阵生成，与基线 SHA 相比得到相同的 9 个点，仅 `image` 不同（`nodes` 4/4/4/6/6/6/8/8/8，评测与全部点均保留）；四个配方的容器字段与主配置镜像一致。
- 运行：N/A。由于在任何 GPU 使用之前已从镜像自带源码确认不兼容，因此未调度 `e2e-tests.yml`。
- 诊断（已确认，来自 vLLM `v0.28.0` 标签，提交 `2cf0a691`）：
  1. `vllm/config/speculative.py` 第 1049-1057 行：当 `method == "dspark"`、草稿模型 architectures 含 `K3DSparkModel` 且 `decode_context_parallel_size > 1` 时抛出 `ValueError("MLA DSpark does not currently support decode context parallelism; set decode_context_parallel_size=1.")`。本配方的 `speculative-config` 使用 `dspark` 方法、草稿模型 `Inferact/Kimi-K3-DSpark`（HF 配置 architectures 为 `["K3DSparkModel"]`），且 prefill 与 decode 均设置 `decode-context-parallel-size: 8`。该检查由上游 `[Spec decode] Support Kimi-K3 DCP with DSpark (#52188)`（`d1e3eee6f`，2026-08-17）移除，而 `v0.28.0` 不包含该提交。
  2. `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py` 第 119-127 行：当 KV cache 分组数大于 1 且 `pcp * dcp > 1` 时抛出 `ValueError("MooncakeStoreConnector does not support: PCP/DCP > 1 (pcp=1, dcp=8) with hybrid attention")`。Kimi-K3 是 KDA + MLA 混合模型，本配方的 `kv-transfer-config` 在 DCP 8 下使用 `MooncakeStoreConnector`。该限制由上游 vllm-project/vllm#53324（2026-08-29 合并）解除，同样不在 `v0.28.0` 中。
  3. `git compare v0.28.0...3696c772` 结果为 `diverged`（领先 428 个提交，落后 13 个）。这 428 个提交包含 `Support kimi k3 nvfp4 checkpoint (#53132)`、`[Kimi-K3] support DCP partial prefix cache hit (#50493)` 与 `[KV Connector] Add decode offloading to Mooncake Store consumers (#52466)`。
- 基准/评测结果：N/A（未运行）。相对基线的逐点差异：N/A（无测量）。
- 供人工评估的说明（未尝试）：当前镜像是 vLLM 提交 `3696c772` 的本地构建开发镜像（OCI 标签 `build.commit=unknown`、`build.pipeline=local`），该提交不在 vLLM `main` 上（含 32 个仅存在于开发分支的提交，包括 `[KV Connector] Support MooncakeStore with hybrid DCP prefix caching`、`[Kimi K3] Add FlashInfer NVFP4 MegaMoE support`、`Add compact group-specific Mooncake values`、`Mitigate Mooncake load timeouts with sub-batching`、`Retry Mooncake puts under transient pressure`）。官方 main nightly（例如 `vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2`，2026-09-09，arm64，`CUDA_VERSION=13.0.2`）已不含上述两处拒绝，且其中 `TOKENSPEED_MLA` 声明支持 DSpark DCP，但配方的 Mooncake 额外配置键 `compact_group_io` 与 `max_load_batch_keys` 在 `main` 上没有对应实现，且多项仅在开发分支的 Mooncake/KDA 修复尚未合并。因此 main nightly 的兼容性不确定；由于定向运行加最终全量扫描无法在本会话的作业时限内完成，故未调度。
- 下一步：停止。`v0.28.0` 镜像不兼容已确认；保留分支以阻止该精确候选，同时允许源镜像或发布元数据变化后的候选被选中。

## 最终全量扫描

- N/A。未到达该阶段；未添加任何 sweep 标签，PR 保持草稿并已关闭。
