### PR TITLE
[AgentX Metrics] bind expected output lengths to the declared dataset / 将预期输出长度绑定到声明的数据集

### DIFF
--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -190,6 +190,14 @@ separate from estimated whole-system power.
 
 Every nonblank JSONL record increments `records_total`. Records with `metadata.benchmark_phase` other than `profiling` are warmup diagnostics and are excluded. Records with a truthy `error` are also excluded and categorized. Older records with no phase are treated as profiling. The retained count becomes `num_requests_successful`. The full accounting is preserved in `request_accounting` with profiled, total dropped, warmup dropped, error dropped, and `error_categories` fields.
 
+`request_metrics.tokens.output_expected` uses local trace metadata only from the
+exact `metadata.dataset.hf_dataset_name` declared by AIPerf. Since the export
+does not record a resolved dataset revision, the matching cache must contain
+exactly one snapshot. Missing identity, missing metadata, or multiple snapshots
+leave this distribution empty; cache modification times and other datasets
+are never used to guess. Actual tokens, GPU energy denominators, and AIPerf's
+theoretical cache-hit metric retain their existing sources.
+
 The AgentX aggregate has top-level identity and topology fields compatible with benchmark ingestion.
 
 `num_gpus` explicitly records the physical count used by the shared processor.

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -184,6 +184,13 @@ raw tree:           results/**, excluding inputs.json and profile_export_raw.jso
 
 每条非空 JSONL 记录都会增加 `records_total`。`metadata.benchmark_phase` 不等于 `profiling` 的记录是 warmup 诊断，会被排除。含真值 `error` 的记录也会被排除并分类。没有 phase 的旧记录按 profiling 处理。保留记录数成为 `num_requests_successful`。完整计数保存在 `request_accounting` 中，包括 profiled、总丢弃、warmup 丢弃、错误丢弃和 `error_categories`。
 
+`request_metrics.tokens.output_expected` 只读取 AIPerf 在
+`metadata.dataset.hf_dataset_name` 中明确声明的数据集的本地 trace 元数据。
+由于导出内容没有记录实际解析到的数据集 revision，对应缓存必须恰好只有一个 snapshot。
+缺少数据集身份、缺少元数据或存在多个 snapshot 时，该分布保持为空；
+不会根据缓存修改时间或其他数据集进行猜测。实际 token 数、GPU 能耗的分母及
+AIPerf 理论缓存命中率继续使用各自原有的数据来源。
+
 AgentX 聚合的顶层身份和拓扑字段与基准摄取兼容。
 
 `num_gpus` 明确记录共享处理器使用的物理 GPU 数。单节点运行使用

--- a/utils/agentic/aggregation/request_metrics.py
+++ b/utils/agentic/aggregation/request_metrics.py
@@ -269,7 +269,9 @@ def compute_qps_stats(records: list[dict[str, Any]]) -> tuple[dict[str, Any], di
     return flat, {"window_seconds": window, "samples": len(qps_values), **_nest_stats("qps", flat)}
 
 
-def compute_workload_stats(records: list[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
+def compute_workload_stats(
+    records: list[dict[str, Any]], hf_dataset_name: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
     input_tokens = extract_per_record_ints(records, "input_sequence_length")
     output_tokens = extract_per_record_ints(records, "output_sequence_length")
 
@@ -277,7 +279,7 @@ def compute_workload_stats(records: list[dict[str, Any]]) -> tuple[dict[str, Any
     flat.update(_distribution("input_tokens", input_tokens))
     flat.update(_distribution("output_tokens_actual", output_tokens))
 
-    expected = expected_output_lengths(records)
+    expected = expected_output_lengths(records, hf_dataset_name)
     if expected:
         flat.update(_distribution("output_tokens_expected", expected))
 
@@ -371,10 +373,15 @@ def compute_request_metrics(
     aggregate = aggregate or {}
     flat: dict[str, Any] = {}
     nested: dict[str, Any] = {}
+    metadata = aggregate.get("metadata")
+    dataset = metadata.get("dataset") if isinstance(metadata, dict) else None
+    hf_dataset_name = dataset.get("hf_dataset_name") if isinstance(dataset, dict) else None
+    if not isinstance(hf_dataset_name, str):
+        hf_dataset_name = None
 
     qps_flat, qps_nested = compute_qps_stats(records)
     latency_flat, latency_nested = compute_latency_stats(records)
-    workload_flat, workload_nested = compute_workload_stats(records)
+    workload_flat, workload_nested = compute_workload_stats(records, hf_dataset_name)
     cache_flat, cache_nested = compute_cache_stats(records, aggregate)
     throughput_flat, throughput_nested = compute_throughput_stats(records)
 

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -1576,6 +1576,9 @@ def test_processor_uses_aiperf_theoretical_cache_metric(tmp_path: Path):
                     "count": 4,
                     "sum": 1,
                 },
+                "metadata": {
+                    "dataset": {"hf_dataset_name": "semianalysisai/cc-traces-weka-042026"}
+                },
             },
             f,
         )
@@ -1637,6 +1640,44 @@ def test_processor_uses_aiperf_theoretical_cache_metric(tmp_path: Path):
     assert agg["request_metrics"]["tokens"]["output_expected"]["mean"] == pytest.approx(
         55.0
     )
+
+
+@pytest.mark.parametrize("cache_state", ["matching", "missing", "ambiguous", "no_identity"])
+def test_processor_expected_output_uses_declared_dataset(tmp_path: Path, cache_state: str):
+    result_dir = _write_fixture(tmp_path)
+    profile_path = result_dir / "aiperf_artifacts" / "profile_export_aiperf.json"
+    profile = json.loads(profile_path.read_text())
+    if cache_state == "no_identity":
+        del profile["metadata"]["dataset"]["hf_dataset_name"]
+    profile["theoretical_prefix_cache_hit"] = {"unit": "%", "avg": 25.0}
+    profile_path.write_text(json.dumps(profile))
+
+    hf_cache = tmp_path / "hf"
+    snapshots = [("cc-traces-weka-062126-256k", "newer", 900, 200)]
+    if cache_state != "missing":
+        snapshots.append(("cc-traces-weka-062126", "correct", 100, 100))
+    if cache_state == "ambiguous":
+        snapshots.append(("cc-traces-weka-062126", "another", 200, 300))
+    for dataset, revision, output, modified_at in snapshots:
+        snapshot = hf_cache / f"datasets--semianalysisai--{dataset}" / "snapshots" / revision
+        snapshot.mkdir(parents=True)
+        traces = [
+            {"id": trace_id, "requests": [{"type": "n", "out": output}] * turns}
+            for trace_id, turns in [("trace-A", 3), ("trace-B", 2)]
+        ]
+        (snapshot / "traces.jsonl").write_text("\n".join(json.dumps(trace) for trace in traces))
+        os.utime(snapshot, (modified_at, modified_at))
+
+    agg = _run_processor(result_dir, tmp_path / "out", {"HF_HUB_CACHE": str(hf_cache)})
+
+    expected = agg["request_metrics"]["tokens"]["output_expected"]
+    if cache_state == "matching":
+        assert expected["mean"] == 100
+    else:
+        assert expected == {}
+    assert agg["request_metrics"]["tokens"]["output_actual"]["mean"] == 55
+    assert agg["num_requests_successful"] == 5
+    assert agg["request_metrics"]["cache"]["theoretical_cache_hit_rate"] == 0.25
 
 
 def test_processor_supports_per_run_subdir_layout(tmp_path: Path):

--- a/utils/agentic/aggregation/trace_metadata.py
+++ b/utils/agentic/aggregation/trace_metadata.py
@@ -8,9 +8,6 @@ from pathlib import Path
 from typing import Any
 
 
-_TRACE_METADATA_CACHE: dict[str, list[dict[str, Any]]] | None = None
-
-
 def conversation_id_to_trace_id(conv_id: str | None) -> str | None:
     """Strip aiperf's ``::sa:<agent>`` suffix to recover the parent trace id."""
     if not conv_id:
@@ -18,7 +15,10 @@ def conversation_id_to_trace_id(conv_id: str | None) -> str | None:
     return conv_id.split("::", 1)[0]
 
 
-def _hf_traces_dir() -> Path | None:
+def _hf_traces_dir(hf_dataset_name: str | None) -> Path | None:
+    if not hf_dataset_name:
+        return None
+
     hub_cache = os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
     if hub_cache:
         cache_root = Path(hub_cache)
@@ -26,21 +26,13 @@ def _hf_traces_dir() -> Path | None:
         home = os.environ.get("HF_HOME")
         cache_root = Path(home) / "hub" if home else Path.home() / ".cache" / "huggingface" / "hub"
 
-    if not cache_root.is_dir():
+    snap_root = cache_root / f"datasets--{hf_dataset_name.replace('/', '--')}" / "snapshots"
+    if not snap_root.is_dir():
         return None
 
-    snapshots: list[Path] = []
-    for dataset_dir in cache_root.glob("datasets--semianalysisai--cc-traces-weka*"):
-        snap_root = dataset_dir / "snapshots"
-        if not snap_root.is_dir():
-            continue
-        snapshots.extend(p for p in snap_root.iterdir() if p.is_dir())
-    snapshots.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-
-    for candidate in snapshots:
-        if any(candidate.glob("*.jsonl")) or any(candidate.glob("*.json")):
-            return candidate
-    return None
+    # The export has no resolved revision; multiple snapshots are ambiguous.
+    snapshots = [path for path in snap_root.iterdir() if path.is_dir()]
+    return snapshots[0] if len(snapshots) == 1 else None
 
 
 def _iter_trace_blobs(traces_dir: Path):
@@ -66,16 +58,11 @@ def _iter_trace_blobs(traces_dir: Path):
             continue
 
 
-def load_trace_metadata() -> dict[str, list[dict[str, Any]]]:
+def load_trace_metadata(hf_dataset_name: str | None) -> dict[str, list[dict[str, Any]]]:
     """Build {trace_id: [{hash_ids, output_length}, ...]} from local HF cache."""
-    global _TRACE_METADATA_CACHE
-    if _TRACE_METADATA_CACHE is not None:
-        return _TRACE_METADATA_CACHE
-
     out: dict[str, list[dict[str, Any]]] = {}
-    traces_dir = _hf_traces_dir()
+    traces_dir = _hf_traces_dir(hf_dataset_name)
     if traces_dir is None:
-        _TRACE_METADATA_CACHE = out
         return out
 
     for blob in _iter_trace_blobs(traces_dir):
@@ -98,12 +85,13 @@ def load_trace_metadata() -> dict[str, list[dict[str, Any]]]:
         if per_turn:
             out[str(trace_id)] = per_turn
 
-    _TRACE_METADATA_CACHE = out
     return out
 
 
-def expected_output_lengths(records: list[dict[str, Any]]) -> list[int]:
-    metadata = load_trace_metadata()
+def expected_output_lengths(
+    records: list[dict[str, Any]], hf_dataset_name: str | None
+) -> list[int]:
+    metadata = load_trace_metadata(hf_dataset_name)
     if not metadata:
         return []
 


### PR DESCRIPTION
## Description

When several AgentX datasets share an HF cache, expected-output statistics currently use the newest cached dataset, even when AIPerf declares a different dataset. Bind the lookup to `metadata.dataset.hf_dataset_name` and omit expected-output statistics if identity, metadata, or a unique snapshot is unavailable. Actual tokens, throughput, measured GPU energy and theoretical cache-hit metrics keep their existing sources.

The four real-processor regression cases fail on the base revision and pass with this fix; **225 required result-processing tests pass**. Replaying the [GLM B200 artifacts](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34383379466) with both the full dataset and a newer 256k cache reproduces every native metric, with only the parent PR's `num_gpus: 8` addition. The GLM native expected-output values were correct; this change fixes the unsafe cache-selection rule rather than claiming those values were wrong.

This metadata-only draft is stacked on #2923. No recipe, serving behavior, GPU sweep, historical-data rewrite or publication is included. CODEOWNER/Core review and current-head sign-off remain required.

## Related Issue

No linked GitHub issue. / 暂无关联 GitHub issue。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [ ] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

Changelog and sweep reuse are not applicable to this metadata-only diff; the CODEOWNER must document any non-applicable checklist items through the normal verifier.

## 中文说明

多个 AgentX 数据集共用 HF 缓存时，预期输出长度统计原先会选择修改时间最新的数据集，即使 AIPerf 声明了另一个数据集。现在只读取 `metadata.dataset.hf_dataset_name` 指定的数据集；缺少身份、元数据或唯一 snapshot 时省略该统计。实际 token、吞吐量、GPU 实测能耗及理论缓存命中率的数据来源保持不变。

四个真实处理器回归用例在基线失败、修复后通过；**225 项必需结果处理测试通过**。同时保留完整数据集和修改时间更新的 256k 缓存，重放 GLM B200 工件后仍复现全部原生指标，唯一差异是父 PR 新增的 `num_gpus: 8`。该 GLM 原生预期输出值是正确的；此修复针对不安全的缓存选择规则，并不声称该测量值错误。

本草稿堆叠在 #2923 上，仅修改元数据处理，不修改配方、服务行为，不启动 GPU 扫描，也不重写或发布历史数据。仍需 CODEOWNER/Core 审查与当前版本签核；不适用的 changelog/reuse 清单项须由 CODEOWNER 通过正常校验流程说明。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how expected-output distributions are derived during AgentX aggregation; wrong or ambiguous cache can omit metrics rather than silently use the wrong dataset, but other published metrics stay on existing paths.
> 
> **Overview**
> Fixes AgentX **`request_metrics.tokens.output_expected`** so it no longer picks the newest cached `cc-traces-weka*` snapshot when several datasets share a Hugging Face hub cache.
> 
> **`compute_request_metrics`** now reads **`metadata.dataset.hf_dataset_name`** from `profile_export_aiperf.json` and passes it into trace lookup. **`trace_metadata`** resolves only `datasets--<name>/snapshots/` for that dataset, uses the snapshot directory only when there is **exactly one** revision (no mtime-based guessing), and drops the old process-wide trace cache. Missing name, missing cache, or multiple snapshots leave **`output_expected`** empty; actual tokens, throughput, GPU energy, and AIPerf theoretical cache-hit metrics are unchanged.
> 
> English and Chinese ingestion docs describe the contract. A parametrized processor test covers matching, missing, ambiguous, and no-identity cache cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d97b772ce46db91eb69da85b5e0fbf77b1e61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->