### PR TITLE
Add MiniMax-M3 GB200 aggregate frontier / 添加 MiniMax-M3 GB200 聚合前沿

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic-nightly-native.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic-nightly-native.yaml
@@ -1,20 +1,28 @@
-name: "minimax-m3-vllm-agg-gb200-tp4-vllm-simple-agentic"
+name: "minimax-m3-vllm-agg-gb200-tp4-agentic-nightly-native"
 
 model:
   path: "minimax-m3-nvfp4"
-  container: "vllm/vllm-openai:v0.28.0"
+  container: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7"
   precision: "fp4"
 
 identity:
   model: { repo: "nvidia/MiniMax-M3-NVFP4" }
-  container: { image: "vllm/vllm-openai:v0.28.0" }
-  frameworks: { dynamo: "1.5.0.dev20260906" }
+  container: { image: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7" }
+  frameworks: { dynamo: "1.5.0.dev20260908" }
 
-dynamo: { version: "1.5.0.dev20260906", install: true }
+dynamo: { version: "1.5.0.dev20260908", install: true }
 environment: { ETCD_LEASE_TTL: "7200" }
+
 slurm: { time_limit: "12:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
-resources: { gpu_type: "gb200", gpus_per_node: 4, agg_nodes: 1, agg_workers: 1, gpus_per_agg: 4 }
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+
 infra: { etcd_nats_dedicated_node: false, nats_max_payload_mb: 32 }
 
 frontend:
@@ -22,11 +30,7 @@ frontend:
   enable_multiple_frontends: false
   env: { DYN_TCP_REQUEST_TIMEOUT: "60" }
   args:
-    dyn-chat-processor: "vllm"
     trust-remote-code: true
-    tool-call-parser: "minimax_m3"
-    reasoning-parser: "minimax_m3"
-    enable-auto-tool-choice: true
     router-mode: "kv"
     router-kv-events: true
     router-temperature: "0"
@@ -43,7 +47,6 @@ backend:
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
     VLLM_LOG_STATS_INTERVAL: "1"
-    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
     NCCL_CUMEM_ENABLE: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_NVLS_ENABLE: "1"
@@ -60,15 +63,14 @@ backend:
       enable-prefix-caching: true
       kv-cache-metrics: true
       attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8"}'
+      compilation-config: '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
       block-size: 128
       gpu-memory-utilization: 0.9
       max-model-len: 1048576
       language-model-only: true
       kv-cache-dtype: "fp8"
-      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
-      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":777389080576,"cpu_bytes_to_use_per_rank":194347270144,"lazy_offload":true}}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASHINFER"}'
       stream-interval: 20
-      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       max-cudagraph-capture-size: 512
       max-num-batched-tokens: 16384
       no-enable-flashinfer-autotune: true

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic.yaml
@@ -2,15 +2,15 @@ name: "minimax-m3-vllm-agg-gb200-tp4-agentic"
 
 model:
   path: "minimax-m3-nvfp4"
-  container: "vllm/vllm-openai:v0.27.1"
+  container: "vllm/vllm-openai:v0.28.0"
   precision: "fp4"
 
 identity:
   model: { repo: "nvidia/MiniMax-M3-NVFP4" }
-  container: { image: "vllm/vllm-openai:v0.27.1" }
-  frameworks: { dynamo: "1.3.1" }
+  container: { image: "vllm/vllm-openai:v0.28.0" }
+  frameworks: { dynamo: "1.5.0.dev20260906" }
 
-dynamo: { version: "1.3.1", install: true }
+dynamo: { version: "1.5.0.dev20260906", install: true }
 environment: { ETCD_LEASE_TTL: "7200" }
 
 slurm: { time_limit: "12:00:00" }
@@ -37,7 +37,6 @@ frontend:
     enable-auto-tool-choice: true
     router-mode: "kv"
     router-kv-events: true
-    router-reset-states: true
     router-temperature: "0"
     router-session-affinity-ttl-secs: 14400
     kv-cache-block-size: 128
@@ -67,7 +66,7 @@ backend:
       trust-remote-code: true
       enable-prefix-caching: true
       kv-cache-metrics: true
-      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8"}'
       compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       block-size: 128
       gpu-memory-utilization: 0.9

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic-nightly-native.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic-nightly-native.yaml
@@ -1,16 +1,16 @@
-name: "minimax-m3-vllm-agg-gb200-tp4-vllm-simple-agentic"
+name: "minimax-m3-vllm-agg-gb200-tp4-vllm-simple-agentic-nightly-native"
 
 model:
   path: "minimax-m3-nvfp4"
-  container: "vllm/vllm-openai:v0.28.0"
+  container: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7"
   precision: "fp4"
 
 identity:
   model: { repo: "nvidia/MiniMax-M3-NVFP4" }
-  container: { image: "vllm/vllm-openai:v0.28.0" }
-  frameworks: { dynamo: "1.5.0.dev20260906" }
+  container: { image: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7" }
+  frameworks: { dynamo: "1.5.0.dev20260908" }
 
-dynamo: { version: "1.5.0.dev20260906", install: true }
+dynamo: { version: "1.5.0.dev20260908", install: true }
 environment: { ETCD_LEASE_TTL: "7200" }
 slurm: { time_limit: "12:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
@@ -22,11 +22,7 @@ frontend:
   enable_multiple_frontends: false
   env: { DYN_TCP_REQUEST_TIMEOUT: "60" }
   args:
-    dyn-chat-processor: "vllm"
     trust-remote-code: true
-    tool-call-parser: "minimax_m3"
-    reasoning-parser: "minimax_m3"
-    enable-auto-tool-choice: true
     router-mode: "kv"
     router-kv-events: true
     router-temperature: "0"
@@ -65,10 +61,10 @@ backend:
       max-model-len: 1048576
       language-model-only: true
       kv-cache-dtype: "fp8"
-      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASHINFER"}'
       kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":777389080576,"cpu_bytes_to_use_per_rank":194347270144,"lazy_offload":true}}'
       stream-interval: 20
-      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      compilation-config: '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
       max-cudagraph-capture-size: 512
       max-num-batched-tokens: 16384
       no-enable-flashinfer-autotune: true

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp8-agentic-nightly-native.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp8-agentic-nightly-native.yaml
@@ -1,20 +1,28 @@
-name: "minimax-m3-vllm-agg-gb200-tp4-vllm-simple-agentic"
+name: "minimax-m3-vllm-agg-gb200-tp8-agentic-nightly-native"
 
 model:
   path: "minimax-m3-nvfp4"
-  container: "vllm/vllm-openai:v0.28.0"
+  container: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7"
   precision: "fp4"
 
 identity:
   model: { repo: "nvidia/MiniMax-M3-NVFP4" }
-  container: { image: "vllm/vllm-openai:v0.28.0" }
-  frameworks: { dynamo: "1.5.0.dev20260906" }
+  container: { image: "vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7" }
+  frameworks: { dynamo: "1.5.0.dev20260908" }
 
-dynamo: { version: "1.5.0.dev20260906", install: true }
+dynamo: { version: "1.5.0.dev20260908", install: true }
 environment: { ETCD_LEASE_TTL: "7200" }
+
 slurm: { time_limit: "12:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
-resources: { gpu_type: "gb200", gpus_per_node: 4, agg_nodes: 1, agg_workers: 1, gpus_per_agg: 4 }
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+  gpus_per_agg: 8
+
 infra: { etcd_nats_dedicated_node: false, nats_max_payload_mb: 32 }
 
 frontend:
@@ -22,11 +30,7 @@ frontend:
   enable_multiple_frontends: false
   env: { DYN_TCP_REQUEST_TIMEOUT: "60" }
   args:
-    dyn-chat-processor: "vllm"
     trust-remote-code: true
-    tool-call-parser: "minimax_m3"
-    reasoning-parser: "minimax_m3"
-    enable-auto-tool-choice: true
     router-mode: "kv"
     router-kv-events: true
     router-temperature: "0"
@@ -41,9 +45,8 @@ backend:
     VLLM_ENGINE_READY_TIMEOUT_S: "7200"
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
     VLLM_LOG_STATS_INTERVAL: "1"
-    VLLM_USE_SIMPLE_KV_OFFLOAD: "1"
     NCCL_CUMEM_ENABLE: "1"
     NCCL_MNNVL_ENABLE: "1"
     NCCL_NVLS_ENABLE: "1"
@@ -54,7 +57,7 @@ backend:
   vllm_config:
     aggregated:
       served-model-name: "nvidia/MiniMax-M3-NVFP4"
-      tensor-parallel-size: 4
+      tensor-parallel-size: 8
       pipeline-parallel-size: 1
       trust-remote-code: true
       enable-prefix-caching: true
@@ -65,10 +68,9 @@ backend:
       max-model-len: 1048576
       language-model-only: true
       kv-cache-dtype: "fp8"
-      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
-      kv-transfer-config: '{"kv_connector":"SimpleCPUOffloadConnector","kv_role":"kv_both","kv_connector_extra_config":{"cpu_bytes_to_use":777389080576,"cpu_bytes_to_use_per_rank":194347270144,"lazy_offload":true}}'
+      speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASHINFER"}'
       stream-interval: 20
-      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      compilation-config: '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
       max-cudagraph-capture-size: 512
       max-num-batched-tokens: 16384
       no-enable-flashinfer-autotune: true

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp8-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp8-agentic.yaml
@@ -1,16 +1,30 @@
-name: "minimax-m3-vllm-agg-gb200-dep8-agentic"
+name: "minimax-m3-vllm-agg-gb200-tp8-agentic"
 
-model: { path: "minimax-m3-nvfp4", container: "vllm/vllm-openai:v0.27.1", precision: "fp4" }
+model:
+  path: "minimax-m3-nvfp4"
+  container: "vllm/vllm-openai:v0.28.0"
+  precision: "fp4"
+
 identity:
   model: { repo: "nvidia/MiniMax-M3-NVFP4" }
-  container: { image: "vllm/vllm-openai:v0.27.1" }
-  frameworks: { dynamo: "1.3.1" }
-dynamo: { version: "1.3.1", install: true }
+  container: { image: "vllm/vllm-openai:v0.28.0" }
+  frameworks: { dynamo: "1.5.0.dev20260906" }
+
+dynamo: { version: "1.5.0.dev20260906", install: true }
 environment: { ETCD_LEASE_TTL: "7200" }
+
 slurm: { time_limit: "12:00:00" }
 health_check: { max_attempts: 2160, interval_seconds: 10 }
-resources: { gpu_type: "gb200", gpus_per_node: 4, agg_nodes: 2, agg_workers: 1, gpus_per_agg: 8 }
+
+resources:
+  gpu_type: "gb200"
+  gpus_per_node: 4
+  agg_nodes: 2
+  agg_workers: 1
+  gpus_per_agg: 8
+
 infra: { etcd_nats_dedicated_node: false, nats_max_payload_mb: 32 }
+
 frontend:
   type: dynamo
   enable_multiple_frontends: false
@@ -23,20 +37,19 @@ frontend:
     enable-auto-tool-choice: true
     router-mode: "kv"
     router-kv-events: true
-    router-reset-states: true
     router-temperature: "0"
     router-session-affinity-ttl-secs: 14400
     kv-cache-block-size: 128
+
 backend:
   type: vllm
   connector: null
-  dp_launch_mode: per_node
   kv_events_config: { aggregated: true }
   aggregated_environment:
     VLLM_ENGINE_READY_TIMEOUT_S: "7200"
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
     VLLM_FLOAT32_MATMUL_PRECISION: "high"
-    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "trtllm"
+    VLLM_FLASHINFER_ALLREDUCE_BACKEND: "mnnvl"
     VLLM_LOG_STATS_INTERVAL: "1"
     NCCL_CUMEM_ENABLE: "1"
     NCCL_MNNVL_ENABLE: "1"
@@ -48,31 +61,30 @@ backend:
   vllm_config:
     aggregated:
       served-model-name: "nvidia/MiniMax-M3-NVFP4"
-      tensor-parallel-size: 1
+      tensor-parallel-size: 8
       pipeline-parallel-size: 1
-      data-parallel-size: 8
-      data-parallel-rpc-port: 13345
-      enable-expert-parallel: true
       trust-remote-code: true
       enable-prefix-caching: true
       kv-cache-metrics: true
-      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8","minimax_m3_msa_decode_backend":"cutlass"}'
+      attention-config: '{"backend":"FLASHINFER","use_trtllm_attention":true,"indexer_kv_dtype":"fp8"}'
       block-size: 128
-      gpu-memory-utilization: 0.95
+      gpu-memory-utilization: 0.9
       max-model-len: 1048576
       language-model-only: true
       kv-cache-dtype: "fp8"
       speculative-config: '{"method":"eagle3","model":"Inferact/MiniMax-M3-EAGLE3-GQA","num_speculative_tokens":3,"attention_backend":"FLASH_ATTN"}'
-      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       stream-interval: 20
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       max-cudagraph-capture-size: 512
       max-num-batched-tokens: 16384
       no-enable-flashinfer-autotune: true
       reasoning-parser: "minimax_m3"
       dyn-tool-call-parser: "minimax_m3"
       dyn-reasoning-parser: "minimax_m3"
+
 sbatch_directives: { cpus-per-task: "144", mem: "0" }
 srun_options: { container-remap-root: "" }
+
 benchmark:
   type: custom
   command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7930,26 +7930,23 @@ minimaxm3-fp4-b200-trtllm-agentic-mtp:
       search-space:
       - { tp: 4, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [5, 10, 15, 20, 25, 30, 35, 40, 45] }
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: native }, conc-list: [1, 5] }
-# Retain the GB200 aggregate SimpleCPU-offload configuration at concurrency 20
-# and 30.
 minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
-  image: vllm/vllm-openai:v0.27.1
+  image: vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7
   model: nvidia/MiniMax-M3-NVFP4
   model-prefix: minimaxm3
   runner: cluster:gb200-nv
   precision: fp4
   framework: dynamo-vllm
-  router: { name: dynamo-router, version: "1.3.1" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260908" }
   multinode: true
   disagg: false
   scenarios:
     agentic-coding:
-    - dram-utilization: 0.61
+    - dram-utilization: 0.861904761904762
       search-space:
       - spec-decoding: mtp
-        kv-offloading: dram
-        kv-offload-backend: { name: vllm-simple }
-        conc-list: [20, 30]
+        kv-offloading: none
+        conc-list: [1, 10]
         num-nodes: 1
         worker:
           num-worker: 1
@@ -7957,7 +7954,34 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp:
           ep: 1
           dp-attn: false
           additional-settings:
-          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic.yaml"
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-agentic-nightly-native.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: vllm-simple }
+        conc-list: [15, 25, 30]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp4-vllm-simple-agentic-nightly-native.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [1]
+        num-nodes: 2
+        worker:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/vllm/minimax-m3/gb200-fp4/agentic/agg-tp8-agentic-nightly-native.yaml"
           - "SYNTHETIC_ACCEPTANCE=true"
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
 

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7029,4 +7029,4 @@
   description:
     - "Publish the GB200 aggregate MiniMax-M3 frontier on vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7 with Dynamo 1.5.0.dev20260908, using the native minimax_m3 parser on the worker."
     - "Replace the prior aggregate search space with TP4 resident (c1, c10), TP4 SimpleCPU-offload (c15, c25, c30), and two-node TP8 resident (c1) points."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2944

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7021,3 +7021,12 @@
     - "Refresh the full GB200 Dynamo-vLLM AgentX configuration across the configured aggregate and disaggregated topology points."
     - "Retain aggregate SimpleCPU-offload concurrency 20 and 30, and configure Mooncake host KV storage, NIXL over UCX, explicit thinking mode, and the committed MiniMax-M3 EAGLE3-GQA acceptance target."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2807
+
+- config-keys:
+    - minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Publish the GB200 aggregate MiniMax-M3 frontier on vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7 with Dynamo 1.5.0.dev20260908, using the native minimax_m3 parser on the worker."
+    - "Replace the prior aggregate search space with TP4 resident (c1, c10), TP4 SimpleCPU-offload (c15, c25, c30), and two-node TP8 resident (c1) points."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX


### PR DESCRIPTION
## Description / 描述
- Update `minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp`: image `vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7`.
- 更新 `minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp`：镜像 `vllm/vllm-openai:nightly-9ea8f3ffc354901b740f0b31988900897b7221d7`。

## Type of Change / 变更类型
- [x] Configuration change / 配置变更

## Checklist / 检查清单
- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries
- [ ] Before merging via reuse, an authorized maintainer has commented `/reuse-sweep-run` on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and Slurm recipe configuration only; changes which cluster jobs run and reported perf baselines, not production service code.
> 
> **Overview**
> Publishes a new **GB200 aggregate MiniMax-M3 agentic frontier** on `minimaxm3-fp4-gb200-dynamo-vllm-agentic-agg-mtp`, pointing the master config at **vLLM nightly** (`nightly-9ea8f3ffc354901b740f0b31988900897b7221d7`) and **Dynamo 1.5.0.dev20260908**, with higher **dram-utilization** (~0.86) and a revised **agentic-coding search space**: TP4 resident (c1, c10), TP4 **SimpleCPU** offload (c15, c25, c30), and **two-node TP8** resident (c1), each wired to new **`*-nightly-native`** Slurm recipes plus **synthetic acceptance** env overrides.
> 
> Adds three nightly-native recipes (TP4 agentic, TP4 vLLM-simple offload, TP8 agentic) that lean on **worker-side** `minimax_m3` parsers, **FLASHINFER** speculative attention, and **`FULL_AND_PIECEWISE`** CUDA graphs where applicable; TP8 nightly uses **`mnnvl`** FlashInfer allreduce.
> 
> Updates the stable agentic recipes to **v0.28.0** / Dynamo **1.5.0.dev20260906**, drops **`router-reset-states`** and the Cutlass MSA decode override in attention config, enlarges SimpleCPU offload pools with **`lazy_offload: true`**, and renames/repurposes **`agg-tp8-agentic`** from **DP8** (`dep8`) to true **tensor-parallel 8** (removes per-node DP launch and data-parallel sizing). Documents the change in **`perf-changelog.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e75355fa90f399c38a059e2354af2a6eedc196b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->