### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-b200-sglang SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp4-b200-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1234,7 +1234,7 @@ qwen3.5-fp8-b200-sglang-agentic-mtp:
       - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [16, 18, 20, 22, 24, 28, 32] }
 
 qwen3.5-fp4-b200-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
   model-prefix: qwen3.5
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7058,3 +7058,10 @@
   description:
     - "Remove the unstable concurrency-1152 2P DEP8 prefill plus DEP12 decode point after repeated benchmark failures."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2623
+
+- config-keys:
+    - qwen3.5-fp4-b200-sglang
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9)."
+    - "Model nvidia/Qwen3.5-397B-A17B-NVFP4-V2, TP4/EP1 and TP2/EP1 topologies, the 8k/1k workload and the launch script are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2954


### PR DESCRIPTION
Bump the `qwen3.5-fp4-b200-sglang` master image from `lmsysorg/sglang:v0.5.14-cu130` to `lmsysorg/sglang:v0.5.19-cu130` (digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`). Model (`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`), TP4/EP1 and TP2/EP1 topologies, the 8k/1k fixed-seq-len workload and the launch script are unchanged.

## Baseline

- Published date: 2026-08-10, image `lmsysorg/sglang:v0.5.14-cu130` (digest `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`)
- Workload: single_turn fixed-seq-len ISL 8192 / OSL 1024, B200 single node (`cluster:b200-nscale`), SGLang, FP4, no speculative decoding, TP4/EP1 at concurrency 4 and TP2/EP1 at concurrency 4-128
- Producer run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30506346629/attempts/1 (head `99e3a3fdaee4f2822ff43442509915f9a3a1bae0`; logical curve snapshot `curve_workflow_run_id` 2287 is not the producer)
- API queries: `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-10&exact=true`, `GET /api/v1/workflow-info?date=2026-08-10`, `GET /api/v1/evaluations?model=Qwen-3.5-397B-A17B`
- Old engine source: sgl-project/sglang tag `v0.5.14` = https://github.com/sgl-project/sglang/commit/49e384ce9d304648e9959666ecb8ce8cd98d0deb
- New engine source: sgl-project/sglang tag `v0.5.19` = https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1

| TP/EP | Conc | tput/GPU (tok/s) | output tput/GPU (tok/s) | mean TPOT (ms) | mean TTFT (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| TP4/EP1 | 4 | 1385.5 | 154.1 | 5.88 | 439.6 |
| TP2/EP1 | 4 | 2491.3 | 277.1 | 6.66 | 376.4 |
| TP2/EP1 | 8 | 3949.4 | 444.0 | 8.24 | 584.2 |
| TP2/EP1 | 16 | 5621.2 | 622.9 | 11.82 | 647.0 |
| TP2/EP1 | 32 | 7784.4 | 870.5 | 16.93 | 973.4 |
| TP2/EP1 | 64 | 10511.9 | 1166.2 | 25.34 | 1536.9 |
| TP2/EP1 | 128 | 13655.1 | 1512.5 | 39.25 | 2281.5 |

- Published eval: N/A for the 2026-08-10 run (the public `evaluations` feed has no gsm8k row for this identity on that date; its only rows for B200 SGLang FP4 non-MTP are from 2026-04-08 on an older image and are not comparable).

---

将 `qwen3.5-fp4-b200-sglang` 主配置镜像从 `lmsysorg/sglang:v0.5.14-cu130` 更新至 `lmsysorg/sglang:v0.5.19-cu130`（摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`）。模型（`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`）、TP4/EP1 与 TP2/EP1 拓扑、8k/1k 固定序列长度工作负载以及启动脚本均保持不变。

## 基线

- 发布日期：2026-08-10，镜像 `lmsysorg/sglang:v0.5.14-cu130`（摘要 `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`）
- 工作负载：single_turn 固定序列长度 ISL 8192 / OSL 1024，B200 单节点（`cluster:b200-nscale`），SGLang，FP4，无投机解码，TP4/EP1 并发 4 与 TP2/EP1 并发 4-128
- 生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30506346629/attempts/1（head `99e3a3fdaee4f2822ff43442509915f9a3a1bae0`；逻辑曲线快照 `curve_workflow_run_id` 2287 不是生产运行）
- API 查询：`GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-10&exact=true`、`GET /api/v1/workflow-info?date=2026-08-10`、`GET /api/v1/evaluations?model=Qwen-3.5-397B-A17B`
- 旧引擎源码：sgl-project/sglang 标签 `v0.5.14` = https://github.com/sgl-project/sglang/commit/49e384ce9d304648e9959666ecb8ce8cd98d0deb
- 新引擎源码：sgl-project/sglang 标签 `v0.5.19` = https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1

基线数值见上方英文表格（tput/GPU、output tput/GPU、平均 TPOT、平均 TTFT）。

- 已发布评测：2026-08-10 运行为 N/A（公开 `evaluations` 数据中该身份在该日期没有 gsm8k 记录；B200 SGLang FP4 非 MTP 仅有 2026-04-08 旧镜像的记录，不可比较）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only container image pin and changelog; no application logic or runtime behavior changes in-repo.
> 
> **Overview**
> Bumps the **`qwen3.5-fp4-b200-sglang`** benchmark config from **`lmsysorg/sglang:v0.5.14-cu130`** to **`lmsysorg/sglang:v0.5.19-cu130`** in `nvidia-master.yaml`.
> 
> Adds a matching **`perf-changelog.yaml`** entry (PR #2954) noting the digest update and that model, TP/EP topologies, the 8k/1k fixed-seq-len workload, and launch script are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd10a225819639b65dc031e3ef2733f72842eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->