### PR TITLE
refactor: share eval artifact selection rules / 共享评测工件选择规则

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,6 +220,8 @@ Test builders with small, independently worked examples and read-only inputs. Fo
 
 For eval-only jobs, throughput output is not required. The workflow instead requires at least one `results*.json`. For jobs marked to run eval, uploads may contain `meta_env.json`, `results*.json`, `sample*.jsonl`, SWE-bench predictions and reports, and trajectory files. [`utils/evals/validate_scores.py`](../utils/evals/validate_scores.py) checks produced eval scores.
 
+[`infx.results.evals`](../infx/results/evals.py) shares format-marker recognition, staged concurrency suffix parsing, and result recency ordering between the eval collector and reusable-artifact validator. Filename timestamps and legacy file mtimes use epoch nanoseconds, with filenames breaking ties. Each caller retains its own file discovery, metric validation, diagnostics, and artifact writes; recognizing a format does not imply that its results are valid or reusable.
+
 Agentic throughput jobs have a different contract. They validate AIPerf output with [`utils/agentic/validation/validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py), upload an aggregate `bmk_agentic_<suffix>` artifact, and upload the raw `agentic_<suffix>` sibling containing trace-replay material. InferenceX-app pairs those siblings by their shared suffix. Agentic eval-only jobs follow the eval output contract instead and do not require a throughput result.
 
 Server logs and GPU metrics are diagnostic side artifacts. They are uploaded with `always()` so a failed run can still be investigated. Their presence does not turn a failed benchmark into a valid result.

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -220,6 +220,8 @@ result = build_result(raw_benchmark, runtime_env)
 
 对于仅评测作业，不要求吞吐量输出。工作流改为要求至少存在一个 `results*.json`。对于标记为运行评测的作业，上传内容可能包含 `meta_env.json`、`results*.json`、`sample*.jsonl`、SWE-bench 预测和报告以及轨迹文件。[`utils/evals/validate_scores.py`](../utils/evals/validate_scores.py) 会检查生成的评测分数。
 
+[`infx.results.evals`](../infx/results/evals.py) 为评测收集器和可复用工件验证器共享格式标记识别、暂存文件的并发数后缀解析，以及结果时间排序逻辑。文件名中的时间戳和旧格式文件的修改时间统一转换为 Unix 纪元纳秒数，时间相同时按文件名排序。各调用方保留自己的文件查找、指标验证、诊断和工件写入逻辑；识别出格式并不意味着结果有效或可复用。
+
 智能体吞吐量作业采用不同的契约。它们使用 [`utils/agentic/validation/validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py) 验证 AIPerf 输出，上传聚合的 `bmk_agentic_<suffix>` 工件，并上传包含追踪重放材料的原始 `agentic_<suffix>` 同级工件。InferenceX-app 通过它们共享的后缀对这些同级工件进行配对。智能体仅评测作业改为遵循评测输出契约，不要求吞吐量结果。
 
 服务器日志和 GPU 指标是诊断辅助工件。它们通过 `always()` 上传，因此失败的运行仍可供调查。它们的存在不会将失败的基准测试转变为有效结果。

--- a/infx/results/__init__.py
+++ b/infx/results/__init__.py
@@ -1,5 +1,5 @@
 """Composable result builders and shared transformations.
 
-Processors own their input formats and policies. Shared helpers take explicit
-values and return dictionaries; CLI adapters own environment and artifact I/O.
+Processors own their input formats and policies. CLI adapters own environment
+defaults, file discovery, and artifact writes.
 """

--- a/infx/results/evals.py
+++ b/infx/results/evals.py
@@ -1,0 +1,49 @@
+"""Format recognition and ordering shared by offline eval artifact readers."""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+EVAL_RESULT_FORMAT = "inferencex-eval-v1"
+_CONC_SUFFIX_RE = re.compile(r"_conc(\d+)(?:_\d+)?\.json$")
+_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?")
+
+
+def is_eval_result(data: object) -> bool:
+    """Recognize an eval format marker without validating its metrics."""
+    return isinstance(data, dict) and (
+        "lm_eval_version" in data
+        or data.get("result_format") == EVAL_RESULT_FORMAT
+    )
+
+
+def result_concurrency(name: str) -> int | None:
+    """Read a trailing ``_concN`` with an optional numeric staging suffix."""
+    match = _CONC_SUFFIX_RE.search(name)
+    return int(match.group(1)) if match else None
+
+
+def result_order(path: Path) -> tuple[int, str]:
+    """Order by filename time or legacy mtime, then name to break ties.
+
+    Both timestamps use UTC epoch nanoseconds. Invalid filename dates fall
+    back to mtime, and subnanosecond digits are truncated.
+    """
+    match = _TIMESTAMP_RE.search(path.name)
+    if match:
+        try:
+            base, separator, fraction = match.group(0).partition(".")
+            parsed = datetime.strptime(base, "%Y-%m-%dT%H-%M-%S").replace(
+                tzinfo=timezone.utc
+            )
+            delta = parsed - datetime(1970, 1, 1, tzinfo=timezone.utc)
+            fractional_ns = int((fraction + "000000000")[:9]) if separator else 0
+            return (
+                delta.days * 86_400_000_000_000
+                + delta.seconds * 1_000_000_000
+                + fractional_ns,
+                path.name,
+            )
+        except ValueError:
+            pass
+    return path.stat().st_mtime_ns, path.name

--- a/infx/results/evals.py
+++ b/infx/results/evals.py
@@ -1,5 +1,7 @@
 """Format recognition and ordering shared by offline eval artifact readers."""
 
+from __future__ import annotations
+
 import re
 from datetime import datetime, timezone
 from pathlib import Path

--- a/utils/collect_eval_results.py
+++ b/utils/collect_eval_results.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 import json
 import math
-import re
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from tabulate import tabulate
+
+if not __package__:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from infx.results.evals import EVAL_RESULT_FORMAT, is_eval_result, result_order
+from infx.results.evals import result_concurrency as _result_concurrency
 
 MODEL = "Model"
 HARDWARE = "Hardware"
@@ -33,9 +37,6 @@ EM_STRICT = "EM Strict"
 EM_FLEXIBLE = "EM Flexible"
 N_EFF = "N (eff)"
 SPEC_DECODING = "Spec Decode"
-
-CONC_SUFFIX_RE = re.compile(r"_conc(\d+)(?:_\d+)?\.json$")
-EVAL_RESULT_FORMAT = "inferencex-eval-v1"
 
 
 def load_json(path: Path) -> Optional[Dict[str, Any]]:
@@ -70,8 +71,7 @@ def find_eval_sets(root: Path) -> List[Path]:
 
 def result_concurrency(path: Path) -> Optional[int]:
     """Extract a batched eval concurrency from a staged result filename."""
-    match = CONC_SUFFIX_RE.search(path.name)
-    return int(match.group(1)) if match else None
+    return _result_concurrency(path.name)
 
 
 def detect_lm_eval_jsons(d: Path, batched: bool = False) -> List[Path]:
@@ -86,45 +86,15 @@ def detect_lm_eval_jsons(d: Path, batched: bool = False) -> List[Path]:
     )
     lm_paths = []
 
-    def recency_key(path: Path) -> Tuple[int, str]:
-        match = re.search(
-            r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?",
-            path.name,
-        )
-        if match:
-            try:
-                timestamp = match.group(0)
-                base, separator, fraction = timestamp.partition(".")
-                parsed = datetime.strptime(
-                    base,
-                    "%Y-%m-%dT%H-%M-%S",
-                ).replace(tzinfo=timezone.utc)
-                fractional_ns = (
-                    int((fraction + "000000000")[:9])
-                    if separator
-                    else 0
-                )
-                order_ns = (
-                    int(parsed.timestamp()) * 1_000_000_000
-                    + fractional_ns
-                )
-            except ValueError:
-                order_ns = path.stat().st_mtime_ns
-        else:
-            order_ns = path.stat().st_mtime_ns
-        return order_ns, path.name
-
     for p in immediate_jsons:
         data = load_json(p)
-        if not isinstance(data, dict):
-            continue
-        if data.get('result_format') == EVAL_RESULT_FORMAT or 'lm_eval_version' in data:
+        if is_eval_result(data):
             lm_paths.append(p)
 
     if not lm_paths:
         return []
     if not batched:
-        return [max(lm_paths, key=recency_key)]
+        return [max(lm_paths, key=result_order)]
 
     latest_by_conc: Dict[int, Path] = {}
     for path in lm_paths:
@@ -132,7 +102,7 @@ def detect_lm_eval_jsons(d: Path, batched: bool = False) -> List[Path]:
         if conc is None:
             continue
         current = latest_by_conc.get(conc)
-        if current is None or recency_key(path) > recency_key(current):
+        if current is None or result_order(path) > result_order(current):
             latest_by_conc[conc] = path
     return [latest_by_conc[conc] for conc in sorted(latest_by_conc)]
 

--- a/utils/test_collect_eval_results.py
+++ b/utils/test_collect_eval_results.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -10,9 +12,47 @@ from collect_eval_results import (
     EVAL_RESULT_FORMAT,
     build_row,
     collect_eval_rows,
+    detect_lm_eval_jsons,
+    result_concurrency,
 )
 from evals.kimi_vendor_eval import RESULT_FORMAT as KIMI_VENDOR_RESULT_FORMAT
 from evals.minimax_provider_eval import RESULT_FORMAT as MINIMAX_RESULT_FORMAT
+
+
+@pytest.mark.parametrize("payload,recognized", [
+    ({"lm_eval_version": "0.4.0"}, True),
+    ({"lm_eval_version": None}, True),
+    ({"result_format": "inferencex-eval-v1"}, True),
+    ({"result_format": "foreign", "lm_eval_version": False}, True),
+    ({"result_format": "foreign"}, False),
+    ({"result_format": ["inferencex-eval-v1"]}, False),
+    ({"results": {}}, False), (None, False), ([], False),
+])
+def test_result_readers_recognize_format_markers(
+    tmp_path: Path, payload: object, recognized: bool,
+) -> None:
+    from validate_reusable_sweep_artifacts import _recognized_eval_result_paths
+
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(payload))
+    expected = [path] if recognized else []
+    assert detect_lm_eval_jsons(tmp_path) == expected
+    assert _recognized_eval_result_paths([path]) == expected
+
+
+@pytest.mark.parametrize("name,expected", [
+    ("results_conc16.json", 16), ("results_conc16_2.json", 16),
+    ("results_conc0004.json", 4), ("results_conc0.json", 0),
+    ("results_conc4_conc16_2.json", 16),
+    ("results_conc-4.json", None), ("results_conc4_extra.json", None),
+    ("results_conc4.json.bak", None), ("results_conc4_2_3.json", None),
+    ("results.json", None),
+])
+def test_result_readers_parse_concurrency_suffixes(name: str, expected: int | None) -> None:
+    from validate_reusable_sweep_artifacts import _result_concurrency
+
+    assert result_concurrency(Path(name)) == expected
+    assert _result_concurrency(name) == expected
 
 
 def test_build_row_preserves_sequence_lengths() -> None:
@@ -64,6 +104,43 @@ def _write_lm_eval_result(
         },
         "n-samples": {task: {"effective": 10}},
     }))
+
+
+def test_collector_discovers_custom_names_but_not_metadata_or_nested_files(
+    tmp_path: Path,
+) -> None:
+    custom = tmp_path / "custom.json"
+    _write_lm_eval_result(custom, 0.75)
+    _write_lm_eval_result(tmp_path / "meta_env.json", 0.25)
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write_lm_eval_result(nested / "results.json", 0.5)
+    assert detect_lm_eval_jsons(tmp_path) == [custom]
+
+
+def test_collector_cli_runs_outside_checkout(tmp_path: Path) -> None:
+    artifact = tmp_path / "eval_input"
+    artifact.mkdir()
+    (artifact / "meta_env.json").write_text('{"conc": 4}')
+    result = artifact / "custom.json"
+    _write_lm_eval_result(result, 0.75)
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+
+    completed = subprocess.run(
+        [sys.executable, str(Path(__file__).with_name("collect_eval_results.py")),
+         str(artifact), "test"],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stderr == ""
+    assert "### Single-Node Eval Results" in completed.stdout
+    rows = json.loads((tmp_path / "agg_eval_test.json").read_text())
+    assert len(rows) == 1
+    assert rows[0]["score"] == 0.75
+    assert rows[0]["conc"] == 4
+    assert rows[0]["source"] == str(result)
 
 
 def test_collect_eval_rows_expands_batched_concurrencies(

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -2,20 +2,54 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from validate_reusable_sweep_artifacts import (
+    _result_order,
     agentic_key,
     benchmark_key,
     dedupe_reran_evals,
     eval_key,
     eval_result_key,
-    main,
     validate_agentic_artifacts,
     validate_eval_artifacts,
     validate_fixed_artifacts,
 )
+
+
+@pytest.mark.parametrize("name,expected_ns", [
+    ("results_1970-01-01T00-00-00.json", 0),
+    ("results_1970-01-01T00-00-01.000000009.json", 1_000_000_009),
+    ("results_1970-01-01T00-00-00.1234567899_conc4_2.json", 123_456_789),
+    ("results_1969-12-31T23-59-59.75.json", -250_000_000),
+    ("results_1970-01-02T00-00-00.json", 86_400_000_000_000),
+    ("results_2026-99-99T99-99-99.json", 9_000_000_000),
+    ("results_legacy.json", 9_000_000_000),
+])
+def test_result_order_preserves_nanoseconds_and_legacy_fallback(
+    tmp_path: Path, name: str, expected_ns: int,
+) -> None:
+    path = tmp_path / name
+    path.write_text("{}")
+    os.utime(path, ns=(9_000_000_000, 9_000_000_000))
+    assert _result_order(path) == (expected_ns, name)
+
+
+def test_result_order_breaks_equal_recency_by_filename(tmp_path: Path) -> None:
+    from collect_eval_results import detect_lm_eval_jsons
+
+    early = tmp_path / "results_a_1970-01-01T00-00-01.1.json"
+    late = tmp_path / "results_z_1970-01-01T00-00-01.100000000.json"
+    for path in (late, early):
+        path.write_text('{"lm_eval_version":"0.4.0"}')
+    os.utime(early, ns=(9_000_000_000, 9_000_000_000))
+    os.utime(late, ns=(1_000_000_000, 1_000_000_000))
+    assert _result_order(early) < _result_order(late)
+    assert detect_lm_eval_jsons(tmp_path) == [late]
 
 
 def write_eval_aggregate(
@@ -816,23 +850,27 @@ def test_agentic_validation_handles_mapping_kv_offload_backend(
     assert "agentic point artifacts contain 1 duplicate row(s)" in errors
 
 
-def test_eval_only_main_does_not_require_benchmark_artifacts(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
+def test_eval_only_cli_runs_outside_checkout_without_benchmark_artifacts(tmp_path: Path) -> None:
     write_eval_aggregate(tmp_path, [single_eval_result(32)])
     write_raw_eval_artifact(tmp_path, 32)
-    monkeypatch.setattr(
-        sys,
-        "argv",
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    completed = subprocess.run(
         [
-            "validate_reusable_sweep_artifacts.py",
+            sys.executable,
+            str(Path(__file__).with_name("validate_reusable_sweep_artifacts.py")),
             "--artifacts-dir",
             str(tmp_path),
         ],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=10,
     )
 
-    assert main() == 0
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stderr == ""
+    assert completed.stdout == (
+        "Reusable sweep artifacts validated: "
+        "0 fixed-sequence row(s), 0 agentic row(s), 1 eval row(s).\n"
+    )
 
 
 # ── dedupe_reran_evals ────────────────────────────────────────────────────────

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -10,9 +10,15 @@ import re
 import shutil
 import sys
 from collections import Counter
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
+
+if not __package__:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from infx.results.evals import is_eval_result
+from infx.results.evals import result_concurrency as _result_concurrency
+from infx.results.evals import result_order as _result_order
 
 
 def as_bool(value: Any) -> bool:
@@ -638,63 +644,6 @@ def validate_run_stats(artifacts_dir: Path, required: bool) -> list[str]:
 # with no result file are left in place for validation to reject. Eval-only;
 # fixed-sequence and agentic artifacts are untouched.
 
-# lm-eval result files are ``results_<ISO>.json`` (optionally a ``_concN`` /
-# staging suffix). Timestamped names and legacy mtimes are both converted to
-# epoch nanoseconds so mixed naming schemes have one coherent ordering.
-_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d+)?")
-_EVAL_RESULT_FORMAT = "inferencex-eval-v1"
-
-# Batched result files carry their concurrency as a ``_concN`` suffix (kept in
-# sync with ``collect_eval_results.CONC_SUFFIX_RE``).
-_CONC_SUFFIX_RE = re.compile(r"_conc(\d+)(?:_\d+)?\.json$")
-
-
-def _result_concurrency(name: str) -> Optional[int]:
-    """Extract a batched eval concurrency from a staged result file name."""
-    match = _CONC_SUFFIX_RE.search(name)
-    return int(match.group(1)) if match else None
-
-
-def _result_timestamp(name: str) -> Optional[str]:
-    """Extract the sortable lm-eval timestamp from a result file name."""
-    match = _TIMESTAMP_RE.search(name)
-    return match.group(0) if match else None
-
-
-def _timestamp_ns(stamp: str) -> int:
-    """Convert an lm-eval filename timestamp to UTC epoch nanoseconds."""
-    date, clock = stamp.split("T", 1)
-    hms, separator, fraction = clock.partition(".")
-    parsed = datetime.strptime(
-        f"{date}T{hms}",
-        "%Y-%m-%dT%H-%M-%S",
-    ).replace(tzinfo=timezone.utc)
-    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
-    delta = parsed - epoch
-    fractional_ns = (
-        int((fraction + "000000000")[:9]) if separator else 0
-    )
-    return (
-        delta.days * 86_400_000_000_000
-        + delta.seconds * 1_000_000_000
-        + fractional_ns
-    )
-
-
-def _result_order(path: Path) -> tuple[int, str]:
-    """Return one deterministic recency key for timestamped and legacy files."""
-    stamp = _result_timestamp(path.name)
-    try:
-        recency = (
-            _timestamp_ns(stamp)
-            if stamp is not None
-            else path.stat().st_mtime_ns
-        )
-    except ValueError:
-        recency = path.stat().st_mtime_ns
-    return recency, path.name
-
-
 def _recognized_eval_result_paths(paths: Iterable[Path]) -> list[Path]:
     """Return result JSONs carrying a collector-recognized eval marker."""
     recognized: list[Path] = []
@@ -703,10 +652,7 @@ def _recognized_eval_result_paths(paths: Iterable[Path]) -> list[Path]:
             data = load_json(path)
         except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
-        if isinstance(data, dict) and (
-            "lm_eval_version" in data
-            or data.get("result_format") == _EVAL_RESULT_FORMAT
-        ):
+        if is_eval_result(data):
             recognized.append(path)
     return recognized
 
@@ -721,10 +667,7 @@ def _raw_result_error(path: Path) -> Optional[str]:
         return "is not an object"
     if "integration_error" in data:
         return "reports an integration error"
-    if (
-        "lm_eval_version" not in data
-        and data.get("result_format") != _EVAL_RESULT_FORMAT
-    ):
+    if not is_eval_result(data):
         return "has no recognized eval result format"
 
     results = data.get("results")


### PR DESCRIPTION
## English

The eval collector and reusable-artifact validator independently recognize result formats, parse staged concurrency suffixes, and order reruns. Share those rules in `infx.results.evals` so a filename or format change has one implementation to update.

Both existing commands import the shared helpers and continue working from outside the checkout. File discovery, strict versus tolerant validation, metric interpretation, diagnostics, and artifact writes stay with their existing owners. Recognized failures still prevent stale successful results from winning. No recipe, benchmark, dependency, or CLI contract changes.

This is the first PR in the eval-processing extraction series. It removes 36 net production lines; tests add 115 net lines, with independently specified expected results and real CLI coverage. Metric normalization and row construction remain a separate follow-up. The container-side `utils/evals/validate_scores.py` keeps its existing implementation; this PR consolidates the two offline readers.

Validation:
- All 90 targeted regression tests pass against both the original implementation and this branch (0.25s / 0.27s locally).
- 360 filename combinations match for concurrency parsing and nanosecond ordering, including pre-epoch dates, fractional precision, invalid dates, legacy mtimes, and staging suffixes.
- 37 before/after CLI comparisons match exit status, stdout, stderr, and complete artifact bytes/directory trees, including real deduplication and pruning, malformed/foreign results, failed reruns, overlapping batches, and usage errors.
- The exact validator, reuse, and gating CI test command passes: 563 tests in 5.08s.

## 中文

评测收集器和可复用工件验证器原先分别实现结果格式识别、暂存文件并发数后缀解析及重跑结果排序。本 PR 将这些共同规则提取到 `infx.results.evals`，以后调整文件命名或格式识别时只需修改一处实现。

两个现有命令直接导入共享函数，并继续支持从检出目录之外运行。文件查找、严格验证与容错处理、指标解释、诊断输出和工件写入仍由原来的调用方负责。较新的失败结果仍会阻止较旧的成功结果胜出。不改变配方、基准测试、依赖或 CLI 契约。

这是评测结果处理提取系列的第一个 PR。生产代码净减少 36 行；测试净增加 115 行，使用独立确定的预期值并覆盖真实 CLI。指标归一化和结果行构建留待后续 PR。在容器内运行的 `utils/evals/validate_scores.py` 保留现有实现；本 PR 只统一两个离线读取器的共同规则。

验证：
- 90 项针对性回归测试在原始实现和本分支上均通过，本地分别耗时 0.25 秒和 0.27 秒。
- 360 种文件名组合的并发数解析和纳秒排序结果一致，涵盖纪元前日期、小数精度、无效日期、旧格式修改时间及暂存后缀。
- 37 次修改前后的 CLI 对比中，退出状态、标准输出、标准错误、全部工件字节及目录结构完全一致，涵盖真实去重与裁剪、格式损坏或不受支持的结果、失败重跑、重叠批次和参数错误。
- 完整执行 CI 中验证器、复用和门控测试的原始命令：563 项测试通过，耗时 5.08 秒。
