### PR TITLE
[Klaud Cold] Update dsr1-fp8-h100-dynamo-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp8-h100-dynamo-sglang 的 SGLang 镜像升级至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2302,7 +2302,7 @@ dsr1-fp8-h100-dynamo-trt:
           dp-attn: true
 
 dsr1-fp8-h100-dynamo-sglang:
-  image: lmsysorg/sglang:v0.5.8-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: cluster:h100-dgxc


### PR DESCRIPTION
Update the `dsr1-fp8-h100-dynamo-sglang` master image from `lmsysorg/sglang:v0.5.8-cu130` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, tag commit [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). Model, disaggregated 1P/1D TP16 topology, EAGLE/MTP settings, the two upstream srt-slurm recipe references and the 8k1k concurrency lists are unchanged.

## Baseline

- **Published date:** 2026-02-13 (`benchmarks?model=DeepSeek-R1-0528&date=2026-02-13&exact=true`, `workflow-info?date=2026-02-13`, `evaluations?model=DeepSeek-R1-0528&date=2026-02-13&exact=true`)
- **Old image:** `lmsysorg/sglang:v0.5.8-cu130` (Docker Hub digest `sha256:ef0d14df76c2c90ce651c274bc607600d09426128231722a96d52bb5472e1ebf`, tag commit [sgl-project/sglang@0189f41](https://github.com/sgl-project/sglang/commit/0189f41c30ede088a040a711a384f3024b8d7af5)). Baseline mismatch: the published rows carry this label, but `runners/launch_h100-dgxc-slurm.sh` maps every H100 dynamo-sglang job to the staged squash file `lmsysorg_sglang_v0.5.8.post1-cu130.sqsh`, so the producing container was `lmsysorg/sglang:v0.5.8.post1-cu130` (digest `sha256:b6f9f50829ec45428db4451616978c45eb3d8d91488a702e78bccd06154d6bef`).
- **Workload / topology:** H100 `cluster:h100-dgxc`, `deepseek-ai/DeepSeek-R1-0528` FP8, Dynamo + SGLang disaggregated, NIXL KV transfer, EAGLE MTP (2 steps, top-k 1, 3 draft tokens), fixed-seq-len 8k1k (ISL 8192 / OSL 1024), two deployment shapes of 4 nodes each: 1 prefill worker TP16 EP1 plus 1 decode worker TP16 EP1 (upstream recipe `recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-tp-mtp.yaml`, concurrency 1-128) and 1 prefill worker TP16 EP1 plus 1 decode worker TP16 EP16 with DP attention (`recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml`, concurrency 1-64), both from [NVIDIA/srt-slurm `sa-submission-q2-2026`](https://github.com/NVIDIA/srt-slurm/tree/sa-submission-q2-2026/recipes/h100/8k1k/mtp)
- **Producer:** [run 21973157671](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21973157671/attempts/1) (head `78d48618f771603c6a06e61b0083362814d30919`, changelog PRs [#643](https://github.com/SemiAnalysisAI/InferenceX/pull/643) and [#644](https://github.com/SemiAnalysisAI/InferenceX/pull/644)); 15 benchmark points, result IDs below

**1P TP16 EP1 / 1D TP16 EP1 (TEP)**

| Conc | Result ID | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 94693 | 29.0 | 6.5 | 0.560 | 9.48 | 9.24 |
| 2 | 94698 | 51.1 | 11.5 | 0.600 | 9.99 | 9.68 |
| 4 | 94700 | 87.5 | 19.5 | 0.611 | 12.24 | 11.63 |
| 8 | 94702 | 127.2 | 28.6 | 0.625 | 16.87 | 16.04 |
| 16 | 94694 | 178.6 | 39.6 | 0.853 | 24.51 | 22.77 |
| 32 | 94699 | 230.3 | 51.5 | 0.987 | 37.62 | 35.71 |
| 64 | 94701 | 279.8 | 62.1 | 13.348 | 50.46 | 59.04 |
| 128 | 94692 | 279.7 | 62.0 | 72.637 | 48.76 | 116.48 |

**1P TP16 EP1 / 1D TP16 EP16 DP-attention (DEP)**

| Conc | Result ID | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 94645 | 13.8 | 3.1 | 2.139 | 18.49 | 18.84 |
| 2 | 94646 | 27.1 | 6.1 | 0.744 | 19.47 | 19.30 |
| 4 | 94647 | 51.9 | 11.5 | 0.754 | 20.55 | 18.80 |
| 8 | 94649 | 92.9 | 20.9 | 0.875 | 22.63 | 21.37 |
| 16 | 94643 | 159.0 | 35.2 | 0.923 | 27.15 | 25.61 |
| 32 | 94644 | 243.2 | 54.4 | 1.022 | 34.71 | 32.89 |
| 64 | 94648 | 396.6 | 88.0 | 2.264 | 40.94 | 40.11 |

- **Published eval:** N/A for 2026-02-13 (no evaluation rows ingested for this family on the baseline date). The nearest published gsm8k rows for the family are dated 2026-04-23 ([run 24816108884](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24816108884), TEP concurrency 64 `em_strict` 0.9545 / `em_flexible` 0.9553, DEP concurrency 32 `em_strict` 0.9575 / `em_flexible` 0.9583) and are not part of the frozen baseline.

---

将 `dsr1-fp8-h100-dynamo-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.8-cu130` 升级到当前 SGLang 发布版 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，标签提交 [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。模型、分离式 1P/1D TP16 拓扑、EAGLE/MTP 设置、两个上游 srt-slurm 配方引用以及 8k1k 并发列表均保持不变。

## 基线

- **发布日期：** 2026-02-13（`benchmarks?model=DeepSeek-R1-0528&date=2026-02-13&exact=true`，`workflow-info?date=2026-02-13`，`evaluations?model=DeepSeek-R1-0528&date=2026-02-13&exact=true`）
- **旧镜像：** `lmsysorg/sglang:v0.5.8-cu130`（Docker Hub 摘要 `sha256:ef0d14df76c2c90ce651c274bc607600d09426128231722a96d52bb5472e1ebf`，标签提交 [sgl-project/sglang@0189f41](https://github.com/sgl-project/sglang/commit/0189f41c30ede088a040a711a384f3024b8d7af5)）。基线不一致：已发布数据行标注的是该镜像，但 `runners/launch_h100-dgxc-slurm.sh` 将所有 H100 dynamo-sglang 任务映射到预置的 squash 文件 `lmsysorg_sglang_v0.5.8.post1-cu130.sqsh`，因此实际产出数据的容器是 `lmsysorg/sglang:v0.5.8.post1-cu130`（摘要 `sha256:b6f9f50829ec45428db4451616978c45eb3d8d91488a702e78bccd06154d6bef`）。
- **工作负载 / 拓扑：** H100 `cluster:h100-dgxc`，`deepseek-ai/DeepSeek-R1-0528` FP8，Dynamo + SGLang 分离式部署，NIXL KV 传输，EAGLE MTP（2 步、top-k 1、3 个草稿 token），固定序列长度 8k1k（ISL 8192 / OSL 1024），两种各占 4 节点的部署形态：1 个 prefill worker TP16 EP1 加 1 个 decode worker TP16 EP1（上游配方 `recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-tp-mtp.yaml`，并发 1-128），以及 1 个 prefill worker TP16 EP1 加 1 个 decode worker TP16 EP16 并启用 DP attention（`recipes/h100/8k1k/mtp/h100-fp8-1p1d-max-dep-mtp.yaml`，并发 1-64），均来自 [NVIDIA/srt-slurm `sa-submission-q2-2026`](https://github.com/NVIDIA/srt-slurm/tree/sa-submission-q2-2026/recipes/h100/8k1k/mtp)
- **数据来源：** [运行 21973157671](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/21973157671/attempts/1)（head `78d48618f771603c6a06e61b0083362814d30919`，changelog PR [#643](https://github.com/SemiAnalysisAI/InferenceX/pull/643) 与 [#644](https://github.com/SemiAnalysisAI/InferenceX/pull/644)）；共 15 个基准点，结果 ID 见下表

**1P TP16 EP1 / 1D TP16 EP1（TEP）**

| 并发 | 结果 ID | 总吞吐 tok/s/GPU | 输出吞吐 tok/s/GPU | TTFT 中位数 (s) | TPOT 中位数 (ms) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 94693 | 29.0 | 6.5 | 0.560 | 9.48 | 9.24 |
| 2 | 94698 | 51.1 | 11.5 | 0.600 | 9.99 | 9.68 |
| 4 | 94700 | 87.5 | 19.5 | 0.611 | 12.24 | 11.63 |
| 8 | 94702 | 127.2 | 28.6 | 0.625 | 16.87 | 16.04 |
| 16 | 94694 | 178.6 | 39.6 | 0.853 | 24.51 | 22.77 |
| 32 | 94699 | 230.3 | 51.5 | 0.987 | 37.62 | 35.71 |
| 64 | 94701 | 279.8 | 62.1 | 13.348 | 50.46 | 59.04 |
| 128 | 94692 | 279.7 | 62.0 | 72.637 | 48.76 | 116.48 |

**1P TP16 EP1 / 1D TP16 EP16 DP-attention（DEP）**

| 并发 | 结果 ID | 总吞吐 tok/s/GPU | 输出吞吐 tok/s/GPU | TTFT 中位数 (s) | TPOT 中位数 (ms) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 94645 | 13.8 | 3.1 | 2.139 | 18.49 | 18.84 |
| 2 | 94646 | 27.1 | 6.1 | 0.744 | 19.47 | 19.30 |
| 4 | 94647 | 51.9 | 11.5 | 0.754 | 20.55 | 18.80 |
| 8 | 94649 | 92.9 | 20.9 | 0.875 | 22.63 | 21.37 |
| 16 | 94643 | 159.0 | 35.2 | 0.923 | 27.15 | 25.61 |
| 32 | 94644 | 243.2 | 54.4 | 1.022 | 34.71 | 32.89 |
| 64 | 94648 | 396.6 | 88.0 | 2.264 | 40.94 | 40.11 |

- **已发布评测：** 2026-02-13 为 N/A（基线日期没有该配方的评测数据入库）。该配方最近的已发布 gsm8k 数据日期为 2026-04-23（[运行 24816108884](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24816108884)，TEP 并发 64 `em_strict` 0.9545 / `em_flexible` 0.9553，DEP 并发 32 `em_strict` 0.9575 / `em_flexible` 0.9583），不属于冻结的基线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
