### PR TITLE
[Klaud Cold] Update dsv4-fp4-gb300-dynamo-sglang-agentic-agg SGLang image to v0.5.19-cu130 / 将 dsv4-fp4-gb300-dynamo-sglang-agentic-agg 的 SGLang 镜像更新到 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/agentic/agg-gb300-tp4-mtp-lowlatency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/agentic/agg-gb300-tp4-mtp-lowlatency.yaml
@@ -12,11 +12,11 @@ identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro-0813"
   container:
-    image: "lmsysorg/sglang:nightly-dev-cu13-20260829-89816a21"
+    image: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
 
 dynamo:
   install: true
-  wheel: "1.5.0.dev20260902"
+  wheel: "1.5.0.dev20260910"
 
 slurm:
   time_limit: "4:00:00"

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/agentic/agg-gb300-tp8-mtp-lowlatency.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/deepseek-v4/agentic/agg-gb300-tp8-mtp-lowlatency.yaml
@@ -12,11 +12,11 @@ identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro-0813"
   container:
-    image: "lmsysorg/sglang:nightly-dev-cu13-20260829-89816a21"
+    image: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
 
 dynamo:
   install: true
-  wheel: "1.5.0.dev20260902"
+  wheel: "1.5.0.dev20260910"
 
 slurm:
   time_limit: "4:00:00"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8795,13 +8795,13 @@ kimik3-fp4-gb200-dynamo-vllm-agentic-dspark-mooncake-tp8pp2:
           additional-settings:
           - "CONFIG_FILE=recipes/vllm/kimi-k3/agentic/agg-gb200-tp8pp2-mooncake-c96-agentic.yaml"
 dsv4-fp4-gb300-dynamo-sglang-agentic-agg:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260829-89816a21
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: deepseek-ai/DeepSeek-V4-Pro-0813
   model-prefix: dsv4
   runner: cluster:gb300-nv
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "1.5.0.dev20260902" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260910" }
   multinode: true
   disagg: false
   scenarios:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7070,3 +7070,10 @@
     - "MTP draft length by concurrency: speculative-num-steps 3 (golden AL 2.49) below conc 256, and 1 (golden AL 1.79) at and above it."
     - "Trim the search space to TP8 no-offload conc [1, 4, 16], TP8 hicache conc [32, 48], and TP8 DP-attention hicache conc [128, 256]."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2885
+
+- config-keys:
+    - dsv4-fp4-gb300-dynamo-sglang-agentic-agg
+  description:
+    - "Update the SGLang image from nightly-dev-cu13-20260829-89816a21 to the digest-pinned v0.5.19-cu130 release (lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9)."
+    - "Move the TP8 and TP4 low-latency recipes and the master router metadata from Dynamo 1.5.0.dev20260902 to 1.5.0.dev20260910, the nightly that carries the ServerArgs.get_model_config()/use_mla_backend() compatibility fix for SGLang #36972 and pins sglang==0.5.19."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2969


### PR DESCRIPTION
Refresh `dsv4-fp4-gb300-dynamo-sglang-agentic-agg` from the SGLang `nightly-dev-cu13-20260829-89816a21` nightly to the digest-pinned `v0.5.19-cu130` release, moving the recipes' Dynamo wheel to the `1.5.0.dev20260910` nightly that Dynamo pairs with SGLang 0.5.19.

## Baseline

- Published date: 2026-09-10 (`/api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-09-10&exact=true`, `/api/v1/workflow-info?date=2026-09-10&benchmarkType=agentic_traces`)
- Old image: `lmsysorg/sglang:nightly-dev-cu13-20260829-89816a21` with Dynamo `1.5.0.dev20260902` and srt-slurm `v1.0.40`
- Producer: [run 33933793466 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33933793466/attempts/1) at `322307a973fd7d565d020559565341c1d6bc3a79` (PR #2623 sweep)
- Workload: DeepSeek-V4-Pro-0813 FP4, agentic-coding trace replay, DSpark block-size 6 speculative decoding (synthetic acceptance length 3.77), aggregated; TP8 on 2 GB300 nodes at concurrency 1 and 4, TP4 on 1 node at concurrency 8
- Source: [SGLang 89816a21…v0.5.19](https://github.com/sgl-project/sglang/compare/89816a21...0bcd822377da7b5718e674eaf9c870d349424dd1) (179 commits), [Dynamo #14234](https://github.com/ai-dynamo/dynamo/pull/14234), [Dynamo #14151](https://github.com/ai-dynamo/dynamo/pull/14151)

| Point | Output tok/s/GPU | Total tok/s/GPU | Median interactivity (tok/s/user) | Mean TTFT (s) | Mean TPOT (ms) | Avg power (W) |
| --- | --- | --- | --- | --- | --- | --- |
| TP8 conc 1 (id 441368) | 18.25 | 2492.8 | 312.5 | 0.808 | 3.30 | N/A (power_valid 0) |
| TP8 conc 4 (id 441364) | 27.39 | 3905.5 | 294.1 | 0.692 | 3.65 | N/A (power_valid 0) |
| TP4 conc 8 (id 441362) | 93.38 | 12415.4 | 207.5 | 0.749 | 5.18 | 575.1 |

- Evals: N/A. The family generates no eval jobs (`run-eval: false` on all three points) and the dashboard publishes no evaluation rows for these aggregated points on 2026-09-10.

---

将 `dsv4-fp4-gb300-dynamo-sglang-agentic-agg` 从 SGLang `nightly-dev-cu13-20260829-89816a21` 夜间构建更新到按摘要固定的 `v0.5.19-cu130` 正式版，并将配方中的 Dynamo wheel 切换到 Dynamo 与 SGLang 0.5.19 配套的 `1.5.0.dev20260910` 夜间版。

## 基线

- 发布日期：2026-09-10（`/api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-09-10&exact=true`、`/api/v1/workflow-info?date=2026-09-10&benchmarkType=agentic_traces`）
- 旧镜像：`lmsysorg/sglang:nightly-dev-cu13-20260829-89816a21`，Dynamo `1.5.0.dev20260902`，srt-slurm `v1.0.40`
- 生产运行：[run 33933793466 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33933793466/attempts/1)，提交 `322307a973fd7d565d020559565341c1d6bc3a79`（PR #2623 的 sweep）
- 工作负载：DeepSeek-V4-Pro-0813 FP4，agentic-coding 轨迹回放，DSpark block-size 6 投机解码（合成接受长度 3.77），聚合部署；TP8 跨 2 个 GB300 节点、并发 1 和 4；TP4 单节点、并发 8
- 源码：[SGLang 89816a21…v0.5.19](https://github.com/sgl-project/sglang/compare/89816a21...0bcd822377da7b5718e674eaf9c870d349424dd1)（179 个提交）、[Dynamo #14234](https://github.com/ai-dynamo/dynamo/pull/14234)、[Dynamo #14151](https://github.com/ai-dynamo/dynamo/pull/14151)

| 点位 | 输出 tok/s/GPU | 总 tok/s/GPU | 交互性中位数（tok/s/用户） | 平均 TTFT（秒） | 平均 TPOT（毫秒） | 平均功耗（W） |
| --- | --- | --- | --- | --- | --- | --- |
| TP8 并发 1（id 441368） | 18.25 | 2492.8 | 312.5 | 0.808 | 3.30 | N/A（power_valid 0） |
| TP8 并发 4（id 441364） | 27.39 | 3905.5 | 294.1 | 0.692 | 3.65 | N/A（power_valid 0） |
| TP4 并发 8（id 441362） | 93.38 | 12415.4 | 207.5 | 0.749 | 5.18 | 575.1 |

- 评测：N/A。该配置族不生成评测任务（三个点位均为 `run-eval: false`），且仪表盘在 2026-09-10 没有发布这些聚合点位的评测数据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only image and Dynamo version pins for an existing benchmark family; no application or infra logic changes.
> 
> **Overview**
> Updates **`dsv4-fp4-gb300-dynamo-sglang-agentic-agg`** from the SGLang **`nightly-dev-cu13-20260829-89816a21`** nightly to digest-pinned **`lmsysorg/sglang:v0.5.19-cu130`**, and bumps the paired **Dynamo** wheel/router from **`1.5.0.dev20260902`** to **`1.5.0.dev20260910`** (the nightly aligned with SGLang 0.5.19 and the `ServerArgs.get_model_config()` / `use_mla_backend()` fix).
> 
> The same image and wheel changes land in the **TP4** and **TP8** low-latency slurm recipes and in **`nvidia-master.yaml`**; **`perf-changelog.yaml`** records the config-key update for PR **#2969**. Benchmark topology, workloads, and launch scripts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bf4d8c421f5769f9e19d60c3604140cc9cb00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->