### PR TITLE
fix(evals): preserve nested lm-eval artifacts for sweep summaries

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -2163,7 +2163,12 @@ append_lm_eval_summary() {
     fi
 
     # Copy the complete allowlisted eval artifact set before removing its temp dir.
-    stage_eval_artifacts "$(pwd)" "$out_dir" || return $?
+    local artifact_dir
+    local artifact_sources=("$out_dir")
+    while IFS= read -r -d '' artifact_dir; do
+        [ "$artifact_dir" = "$out_dir" ] || artifact_sources+=("$artifact_dir")
+    done < <(find "$out_dir" -type d -print0 2>/dev/null)
+    stage_eval_artifacts "$(pwd)" "${artifact_sources[@]}" || return $?
 
     # Best-effort cleanup of the temp directory
     if [ -n "${out_dir}" ] && [ -d "${out_dir}" ]; then

--- a/docs/eval-agentx-procedures.md
+++ b/docs/eval-agentx-procedures.md
@@ -171,6 +171,8 @@ gh run download "$RUN_ID" --repo SemiAnalysisAI/InferenceX \
 
 Retain `meta_env.json`, `results*.json`, and `sample*.jsonl`. Agentic SWE-bench additionally uploads `agent_preds.json`, `predictions.jsonl`, `swebench_report_*.json`, and trajectory files in the single-node template. The aggregate is a navigation aid, not a substitute for raw samples and batch completeness.
 
+Single-concurrency lm-eval can write `results*.json` and `sample*.jsonl` below a model-named subdirectory of `EVAL_RESULT_DIR`. `append_lm_eval_summary` recursively stages only the allowlisted eval artifacts into the workspace root before removing the temporary directory, where the workflow's flat upload patterns can find them.
+
 ## 7. Run AgentX: fast feedback versus canonical evidence
 
 AgentX is AIPerf `inferencex-agentx-mvp` trace replay, not a fixed-token synthetic benchmark. The checked-in default uses ten additional warmup requests per trajectory lane and the recipe's configured profile duration. `agentx-fast` forces one warmup request per lane and a 1,200-second profile. It affects single- and multi-node AgentX throughput only. Fixed-sequence throughput and evals remain canonical. Fast runs are not eligible for artifact reuse ([workflow policy](../.github/workflows/README.md#agentx-fast-mode), [fast replay settings](../benchmarks/benchmark_lib.sh#L2104-L2128)).

--- a/docs/eval-agentx-procedures_zh.md
+++ b/docs/eval-agentx-procedures_zh.md
@@ -171,6 +171,8 @@ gh run download "$RUN_ID" --repo SemiAnalysisAI/InferenceX \
 
 保留 `meta_env.json`、`results*.json` 和 `sample*.jsonl`。Agentic SWE-bench 在单节点模板中还会上传 `agent_preds.json`、`predictions.jsonl`、`swebench_report_*.json` 和 trajectory 文件。Aggregate 是导航工具，不能替代原始样本与 batch 完整性证据。
 
+单并发 lm-eval 可能会把 `results*.json` 和 `sample*.jsonl` 写入 `EVAL_RESULT_DIR` 下以模型命名的子目录。`append_lm_eval_summary` 会在删除临时目录前，递归地把允许列表中的 eval artifact 暂存到 workspace 根目录，使工作流的扁平上传模式能够找到这些文件。
+
 ## 7. 运行 AgentX：快速反馈与 canonical 证据
 
 AgentX 是 AIPerf `inferencex-agentx-mvp` trace replay，不是固定 token 的合成 benchmark。仓库默认设置对每条 trajectory lane 额外执行十个 warmup 请求，并使用 recipe 配置的 profile 时长。`agentx-fast` 强制每条 lane 只运行一个 warmup 请求，并将 profile 设为 1,200 秒。它只影响单节点和多节点 AgentX 吞吐量；定长序列吞吐量与 eval 保持 canonical。Fast 运行不符合 artifact reuse 条件（[工作流策略](../.github/workflows/README.md#agentx-fast-mode)、[fast replay 设置](../benchmarks/benchmark_lib.sh#L2104-L2128)）。

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -1551,6 +1551,42 @@ append_lm_eval_summary >/dev/null
     assert not results_dir.exists()
 
 
+def test_summary_stages_nested_lm_eval_outputs_before_cleanup(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    results_dir = tmp_path / "results"
+    nested_results_dir = results_dir / "local-chat-completions__test-model"
+    work_dir.mkdir()
+    nested_results_dir.mkdir(parents=True)
+    result = nested_results_dir / "results_2026-09-09T12-00-00.json"
+    sample = nested_results_dir / "samples_gsm8k_2026-09-09T12-00-00.jsonl"
+    result_content = '{"lm_eval_version": "test"}'
+    sample_content = '{"doc_id": 1}\n'
+    result.write_text(result_content)
+    sample.write_text(sample_content)
+    (nested_results_dir / "debug.log").write_text("do not stage")
+    script = r"""
+source "$BENCHMARK_LIB"
+cd "$WORK_DIR"
+append_lm_eval_summary >/dev/null
+"""
+    env = {
+        **os.environ,
+        "BENCHMARK_LIB": str(BENCHMARK_LIB),
+        "WORK_DIR": str(work_dir),
+        "EVAL_RESULT_DIR": str(results_dir),
+        "MODEL": "test-model",
+        "CONC": "7",
+        "KV_OFFLOADING": "none",
+    }
+
+    subprocess.run(["bash", "-c", script], env=env, check=True)
+
+    assert (work_dir / result.name).read_text() == result_content
+    assert (work_dir / sample.name).read_text() == sample_content
+    assert not (work_dir / "debug.log").exists()
+    assert not results_dir.exists()
+
+
 def test_stage_eval_artifacts_copies_eval_outputs_only(tmp_path: Path) -> None:
     source_one = tmp_path / "source-one"
     source_two = tmp_path / "source-two"


### PR DESCRIPTION
## Description

Single-concurrency lm-eval can write `results*.json` and `sample*.jsonl` under a model-named subdirectory of `EVAL_RESULT_DIR`. `append_lm_eval_summary` previously staged only files immediately inside `EVAL_RESULT_DIR` and then deleted that temporary directory.

This left affected per-config artifacts with `meta_env.json` but without the raw result and sample files. Because `collect-evals` needs the result JSON to extract scores, the sweep produced no eval rows: the Eval Summary table was missing and `agg_eval_all.json` was empty even though lm-eval had written results. The temporary-directory cleanup also made those unstaged results unavailable for later diagnosis.

The fix enumerates directories inside the dedicated `EVAL_RESULT_DIR` and passes each one through the existing shallow, allowlisted `stage_eval_artifacts` helper before cleanup. Nested result and sample files are flattened into the workspace root for the workflow's existing upload patterns. The shared staging helper remains shallow, so callers that inspect broad directories do not recursively collect unrelated files.

A regression test exercises the real summary function with nested result and sample files. It verifies that both files survive, an unrelated log remains excluded, and the temporary result directory is removed only after staging. The English and Chinese eval procedure guides now document this behavior.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Validation

- `uv run --with pytest --with pyyaml pytest -q utils/evals/test_run_eval_dispatch.py` — 105 passed
- `bash -n benchmarks/benchmark_lib.sh`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries** (not applicable: this changes post-eval artifact collection only)
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Post-eval artifact staging only; no inference or scoring logic changes. Risk is limited to whether directory enumeration could stage from unexpected paths under EVAL_RESULT_DIR.
> 
> **Overview**
> Fixes **single-concurrency lm-eval** runs where `results*.json` and `sample*.jsonl` land under a **model-named subdirectory** of `EVAL_RESULT_DIR`. **`append_lm_eval_summary`** now discovers every directory under that temp tree and passes each to the existing allowlisted **`stage_eval_artifacts`** helper (still shallow per directory), so nested outputs are **flattened to the workspace root** before the temp dir is removed.
> 
> Without this, sweeps could upload **`meta_env.json`** but miss raw results, leaving **`collect-evals`** with no scores and an empty Eval Summary / **`agg_eval_all.json`**. A regression test covers nested staging, exclusion of non-allowlisted files, and cleanup timing; **English and Chinese** eval procedure docs note the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822299ab98fbf2a33d35e6daf4a5e983393a6faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->