### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-mi300x-sglang-agentic-mtp SGLang ROCm image to v0.5.19-rocm720-mi30x-20260908 / 将 qwen3.5-fp8-mi300x-sglang-agentic-mtp 的 SGLang ROCm 镜像更新为 v0.5.19-rocm720-mi30x-20260908

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -429,7 +429,7 @@ qwen3.5-fp8-mi300x-sglang:
 # AgentX Pareto sweep for Qwen3.5 FP8 on MI300X. The fast discovery run peaks
 # at c24; c32 records the post-knee throughput and latency cliff.
 qwen3.5-fp8-mi300x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260909
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260908
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi300x-amd

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -429,7 +429,7 @@ qwen3.5-fp8-mi300x-sglang:
 # AgentX Pareto sweep for Qwen3.5 FP8 on MI300X. The fast discovery run peaks
 # at c24; c32 records the post-knee throughput and latency cliff.
 qwen3.5-fp8-mi300x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi300x-amd

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -429,7 +429,7 @@ qwen3.5-fp8-mi300x-sglang:
 # AgentX Pareto sweep for Qwen3.5 FP8 on MI300X. The fast discovery run peaks
 # at c24; c32 records the post-knee throughput and latency cliff.
 qwen3.5-fp8-mi300x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260909
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:mi300x-amd


### PR DESCRIPTION
**Family:** `configs/amd-master.yaml:qwen3.5-fp8-mi300x-sglang-agentic-mtp` (MI300X, SGLang, Qwen/Qwen3.5-397B-A17B-FP8, AgentX agentic-coding, native EAGLE MTP, TP8/EP1 + TP8/EP8, conc 4/16/20/24/32)
**Image:** `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730` → `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260908` (digest `sha256:2107bc0a406e3f1d1bbe41d7f17131659e3ff18b54d2d1c624f897cd84d170e5`, Docker Hub last pushed 2026-09-08T13:59:51Z, amd64/linux). The initial attempt used the 2026-09-07 nightly (`sha256:e5c773e5…`, crashed at runtime) and Repair 1 the 2026-09-09 nightly (`sha256:1fd72c1a…`, rejected the recipe's `--cuda-graph-max-bs` flag); see the attempt sections.
**Candidate:** `7194ba06f4ff3ea4-0f7930fff108ab30` (public observation dated 2026-08-12, release hint v0.5.19). Telemetry cluster: `mi300x-amd` (runner `cluster:mi300x-amd`, 9 runner slots in `configs/runners.yaml`, single-node `nodes:1`).

## Current status / next step
- Status: **stopped, closed without success.** Three v0.5.19 rocm720-mi30x images were tried: the 2026-09-07 and 2026-09-08 nightlies crash every AgentX point with a HIP illegal memory access on the recipe's AITER paged-attention + native EAGLE MTP path, and the 2026-09-09 nightly removed the `--cuda-graph-max-bs` flag the recipe passes. Repairs used: 2 of 5; stopped on the same runtime failure twice without progress. All three owned runs are terminal (failure). No sweep label was ever applied and no final sweep ran.
- Disposition: confirmed image incompatibility of the v0.5.19 mi30x ROCm builds with this recipe as shipped. The PR is closed and the candidate branch is retained so this exact source image/release pair is not re-selected. Manual review suggestion (out of Klaud scope): the MI325X sibling passes on the same v0.5.19 nightly with `SGLANG_USE_AITER_UNIFIED_ATTN=1` and fp8 KV, and newer nightlies need `--cuda-graph-max-bs-decode`; both would be recipe-script changes. The untried `lmsysorg/sglang:v0.5.19-rocm720-mi30x` release tag (pushed 2026-09-04) predates every fix considered here and was not attempted.
- Next step: none automated.

Green targeted benchmarks do not prove that global PR checks pass; final validation uses `run-sweep.yml` on the PR head.

## Baseline (published 2026-08-12)
- Source: public dashboard API, `GET /api/v1/workflow-info?date=2026-08-12&benchmarkType=agentic_traces` and `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-12&exact=true&sequence=agentic-traces` (no `view`).
- Identity verified on all 10 points: hardware mi300x, framework sglang, model qwen3.5, precision fp8, spec_method mtp, disagg false, benchmark_type agentic_traces, offload_mode off, decode_tp 8, decode_ep 1 or 8, image `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730`.
- Producer: run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31565633094/attempts/1 (head SHA `429229453b7e587826936eab7cb739dd79671f4f`, "Run Sweep - [AMD] [AgentX] Add MI300X Qwen3.5 FP8 SGLang MTP"). Published benchmark row IDs 439568–439577.
- Published eval: gsm8k, eval row 9361, TP8/EP1 conc 32, score 0.9765 (em_strict 0.9765, em_flexible 0.9757, n_eff 1319), same producer run.
- Baseline per-point metrics (per-GPU total throughput tok/s/GPU, median TPOT s, median TTFT s):

| Point | tput/GPU | median TPOT | median TTFT |
| --- | --- | --- | --- |
| TP8/EP1 c4 | 710.95 | 0.04607 | 3.501 |
| TP8/EP1 c16 | 2603.01 | 0.08126 | 4.761 |
| TP8/EP1 c20 | 3045.57 | 0.08466 | 5.021 |
| TP8/EP1 c24 | 3325.48 | 0.08947 | 5.457 |
| TP8/EP1 c32 | 2334.82 | 0.21576 | 65.571 |
| TP8/EP8 c4 | 712.63 | 0.04694 | 3.406 |
| TP8/EP8 c16 | 2585.75 | 0.08189 | 4.823 |
| TP8/EP8 c20 | 3050.84 | 0.08472 | 4.981 |
| TP8/EP8 c24 | 3330.68 | 0.08981 | 5.443 |
| TP8/EP8 c32 | 2320.39 | 0.22063 | 64.792 |

- The baseline is frozen for all attempts; the old image is never re-run.

## Initial attempt
- Image/commit: `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907` at 5f7435bd627f8322662b24841adedb0273e91405.
- Change: `configs/amd-master.yaml` image field only. Local check: `test-config --config-files configs/amd-master.yaml --config-keys qwen3.5-fp8-mi300x-sglang-agentic-mtp` generates the same 10 points at base and head with only `image` differing.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34389410451 (`e2e-tests.yml` from `main`, `inputs.ref`=5f7435bd627f8322662b24841adedb0273e91405, `fail-fast=true`, `klaud-run=true`, dispatched 2026-09-09T18:30Z). Outcome: **failure** (TP8/EP8 c24 failed; fail-fast cancelled the other 9 points).
- Results: N/A for all 10 points (no point completed its 3600 s profiling window; the one uploaded aggregate covers 103 requests / 329 s before the server died and fails AIPerf's 95% metric-coverage check). Eval: N/A (not scheduled in the targeted command).
- Diagnosis: all 8 points that reached profiling (TP8/EP1 c4/c16/c20/c24/c32, TP8/EP8 c20/c24/c32) died 3 to 45 minutes into profiling with the identical signature: `torch.AcceleratorError: HIP error: an illegal memory access was encountered` raised at `sglang/srt/layers/attention/aiter_backend.py:1549` (`kv_indices = torch.empty(...)` in `init_forward_metadata`) called from `hybrid_linear_attn_backend.py:1139` inside `eager_runner._execute_extend` during `eagle_worker_v2.verify` → `run_eagle_verify`; one scheduler rank then aborted (exit code -6) and the server stopped serving. Warmup (up to 351 requests) completed on every point, so model load, CUDA-graph capture and short requests work; the fault appears once long agentic sessions (mean input ~60k tokens) are replayed with MTP. Upstream sgl-project/sglang#37165 ("Clear deferred init metadata before speculative decode", merged 2026-09-07T19:41Z, after the 0907 nightly was pushed at 13:58Z) describes stale deferred Mamba clear/COW indices being replayed by built-in EAGLE/MTP draft-extend batches on hybrid Mamba models, which matches Qwen3.5 (GDN hybrid) with native EAGLE MTP here. The MI325X sibling (#2870) passed on the same 0907 image but runs `SGLANG_USE_AITER_UNIFIED_ATTN=1` with fp8 KV, a different attention path.
- Next step: Repair 1/5 with the 2026-09-09 nightly that includes #37165.

## Repair 1/5
- Image/commit: `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260909` (digest `sha256:1fd72c1aa7304637ffb90ea17bd069c9a97dc594f584fc82945cc30c47c29605`, Docker Hub last pushed 2026-09-09T13:58:08Z) at 8aff3c722b7af51fd56b9d82bbd7e336700efec3.
- Change: `configs/amd-master.yaml` image field only; generated matrix still differs from base only in `image`. The 0909 nightly carries sgl-project/sglang#37165 (deferred Mamba metadata cleared before speculative decode), #38467 (AITER FP8 ASM prefill GQA gate) and #34820 (Mamba prefix-cache checkpoint dtype) on top of the 0907 build.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34399239493 (`e2e-tests.yml` from `main`, `inputs.ref`=8aff3c722b7af51fd56b9d82bbd7e336700efec3, `fail-fast=true`, `klaud-run=true`, dispatched 2026-09-09T20:08Z). Outcome: **failure** within 7 minutes (TP8/EP1 c20 failed at server launch; fail-fast cancelled the other 9 points).
- Results: N/A for all 10 points (server never started). Eval: N/A.
- Diagnosis: `sglang serve: error: ambiguous option: --cuda-graph-max-bs could match --cuda-graph-max-bs-decode, --cuda-graph-max-bs-prefill`. The 2026-09-09 nightly no longer accepts the deprecated `--cuda-graph-max-bs` alias that the unchanged recipe script passes: upstream sgl-project/sglang#38375 ("Retire get_global_server_args, and clear the deprecated flags that have a replacement", merged 2026-09-08T23:42Z, after the 0908 nightly and before the 0909 nightly) removed it. Adapting the flag would change the recipe command, which is out of scope for this image refresh, so the 0909 nightly is incompatible as shipped.
- Next step: Repair 2/5 with the 2026-09-08 nightly, which includes #37165 (the Mamba/EAGLE metadata fix) but predates #38375 (the CLI removal).
- Eval coverage: the prescribed `test-config` command emits benchmark rows only (Qwen3.5 agentic GSM8K is opt-in in `mark_eval_entries`). The changelog-driven `run-sweep.yml` final sweep generates eval rows with `--evals-only`, which schedules the default lm-eval GSM8K row at TP8/EP1 conc 32 (`qwen3.5_tp8_conc32_kvnone_spec-mtp`), the same point as the published baseline eval.

## Repair 2/5
- Image/commit: `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260908` (digest `sha256:2107bc0a406e3f1d1bbe41d7f17131659e3ff18b54d2d1c624f897cd84d170e5`, Docker Hub last pushed 2026-09-08T13:59:51Z) at 22694f52afa460e655155763e14b65d802d5dcb7.
- Change: `configs/amd-master.yaml` image field only; generated matrix still differs from base only in `image`. The 0908 nightly includes sgl-project/sglang#37165 (merged 2026-09-07T19:41Z) and predates #38375 (merged 2026-09-08T23:42Z), so the recipe's `--cuda-graph-max-bs` flag is still accepted.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34400355480 (`e2e-tests.yml` from `main`, `inputs.ref`=22694f52afa460e655155763e14b65d802d5dcb7, `fail-fast=true`, `klaud-run=true`, dispatched 2026-09-09T20:19Z). Outcome: **failure** (TP8/EP8 c16 failed after 87 minutes; fail-fast cancelled the other 9 points, TP8/EP8 c32 never started).
- Results: N/A for all 10 points (no point completed its profiling window; the four points that reached the AIPerf summary report 6.8% to 8.1% metric coverage against the required 95%). Eval: N/A.
- Diagnosis: the same runtime fault as the initial attempt. All 9 points that started crashed with `torch.AcceleratorError: HIP error: an illegal memory access was encountered`: TP8/EP1 c4 and TP8/EP8 c4 on the very first warmup prefill batch (5 sequences, 400 tokens), the other seven 5 to 7 minutes after warmup completed (c16/c20/c24 at 20:49 to 21:01 UTC, c32 at 21:13 UTC). Because the fault is asynchronous it surfaced in different Python frames (`logits_processor._copy_logits_to_buffer`, `vocab_parallel_embedding`, `eagle_worker_v2.draft_forward`, `torch.cuda.set_stream`), but every server lost a scheduler rank with exit code -6. Upstream #37165, present in this nightly, did not resolve it, so the deferred-Mamba-metadata theory is not the cause. Old image (`v0.5.16-rocm720-mi30x-20260730`) published this family successfully on this same cluster on 2026-08-12, and the MI325X sibling passed on the 0907 nightly with `SGLANG_USE_AITER_UNIFIED_ATTN=1`, so the regression is between the v0.5.16 and v0.5.19 mi30x ROCm builds on the recipe's AITER paged-attention + native EAGLE MTP path.
- Next step: none within scope. This is the same failure class as the initial attempt without progress; the newest nightly (0909) additionally removed the `--cuda-graph-max-bs` flag the recipe passes. Stopping.

## Final full sweep
- N/A: no targeted attempt passed, so no `perf-changelog.yaml` entry was appended, the PR was never marked ready, and no sweep label was applied. `run-sweep.yml` never ran on this branch.

---

**配方族：** `configs/amd-master.yaml:qwen3.5-fp8-mi300x-sglang-agentic-mtp`（MI300X，SGLang，Qwen/Qwen3.5-397B-A17B-FP8，AgentX agentic-coding，原生 EAGLE MTP，TP8/EP1 + TP8/EP8，并发 4/16/20/24/32）
**镜像：** `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730` → `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260908`（摘要 `sha256:2107bc0a406e3f1d1bbe41d7f17131659e3ff18b54d2d1c624f897cd84d170e5`，Docker Hub 最后推送时间 2026-09-08T13:59:51Z，amd64/linux）。首次尝试使用 2026-09-07 nightly（`sha256:e5c773e5…`，运行时崩溃），修复 1 使用 2026-09-09 nightly（`sha256:1fd72c1a…`，拒绝配方的 `--cuda-graph-max-bs` 参数）；详见各尝试章节。
**候选：** `7194ba06f4ff3ea4-0f7930fff108ab30`（公开观测日期 2026-08-12，版本提示 v0.5.19）。遥测集群：`mi300x-amd`（runner `cluster:mi300x-amd`，`configs/runners.yaml` 中 9 个 runner 槽位，单节点 `nodes:1`）。

## 当前状态 / 下一步
- 状态：**已停止，未成功并关闭。** 共尝试了三个 v0.5.19 rocm720-mi30x 镜像：2026-09-07 与 2026-09-08 nightly 在配方的 AITER 分页 attention + 原生 EAGLE MTP 路径上使每个 AgentX 点因 HIP 非法内存访问崩溃；2026-09-09 nightly 则移除了配方使用的 `--cuda-graph-max-bs` 参数。已用修复次数：2/5；因相同运行时故障重复出现且无进展而停止。三个自有运行均已终止（失败）。从未添加 sweep 标签，也未运行最终 sweep。
- 处置：确认 v0.5.19 mi30x ROCm 构建与按原样运行的本配方不兼容。PR 已关闭，候选分支保留，以避免再次选中同一源镜像/版本组合。人工审查建议（超出 Klaud 范围）：MI325X 同类配方在同一 v0.5.19 nightly 上使用 `SGLANG_USE_AITER_UNIFIED_ATTN=1` 与 fp8 KV 可通过，且更新的 nightly 需要 `--cuda-graph-max-bs-decode`；两者均属配方脚本改动。未尝试的 `lmsysorg/sglang:v0.5.19-rocm720-mi30x` 发布标签（2026-09-04 推送）早于此处考虑的所有修复，未被尝试。
- 下一步：无自动化步骤。

定向基准通过并不代表 PR 的全局检查通过；最终验证以 PR head 上的 `run-sweep.yml` 为准。

## 基线（发布于 2026-08-12）
- 来源：公开仪表盘 API，`GET /api/v1/workflow-info?date=2026-08-12&benchmarkType=agentic_traces` 与 `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-12&exact=true&sequence=agentic-traces`（不带 `view`）。
- 全部 10 个点的身份已核对：硬件 mi300x、框架 sglang、模型 qwen3.5、精度 fp8、投机方法 mtp、非分离式、benchmark_type agentic_traces、offload_mode off、decode_tp 8、decode_ep 1 或 8，镜像 `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi30x-20260730`。
- 生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31565633094/attempts/1（head SHA `429229453b7e587826936eab7cb739dd79671f4f`，"Run Sweep - [AMD] [AgentX] Add MI300X Qwen3.5 FP8 SGLang MTP"）。已发布基准行 ID 439568–439577。
- 已发布评测：gsm8k，评测行 9361，TP8/EP1 并发 32，得分 0.9765（em_strict 0.9765，em_flexible 0.9757，n_eff 1319），同一生产运行。
- 基线各点指标（每 GPU 总吞吐 tok/s/GPU、TPOT 中位数 s、TTFT 中位数 s）：

| 点 | 吞吐/GPU | TPOT 中位数 | TTFT 中位数 |
| --- | --- | --- | --- |
| TP8/EP1 c4 | 710.95 | 0.04607 | 3.501 |
| TP8/EP1 c16 | 2603.01 | 0.08126 | 4.761 |
| TP8/EP1 c20 | 3045.57 | 0.08466 | 5.021 |
| TP8/EP1 c24 | 3325.48 | 0.08947 | 5.457 |
| TP8/EP1 c32 | 2334.82 | 0.21576 | 65.571 |
| TP8/EP8 c4 | 712.63 | 0.04694 | 3.406 |
| TP8/EP8 c16 | 2585.75 | 0.08189 | 4.823 |
| TP8/EP8 c20 | 3050.84 | 0.08472 | 4.981 |
| TP8/EP8 c24 | 3330.68 | 0.08981 | 5.443 |
| TP8/EP8 c32 | 2320.39 | 0.22063 | 64.792 |

- 基线在所有尝试中保持冻结；旧镜像绝不重跑。

## 首次尝试
- 镜像/提交：`lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260907`，提交 5f7435bd627f8322662b24841adedb0273e91405。
- 改动：仅 `configs/amd-master.yaml` 的 image 字段。本地检查：`test-config --config-files configs/amd-master.yaml --config-keys qwen3.5-fp8-mi300x-sglang-agentic-mtp` 在 base 与 head 生成相同的 10 个点，仅 `image` 不同。
- 运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34389410451（从 `main` 派发的 `e2e-tests.yml`，`inputs.ref`=5f7435bd627f8322662b24841adedb0273e91405，`fail-fast=true`，`klaud-run=true`，派发时间 2026-09-09T18:30Z）。结果：**失败**（TP8/EP8 c24 失败；fail-fast 取消了其余 9 个点）。
- 结果：全部 10 个点均为 N/A（没有任何点完成 3600 s 的 profiling 窗口；唯一上传的聚合结果仅覆盖服务器崩溃前的 103 个请求 / 329 s，未通过 AIPerf 95% 指标覆盖率检查）。评测：N/A（定向命令未调度评测）。
- 诊断：进入 profiling 的 8 个点（TP8/EP1 c4/c16/c20/c24/c32，TP8/EP8 c20/c24/c32）在 profiling 开始后 3 至 45 分钟内以完全相同的特征崩溃：`torch.AcceleratorError: HIP error: an illegal memory access was encountered`，抛出位置为 `sglang/srt/layers/attention/aiter_backend.py:1549`（`init_forward_metadata` 中的 `kv_indices = torch.empty(...)`），调用链为 `hybrid_linear_attn_backend.py:1139` ← `eager_runner._execute_extend` ← `eagle_worker_v2.verify` → `run_eagle_verify`；随后一个 scheduler rank 以退出码 -6 中止，服务器停止服务。每个点的预热（最多 351 个请求）均已完成，说明模型加载、CUDA graph 捕获和短请求正常；故障在回放长 agentic 会话（平均输入约 60k token）并启用 MTP 后出现。上游 sgl-project/sglang#37165（"Clear deferred init metadata before speculative decode"，2026-09-07T19:41Z 合并，晚于 0907 nightly 13:58Z 的推送时间）描述了混合 Mamba 模型在内置 EAGLE/MTP draft-extend 批次中重放过期 Mamba clear/COW 索引的问题，与此处 Qwen3.5（GDN 混合架构）+ 原生 EAGLE MTP 的情况一致。MI325X 同类配方（#2870）在同一 0907 镜像上通过，但它使用 `SGLANG_USE_AITER_UNIFIED_ATTN=1` 与 fp8 KV，走的是另一条 attention 路径。
- 下一步：使用包含 #37165 的 2026-09-09 nightly 进行修复 1/5。

## 修复 1/5
- 镜像/提交：`lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260909`（摘要 `sha256:1fd72c1aa7304637ffb90ea17bd069c9a97dc594f584fc82945cc30c47c29605`，Docker Hub 最后推送时间 2026-09-09T13:58:08Z），提交 8aff3c722b7af51fd56b9d82bbd7e336700efec3。
- 改动：仅 `configs/amd-master.yaml` 的 image 字段；生成的矩阵与 base 相比仍仅 `image` 不同。0909 nightly 在 0907 构建基础上包含 sgl-project/sglang#37165（投机解码前清除延迟 Mamba 元数据）、#38467（AITER FP8 ASM prefill 的 GQA 门控）和 #34820（Mamba 前缀缓存检查点 dtype）。
- 运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34399239493（从 `main` 派发的 `e2e-tests.yml`，`inputs.ref`=8aff3c722b7af51fd56b9d82bbd7e336700efec3，`fail-fast=true`，`klaud-run=true`，派发时间 2026-09-09T20:08Z）。结果：7 分钟内**失败**（TP8/EP1 c20 在服务器启动时失败；fail-fast 取消了其余 9 个点）。
- 结果：全部 10 个点均为 N/A（服务器从未启动）。评测：N/A。
- 诊断：`sglang serve: error: ambiguous option: --cuda-graph-max-bs could match --cuda-graph-max-bs-decode, --cuda-graph-max-bs-prefill`。2026-09-09 nightly 不再接受配方脚本（未改动）传入的已弃用别名 `--cuda-graph-max-bs`：上游 sgl-project/sglang#38375（"Retire get_global_server_args, and clear the deprecated flags that have a replacement"，2026-09-08T23:42Z 合并，晚于 0908 nightly、早于 0909 nightly）将其移除。改动该参数意味着修改配方命令，超出本次镜像刷新的范围，因此 0909 nightly 按原样不兼容。
- 下一步：使用 2026-09-08 nightly 进行修复 2/5，该版本包含 #37165（Mamba/EAGLE 元数据修复）但早于 #38375（CLI 移除）。
- 评测覆盖：规定的 `test-config` 命令仅生成基准行（Qwen3.5 agentic GSM8K 在 `mark_eval_entries` 中为可选项）。由 changelog 驱动的 `run-sweep.yml` 最终 sweep 使用 `--evals-only` 生成评测行，会调度默认的 lm-eval GSM8K 行 TP8/EP1 并发 32（`qwen3.5_tp8_conc32_kvnone_spec-mtp`），与已发布基线评测的点一致。

## 修复 2/5
- 镜像/提交：`lmsysorg/sglang-rocm:v0.5.19-rocm720-mi30x-20260908`（摘要 `sha256:2107bc0a406e3f1d1bbe41d7f17131659e3ff18b54d2d1c624f897cd84d170e5`，Docker Hub 最后推送时间 2026-09-08T13:59:51Z），提交 22694f52afa460e655155763e14b65d802d5dcb7。
- 改动：仅 `configs/amd-master.yaml` 的 image 字段；生成的矩阵与 base 相比仍仅 `image` 不同。0908 nightly 包含 sgl-project/sglang#37165（2026-09-07T19:41Z 合并）且早于 #38375（2026-09-08T23:42Z 合并），因此配方的 `--cuda-graph-max-bs` 参数仍被接受。
- 运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34400355480（从 `main` 派发的 `e2e-tests.yml`，`inputs.ref`=22694f52afa460e655155763e14b65d802d5dcb7，`fail-fast=true`，`klaud-run=true`，派发时间 2026-09-09T20:19Z）。结果：**失败**（TP8/EP8 c16 在 87 分钟后失败；fail-fast 取消了其余 9 个点，TP8/EP8 c32 从未开始）。
- 结果：全部 10 个点均为 N/A（没有任何点完成 profiling 窗口；到达 AIPerf 汇总的四个点报告指标覆盖率为 6.8% 至 8.1%，要求 95%）。评测：N/A。
- 诊断：与首次尝试相同的运行时故障。已启动的 9 个点全部因 `torch.AcceleratorError: HIP error: an illegal memory access was encountered` 崩溃：TP8/EP1 c4 与 TP8/EP8 c4 在预热的第一个 prefill 批次（5 个序列、400 token）即崩溃，其余七个点在预热完成后 5 至 7 分钟崩溃（c16/c20/c24 在 20:49 至 21:01 UTC，c32 在 21:13 UTC）。由于该故障是异步的，它出现在不同的 Python 帧中（`logits_processor._copy_logits_to_buffer`、`vocab_parallel_embedding`、`eagle_worker_v2.draft_forward`、`torch.cuda.set_stream`），但每个服务器都有一个 scheduler rank 以退出码 -6 退出。此 nightly 已包含上游 #37165，但问题未解决，因此延迟 Mamba 元数据并非根因。旧镜像（`v0.5.16-rocm720-mi30x-20260730`）于 2026-08-12 在同一集群上成功发布了本配方族，MI325X 同类配方在 0907 nightly 上使用 `SGLANG_USE_AITER_UNIFIED_ATTN=1` 通过，因此回归位于 v0.5.16 与 v0.5.19 mi30x ROCm 构建之间、配方所用的 AITER 分页 attention + 原生 EAGLE MTP 路径上。
- 下一步：范围内无可行步骤。这是与首次尝试相同的故障类别且无进展；最新 nightly（0909）还移除了配方使用的 `--cuda-graph-max-bs` 参数。停止。

## 最终全量 sweep
- N/A：没有任何定向尝试通过，因此未追加 `perf-changelog.yaml` 条目，PR 从未标记为 ready，也未添加 sweep 标签。`run-sweep.yml` 从未在此分支上运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
