### PR TITLE
[AgentX Metrics] preserve SGLang metrics behind Dynamo / 保留 Dynamo 后端的 SGLang 指标

### DIFF
--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -215,6 +215,15 @@ Other important AgentX fields include:
 | Server metrics | `server_metrics.cache`, `kv_cache`, token totals, source details, and any `warnings` |
 | Compatibility | `kv_cache_pool_tokens` mirrors `server_metrics.kv_cache.gpu_total_tokens` |
 
+When a `dynamo-sglang` run includes `sglang:` telemetry, the processor uses the
+existing SGLang adapter for cache, utilization, and token metrics. Dynamo
+frontend metrics remain in the raw server export; their scrape boundaries can
+include warmup requests and need not match profiling-only request totals.
+Logical GPU KV capacity remains `null` with a warning on this path because
+Dynamo can expose replicated TP-rank capacity gauges. HiCache host utilization
+and cache-source counters remain available when emitted. A missing host-hit
+counter does not prove zero CPU cache hits. Dynamo-vLLM aggregation is unchanged.
+
 The app flattens nested AgentX v3 values into canonical metric keys. Examples include `median_ttft`, `p95_e2el`, `total_tput_tps`, `tput_per_gpu`, `server_gpu_cache_hit_rate`, and `gpu_kv_cache_usage_pct`. It maps p50 to `median`. Full-response ITL fields take precedence when present, and interactivity percentiles are derived as the reciprocal of the matching ITL percentile so historical and current rows use one definition.
 
 Before normal upload, the single-node workflow runs [`validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py). It requires an aggregate object, a numeric non-negative `request_count.avg`, positive completed requests, and an error rate at or below the configured threshold. Passing this gate does not mean no requests failed. Failed request records remain visible through `request_accounting` but do not contribute to performance metrics.

--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -215,14 +215,11 @@ Other important AgentX fields include:
 | Server metrics | `server_metrics.cache`, `kv_cache`, token totals, source details, and any `warnings` |
 | Compatibility | `kv_cache_pool_tokens` mirrors `server_metrics.kv_cache.gpu_total_tokens` |
 
-When a `dynamo-sglang` run includes `sglang:` telemetry, the processor uses the
-existing SGLang adapter for cache, utilization, and token metrics. Dynamo
-frontend metrics remain in the raw server export; their scrape boundaries can
-include warmup requests and need not match profiling-only request totals.
-Logical GPU KV capacity remains `null` with a warning on this path because
-Dynamo can expose replicated TP-rank capacity gauges. HiCache host utilization
-and cache-source counters remain available when emitted. A missing host-hit
-counter does not prove zero CPU cache hits. Dynamo-vLLM aggregation is unchanged.
+For a `dynamo-sglang` run with `sglang:` telemetry, the processor uses the
+SGLang adapter for cache, utilization, and token metrics. Logical GPU KV capacity
+remains `null` with a warning because TP ranks may report duplicate capacity
+values. Raw Dynamo frontend totals may include warmup requests. Missing host-hit
+counters do not imply zero CPU cache hits.
 
 The app flattens nested AgentX v3 values into canonical metric keys. Examples include `median_ttft`, `p95_e2el`, `total_tput_tps`, `tput_per_gpu`, `server_gpu_cache_hit_rate`, and `gpu_kv_cache_usage_pct`. It maps p50 to `median`. Full-response ITL fields take precedence when present, and interactivity percentiles are derived as the reciprocal of the matching ITL percentile so historical and current rows use one definition.
 

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -208,7 +208,10 @@ AgentX 聚合的顶层身份和拓扑字段与基准摄取兼容。
 | 服务器指标 | `server_metrics.cache`、`kv_cache`、token 总数、来源详情，以及可能存在的 `warnings` |
 | 兼容性 | `kv_cache_pool_tokens` 镜像 `server_metrics.kv_cache.gpu_total_tokens` |
 
-当 `dynamo-sglang` 运行包含 `sglang:` 遥测时，处理器使用现有 SGLang 适配器聚合缓存、利用率和 token 指标。Dynamo 前端指标仍保留在原始服务器导出中；其抓取边界可能包含预热请求，因此不一定与仅含 profiling 请求的总数一致。此路径的逻辑 GPU KV 容量保持 `null` 并附带警告，因为 Dynamo 可能导出多个 TP rank 重复报告的容量值。只要服务器提供，HiCache 主机利用率和各缓存来源的计数仍会保留。缺少主机命中计数并不代表 CPU 缓存命中为零。Dynamo-vLLM 的聚合行为保持不变。
+当 `dynamo-sglang` 运行包含 `sglang:` 遥测时，处理器使用 SGLang 适配器
+聚合缓存、利用率和 token 指标。逻辑 GPU KV 容量保持 `null` 并附带警告，
+因为多个 TP rank 可能重复报告容量值。原始 Dynamo 前端总数可能包含预热请求。
+缺少主机命中计数并不代表 CPU 缓存命中为零。
 
 应用会将嵌套 AgentX v3 值展平为规范指标键。例如 `median_ttft`、`p95_e2el`、`total_tput_tps`、`tput_per_gpu`、`server_gpu_cache_hit_rate` 和 `gpu_kv_cache_usage_pct`。p50 映射为 `median`。存在 full-response ITL 字段时优先使用它。交互性百分位数按对应 ITL 百分位数的倒数派生，使历史记录和当前记录采用同一定义。
 

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -208,6 +208,8 @@ AgentX 聚合的顶层身份和拓扑字段与基准摄取兼容。
 | 服务器指标 | `server_metrics.cache`、`kv_cache`、token 总数、来源详情，以及可能存在的 `warnings` |
 | 兼容性 | `kv_cache_pool_tokens` 镜像 `server_metrics.kv_cache.gpu_total_tokens` |
 
+当 `dynamo-sglang` 运行包含 `sglang:` 遥测时，处理器使用现有 SGLang 适配器聚合缓存、利用率和 token 指标。Dynamo 前端指标仍保留在原始服务器导出中；其抓取边界可能包含预热请求，因此不一定与仅含 profiling 请求的总数一致。此路径的逻辑 GPU KV 容量保持 `null` 并附带警告，因为 Dynamo 可能导出多个 TP rank 重复报告的容量值。只要服务器提供，HiCache 主机利用率和各缓存来源的计数仍会保留。缺少主机命中计数并不代表 CPU 缓存命中为零。Dynamo-vLLM 的聚合行为保持不变。
+
 应用会将嵌套 AgentX v3 值展平为规范指标键。例如 `median_ttft`、`p95_e2el`、`total_tput_tps`、`tput_per_gpu`、`server_gpu_cache_hit_rate` 和 `gpu_kv_cache_usage_pct`。p50 映射为 `median`。存在 full-response ITL 字段时优先使用它。交互性百分位数按对应 ITL 百分位数的倒数派生，使历史记录和当前记录采用同一定义。
 
 正常上传前，单节点工作流会运行 [`validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py)。它要求聚合为对象，`request_count.avg` 是非负数值，已完成请求数为正，错误率不高于配置阈值。通过该门禁不表示没有失败请求。失败请求记录仍可通过 `request_accounting` 观察，但不参与性能指标计算。

--- a/utils/agentic/aggregation/backends/dynamo_vllm.py
+++ b/utils/agentic/aggregation/backends/dynamo_vllm.py
@@ -14,6 +14,10 @@ class DynamoVllmBackend(VllmBackend):
     def matches(self, metrics: dict[str, dict[str, Any]], framework: str) -> bool:
         metric_names = set(metrics)
         framework = framework.lower()
+        if framework == "dynamo-sglang" and any(
+            name.startswith("sglang:") for name in metric_names
+        ):
+            return False
         return framework.startswith("dynamo") or any(
             name.startswith("dynamo_") for name in metric_names
         )

--- a/utils/agentic/aggregation/server_metrics.py
+++ b/utils/agentic/aggregation/server_metrics.py
@@ -57,9 +57,16 @@ def compute_server_metrics(
     nested["adapter"] = adapter.name
     adapter.populate(metrics, flat, nested)
 
-    capacity = adapter.gpu_kv_capacity_tokens(metrics, log_paths)
-    if capacity is not None:
-        nested["kv_cache"]["gpu_total_tokens"] = capacity
+    if framework.lower() == "dynamo-sglang" and adapter.name == "sglang":
+        # Dynamo can export replicated TP-rank gauges for one logical KV pool.
+        nested["kv_cache"]["gpu_total_tokens"] = None
+        warnings.append(
+            "Dynamo-SGLang logical KV capacity is unsupported: rank replicas are not normalized"
+        )
+    else:
+        capacity = adapter.gpu_kv_capacity_tokens(metrics, log_paths)
+        if capacity is not None:
+            nested["kv_cache"]["gpu_total_tokens"] = capacity
 
     apply_profile_totals(flat, records)
     if nested["tokens"]["prompt_total"] is None:

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -1291,7 +1291,8 @@ def test_processor_ignores_server_warmup_metrics_for_headline_stats(
     assert agg["server_metrics"]["tokens"]["prompt_total"] == 1000
 
 
-def test_processor_normalizes_sglang_server_metrics(tmp_path: Path):
+@pytest.mark.parametrize("framework", ["sglang", "dynamo-sglang"])
+def test_processor_normalizes_sglang_server_metrics(tmp_path: Path, framework: str):
     result_dir = _write_fixture(tmp_path)
     artifact = result_dir / "aiperf_artifacts"
     server_metrics = {
@@ -1331,13 +1332,30 @@ def test_processor_normalizes_sglang_server_metrics(tmp_path: Path):
             },
         }
     }
+    if framework == "dynamo-sglang":
+        server_metrics["metrics"].update(
+            {
+                "dynamo_frontend_input_sequence_tokens": {
+                    "type": "counter",
+                    "series": [{"stats": {"total": 1100.0}}],
+                },
+                "sglang:max_total_num_tokens": {
+                    "type": "gauge",
+                    "series": [
+                        {"labels": {"tp_rank": "0"}, "stats": {"max": 1000.0}},
+                        {"labels": {"tp_rank": "1"}, "stats": {"max": 1000.0}},
+                    ],
+                },
+            }
+        )
+        (result_dir / "server.log").write_text("max_total_num_tokens=1000, dp_size=1")
     with open(artifact / "server_metrics_export.json", "w") as f:
         json.dump(server_metrics, f)
 
     agg = _run_processor(
         result_dir,
         tmp_path / "out",
-        env_overrides={"FRAMEWORK": "sglang"},
+        env_overrides={"FRAMEWORK": framework},
     )
 
     assert agg["server_metrics"]["adapter"] == "sglang"
@@ -1349,6 +1367,15 @@ def test_processor_normalizes_sglang_server_metrics(tmp_path: Path):
     assert agg["server_metrics"]["kv_cache"]["gpu_usage_pct"] == pytest.approx(0.75)
     assert agg["server_metrics"]["kv_cache"]["cpu_usage_pct"] == pytest.approx(0.3)
     assert agg["server_metrics"]["tokens"]["prompt_by_source"]["computed"] == 500.0
+
+    assert agg["server_metrics"]["tokens"]["prompt_total"] == 1000
+    assert agg["server_metrics"]["tokens"]["generation_total"] == 200
+    if framework == "dynamo-sglang":
+        assert agg["server_metrics"]["kv_cache"]["gpu_total_tokens"] is None
+        assert agg["kv_cache_pool_tokens"] is None
+        assert any(
+            "rank replicas are not normalized" in warning for warning in agg["warnings"]
+        )
 
 
 def test_processor_normalizes_trtllm_server_metrics(tmp_path: Path):


### PR DESCRIPTION
## Description

AgentX `dynamo-sglang` results currently select the Dynamo-vLLM adapter even when SGLang telemetry is available, dropping cache/HiCache metrics and taking frontend totals that can include a warmup request. Select the existing SGLang adapter for this concrete path. Keep logical GPU KV capacity null with an explicit warning because TP-rank gauges can repeat one pool; preserve Dynamo-vLLM behavior.

Stacked on [#2923](https://github.com/SemiAnalysisAI/InferenceX/pull/2923). This changes offline result processing only and has no `perf-changelog.yaml` change or main GPU-sweep trigger. Source review, required CI and the parent dependency remain the delivery gates.

AgentX 的 `dynamo-sglang` 结果即使包含 SGLang 遥测，也会错误地选择 Dynamo-vLLM 适配器，丢失缓存及 HiCache 指标，并采用可能包含预热请求的前端总数。此修改让该路径使用现有 SGLang 适配器。由于多个 TP rank 可能重复报告同一 KV 池，逻辑 GPU KV 容量保持 null 并附带明确警告；Dynamo-vLLM 行为不变。

本 PR 基于 [#2923](https://github.com/SemiAnalysisAI/InferenceX/pull/2923)，仅修改离线结果处理，没有 `perf-changelog.yaml` 改动，也不会触发 main GPU 扫描。落地仍需源码评审、必要 CI 及基础 PR 合并。

Validation:232 local result-processing tests pass. Replaying the retained [GLM-5.2 GB200 run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34388569945) recovers device-cache/HiCache utilization and exact279-request server totals; all original request and power fields remain bit-equivalent. Raw Dynamo frontend data remains in the server export. No serving, recipe, or GPU execution changes. Expected-output cache provenance remains a separate unresolved limitation.

验证：232 项本地结果处理测试通过。使用已保留的 GLM-5.2 GB200 工件回放，恢复设备缓存、HiCache 利用率及精确匹配279个请求的服务器总数；原有请求和功耗字段逐值保持一致。Dynamo 前端原始数据仍保留在服务器导出中。未修改服务、recipe 或 GPU 执行逻辑。预期输出长度的缓存来源问题仍独立保留。

## Related Issue

AgentX automatic measured-power and result-accounting integration. No separate issue.
AgentX 自动实测功耗与结果计数集成；无单独 issue。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [ ] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries** — Not applicable: offline result normalization only; no runtime or recipe changes. 仅修改离线结果归一化，不改变运行时或 recipe。
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Offline aggregate post-processing only; no serving or benchmark runtime changes. Published metrics for dynamo-sglang runs with SGLang telemetry will differ (more accurate cache/token fields, null KV pool size).
> 
> **Overview**
> Fixes **offline AgentX server-metric normalization** for `dynamo-sglang` when exports include `sglang:` telemetry. **`DynamoVllmBackend.matches`** no longer claims those runs, so the **SGLang adapter** handles cache, HiCache, utilization, and token totals instead of Dynamo frontend counters (which can include warmup).
> 
> For that adapter pair, **`compute_server_metrics`** leaves **`gpu_total_tokens`** / **`kv_cache_pool_tokens`** as **`null`** and emits a warning that logical KV capacity is unsupported because TP-rank gauges can duplicate one pool. Plain **`sglang`** and other Dynamo paths are unchanged.
> 
> **Docs** (EN/ZH) describe this behavior. **Tests** parametrize SGLang normalization over `sglang` and `dynamo-sglang`, including the null capacity and warning expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3922dcfcca7103886f4b507a47f1ec3c2f72a6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->