### PR TITLE
chore: update Claude models and command templates / 更新 Claude 模型与命令模板

### DIFF
--- a/.claude/commands/add-model-hardware.md
+++ b/.claude/commands/add-model-hardware.md
@@ -159,7 +159,7 @@ values, `spec-decoding` set where intended. Ensure both yaml files keep a traili
 ## Step 7 — PR + label + monitor
 
 ```bash
-git add -A && git commit -m "<key>: <one-line>" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git add -A && git commit -m "<key>: <one-line>"
 git push -u origin feat/<model>-<sku>[-mtp]-dayzero
 gh pr create --repo SemiAnalysisAI/InferenceX --base main \
   --title "[Klaud Cold] <key>: day-zero <MODEL> <SKU> recipe" --body "<summary>"

--- a/.claude/commands/nuke.md
+++ b/.claude/commands/nuke.md
@@ -108,13 +108,12 @@ For each family, run strictly sequentially because git checkouts can't be parall
 
 ```bash
 git checkout main -q && git reset --hard origin/main -q
-branch="klaud-cold/<basekey>-<TAG>"
+branch="klaud/<basekey>-<TAG>"
 git checkout -b "$branch" -q
 python3 /tmp/edit_image.py <master.yaml> <NEW_IMAGE> <key> [<key>-mtp]
 python3 /tmp/append_changelog.py perf-changelog.yaml "<DESC>" <key> [<key>-mtp]
 git add -A
-git commit -q -m "[Klaud Cold] Update <basekey>[ (+mtp)] <PHRASE> to <TAG>" \
-  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git commit -q -m "[Klaud Cold] Update <basekey>[ (+mtp)] <PHRASE> to <TAG>"
 git push -u origin "$branch" -q --force-with-lease
 url=$(gh pr create --repo SemiAnalysisAI/InferenceX --base main --head "$branch" \
       --title "[Klaud Cold] Update <basekey>[ (+mtp)] <PHRASE> to <TAG>" \

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -69,7 +69,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__inferencemax-repos__*,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Write,Edit,Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |

--- a/.github/workflows/codeowner-signoff-verify.yml
+++ b/.github/workflows/codeowner-signoff-verify.yml
@@ -257,7 +257,7 @@ jobs:
             {"fastMode": true}
 
           claude_args: |
-            --model 'claude-fable-5'
+            --model 'claude-fable-5-1'
             --mcp-config '{"mcpServers": {"fetch": {"command": "npx", "args": ["-y", "@anthropic-ai/mcp-server-fetch@latest"]}, "inferencemax-repos": {"command": "python3", "args": ["${{ github.workspace }}/.claude/mcp/server.py"], "env": {"INFERENCEMAX_ROOT": "${{ github.workspace }}"}}}}'
             --allowedTools "Read,Glob,Grep,WebFetch,mcp__github__*,mcp__github_ci__*,mcp__fetch__*,mcp__inferencemax-repos__*,Bash"
           prompt: |

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -251,7 +251,7 @@ jobs:
                   settings: |
                       {"fastMode": true}
                   claude_args: |
-                      --model 'claude-fable-5'
+                      --model 'claude-fable-5-1'
                       --max-turns 8
                       --allowedTools "Read,Glob,Grep,Bash(git diff:*)"
                       --json-schema '{"type":"object","properties":{"criteria":{"type":"array","items":{"type":"string","enum":["multi-node","agentic","eval-only","fp4","mtp","eagle","eagle3","sglang","vllm","dynamo-sglang","dynamo-vllm","glm5","glm5.1","kimik2.5","kimik3","dsv4","minimaxm3","qwen3.5","dsr1","checklist-complete","patchwork"]},"uniqueItems":true},"reason":{"type":"string"}},"required":["criteria","reason"]}'


### PR DESCRIPTION
Update the four remaining Claude workflow model pins from `claude-fable-5` to `claude-fable-5-1`. Change the `nuke` command's branch template to `klaud/` and remove hard-coded `Co-Authored-By` trailers from `nuke` and `add-model-hardware`.

Validation: `git diff --check` and `actionlint -shellcheck= -pyflakes=` passed for all four changed workflows.

## 中文说明

将其余四个 Claude 工作流的模型配置从 `claude-fable-5` 更新为 `claude-fable-5-1`。将 `nuke` 命令的分支模板改为 `klaud/`，并删除 `nuke` 和 `add-model-hardware` 中硬编码的 `Co-Authored-By` 提交署名。

验证：`git diff --check` 通过，四个修改后的工作流均通过 `actionlint -shellcheck= -pyflakes=` 检查。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI model-pin changes only; no benchmark configs, auth, or runtime serving logic.
> 
> **Overview**
> Updates **four** GitHub Actions workflows that invoke Claude Code (`claude-pr-review`, `claude`, `codeowner-signoff-verify`, and the sweep priority classifier in `run-sweep`) so their `--model` pin moves from `claude-fable-5` to **`claude-fable-5-1`**.
> 
> Adjusts **Claude command docs** only: the `nuke` playbook now uses branch names `klaud/<basekey>-<TAG>` instead of `klaud-cold/…`, and both `nuke` and `add-model-hardware` drop the hard-coded **`Co-Authored-By`** lines from example `git commit` commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f23241c6933beba38eb6fdebd741c8c7f73c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->