### PR TITLE
[Klaud Cold] Update minimaxm3-fp8-h200-vllm-agentic-mtp vLLM image to v0.29.0 (digest-pinned) / 将 minimaxm3-fp8-h200-vllm-agentic-mtp 的 vLLM 镜像更新至 v0.29.0（按摘要固定）

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -7649,7 +7649,7 @@ minimaxm3-fp8-h100-vllm-agentic-mtp:
       - { tp: 8, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, conc-list: [6, 8] }
 
 minimaxm3-fp8-h200-vllm-agentic-mtp:
-  image: vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36
+  image: vllm/vllm-openai:v0.29.0@sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1
   model: MiniMaxAI/MiniMax-M3-MXFP8
   model-prefix: minimaxm3
   runner: cluster:h200-dgxc

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7021,3 +7021,9 @@
     - "Refresh the full GB200 Dynamo-vLLM AgentX configuration across the configured aggregate and disaggregated topology points."
     - "Retain aggregate SimpleCPU-offload concurrency 20 and 30, and configure Mooncake host KV storage, NIXL over UCX, explicit thinking mode, and the committed MiniMax-M3 EAGLE3-GQA acceptance target."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2807
+
+- config-keys:
+    - minimaxm3-fp8-h200-vllm-agentic-mtp
+  description:
+    - "Update vLLM image from vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36 (2026-09-07 upstream nightly, tag commit vllm-project/vllm@d9105ea8) to vllm/vllm-openai:v0.29.0 pinned by manifest digest sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1 (vLLM release v0.29.0, tag commit vllm-project/vllm@98dff2a8, Docker Hub tag pushed 2026-09-09T06:06Z, CUDA 13.0 build). benchmarks/single_node/agentic/minimaxm3_fp8_h200_mtp.sh is unchanged: TRITON_ATTN attention, fp8 KV, EAGLE3 with the Inferact MiniMax-M3 EAGLE3-GQA draft and the committed golden synthetic acceptance length 2.78, Mooncake 0.3.11.post1 DRAM offload on the host-tier arm; the resident TP8 c1/c2/c4/c6/c8/c10 and Mooncake DRAM offload c12/c14 grid is unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2953


### PR DESCRIPTION
Refresh `minimaxm3-fp8-h200-vllm-agentic-mtp` from the 2026-09-07 upstream nightly `vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36` to the vLLM release `vllm/vllm-openai:v0.29.0`, pinned by manifest digest `sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1`. Only the master image string changes; `benchmarks/single_node/agentic/minimaxm3_fp8_h200_mtp.sh`, the TP8 EAGLE3 topology, the Mooncake DRAM-offload arm and the c1-c14 grid are unchanged.

## Baseline (published 2026-09-08)

- Old image: `vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36` (vLLM main commit [`d9105ea8`](https://github.com/vllm-project/vllm/commit/d9105ea8001e0a6d77a96327d17515bb5791fb36), 2026-09-07; Docker Hub digest `sha256:254eebf919e8b7b0d530d97fccc606c36f380ff6724d64bc190951bec1aee838`). Identity verified on all 8 rows: model MiniMax-M3 (`MiniMaxAI/MiniMax-M3-MXFP8`), hardware h200, framework vllm, precision fp8, spec_method mtp (EAGLE3 draft `Inferact/MiniMax-M3-EAGLE3-GQA`, 3 speculative tokens, golden synthetic AL 2.78), disagg false, benchmark_type agentic_traces, TP8 on `cluster:h200-dgxc`, 1-hour AgentX coding-trace replay.
- New image source: vLLM tag [`v0.29.0`](https://github.com/vllm-project/vllm/releases/tag/v0.29.0) = commit [`98dff2a8`](https://github.com/vllm-project/vllm/commit/98dff2a81d747d1dba01a47f939f48c3526d4206) (release published 2026-09-09; Docker Hub tag pushed 2026-09-09T06:06Z, CUDA 13.0 build). The release branch forked from main at [`f5c3cc24`](https://github.com/vllm-project/vllm/commit/f5c3cc240bc1fc0519694fe689edb87dee8dfd92); the old nightly carries 300 main commits the release lacks and the release carries 14 release-branch commits the nightly lacks ([compare](https://github.com/vllm-project/vllm/compare/v0.29.0...d9105ea8001e0a6d77a96327d17515bb5791fb36)).
- API queries: `GET /api/v1/workflow-info?date=2026-09-08&benchmarkType=agentic_traces` (changelog entry for this key, PR #2875, head `aac901a1`) and `GET /api/v1/benchmarks?model=MiniMax-M3&date=2026-09-08&exact=true&sequence=agentic-traces` (no `view`; 14 rows, 8 match this identity). `GET /api/v1/evaluations` has no row for this single-node identity; eval values below come from the producer run's `eval_results_all` artifact.
- Producer of all 8 points and 8 evals: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34174440759/attempts/1 (PR #2875 sweep, head SHA `ebf645526a9178e1131a99593071e6fa01d04107`, reused at merge commit `aac901a16a0968702e978d2ab2eb0de725958559`). Curve snapshot IDs are not used as producers. Recipe fingerprints: `6d8ae56106e80615a97eb6a60fc098c79431a94e` (resident) and `b49c7028af3a565848740cbb80701b79d6981242` (Mooncake DRAM offload).
- Published throughput (tokens/s per GPU; latency in seconds; interactivity in tokens/s per user) and the producer run's eval per point:

| conc | KV offload | total tput/GPU | output tput/GPU | mean TTFT | mean TPOT | median interactivity | gsm8k em_strict (n=1319) |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | none | 1078.8 | 8.27 | 2.089 | 0.011 | 102.0 | 0.9719 |
| 2 | none | 1290.3 | 10.57 | 0.901 | 0.010 | 115.7 | 0.9719 |
| 4 | none | 1542.8 | 12.82 | 0.992 | 0.018 | 54.9 | 0.9735 |
| 6 | none | 2218.9 | 17.66 | 0.955 | 0.023 | 39.1 | 0.9735 |
| 8 | none | 3417.9 | 25.40 | 0.938 | 0.024 | 39.0 | 0.9682 |
| 10 | none | 3996.4 | 31.80 | 1.276 | 0.028 | 33.4 | 0.9666 |
| 12 | dram (Mooncake 0.3.11.post1) | 4263.4 | 33.91 | 1.164 | 0.029 | 32.5 | 0.9697 |
| 14 | dram (Mooncake 0.3.11.post1) | 4476.4 | 37.05 | 1.299 | 0.030 | 31.4 | 0.9697 |

- Eval mismatch: the baseline sweep ran lm-eval `gsm8k`; the current default eval for this family is the MiniMax vendor `minimax_m3_smoke` tool-call suite, so eval scores from this PR are N/A against the baseline (different task) and are reported on their own.

---

将 `minimaxm3-fp8-h200-vllm-agentic-mtp` 的镜像从 2026-09-07 上游 nightly `vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36` 刷新为 vLLM 正式版 `vllm/vllm-openai:v0.29.0`，并按清单摘要 `sha256:c2914767605584b6d8f45686b82de173ecc99e781897aa3d0a66dacd72c51ae1` 固定。仅修改主配置中的镜像字符串；`benchmarks/single_node/agentic/minimaxm3_fp8_h200_mtp.sh`、TP8 EAGLE3 拓扑、Mooncake DRAM 卸载分支以及 c1-c14 网格均保持不变。

## 基线（发布于 2026-09-08）

- 旧镜像：`vllm/vllm-openai:nightly-d9105ea8001e0a6d77a96327d17515bb5791fb36`（vLLM main 提交 [`d9105ea8`](https://github.com/vllm-project/vllm/commit/d9105ea8001e0a6d77a96327d17515bb5791fb36)，2026-09-07；Docker Hub 摘要 `sha256:254eebf919e8b7b0d530d97fccc606c36f380ff6724d64bc190951bec1aee838`）。全部 8 行均已核对身份：模型 MiniMax-M3（`MiniMaxAI/MiniMax-M3-MXFP8`）、硬件 h200、框架 vllm、精度 fp8、spec_method mtp（EAGLE3 草稿模型 `Inferact/MiniMax-M3-EAGLE3-GQA`，3 个推测 token，黄金合成接受长度 2.78）、disagg false、benchmark_type agentic_traces、`cluster:h200-dgxc` 上 TP8、1 小时 AgentX 编码轨迹回放。
- 新镜像来源：vLLM 标签 [`v0.29.0`](https://github.com/vllm-project/vllm/releases/tag/v0.29.0) = 提交 [`98dff2a8`](https://github.com/vllm-project/vllm/commit/98dff2a81d747d1dba01a47f939f48c3526d4206)（正式版发布于 2026-09-09；Docker Hub 标签推送于 2026-09-09T06:06Z，CUDA 13.0 构建）。发布分支从 main 的 [`f5c3cc24`](https://github.com/vllm-project/vllm/commit/f5c3cc240bc1fc0519694fe689edb87dee8dfd92) 分叉；旧 nightly 包含 300 个正式版没有的 main 提交，正式版包含 14 个 nightly 没有的发布分支提交（[对比](https://github.com/vllm-project/vllm/compare/v0.29.0...d9105ea8001e0a6d77a96327d17515bb5791fb36)）。
- API 查询：`GET /api/v1/workflow-info?date=2026-09-08&benchmarkType=agentic_traces`（该键的变更日志条目，PR #2875，head `aac901a1`）与 `GET /api/v1/benchmarks?model=MiniMax-M3&date=2026-09-08&exact=true&sequence=agentic-traces`（不带 `view`；14 行，其中 8 行匹配该身份）。`GET /api/v1/evaluations` 没有该单节点身份的记录；下表评测值来自生产运行的 `eval_results_all` 产物。
- 全部 8 个点及 8 个评测的生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34174440759/attempts/1（PR #2875 的 sweep，head SHA `ebf645526a9178e1131a99593071e6fa01d04107`，在合并提交 `aac901a16a0968702e978d2ab2eb0de725958559` 时复用）。未将曲线快照 ID 用作生产者。配方指纹：`6d8ae56106e80615a97eb6a60fc098c79431a94e`（常驻）与 `b49c7028af3a565848740cbb80701b79d6981242`（Mooncake DRAM 卸载）。
- 已发布吞吐（每 GPU tokens/s；延迟单位为秒；交互性为每用户 tokens/s）及生产运行的各点评测：

| 并发 | KV 卸载 | 每 GPU 总吞吐 | 每 GPU 输出吞吐 | 平均 TTFT | 平均 TPOT | 中位交互性 | gsm8k em_strict（n=1319） |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 无 | 1078.8 | 8.27 | 2.089 | 0.011 | 102.0 | 0.9719 |
| 2 | 无 | 1290.3 | 10.57 | 0.901 | 0.010 | 115.7 | 0.9719 |
| 4 | 无 | 1542.8 | 12.82 | 0.992 | 0.018 | 54.9 | 0.9735 |
| 6 | 无 | 2218.9 | 17.66 | 0.955 | 0.023 | 39.1 | 0.9735 |
| 8 | 无 | 3417.9 | 25.40 | 0.938 | 0.024 | 39.0 | 0.9682 |
| 10 | 无 | 3996.4 | 31.80 | 1.276 | 0.028 | 33.4 | 0.9666 |
| 12 | dram（Mooncake 0.3.11.post1） | 4263.4 | 33.91 | 1.164 | 0.029 | 32.5 | 0.9697 |
| 14 | dram（Mooncake 0.3.11.post1） | 4476.4 | 37.05 | 1.299 | 0.030 | 31.4 | 0.9697 |

- 评测不匹配：基线 sweep 运行的是 lm-eval `gsm8k`；该家族当前默认评测为 MiniMax 官方 `minimax_m3_smoke` 工具调用套件，因此本 PR 的评测分数相对基线为 N/A（任务不同），单独报告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
