### PR TITLE
[AgentX] route ordinary B300 recipes to DSXE / 将普通 B300 配方路由至 DSXE

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1158,7 +1158,7 @@ dsv4-fp4-b300-sglang-agentic-hicache-mtp:
   image: lmsysorg/sglang:nightly-dev-cu13-20260827-20621aa1
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: sglang
   multinode: false
@@ -1490,7 +1490,7 @@ kimik3-fp4-b300-vllm-agentic-dspark:
   image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: vllm
   multinode: false
@@ -1703,7 +1703,7 @@ dsv4-fp4-b300-vllm-agentic-mtp:
   image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-426e59f
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: vllm
   multinode: false
@@ -7324,7 +7324,7 @@ qwen3.5-fp8-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp8
   framework: sglang
   multinode: false
@@ -7340,7 +7340,7 @@ qwen3.5-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:v0.5.16-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4
   model-prefix: qwen3.5
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: sglang
   multinode: false
@@ -7360,7 +7360,7 @@ qwen3.8next-fp4-b300-sglang-agentic-mtp:
   image: lmsysorg/sglang:qwen38flashnext
   model: RadixArk/Qwen3.8-Flash-Next-NVFP4
   model-prefix: qwen3.8next
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: sglang
   multinode: false
@@ -7788,7 +7788,7 @@ minimaxm3-fp4-b300-vllm-agentic-mtp:
   image: vllm/vllm-openai:nightly-1dc464d42681d22f38caf1fdc1eb632dc4421c45
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: vllm
   multinode: false
@@ -7887,7 +7887,7 @@ minimaxm3-fp4-b300-trtllm-agentic-mtp:
   image: nvcr.io#nvidia/tensorrt-llm/release:1.3.0rc23.post1
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
-  runner: cluster:b300-nv
+  runner: cluster:b300-dsxe
   precision: fp4
   framework: trt
   multinode: false

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7353,4 +7353,4 @@
   description:
     - "Route ordinary B300 AgentX configurations through the registered DSXE runner after retirement of the B300 NV fleet; preserve model, image, serving flags, and concurrency grids. Dedicated power-ab configurations remain unchanged."
     - "将普通 B300 AgentX 配置切换到已注册的 DSXE runner，保留模型、镜像、服务参数及并发配置；不修改独立 power-ab 配置。"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2923
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2927

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7338,3 +7338,19 @@
     - "Resolve the requested H100 SGLang container instead of a hardcoded older image, and stop benchmark/eval clients when their ready server or required worker exits."
     - "H100 SGLang 使用所请求的容器而非硬编码旧镜像；已就绪的服务或必需工作进程退出后，停止其 benchmark/评测客户端。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3020
+
+- config-keys:
+    - dsv4-fp4-b300-sglang-agentic-hicache-mtp
+    - kimik3-fp4-b300-vllm-agentic-dspark
+    - dsv4-fp4-b300-vllm-agentic-mtp
+    - qwen3.5-fp8-b300-sglang-agentic-mtp
+    - qwen3.5-fp4-b300-sglang-agentic-mtp
+    - qwen3.8next-fp4-b300-sglang-agentic-mtp
+    - minimaxm3-fp4-b300-vllm-agentic-mtp
+    - minimaxm3-fp4-b300-trtllm-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Route ordinary B300 AgentX configurations through the registered DSXE runner after retirement of the B300 NV fleet; preserve model, image, serving flags, and concurrency grids. Dedicated power-ab configurations remain unchanged."
+    - "将普通 B300 AgentX 配置切换到已注册的 DSXE runner，保留模型、镜像、服务参数及并发配置；不修改独立 power-ab 配置。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2923


### PR DESCRIPTION
## Description

Eight ordinary B300 AgentX configurations still target retired `cluster:b300-nv`. Route them to the registered `cluster:b300-dsxe` runner while preserving their model images, serving settings and search spaces. GLM-5.2 already moved to DSXE in #2829 and is excluded from this diff and its new changelog entry. The two dedicated Qwen power-AB configurations are unchanged.

Rebased onto `main` at `127c84be90f1536a92c1bd62f7f8b3b071d615fe`; dependency #2923 is already merged. Historical changelog bytes are preserved, with only this PR's eight-config entry appended at the tail.

Local validation passes: changelog/matrix validation, exact routing-only scope and upstream-preservation checks, and 301 focused changelog/gating tests. The eight configs generate 22 trimmed deployment rows and 122 untrimmed throughput rows, before evaluations. No GPU benchmarks or evaluations were run for this rebase.

B300 hardware validation and sweep scheduling remain pending; the earlier SSH preflight was denied. Before adding a sweep label or merging, confirm the exact generated canonical matrix, hardware checks, budget/window, applicable eval evidence and CODEOWNER/Core sign-off. Manual pilots are not eligible for canonical sweep reuse. This change does not resume the separate paused campaign or claim new measurements or published comparisons.

## Related Issue

No linked GitHub issue. / 暂无关联 GitHub issue。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

Only the eight remaining ordinary config keys are appended; historical changelog bytes are preserved. No separate documentation change is required for this routing-only diff.

## 中文说明

八个普通 B300 AgentX 配置仍指向已下线的 `cluster:b300-nv`。本改动将其切换到已注册的 `cluster:b300-dsxe`，保留模型镜像、服务参数和搜索空间。GLM-5.2 已在 #2829 中迁移到 DSXE，因此不再列入本次差异及新增 changelog 条目；两个专用 Qwen power-AB 配置保持不变。

已变基到 `main` 的 `127c84be90f1536a92c1bd62f7f8b3b071d615fe`；依赖 #2923 已合并。历史 changelog 字节保持原样，仅在文件末尾追加本 PR 的八配置条目。

本地验证通过：changelog/矩阵校验、仅修改路由及保留上游配置的检查，以及 301 项 changelog/门禁测试。八个配置生成 22 个裁剪后的部署行和 122 个未裁剪吞吐行（不含评估）。本次变基未运行 GPU 基准测试或评估。

B300 硬件验证及扫描调度仍待完成；此前 SSH 预检被拒绝。添加扫描标签或合并前，仍需确认实际完整矩阵、硬件检查、预算/调度窗口、适用评估证据及 CODEOWNER/Core 签核。手动试验不满足正常扫描的复用资格。本改动不恢复另一个已暂停的实验活动，也不宣称新增测量或已发布对比。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML routing-only change with no serving logic or recipe parameter edits; main risk is mis-scheduling benchmarks if DSXE capacity or runner registration differs from the retired NV fleet.
> 
> **Overview**
> Routes **eight** ordinary B300 **agentic-coding** benchmark recipes from the retired `cluster:b300-nv` runner to `cluster:b300-dsxe` in `configs/nvidia-master.yaml`. Affected keys span DeepSeek V4, Kimi K3, Qwen 3.5/3.8, and MiniMax M3 across SGLang, vLLM, and TensorRT-LLM; **model, image, precision, and search-space entries are unchanged**—only the `runner` line moves.
> 
> Adds a matching **`perf-changelog.yaml`** entry (agentic-coding) documenting the fleet migration and noting that dedicated Qwen power-A/B configs are **not** modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94f3037a4144ff938a74b1b7c353f09e457a863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->