### PR TITLE
[Klaud Cold] Update dsr1-fp8-gb200-dynamo-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp8-gb200-dynamo-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2777,7 +2777,7 @@ dsr1-fp8-gb200-dynamo-trt:
           dp-attn: false
 
 dsr1-fp8-gb200-dynamo-sglang:
-  image: lmsysorg/sglang:v0.5.8.post1-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: gb200


### PR DESCRIPTION
Refresh the `dsr1-fp8-gb200-dynamo-sglang` master image from `lmsysorg/sglang:v0.5.8.post1-cu130` to `lmsysorg/sglang:v0.5.19-cu130` (pinned by manifest digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, SGLang commit `0bcd822377da7b5718e674eaf9c870d349424dd1`). Family: `configs/nvidia-master.yaml:dsr1-fp8-gb200-dynamo-sglang`; model, precision, topology, workloads, commands and recipe references are unchanged.

## Baseline

- **Published date:** 2026-02-09 (curve snapshot `curve_workflow_run_id` 270). Producer run for every point: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21831958748/attempts/2 (head SHA `37f353be258d8ca3d470c6a942a53dd5e027f82b`, changelog entry from PR #635).
- **Old image:** `lmsysorg/sglang:v0.5.8.post1-cu130` (SGLang tag `v0.5.8.post1` = commit `c1f2241a32b69be69828288b61331887c5647a4b`), with `ai-dynamo==0.8.1` installed at worker start by the srt-slurm recipe.
- **Workload / topology:** DeepSeek-R1-0528 FP8, single-turn fixed-seq-len 8k1k (ISL 8192 / OSL 1024), disaggregated dynamo-sglang on GB200 (4 GPUs per node), no speculative decoding. Three deployment shapes from the master config: low latency 1P TP8 / 1D TP8, mid curve 5P DEP8 / 1D DEP32, max throughput 6P DEP8 / 1D DEP24.
- **API queries:** `GET /api/v1/workflow-info?date=2026-02-09`; `GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-09&exact=true` (no `view`). All 10 configured 8k1k points matched by topology, concurrency and dataset.
- **Source links:** recipe files `recipes/gb200-fp8/8k1k/{low-latency,mid-curve,max_tpt}.yaml` on the launcher's clone target https://github.com/cquil11/srt-slurm-nv/tree/c0583377d5ca4223e1184f56ec79ddf0488f3a12/recipes/gb200-fp8/8k1k (mid-curve and max_tpt are byte-identical to https://github.com/NVIDIA/srt-slurm/tree/sa-submission-q2-2026/recipes/gb200-fp8/8k1k); SGLang https://github.com/sgl-project/sglang/compare/v0.5.8.post1...v0.5.19; Dynamo https://github.com/ai-dynamo/dynamo/tree/v0.8.1.
- **Evals:** N/A (the public `evaluations` feed has no dsr1 GB200 dynamo-sglang FP8 rows).

| Shape | Conc | Output tok/s/GPU | Total tok/s/GPU | Mean TPOT (ms) | Mean TTFT (s) | Result id |
|---|---|---|---|---|---|---|
| 1P TP8 / 1D TP8 (8+8 GPUs) | 4 | 46.1 | 207.4 | 9.99 | 0.52 | `94286` |
| 1P TP8 / 1D TP8 (8+8 GPUs) | 8 | 77.6 | 345.0 | 11.79 | 0.79 | `94285` |
| 1P TP8 / 1D TP8 (8+8 GPUs) | 16 | 126.4 | 570.4 | 14.30 | 0.89 | `94284` |
| 5P DEP8 / 1D DEP32 (40+32 GPUs) | 512 | 762.9 | 3051.8 | 16.95 | 2.74 | `94273` |
| 5P DEP8 / 1D DEP32 (40+32 GPUs) | 1024 | 1338.9 | 5355.2 | 18.53 | 3.88 | `94271` |
| 5P DEP8 / 1D DEP32 (40+32 GPUs) | 2048 | 1640.9 | 6558.3 | 20.48 | 14.28 | `94274` |
| 5P DEP8 / 1D DEP32 (40+32 GPUs) | 6144 | 1713.1 | 6854.3 | 20.69 | 75.81 | `94275` |
| 6P DEP8 / 1D DEP24 (48+24 GPUs) | 2048 | 2390.4 | 7165.5 | 28.81 | 4.81 | `94258` |
| 6P DEP8 / 1D DEP24 (48+24 GPUs) | 4096 | 2692.0 | 8078.2 | 31.01 | 25.91 | `94259` |
| 6P DEP8 / 1D DEP24 (48+24 GPUs) | 6144 | 2728.7 | 8188.4 | 31.27 | 51.72 | `94260` |

---

将 `dsr1-fp8-gb200-dynamo-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.8.post1-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130`（按 manifest 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9` 固定，对应 SGLang 提交 `0bcd822377da7b5718e674eaf9c870d349424dd1`）。配方族：`configs/nvidia-master.yaml:dsr1-fp8-gb200-dynamo-sglang`；模型、精度、拓扑、工作负载、命令与配方引用均保持不变。

## 基线

- **发布日期：** 2026-02-09（曲线快照 `curve_workflow_run_id` 270）。所有数据点的生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21831958748/attempts/2（head SHA `37f353be258d8ca3d470c6a942a53dd5e027f82b`，变更日志条目来自 PR #635）。
- **旧镜像：** `lmsysorg/sglang:v0.5.8.post1-cu130`（SGLang 标签 `v0.5.8.post1` = 提交 `c1f2241a32b69be69828288b61331887c5647a4b`），srt-slurm 配方在 worker 启动时安装 `ai-dynamo==0.8.1`。
- **工作负载 / 拓扑：** DeepSeek-R1-0528 FP8，单轮固定序列长度 8k1k（ISL 8192 / OSL 1024），GB200 上的分离式 dynamo-sglang（每节点 4 GPU），无投机解码。主配置中的三种部署形态：低延迟 1P TP8 / 1D TP8、中段曲线 5P DEP8 / 1D DEP32、最大吞吐 6P DEP8 / 1D DEP24。
- **API 查询：** `GET /api/v1/workflow-info?date=2026-02-09`；`GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-09&exact=true`（不带 `view`）。配置中的全部 10 个 8k1k 数据点均按拓扑、并发和数据集匹配。
- **来源链接：** 启动脚本克隆目标 https://github.com/cquil11/srt-slurm-nv/tree/c0583377d5ca4223e1184f56ec79ddf0488f3a12/recipes/gb200-fp8/8k1k 中的配方文件 `recipes/gb200-fp8/8k1k/{low-latency,mid-curve,max_tpt}.yaml`（mid-curve 与 max_tpt 和 https://github.com/NVIDIA/srt-slurm/tree/sa-submission-q2-2026/recipes/gb200-fp8/8k1k 逐字节一致）；SGLang https://github.com/sgl-project/sglang/compare/v0.5.8.post1...v0.5.19；Dynamo https://github.com/ai-dynamo/dynamo/tree/v0.8.1。
- **评测：** N/A（公开 `evaluations` 数据中没有 dsr1 GB200 dynamo-sglang FP8 的记录）。

| 形态 | 并发 | 输出 tok/s/GPU | 总 tok/s/GPU | 平均 TPOT (ms) | 平均 TTFT (s) | 结果 id |
|---|---|---|---|---|---|---|
| 1P TP8 / 1D TP8（8+8 GPU） | 4 | 46.1 | 207.4 | 9.99 | 0.52 | `94286` |
| 1P TP8 / 1D TP8（8+8 GPU） | 8 | 77.6 | 345.0 | 11.79 | 0.79 | `94285` |
| 1P TP8 / 1D TP8（8+8 GPU） | 16 | 126.4 | 570.4 | 14.30 | 0.89 | `94284` |
| 5P DEP8 / 1D DEP32（40+32 GPU） | 512 | 762.9 | 3051.8 | 16.95 | 2.74 | `94273` |
| 5P DEP8 / 1D DEP32（40+32 GPU） | 1024 | 1338.9 | 5355.2 | 18.53 | 3.88 | `94271` |
| 5P DEP8 / 1D DEP32（40+32 GPU） | 2048 | 1640.9 | 6558.3 | 20.48 | 14.28 | `94274` |
| 5P DEP8 / 1D DEP32（40+32 GPU） | 6144 | 1713.1 | 6854.3 | 20.69 | 75.81 | `94275` |
| 6P DEP8 / 1D DEP24（48+24 GPU） | 2048 | 2390.4 | 7165.5 | 28.81 | 4.81 | `94258` |
| 6P DEP8 / 1D DEP24（48+24 GPU） | 4096 | 2692.0 | 8078.2 | 31.01 | 25.91 | `94259` |
| 6P DEP8 / 1D DEP24（48+24 GPU） | 6144 | 2728.7 | 8188.4 | 31.27 | 51.72 | `94260` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
