### PR TITLE
[Klaud Cold] Update dsr1-fp4-b300-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp4-b300-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1033,7 +1033,7 @@ dsv4-fp4-b200-vllm-mtp:
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4
 # B200 SGLang recipe as-is until B300-specific tuning is available.
 dsr1-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
   runner: b300


### PR DESCRIPTION
Refresh the `dsr1-fp4-b300-sglang` single-node SGLang image from `lmsysorg/sglang:v0.5.12-cu130` to `lmsysorg/sglang:v0.5.19-cu130` (digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, SGLang commit [`0bcd822`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1) = tag [`v0.5.19`](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)). Model, precision, topology, workloads and `benchmarks/single_node/fixed_seq_len/dsr1_fp4_b300.sh` are unchanged.

## Baseline

- **Published date:** 2026-05-22 (public API `workflow-info?date=2026-05-22` and `benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`, filtered to hardware `b300`, framework `sglang`, precision `fp4`, spec `none`, non-disagg, ISL/OSL 8192/1024).
- **Old image:** `lmsysorg/sglang:v0.5.12-cu130` (SGLang commit [`127b9e3`](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624) = tag `v0.5.12`, CUDA 13.0.1, FlashInfer 0.6.11.post1).
- **Workload / topology:** `nvidia/DeepSeek-R1-0528-FP4-V2`, fixed-seq-len 8k/1k single turn, TP4/EP4 conc 1–128 and TP8/EP8 conc 1–16 (13 points), runner `b300` (cluster `b300-dsxe`), evals gsm8k at TP4 conc 64/128.
- **Producer run:** all 13 points and both evals come from [run 26306422380 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1), head SHA `6a4fe2a1272bcd6c9df8ea6539f593088ba90437` ([#1534](https://github.com/SemiAnalysisAI/InferenceX/pull/1534)). Note: that sweep's overall conclusion is recorded as `failure` (it covered six DSR1 SGLang configs); the 13 dsr1-fp4-b300-sglang points were ingested and are the currently published curve. Logical curve snapshot id 1943 is not the producer.

| TP/EP | conc | tput/GPU (tok/s) | output tput/GPU | median TTFT (s) | median TPOT (s) | median E2EL (s) |
|---|---|---|---|---|---|---|
| TP4/EP4 | 1 | 355.6 | 39.7 | 0.190 | 0.0061 | 5.72 |
| TP4/EP4 | 2 | 605.0 | 67.9 | 0.242 | 0.0071 | 6.91 |
| TP4/EP4 | 4 | 1045.5 | 116.3 | 0.228 | 0.0082 | 7.67 |
| TP4/EP4 | 8 | 1651.0 | 185.6 | 0.253 | 0.0103 | 9.82 |
| TP4/EP4 | 16 | 2400.5 | 266.0 | 0.492 | 0.0142 | 13.33 |
| TP4/EP4 | 32 | 3321.2 | 371.4 | 0.734 | 0.0204 | 19.48 |
| TP4/EP4 | 64 | 4495.5 | 498.7 | 1.057 | 0.0306 | 29.21 |
| TP4/EP4 | 128 | 5661.9 | 627.1 | 1.560 | 0.0488 | 46.37 |
| TP8/EP8 | 1 | 186.5 | 20.8 | 0.132 | 0.0059 | 5.45 |
| TP8/EP8 | 2 | 329.9 | 37.0 | 0.165 | 0.0065 | 6.34 |
| TP8/EP8 | 4 | 580.7 | 64.6 | 0.182 | 0.0074 | 6.89 |
| TP8/EP8 | 8 | 968.2 | 108.8 | 0.195 | 0.0088 | 8.30 |
| TP8/EP8 | 16 | 1497.8 | 166.0 | 0.384 | 0.0113 | 10.69 |

Published evals (gsm8k, `evaluations?date=2026-05-22`, same producer run; the API labels these rows `disagg: true` although the recipe is aggregated single-node):

| TP/EP | conc | gsm8k em_strict | gsm8k em_flexible |
|---|---|---|---|
| TP4/EP4 | 64 | 0.9575 | 0.9575 |
| TP4/EP4 | 128 | 0.9545 | 0.9560 |

---

将 `dsr1-fp4-b300-sglang` 单节点 SGLang 镜像从 `lmsysorg/sglang:v0.5.12-cu130` 更新至 `lmsysorg/sglang:v0.5.19-cu130`（摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，SGLang 提交 [`0bcd822`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1) 即标签 [`v0.5.19`](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)）。模型、精度、拓扑、工作负载以及 `benchmarks/single_node/fixed_seq_len/dsr1_fp4_b300.sh` 均保持不变。

## 基线

- **发布日期：** 2026-05-22（公共 API `workflow-info?date=2026-05-22` 与 `benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`，按硬件 `b300`、框架 `sglang`、精度 `fp4`、无投机解码、非分离式、ISL/OSL 8192/1024 过滤）。
- **旧镜像：** `lmsysorg/sglang:v0.5.12-cu130`（SGLang 提交 [`127b9e3`](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624) 即标签 `v0.5.12`，CUDA 13.0.1，FlashInfer 0.6.11.post1）。
- **工作负载 / 拓扑：** `nvidia/DeepSeek-R1-0528-FP4-V2`，fixed-seq-len 8k/1k 单轮，TP4/EP4 并发 1–128 与 TP8/EP8 并发 1–16（共 13 个点），runner `b300`（集群 `b300-dsxe`），评测为 TP4 并发 64/128 的 gsm8k。
- **生产运行：** 全部 13 个点与两项评测均来自 [run 26306422380 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1)，head SHA `6a4fe2a1272bcd6c9df8ea6539f593088ba90437`（[#1534](https://github.com/SemiAnalysisAI/InferenceX/pull/1534)）。说明：该 sweep 的整体结论记录为 `failure`（涵盖六个 DSR1 SGLang 配置），但这 13 个 dsr1-fp4-b300-sglang 点已被摄入并构成当前发布曲线。逻辑曲线快照 id 1943 并非生产运行。

基准数值见上方英文表格（吞吐 tok/s/GPU、输出吞吐、中位 TTFT/TPOT/E2EL）。

已发布评测（gsm8k，`evaluations?date=2026-05-22`，同一生产运行；API 将这些行标记为 `disagg: true`，但该配方实际为聚合式单节点）：TP4/EP4 并发 64 em_strict 0.9575 / em_flexible 0.9575；并发 128 em_strict 0.9545 / em_flexible 0.9560。
