### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-h100-sglang SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp8-h100-sglang 的 SGLang 镜像升级至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -6411,7 +6411,7 @@ dsv4-fp4-b300-dynamo-sglang-mtp:
           dp-attn: true
 
 qwen3.5-fp8-h100-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: h100

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7070,3 +7070,9 @@
     - "MTP draft length by concurrency: speculative-num-steps 3 (golden AL 2.49) below conc 256, and 1 (golden AL 1.79) at and above it."
     - "Trim the search space to TP8 no-offload conc [1, 4, 16], TP8 hicache conc [32, 48], and TP8 DP-attention hicache conc [128, 256]."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2885
+
+- config-keys:
+    - qwen3.5-fp8-h100-sglang
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9); recipe script, TP8/EP1 and TP8/EP8 topology, 8k1k workload and concurrency range unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2968


### PR DESCRIPTION
Update the `qwen3.5-fp8-h100-sglang` master image from `lmsysorg/sglang:v0.5.14-cu130` to `lmsysorg/sglang:v0.5.19-cu130` (digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`). Model, precision, TP8/EP1 + TP8/EP8 topology, 8k1k workload, concurrency range and the recipe script are unchanged.

## Baseline

- **Published date:** 2026-07-05, old image `lmsysorg/sglang:v0.5.14-cu130`
- **Identity:** Qwen-3.5-397B-A17B FP8, H100, SGLang, single-turn 8192/1024, no speculative decoding, single node; TP8/EP1 at conc 1–8, TP8/EP8 at conc 16–256
- **Producer:** [run 28719988201](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719988201) (API-reported head SHA `2eaf828b84ebe5cac3c68fabd8a18be99fc6d924`, changelog [#2060](https://github.com/SemiAnalysisAI/InferenceX/pull/2060)); dashboard curve snapshot `curve_workflow_run_id=2123` is a logical snapshot, not the producer
- **API queries:** `/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true` (no view), `/api/v1/workflow-info?date=2026-07-05`, `/api/v1/evaluations?model=Qwen-3.5-397B-A17B` (filtered client-side to date 2026-07-05 and the producer run)

| TP/EP | Conc | Tput/GPU (tok/s) | Output tput/GPU (tok/s) | Median TTFT (s) | Median TPOT (s) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 8/1 | 1 | 178.78 | 19.97 | 0.389 | 0.00580 | 5.64 |
| 8/1 | 2 | 311.27 | 34.93 | 0.378 | 0.00670 | 6.70 |
| 8/1 | 4 | 513.94 | 57.17 | 0.328 | 0.00823 | 7.78 |
| 8/1 | 8 | 524.64 | 58.98 | 1.301 | 0.01530 | 15.56 |
| 8/8 | 16 | 1062.25 | 117.70 | 0.704 | 0.01594 | 15.21 |
| 8/8 | 32 | 1557.30 | 174.15 | 4.543 | 0.01794 | 21.15 |
| 8/8 | 64 | 1060.70 | 117.68 | 17.044 | 0.04877 | 62.41 |
| 8/8 | 128 | 2550.86 | 282.55 | 14.603 | 0.03893 | 50.71 |
| 8/8 | 256 | 1104.77 | 122.79 | 29.825 | 0.21528 | 235.55 |

**Published evals (gsm8k, same producer run):** conc 64 `em_strict` 0.9666 / `em_flexible` 0.9613; conc 256 `em_strict` 0.9636 / `em_flexible` 0.9575. The public `evaluations` rows for this config carry `disagg: true` and 64 prefill/decode GPUs, which does not match the single-node TP8 recipe; the scores are reported as published and that metadata mismatch is noted here.

---

将 `qwen3.5-fp8-h100-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.14-cu130` 升级至 `lmsysorg/sglang:v0.5.19-cu130`（摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`）。模型、精度、TP8/EP1 与 TP8/EP8 拓扑、8k1k 负载、并发范围及配方脚本保持不变。

## 基线

- **发布日期：** 2026-07-05，旧镜像 `lmsysorg/sglang:v0.5.14-cu130`
- **身份：** Qwen-3.5-397B-A17B FP8、H100、SGLang、单轮 8192/1024、无投机解码、单节点；并发 1–8 为 TP8/EP1，并发 16–256 为 TP8/EP8
- **生产运行：** [run 28719988201](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28719988201)（API 报告的 head SHA `2eaf828b84ebe5cac3c68fabd8a18be99fc6d924`，变更日志 [#2060](https://github.com/SemiAnalysisAI/InferenceX/pull/2060)）；面板曲线快照 `curve_workflow_run_id=2123` 仅为逻辑快照，并非生产运行
- **API 查询：** `/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true`（不带 view）、`/api/v1/workflow-info?date=2026-07-05`、`/api/v1/evaluations?model=Qwen-3.5-397B-A17B`（客户端按 2026-07-05 与生产运行过滤）

| TP/EP | 并发 | 每 GPU 吞吐 (tok/s) | 每 GPU 输出吞吐 (tok/s) | TTFT 中位数 (s) | TPOT 中位数 (s) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 8/1 | 1 | 178.78 | 19.97 | 0.389 | 0.00580 | 5.64 |
| 8/1 | 2 | 311.27 | 34.93 | 0.378 | 0.00670 | 6.70 |
| 8/1 | 4 | 513.94 | 57.17 | 0.328 | 0.00823 | 7.78 |
| 8/1 | 8 | 524.64 | 58.98 | 1.301 | 0.01530 | 15.56 |
| 8/8 | 16 | 1062.25 | 117.70 | 0.704 | 0.01594 | 15.21 |
| 8/8 | 32 | 1557.30 | 174.15 | 4.543 | 0.01794 | 21.15 |
| 8/8 | 64 | 1060.70 | 117.68 | 17.044 | 0.04877 | 62.41 |
| 8/8 | 128 | 2550.86 | 282.55 | 14.603 | 0.03893 | 50.71 |
| 8/8 | 256 | 1104.77 | 122.79 | 29.825 | 0.21528 | 235.55 |

**已发布评测（gsm8k，同一生产运行）：** 并发 64 `em_strict` 0.9666 / `em_flexible` 0.9613；并发 256 `em_strict` 0.9636 / `em_flexible` 0.9575。公共 `evaluations` 记录中该配置标注为 `disagg: true` 且 64 张 prefill/decode GPU，与单节点 TP8 配方不符；此处按已发布数值报告，并在此注明该元数据不一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
