### PR TITLE
[Klaud Cold] Update minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg vLLM image to nightly-385dce36 (v0.29.0 + Mooncake store fix) / 将 minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg 的 vLLM 镜像更新至 nightly-385dce36(v0.29.0 + Mooncake store 修复)

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tep4-tp4-c1-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tep4-tp4-c1-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tep4-tp4-c1-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tep4-tp4-c1-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tep4-tp4-c1-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tp2-tp4-c20-c24-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tp2-tp4-c20-c24-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tp2-tp4-c20-c24-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p1d-tp2-tp4-c20-c24-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p1d-tp2-tp4-c20-c24-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-dep4-tp4-c24-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-dep4-tp4-c24-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-dep4-tp4-c24-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-dep4-tp4-c24-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-dep4-tp4-c24-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-tp2-tp2-c48-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-tp2-tp2-c48-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-tp2-tp2-c48-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/1p3d-tp2-tp2-c48-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-1p3d-tp2-tp2-c48-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-2p5d-tp2-tp2-c120-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-2p5d-tp2-tp2-c120-fp4-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-2p5d-tp2-tp2-c120-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-eval-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/2p5d-tp2-tp2-c120-eval-agentic.yaml
@@ -2,14 +2,14 @@ name: "minimax-m3-vllm-disagg-gb300-2p5d-tp2-tp2-c120-fp4-eval-agentic"
 
 model:
   path: "nvidia/MiniMax-M3-NVFP4"
-  container: "vllm/vllm-openai:v0.29.0"
+  container: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   precision: "fp4"
 
 identity:
   model:
     repo: "nvidia/MiniMax-M3-NVFP4"
   container:
-    image: "vllm/vllm-openai:v0.29.0"
+    image: "vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2"
   frameworks:
     dynamo: "1.4.0.dev20260730"
 

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7643,7 +7643,7 @@ minimaxm3-fp4-b300-vllm-agentic-mtp:
       - { tp: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [24] }
 
 minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
-  image: vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7
+  image: vllm/vllm-openai:v0.29.0
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: cluster:gb300-nv

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7643,7 +7643,7 @@ minimaxm3-fp4-b300-vllm-agentic-mtp:
       - { tp: 2, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: vllm-simple }, conc-list: [24] }
 
 minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
-  image: vllm/vllm-openai:v0.29.0
+  image: vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: cluster:gb300-nv


### PR DESCRIPTION
**Current status:** Stopped after the initial attempt and Repair 1/5 with a confirmed image incompatibility; PR closed, branch retained for manual review. `vllm/vllm-openai:v0.29.0` runs 5 of 6 AgentX points (throughput per GPU +0.5% to +4.4% versus baseline, all 6 default evals pass) but crashes the 2P x 5D conc 120 point on an upstream vLLM Mooncake store connector bug (fixed upstream only after the v0.29.0 tag). The first nightly containing that fix, `nightly-385dce36…`, fails every point at startup on a FlashAttention CuTe (FA4) regression for the EAGLE3 draft with fp8 KV cache, introduced by the 2026-09-05 vllm-flash-attn fork sync. No shipped upstream image currently contains both fixes, and the remaining job time cannot fit another full targeted run plus the final sweep. Next step (manual): re-run this family once a vLLM image contains both vllm-project/vllm#54853 and a vllm-flash-attn fix for the fp8 descale layout error (expected in a later nightly or v0.29.x). The branch keeps the v0.29.0-tested recipe state reachable via commit `a6c5ae2c9f1fa9bd9332216252648c40d7f81736`.

Family: `configs/nvidia-master.yaml:minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg` (runner `cluster:gb300-nv`). Candidate `0d7cb0d3810af263-6146c2a6f202a93b`, base `7fa1d14b6624d433bd4f72a540da739b8f3808d9`. Repairs used: 1 of 5.

Green targeted benchmarks do not prove that global PR checks pass; those checks and human review remain in force.

## Baseline (published 2026-08-21)

- Image: `vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7` (vLLM commit `5e35a6f4`, 2026-08-03). Identity verified on every row: model MiniMax-M3 (`nvidia/MiniMax-M3-NVFP4`), hardware gb300, framework dynamo-vllm, precision fp4, spec_method mtp, disagg true, benchmark_type agentic_traces, kv-offload mooncake 0.3.12.post1, router dynamo-router 1.4.0.dev20260730.
- API queries: `GET /api/v1/workflow-info?date=2026-08-21&benchmarkType=agentic_traces` (changelog entry for this key, PR #2663) and `GET /api/v1/benchmarks?model=MiniMax-M3&date=2026-08-21&exact=true` (no `view`), `GET /api/v1/evaluations` filtered client-side to this identity and date.
- Producer of all six points: run https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32505173269/attempts/1 (head SHA `e78bc8bd6a9a2373e2d652589d7913dffff19d34`, `pull_request` event, conclusion success). No curve snapshot IDs are used as producers.
- Published throughput points (throughput in tokens/s per GPU, latency in seconds):

| conc | topology (P x tp/ep/dp-attn -> D x tp) | total tput/GPU | output tput/GPU | mean TTFT | mean TPOT | row id |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 1x tp4/ep4 -> 1x tp4 | 2821.0 | 19.22 | 0.419 | 0.0029 | 440224 |
| 20 | 1x tp2 -> 1x tp4 | 23913.8 | 151.32 | 0.505 | 0.0041 | 440222 |
| 24 | 1x tp1/ep4/dp-attn -> 3x tp4 | 14070.3 | 83.58 | 0.779 | 0.0033 | 440223 |
| 24 | 1x tp2 -> 1x tp4 | 29109.6 | 176.10 | 0.913 | 0.0046 | 440227 |
| 48 | 1x tp2 -> 3x tp2 | 38508.9 | 254.63 | 1.770 | 0.0057 | 440226 |
| 120 | 2x tp2 -> 5x tp2 | 43977.3 | 346.08 | 2.530 | 0.0076 | 440225 |

- Published evals (gsm8k, exact-match strict) from the same producer run: conc 120 (2x tp2 -> 5x tp2) 0.9719; conc 48 (1x tp2 -> 3x tp2) 0.9727; conc 24 (1x tp2 -> 1x tp4) 0.9697; conc 24 (1x tp1/ep4/dp-attn -> 3x tp4) 0.9712. No published eval rows exist for the conc 1 and conc 20 points (N/A: not published). The current default eval for this family is the MiniMax vendor `minimax_m3_smoke` tool-call suite, so eval scores are not directly comparable to the published gsm8k rows (N/A: different task).

## Initial attempt

- Image/commit: `vllm/vllm-openai:v0.29.0` (Docker Hub tag pushed 2026-09-09T06:06:32Z, manifest-list digest `sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1`, arm64 image digest `sha256:18372a7224938643461b846fb64c5c9d3d6e9727e82caf2dc3043e620c9d4d7a`). Commit `a6c5ae2c9f1fa9bd9332216252648c40d7f81736`.
- Changes: master `image` and `model.container` / `identity.container.image` in the ten `benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/*.yaml` recipes. Nothing else changed; the generated matrix is identical to base except the image field (6 points, node-count 2/4/2/2/4/7, run-eval true).
- Compatibility evidence: vLLM tag `v0.29.0` is commit `98dff2a8`; the old nightly commit is a strict ancestor (compare status ahead, 1196 commits, 0 behind). The default `v0.29.0` tag is the CUDA 13.0 build for x86_64 and aarch64, matching the recipes' `nixl_cu13` UCX module path. srt-slurm installs the exact `ai-dynamo==1.4.0.dev20260730` wheels with `--no-deps`, so the container's vLLM is used as shipped.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34389480259 (dispatched 2026-09-09T18:31Z from `main`, `inputs.ref=a6c5ae2c9f1fa9bd9332216252648c40d7f81736`, `fail-fast=true`, `klaud-run=true`). Conclusion: failure (11 of 12 jobs succeeded; run-stats gb300-nv 11/12).
- Benchmark results: 5 of 6 throughput points completed (`results_bmk/agg_bmk.json`, 5 rows). The conc 120 point failed (N/A: job failed). Per-point deltas versus the frozen baseline, matched by concurrency and prefill/decode topology:

| conc | topology (P x tp/ep/dp-attn -> D x tp) | total tput/GPU new vs base | output tput/GPU new vs base | mean TTFT (s) new vs base | mean TPOT (s) new vs base | median interactivity (tok/s) new vs base |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 1x tp4/ep4 -> 1x tp4 | 2945.3 vs 2821.0 (+4.4%) | 19.75 vs 19.22 (+2.8%) | 0.480 vs 0.419 (+14.5%) | 0.0026 vs 0.0029 (-9.1%) | 385.0 vs 352.1 (+9.3%) |
| 20 | 1x tp2/ep1 -> 1x tp4 | 24024.4 vs 23913.8 (+0.5%) | 151.71 vs 151.32 (+0.3%) | 0.991 vs 0.505 (+96.3%) | 0.0038 vs 0.0041 (-8.5%) | 270.5 vs 253.8 (+6.6%) |
| 24 | 1x tp1/ep4/dpa -> 3x tp4 | 14204.9 vs 14070.3 (+1.0%) | 84.27 vs 83.58 (+0.8%) | 0.871 vs 0.779 (+11.8%) | 0.0028 vs 0.0033 (-13.1%) | 366.9 vs 324.7 (+13.0%) |
| 24 | 1x tp2/ep1 -> 1x tp4 | 29791.0 vs 29109.6 (+2.3%) | 178.77 vs 176.10 (+1.5%) | 0.613 vs 0.913 (-32.9%) | 0.0040 vs 0.0046 (-12.1%) | 253.7 vs 231.5 (+9.6%) |
| 48 | 1x tp2/ep1 -> 3x tp2 | 39112.8 vs 38508.9 (+1.6%) | 259.20 vs 254.63 (+1.8%) | 1.522 vs 1.770 (-14.0%) | 0.0052 vs 0.0057 (-9.0%) | 203.1 vs 183.2 (+10.9%) |
| 120 | 2x tp2 -> 5x tp2 | N/A (job failed, see diagnosis) | N/A | N/A | N/A | N/A |

- Throughput per GPU is `request_metrics.throughput.per_gpu` from the collector aggregate; TTFT/TPOT are means over profiled requests; the mean TTFT increases at conc 1, 20 and 24 (dp-attn) are tail-driven (p50 TTFT +8% to +21%) while mean TPOT improved 8% to 13% on every matched point. These are single-run measurements with no repetition, so small differences are within run-to-run noise. Because the family did not pass completely, none of these deltas are claimed as a validated improvement.
- Eval results (`eval_results_all/agg_eval_all.json`, default `minimax_m3_smoke`, 1 sample, em_strict): 6 of 6 eval-only jobs passed with score 1.0, including the conc 120 eval twin.
- Diagnosis: the conc 120 job (2 prefill x TP2, 5 decode x TP2, 7 nodes) started healthy at 20:30Z and profiled for about 7 minutes before AIPerf aborted at 20:51Z with 188/1879 failed requests (10% threshold). The first server error is on prefill worker 1 (`im-gb300-r01-c009_prefill_w1.out`, 20:51:22Z): the EngineCore died with `AssertionError: Missing current block table for store request ...` raised in `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py:_apply_current_save_block_ids`; the later Mooncake `batch_get_into_multi_buffers` segfaults and RDMA access-violation warnings are teardown symptoms. Upstream fixed this crash in vllm-project/vllm#54853 (`0b066293f3`, merged 2026-09-09T02:15Z, "Resolve connector block tables for every scheduled request"); the compare against tag `v0.29.0` shows the fix is not included. This is an image defect, not a recipe or infrastructure problem.
- Next step taken: Repair 1 moved the image to the first nightly containing the fix.

## Repair 1/5

- Image/commit: `vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2` (vLLM main commit `385dce36`, 2026-09-09T04:53Z, 9 commits after the fix; Docker Hub tag pushed 2026-09-09T06:16:33Z, manifest-list digest `sha256:819ec9c063412e5730d1b0e82046ba540d1bf991f3c4f661a849aae8a0c52374`, arm64 image digest `sha256:b0501f99fec5136f248f78d5850977a2ec32d55cd9a665f4a9ffef24cbdf7fe5`). Commit `777c40e77d6704f54ef582b484cc40c184878d90`.
- Changes: only the image string in the master key and the same ten recipe YAMLs; the generated matrix is identical to base except the image field.
- Run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34404365790 (dispatched 2026-09-09T21:00Z from `main`, `inputs.ref=777c40e77d6704f54ef582b484cc40c184878d90`, `fail-fast=true`, `klaud-run=true`). Outcome: failed and cancelled. The conc 1 benchmark and its eval twin failed at 21:14Z during server startup; fail-fast cancelled the other five throughput points; the conc 24 (dp-attn), conc 20 and conc 24 eval twins then failed on the same startup error; the remaining conc 48 and conc 120 eval twins were cancelled by Klaud at 21:37Z because the failure is deterministic at engine initialization. Final job states: 5 failure, 7 cancelled.
- Benchmark/eval results: N/A (no server reached healthy; `results_bmk` is empty and every eval artifact is an empty failure record).
- Per-point deltas versus baseline: N/A (no completed point).
- Diagnosis: every prefill and decode worker fails identically during `determine_available_memory -> profile_cudagraph_memory -> speculator.capture` for the EAGLE3 draft (`llama_eagle3.py`) with `RuntimeError: Expected strides[leading_dim] == 1, but got 0.` raised from `vllm/vllm_flash_attn/cute/interface.py:_flash_attn_fwd` when converting the fp8 q/k/v descale tensors (`to_cute_tensor(..., leading_dim=1)`). On compute capability 10.x (GB300) the draft's `FLASH_ATTN` backend with `kv-cache-dtype: fp8` must use FA4 (CuTe): `fa_utils.get_flash_attn_version` maps FA3 to FA4 on major >= 10 and `flash_attn_supports_kv_cache_dtype` only allows FA4 there, so no `flash_attn_version` override can avoid the path. The vllm-flash-attn fork pin moved from `06bdd47c` (in v0.29.0, which ran the same draft configuration successfully) to `506341a1` ("Sync Dao-AILab FlashAttention through ce088ab9") via vllm-project/vllm#54819 on 2026-09-05; every nightly from 2026-09-05 onward carries that pin, and the Mooncake fix only exists from 2026-09-09. Therefore no upstream `vllm/vllm-openai` image published so far contains both fixes for this recipe.
- Next step: none within this session. Options for manual review: a later nightly or v0.29.x containing both #54853 and a fix for the CuTe fp8 descale layout; or evaluating a different draft attention backend in the recipe (`speculative-config.attention_backend`), which would be a recipe change beyond a pure image bump.

## Final full sweep

- Not started (N/A: targeted validation did not pass). No sweep label was applied; the PR stayed in draft.

---

**当前状态:** 在初次尝试与修复 1/5 之后因确认的镜像不兼容而停止;PR 已关闭,分支保留以供人工评审。`vllm/vllm-openai:v0.29.0` 可运行 6 个 AgentX 点中的 5 个(每 GPU 吞吐相对基线 +0.5% 至 +4.4%,全部 6 个默认评测通过),但 2P x 5D 并发 120 点因 vLLM 上游 Mooncake store connector 缺陷崩溃(该缺陷仅在 v0.29.0 标签之后于上游修复)。首个包含该修复的 nightly `nightly-385dce36…` 在每个点的启动阶段都因 EAGLE3 草稿模型配合 fp8 KV cache 触发 FlashAttention CuTe(FA4)回归而失败,该回归由 2026-09-05 的 vllm-flash-attn fork 同步引入。目前没有任何已发布的上游镜像同时包含这两个修复,且剩余任务时间也不足以再完成一次完整定向运行加最终 sweep。下一步(人工):待某个 vLLM 镜像同时包含 vllm-project/vllm#54853 与 fp8 descale 布局错误的 vllm-flash-attn 修复(预计在后续 nightly 或 v0.29.x 中)后重新运行该家族。分支保留了经 v0.29.0 测试的 recipe 状态,可通过提交 `a6c5ae2c9f1fa9bd9332216252648c40d7f81736` 访问。

家族:`configs/nvidia-master.yaml:minimaxm3-fp4-gb300-dynamo-vllm-agentic-mtp-disagg`(runner `cluster:gb300-nv`)。候选 `0d7cb0d3810af263-6146c2a6f202a93b`,基线提交 `7fa1d14b6624d433bd4f72a540da739b8f3808d9`。已用修复次数:1/5。

定向基准测试通过并不代表全局 PR 检查通过;这些检查与人工评审仍然有效。

## 基线(发布于 2026-08-21)

- 镜像:`vllm/vllm-openai:nightly-5e35a6f4f9bbc217c599692157ca985c894373f7`(vLLM 提交 `5e35a6f4`,2026-08-03)。每一行均已核对身份:模型 MiniMax-M3(`nvidia/MiniMax-M3-NVFP4`)、硬件 gb300、框架 dynamo-vllm、精度 fp4、spec_method mtp、disagg true、benchmark_type agentic_traces、KV 卸载 mooncake 0.3.12.post1、路由器 dynamo-router 1.4.0.dev20260730。
- API 查询:`GET /api/v1/workflow-info?date=2026-08-21&benchmarkType=agentic_traces`(该 key 的 changelog 条目,PR #2663)、`GET /api/v1/benchmarks?model=MiniMax-M3&date=2026-08-21&exact=true`(不带 `view`)、`GET /api/v1/evaluations`(客户端按身份和日期过滤)。
- 六个点的生产运行:https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32505173269/attempts/1(head SHA `e78bc8bd6a9a2373e2d652589d7913dffff19d34`,`pull_request` 事件,结论 success)。未将曲线快照 ID 当作生产者。
- 已发布吞吐点(吞吐单位 tokens/s/GPU,延迟单位秒):

| 并发 | 拓扑(P x tp/ep/dp-attn -> D x tp) | 总吞吐/GPU | 输出吞吐/GPU | 平均 TTFT | 平均 TPOT | 行 id |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 1x tp4/ep4 -> 1x tp4 | 2821.0 | 19.22 | 0.419 | 0.0029 | 440224 |
| 20 | 1x tp2 -> 1x tp4 | 23913.8 | 151.32 | 0.505 | 0.0041 | 440222 |
| 24 | 1x tp1/ep4/dp-attn -> 3x tp4 | 14070.3 | 83.58 | 0.779 | 0.0033 | 440223 |
| 24 | 1x tp2 -> 1x tp4 | 29109.6 | 176.10 | 0.913 | 0.0046 | 440227 |
| 48 | 1x tp2 -> 3x tp2 | 38508.9 | 254.63 | 1.770 | 0.0057 | 440226 |
| 120 | 2x tp2 -> 5x tp2 | 43977.3 | 346.08 | 2.530 | 0.0076 | 440225 |

- 已发布评测(gsm8k,严格精确匹配),来自同一生产运行:并发 120(2x tp2 -> 5x tp2)0.9719;并发 48(1x tp2 -> 3x tp2)0.9727;并发 24(1x tp2 -> 1x tp4)0.9697;并发 24(1x tp1/ep4/dp-attn -> 3x tp4)0.9712。并发 1 与并发 20 无已发布评测行(N/A:未发布)。该家族当前默认评测为 MiniMax 厂商 `minimax_m3_smoke` 工具调用套件,因此评测分数与已发布的 gsm8k 行不可直接比较(N/A:任务不同)。

## 初次尝试

- 镜像/提交:`vllm/vllm-openai:v0.29.0`(Docker Hub 标签推送于 2026-09-09T06:06:32Z,manifest-list digest `sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1`,arm64 镜像 digest `sha256:18372a7224938643461b846fb64c5c9d3d6e9727e82caf2dc3043e620c9d4d7a`)。提交 `a6c5ae2c9f1fa9bd9332216252648c40d7f81736`。
- 变更:master 的 `image`,以及十个 `benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic/gb300-fp4/*.yaml` recipe 的 `model.container` / `identity.container.image`。其余未改动;生成的矩阵除镜像字段外与基线完全一致(6 个点,node-count 2/4/2/2/4/7,run-eval true)。
- 兼容性证据:vLLM 标签 `v0.29.0` 对应提交 `98dff2a8`;旧 nightly 提交是其严格祖先(compare 状态 ahead,领先 1196 个提交,落后 0)。默认 `v0.29.0` 标签是 x86_64 与 aarch64 的 CUDA 13.0 构建,与 recipe 中的 `nixl_cu13` UCX 模块路径一致。srt-slurm 以 `--no-deps` 安装精确的 `ai-dynamo==1.4.0.dev20260730` wheel,因此容器内的 vLLM 按原样使用。
- 运行:https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34389480259(2026-09-09T18:31Z 从 `main` 分派,`inputs.ref=a6c5ae2c9f1fa9bd9332216252648c40d7f81736`,`fail-fast=true`,`klaud-run=true`)。结论:failure(12 个任务中 11 个成功;run-stats gb300-nv 11/12)。
- 基准结果:6 个吞吐点中 5 个完成(`results_bmk/agg_bmk.json`,5 行)。并发 120 点失败(N/A:任务失败)。按并发与 prefill/decode 拓扑匹配的各点相对冻结基线的差值:

| 并发 | 拓扑(P x tp/ep/dp-attn -> D x tp) | 总吞吐/GPU 新 vs 基线 | 输出吞吐/GPU 新 vs 基线 | 平均 TTFT(秒)新 vs 基线 | 平均 TPOT(秒)新 vs 基线 | 中位交互性(tok/s)新 vs 基线 |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 1x tp4/ep4 -> 1x tp4 | 2945.3 vs 2821.0 (+4.4%) | 19.75 vs 19.22 (+2.8%) | 0.480 vs 0.419 (+14.5%) | 0.0026 vs 0.0029 (-9.1%) | 385.0 vs 352.1 (+9.3%) |
| 20 | 1x tp2/ep1 -> 1x tp4 | 24024.4 vs 23913.8 (+0.5%) | 151.71 vs 151.32 (+0.3%) | 0.991 vs 0.505 (+96.3%) | 0.0038 vs 0.0041 (-8.5%) | 270.5 vs 253.8 (+6.6%) |
| 24 | 1x tp1/ep4/dpa -> 3x tp4 | 14204.9 vs 14070.3 (+1.0%) | 84.27 vs 83.58 (+0.8%) | 0.871 vs 0.779 (+11.8%) | 0.0028 vs 0.0033 (-13.1%) | 366.9 vs 324.7 (+13.0%) |
| 24 | 1x tp2/ep1 -> 1x tp4 | 29791.0 vs 29109.6 (+2.3%) | 178.77 vs 176.10 (+1.5%) | 0.613 vs 0.913 (-32.9%) | 0.0040 vs 0.0046 (-12.1%) | 253.7 vs 231.5 (+9.6%) |
| 48 | 1x tp2/ep1 -> 3x tp2 | 39112.8 vs 38508.9 (+1.6%) | 259.20 vs 254.63 (+1.8%) | 1.522 vs 1.770 (-14.0%) | 0.0052 vs 0.0057 (-9.0%) | 203.1 vs 183.2 (+10.9%) |
| 120 | 2x tp2 -> 5x tp2 | N/A(任务失败,见诊断) | N/A | N/A | N/A | N/A |

- 每 GPU 吞吐取自收集器聚合的 `request_metrics.throughput.per_gpu`;TTFT/TPOT 为剖析请求的均值;并发 1、20 与 24(dp-attn)的平均 TTFT 上升由尾部驱动(p50 TTFT +8% 至 +21%),而每个匹配点的平均 TPOT 改善 8% 至 13%。这些均为单次测量、无重复,较小差异在运行间噪声范围内。由于该家族未完整通过,以上差值均不作为已验证的改进主张。
- 评测结果(`eval_results_all/agg_eval_all.json`,默认 `minimax_m3_smoke`,1 个样本,em_strict):6 个仅评测任务全部通过,分数 1.0,包括并发 120 的评测孪生任务。
- 诊断:并发 120 任务(2 个 prefill x TP2、5 个 decode x TP2,7 节点)于 20:30Z 健康启动,剖析约 7 分钟后 AIPerf 于 20:51Z 因 188/1879 请求失败(10% 阈值)中止。首个服务端错误在 prefill worker 1(`im-gb300-r01-c009_prefill_w1.out`,20:51:22Z):EngineCore 因 `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py:_apply_current_save_block_ids` 抛出的 `AssertionError: Missing current block table for store request ...` 而终止;之后 Mooncake `batch_get_into_multi_buffers` 段错误与 RDMA 访问违规警告均为收尾症状。上游已在 vllm-project/vllm#54853(`0b066293f3`,2026-09-09T02:15Z 合并,"Resolve connector block tables for every scheduled request")修复该崩溃;与标签 `v0.29.0` 的 compare 显示其不含该修复。这是镜像缺陷,而非 recipe 或基础设施问题。
- 已采取的下一步:修复 1 将镜像切换到首个包含该修复的 nightly。

## 修复 1/5

- 镜像/提交:`vllm/vllm-openai:nightly-385dce36bcee42309924a5ece951a96db3dce7f2`(vLLM main 提交 `385dce36`,2026-09-09T04:53Z,位于修复之后 9 个提交;Docker Hub 标签推送于 2026-09-09T06:16:33Z,manifest-list digest `sha256:819ec9c063412e5730d1b0e82046ba540d1bf991f3c4f661a849aae8a0c52374`,arm64 镜像 digest `sha256:b0501f99fec5136f248f78d5850977a2ec32d55cd9a665f4a9ffef24cbdf7fe5`)。提交 `777c40e77d6704f54ef582b484cc40c184878d90`。
- 变更:仅 master key 与同样十个 recipe YAML 中的镜像字符串;生成的矩阵除镜像字段外与基线一致。
- 运行:https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34404365790(2026-09-09T21:00Z 从 `main` 分派,`inputs.ref=777c40e77d6704f54ef582b484cc40c184878d90`,`fail-fast=true`,`klaud-run=true`)。结果:失败并取消。并发 1 基准任务及其评测孪生任务于 21:14Z 在服务启动阶段失败;fail-fast 取消了其余五个吞吐点;并发 24(dp-attn)、并发 20 与并发 24 的评测孪生任务随后因同一启动错误失败;剩余的并发 48 与并发 120 评测孪生任务由 Klaud 于 21:37Z 取消,因为该失败在引擎初始化阶段是确定性的。最终任务状态:5 个失败,7 个取消。
- 基准/评测结果:N/A(无服务达到健康状态;`results_bmk` 为空,所有评测产物均为空的失败记录)。
- 各点相对基线的差值:N/A(无完成的点)。
- 诊断:每个 prefill 与 decode worker 在 EAGLE3 草稿模型(`llama_eagle3.py`)的 `determine_available_memory -> profile_cudagraph_memory -> speculator.capture` 阶段以同样方式失败,`vllm/vllm_flash_attn/cute/interface.py:_flash_attn_fwd` 在转换 fp8 q/k/v descale 张量(`to_cute_tensor(..., leading_dim=1)`)时抛出 `RuntimeError: Expected strides[leading_dim] == 1, but got 0.`。在计算能力 10.x(GB300)上,草稿模型的 `FLASH_ATTN` 后端配合 `kv-cache-dtype: fp8` 必须使用 FA4(CuTe):`fa_utils.get_flash_attn_version` 在 major >= 10 时将 FA3 映射为 FA4,`flash_attn_supports_kv_cache_dtype` 在该架构上仅允许 FA4,因此任何 `flash_attn_version` 覆盖都无法绕开该路径。vllm-flash-attn fork 的 pin 通过 vllm-project/vllm#54819 于 2026-09-05 从 `06bdd47c`(v0.29.0 所用,同一草稿配置在其上运行成功)升至 `506341a1`("Sync Dao-AILab FlashAttention through ce088ab9");2026-09-05 起的每个 nightly 都带有该 pin,而 Mooncake 修复仅从 2026-09-09 起存在。因此目前已发布的上游 `vllm/vllm-openai` 镜像没有一个同时包含此 recipe 所需的两个修复。
- 下一步:本次会话内无。可供人工评审的选项:等待同时包含 #54853 与 CuTe fp8 descale 布局修复的后续 nightly 或 v0.29.x;或在 recipe 中评估另一种草稿注意力后端(`speculative-config.attention_backend`),但这属于超出纯镜像更新范围的 recipe 变更。

## 最终完整 sweep

- 未开始(N/A:定向验证未通过)。未应用任何 sweep 标签;PR 始终为草稿。
