### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-h200-sglang SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp8-h200-sglang 的 SGLang 镜像升级至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1775,7 +1775,7 @@ dsv4-fp4-b300-vllm-mtp:
       - { tp: 4, ep: 4, dp-attn: true, conc-start: 256, conc-end: 512, spec-decoding: mtp }
 
 qwen3.5-fp8-h200-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7070,3 +7070,9 @@
     - "MTP draft length by concurrency: speculative-num-steps 3 (golden AL 2.49) below conc 256, and 1 (golden AL 1.79) at and above it."
     - "Trim the search space to TP8 no-offload conc [1, 4, 16], TP8 hicache conc [32, 48], and TP8 DP-attention hicache conc [128, 256]."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2885
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, tag commit sgl-project/sglang@0bcd822); recipe script, TP8/EP8 topology and the 8k1k concurrency range unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2965


### PR DESCRIPTION
Update the `qwen3.5-fp8-h200-sglang` master image from `lmsysorg/sglang:v0.5.14-cu130` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, tag commit [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). The recipe script, model, TP8/EP8 topology and the 8k1k concurrency range are unchanged.

## Baseline

- **Published date:** 2026-07-04 (`benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true`, `workflow-info?date=2026-07-04`, `evaluations?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true`)
- **Old image:** `lmsysorg/sglang:v0.5.14-cu130` (digest `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`, tag commit [sgl-project/sglang@49e384c](https://github.com/sgl-project/sglang/commit/49e384ce9d304648e9959666ecb8ce8cd98d0deb))
- **Workload / topology:** single-node H200, `Qwen/Qwen3.5-397B-A17B-FP8`, SGLang FP8, TP8 EP8, no speculative decoding, fixed-seq-len 8k1k (ISL 8192 / OSL 1024), concurrency 4 / 8 / 16 / 32 / 64, random dataset
- **Producer:** [run 28719990565](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719990565/attempts/1) (head `e016f0c14bf2aab899de08b538d9b343069b07a5`, changelog PR [#2061](https://github.com/SemiAnalysisAI/InferenceX/pull/2061)); benchmark result IDs 432218, 432222, 432231, 432227, 432220

| Conc | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 486.9 | 54.2 | 0.345 | 8.68 | 8.18 |
| 8 | 765.2 | 86.0 | 0.356 | 10.97 | 10.56 |
| 16 | 1124.1 | 124.6 | 0.357 | 15.41 | 14.36 |
| 32 | 1522.5 | 170.3 | 0.376 | 22.82 | 21.44 |
| 64 | 1992.1 | 221.0 | 0.561 | 35.70 | 33.38 |

- **Published evals:** gsm8k at concurrency 32, `em_strict` 0.9651 / `em_flexible` 0.9583 (evaluation ID 8294) and at concurrency 64, `em_strict` 0.9689 / `em_flexible` 0.9583 (evaluation ID 8293), both from the same producer run. The public evaluations feed labels these rows `disagg: true` with 64 prefill/decode GPUs, which does not match the single-node TP8 recipe; the benchmark rows above carry the correct `disagg: false` identity.

---

将 `qwen3.5-fp8-h200-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.14-cu130` 升级到当前 SGLang 发布版 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，标签提交 [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。配方脚本、模型、TP8/EP8 拓扑以及 8k1k 并发范围均保持不变。

## 基线

- **发布日期：** 2026-07-04（`benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true`，`workflow-info?date=2026-07-04`，`evaluations?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true`）
- **旧镜像：** `lmsysorg/sglang:v0.5.14-cu130`（摘要 `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`，标签提交 [sgl-project/sglang@49e384c](https://github.com/sgl-project/sglang/commit/49e384ce9d304648e9959666ecb8ce8cd98d0deb)）
- **工作负载 / 拓扑：** 单节点 H200，`Qwen/Qwen3.5-397B-A17B-FP8`，SGLang FP8，TP8 EP8，无投机解码，固定序列长度 8k1k（ISL 8192 / OSL 1024），并发 4 / 8 / 16 / 32 / 64，随机数据集
- **数据来源：** [运行 28719990565](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719990565/attempts/1)（head `e016f0c14bf2aab899de08b538d9b343069b07a5`，changelog PR [#2061](https://github.com/SemiAnalysisAI/InferenceX/pull/2061)）；基准结果 ID 432218、432222、432231、432227、432220

| 并发 | 总吞吐 tok/s/GPU | 输出吞吐 tok/s/GPU | TTFT 中位数 (s) | TPOT 中位数 (ms) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 486.9 | 54.2 | 0.345 | 8.68 | 8.18 |
| 8 | 765.2 | 86.0 | 0.356 | 10.97 | 10.56 |
| 16 | 1124.1 | 124.6 | 0.357 | 15.41 | 14.36 |
| 32 | 1522.5 | 170.3 | 0.376 | 22.82 | 21.44 |
| 64 | 1992.1 | 221.0 | 0.561 | 35.70 | 33.38 |

- **已发布评测：** 并发 32 的 gsm8k，`em_strict` 0.9651 / `em_flexible` 0.9583（评测 ID 8294）；并发 64 的 gsm8k，`em_strict` 0.9689 / `em_flexible` 0.9583（评测 ID 8293），均来自同一数据来源运行。公共评测接口将这些行标记为 `disagg: true` 且 64 个 prefill/decode GPU，与单节点 TP8 配方不符；上表基准行的 `disagg: false` 身份是正确的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
