### PR TITLE
feat(agentx): add MiniMax-M3 NVFP4 GB200 Dynamo + TensorRT-LLM aggregate curve / 新增 MiniMax-M3 NVFP4 GB200 Dynamo + TensorRT-LLM 聚合曲线

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c10-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c10-b1-eagle3.yaml
@@ -1,0 +1,149 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=10 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c10-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 10
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '10'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c15-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c15-b1-eagle3.yaml
@@ -1,0 +1,154 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=15 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c15-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 15
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '15'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c20-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c20-b1-eagle3.yaml
@@ -1,0 +1,159 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=20 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c20-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 20
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+        - 16
+        - 17
+        - 18
+        - 19
+        - 20
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '20'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c25-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c25-b1-eagle3.yaml
@@ -1,0 +1,159 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=25 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c25-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 25
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+        - 17
+        - 19
+        - 21
+        - 23
+        - 25
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '25'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c30-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c30-b1-eagle3.yaml
@@ -1,0 +1,159 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=30 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c30-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 30
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 14
+        - 16
+        - 18
+        - 20
+        - 22
+        - 24
+        - 27
+        - 30
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '30'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c40-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c40-b1-eagle3.yaml
@@ -1,0 +1,163 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=40 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c40-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 40
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 14
+        - 16
+        - 18
+        - 20
+        - 22
+        - 24
+        - 26
+        - 28
+        - 30
+        - 32
+        - 34
+        - 36
+        - 38
+        - 40
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '40'
+    DURATION: '3600'

--- a/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c5-b1-eagle3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c5-b1-eagle3.yaml
@@ -1,0 +1,144 @@
+# MiniMax-M3 NVFP4, TensorRT-LLM aggregated TP4 + EAGLE3-GQA (3 draft tokens), one GB200 node, Dynamo frontend.
+# Engine config is the max_batch_size=5 member of the TRT-LLM team's TP4 set (Slack C0AMFBCGBNK, 2026-09-04) with
+# host_cache_size lowered to 128 GiB per rank: 192 GiB x 4 ranks exceeds a 940 GB GB200 node (host OOM, lyris 2928286-92).
+# Forced acceptance is NOT set here: runners/inject_synthetic_acceptance.py injects TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS
+# (= AL - 1 = 1.78 for the committed golden AL 2.78) for throughput runs and leaves eval-only runs on real acceptance.
+name: dynamo-agg-gb200-tp4-c5-b1-eagle3
+model:
+  path: minimax-m3-nvfp4
+  container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  precision: fp4
+dynamo:
+  install: true
+  wheel: 1.4.0.dev20260807
+  request_plane: tcp
+health_check:
+  max_attempts: 270
+  interval_seconds: 10
+resources:
+  gpu_type: gb200
+  gpus_per_node: 4
+  agg_nodes: 1
+  agg_workers: 1
+  gpus_per_agg: 4
+backend:
+  type: trtllm
+  numa_memory_bind: true
+  served_model_name: nvidia/MiniMax-M3-NVFP4
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRANSFORMERS_OFFLINE: '1'
+    HF_HUB_CACHE: /hf_hub_cache
+    TQDM_DISABLE: '1'
+    HF_HUB_DISABLE_PROGRESS_BARS: '1'
+    TLLM_LOG_LEVEL: INFO
+    TLLM_PROFILE_LOG_RANKS: all
+    TRTLLM_SERVER_DISABLE_GC: '1'
+    TRTLLM_WORKER_DISABLE_GC: '1'
+    TRTLLM_ENABLE_PDL: '1'
+    NCCL_GRAPH_MIXING_SUPPORT: '0'
+    MIMALLOC_PURGE_DELAY: '0'
+    PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
+    PYTHONNOUSERSITE: '1'
+    TRTLLM_SERVE_ENABLE_MSGSPEC: '1'
+    TRTLLM_TORCH_COMPILE_CONTEXT_ONLY: '1'
+    DYN_PUBLISH_KV_EVENTS: '0'
+  trtllm_config:
+    aggregated:
+      max_seq_len: 1048576
+      max_num_tokens: 16384
+      max_batch_size: 5
+      cuda_graph_config:
+        enable_padding: true
+        batch_sizes:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+      torch_compile_config:
+        enable_fullgraph: true
+        enable_inductor: false
+        enable_piecewise_cuda_graph: true
+        capture_num_tokens:
+        - 1
+        - 512
+        - 1024
+        - 2048
+        enable_userbuffers: true
+        max_num_streams: 3
+      moe_config:
+        backend: TRTLLM
+        use_low_precision_moe_combine: true
+      sparse_attention_config:
+        algorithm: minimax_m3
+        implementation: msa
+        indexer_kv_dtype: fp8
+        sparse_disable_index_value: true
+        fuse_qkv_index_projection: true
+      kv_cache_config:
+        free_gpu_memory_fraction: 0.94
+        enable_block_reuse: true
+        block_reuse_policy: per_conversation
+        tokens_per_block: 128
+        use_kv_cache_manager_v2: true
+        dtype: fp8
+        event_buffer_max_size: 0
+        host_cache_size: 137438953472
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+      scheduler_config:
+        capacity_scheduler_policy: MAX_UTILIZATION
+      enable_chunked_prefill: true
+      enable_autotuner: true
+      trust_remote_code: true
+      stream_interval: 20
+      print_iter_log: true
+      num_postprocess_workers: 8
+      enable_attention_dp: false
+      tensor_parallel_size: 4
+  publish_events_and_metrics: false
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  env:
+    ETCD_LEASE_TTL: '120'
+    DYN_ROUTER_TEMPERATURE: '0'
+    DYN_TOKENIZER_CACHE: '1'
+    DYN_TOKENIZER_CACHE_BYTES: '8000000000'
+    DYN_TCP_REQUEST_TIMEOUT: '30'
+    DYN_LOG: warn
+    DYN_ROUTER_SESSION_AFFINITY_TTL_SECS: '14400'
+  args:
+    router-mode: kv
+    no-kv-events: true
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: '8000'
+    IS_MULTINODE: 'true'
+    AIPERF_DYNAMO_SESSION_TIMEOUT_SECONDS: '14400'
+    AIPERF_DATASET_MMAP_CACHE_DIR: /aiperf_mmap_cache
+    HF_HUB_CACHE: /hf_hub_cache
+    WEKA_LOADER_OVERRIDE: semianalysis_cc_traces_weka_062126
+    AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES: '0'
+    SERVED_MODEL_NAME: nvidia/MiniMax-M3-NVFP4
+    MAX_MODEL_LEN: '1048576'
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: 'true'
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: '0'
+    OPENAI_API_KEY: EMPTY
+    KV_OFFLOADING: dram
+    KV_OFFLOAD_BACKEND: native
+    KV_OFFLOAD_BACKEND_METADATA: '{"name":"native"}'
+    TOTAL_CPU_DRAM_GB: '512'
+    MODEL: nvidia/MiniMax-M3-NVFP4
+    MODEL_PREFIX: minimaxm3
+    FRAMEWORK: dynamo-trt
+    PRECISION: fp4
+    CONC: '5'
+    DURATION: '3600'

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8020,6 +8020,119 @@ minimaxm3-fp4-gb200-dynamo-vllm-agentic-disagg-mtp:
           - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
         decode: { num-worker: 1, tp: 4, ep: 4, dp-attn: false }
 
+minimaxm3-fp4-gb200-dynamo-trt-agentic-agg-mtp:
+  image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1
+  model: nvidia/MiniMax-M3-NVFP4
+  model-prefix: minimaxm3
+  runner: cluster:gb200-nv
+  precision: fp4
+  framework: dynamo-trt
+  router: { name: dynamo-router, version: "1.4.0.dev20260807" }
+  multinode: true
+  disagg: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.61
+      search-space:
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [5]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c5-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [10]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c10-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [15]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c15-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [20]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c20-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [25]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c25-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [30]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c30-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+      - spec-decoding: mtp
+        kv-offloading: dram
+        kv-offload-backend: { name: native }
+        conc-list: [40]
+        num-nodes: 1
+        worker:
+          num-worker: 1
+          tp: 4
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic/dynamo-agg-gb200-tp4-c40-b1-eagle3.yaml"
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=2.78"
+
 dsv4-fp4-gb200-dynamo-vllm-agentic-mtp-agg:
   image: vllm/vllm-openai:nightly-3ee2df30337a301164c46ae444b76ee67e71c106
   model: deepseek-ai/DeepSeek-V4-Pro

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2970
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7070,3 +7070,13 @@
     - "MTP draft length by concurrency: speculative-num-steps 3 (golden AL 2.49) below conc 256, and 1 (golden AL 1.79) at and above it."
     - "Trim the search space to TP8 no-offload conc [1, 4, 16], TP8 hicache conc [32, 48], and TP8 DP-attention hicache conc [128, 256]."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2885
+
+- config-keys:
+    - minimaxm3-fp4-gb200-dynamo-trt-agentic-agg-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add MiniMax-M3 NVFP4 TensorRT-LLM AgentX on GB200 with Dynamo aggregated serving: TP4 + EAGLE3-GQA (3 draft tokens, committed golden acceptance length 2.78) at concurrency 5, 10, 15, 20, 25, 30 and 40, one srt-slurm recipe per concurrency, 128 GiB per-rank host KV cache, container nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1, Dynamo 1.4.0.dev20260807 frontend."
+    - "Route dynamo-trt minimaxm3/fp4 in runners/launch_gb200-nv.sh (model alias minimax-m3-nvfp4) and pin NVIDIA/srt-slurm v1.0.91, which runs aggregated TRT-LLM workers under numactl -m 0,1."
+    - "Add a TensorRT-LLM synthetic-acceptance injector (frameworks trt and dynamo-trt) that sets TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS = AL - 1 in the recipe worker environment for throughput runs and removes it for eval-only runs; the recipes carry no forced acceptance and the master entry sets SYNTHETIC_ACCEPTANCE=true / SYNTHETIC_ACCEPTANCE_LENGTH=2.78, so AgentX evals verify against real acceptance."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -5595,7 +5595,7 @@
     - "Image ghcr.io/tile-ai/tilert:0.1.5 (tilert 0.1.5.post2 installed at container start); commands aligned to TileRT README Topology A -- NIXL KV transfer, --kv-cache-dtype fp8_ds_mla (prefill) <-> fp8 (decode), max-seq-len 202752; MTP speculative-config wired via spec-decoding=mtp"
     - "Topology: 1 prefill node (TP8) + 1 decode node (TP8), each 8xB200 exclusive; TileRT decode is bs=1 only so conc-list is a single point [1], ISL 1k/8k OSL 1k"
     - "Runner: launch_b200-dgxc.sh tilert early-return branch (zero impact on the dynamo path); tilert_utils/submit.sh issues two srun --ntasks=1, one per role, because prefill and decode need different container images; roles are dispatched by the TILERT_ROLE it exports, and torn down across nodes via a sentinel file on the shared /workspace"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2970
 
 - config-keys:
     - qwen3.5-fp8-b200-sglang-agentic-mtp
@@ -7079,4 +7079,4 @@
     - "Add MiniMax-M3 NVFP4 TensorRT-LLM AgentX on GB200 with Dynamo aggregated serving: TP4 + EAGLE3-GQA (3 draft tokens, committed golden acceptance length 2.78) at concurrency 5, 10, 15, 20, 25, 30 and 40, one srt-slurm recipe per concurrency, 128 GiB per-rank host KV cache, container nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1, Dynamo 1.4.0.dev20260807 frontend."
     - "Route dynamo-trt minimaxm3/fp4 in runners/launch_gb200-nv.sh (model alias minimax-m3-nvfp4) and pin NVIDIA/srt-slurm v1.0.91, which runs aggregated TRT-LLM workers under numactl -m 0,1."
     - "Add a TensorRT-LLM synthetic-acceptance injector (frameworks trt and dynamo-trt) that sets TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS = AL - 1 in the recipe worker environment for throughput runs and removes it for eval-only runs; the recipes carry no forced acceptance and the master entry sets SYNTHETIC_ACCEPTANCE=true / SYNTHETIC_ACCEPTANCE_LENGTH=2.78, so AgentX evals verify against real acceptance."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2970

--- a/runners/launch_gb200-nv.sh
+++ b/runners/launch_gb200-nv.sh
@@ -219,8 +219,14 @@ elif [[ $FRAMEWORK == "dynamo-trt" ]]; then
         export MODEL_PATH="/mnt/lustre01/slurm-shared/glm-model/GLM-5-NVFP4"
         export SERVED_MODEL_NAME="glm-5-nvfp4"
         export SRT_SLURM_MODEL_PREFIX="nvidia/GLM-5-NVFP4"
+    elif [[ $MODEL_PREFIX == "minimaxm3" && $PRECISION == "fp4" ]]; then
+        # Same checkpoint and model.path alias as the dynamo-vllm MiniMax-M3
+        # lanes; the dynamo-trt AgentX recipes use model.path: minimax-m3-nvfp4.
+        export MODEL_PATH="/mnt/lustre01/models/MiniMax-M3-NVFP4"
+        export SERVED_MODEL_NAME="nvidia/MiniMax-M3-NVFP4"
+        export SRT_SLURM_MODEL_PREFIX="minimax-m3-nvfp4"
     else
-        echo "Unsupported model prefix: $MODEL_PREFIX. Supported prefixes are: gptoss, dsr1, kimik2.5, or glm5"
+        echo "Unsupported model prefix: $MODEL_PREFIX. Supported prefixes are: gptoss, dsr1, kimik2.5, glm5, or minimaxm3 (fp4)"
         exit 1
     fi
 elif [[ $FRAMEWORK == "dynamo-vllm" ]]; then
@@ -450,6 +456,16 @@ elif [[ "$IS_AGENTIC" == "1" && "$MODEL_PREFIX" == "kimik3" ]]; then
     mkdir -p recipes/vllm/kimi-k3/agentic || exit 1
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/kimi-k3/agentic" \
         recipes/vllm/kimi-k3/agentic || exit 1
+elif [[ $FRAMEWORK == "dynamo-trt" && $MODEL_PREFIX == "minimaxm3" ]]; then
+    # Select this before the generic Agentic fallback. v1.0.91 carries
+    # srt-slurm #384 (numactl -m 0,1 on aggregated TRT-LLM workers).
+    git clone https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR" || exit 1
+    cd "$SRT_REPO_DIR" || exit 1
+    git checkout v1.0.91 || exit 1
+    # Preserve the InferenceMAX-relative CONFIG_FILE paths inside this checkout.
+    RECIPE_DIR="benchmarks/multi_node/srt-slurm-recipes/trtllm/minimax-m3/gb200-fp4/agentic"
+    mkdir -p "$RECIPE_DIR" || exit 1
+    cp -rT "$GITHUB_WORKSPACE/$RECIPE_DIR" "$RECIPE_DIR" || exit 1
 # TODO(CJQ): migrate the remaining Agentic model paths to released srt-slurm.
 elif [[ "$IS_AGENTIC" == "1" ]]; then
     # Agentic multi-node pins cquil11/srt-slurm-nv revisions that provide:

--- a/runners/synthetic_injectors/__init__.py
+++ b/runners/synthetic_injectors/__init__.py
@@ -35,4 +35,4 @@ def get_injector(framework):
 
 # Import backends after register/get_injector are defined so each module can
 # call register() at import time. Add new frameworks (sglang, trtllm, ...) here.
-from . import sglang, vllm  # noqa: E402,F401
+from . import sglang, trtllm, vllm  # noqa: E402,F401

--- a/runners/synthetic_injectors/trtllm.py
+++ b/runners/synthetic_injectors/trtllm.py
@@ -1,0 +1,79 @@
+"""TensorRT-LLM speculative-acceptance recipe rewriting.
+
+TRT-LLM forces acceptance through the worker environment variable
+``TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS``. Its value is the number of
+*draft* tokens accepted per step, so an acceptance length AL (target token +
+accepted drafts) maps to ``AL - 1``. Throughput opt-ins inject that variable
+into every ``*_environment`` block under ``backend:``; eval-only runs remove it
+so the verifier's real acceptance drives the generated text. The backend is
+registered for both direct trtllm-serve and Dynamo-TRT-LLM recipes.
+"""
+
+import re
+import sys
+
+from . import register
+
+_ENV_KEY = "TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS"
+# A `*_environment:` mapping header under backend (aggregated/prefill/decode).
+_ENV_BLOCK_RE = re.compile(r"^(?P<indent>[ \t]*)(?:aggregated|prefill|decode)_environment:[ \t]*$")
+_ENV_LINE_RE = re.compile(rf"^[ \t]*{_ENV_KEY}:.*\n?", re.MULTILINE)
+_DRAFT_LEN_RE = re.compile(r"^\s*(?:max_draft_len|num_nextn_predict_layers):\s*(\d+)", re.MULTILINE)
+
+
+def spec_tokens_from_recipe(text):
+    """Best-effort: read the speculative draft length from the engine config."""
+    m = _DRAFT_LEN_RE.search(text)
+    return int(m.group(1)) if m else None
+
+
+def _format_value(al):
+    return f"{al - 1:g}"
+
+
+def rewrite(content, al, log):
+    """Force ``AL - 1`` accepted draft tokens in every backend environment block.
+
+    Returns ``(new_content, count)`` where count is the number of environment
+    blocks now carrying the variable (0 => no block found, recipe left unchanged).
+    """
+    value = _format_value(al)
+    # Replace existing settings first so a recipe that already carries the
+    # variable ends up with exactly one line per block.
+    content = _ENV_LINE_RE.sub("", content)
+
+    lines = content.splitlines(keepends=True)
+    out, count, i = [], 0, 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        m = _ENV_BLOCK_RE.match(line.rstrip("\n"))
+        if m:
+            # Child indentation comes from the first non-empty following line;
+            # fall back to two spaces past the header.
+            child_indent = None
+            for nxt in lines[i + 1:]:
+                if nxt.strip():
+                    child_indent = nxt[: len(nxt) - len(nxt.lstrip())]
+                    break
+            if child_indent is None or len(child_indent) <= len(m.group("indent")):
+                child_indent = m.group("indent") + "  "
+            out.append(f"{child_indent}{_ENV_KEY}: '{value}'\n")
+            count += 1
+        i += 1
+    new_content = "".join(out)
+    if count:
+        log(f"Set {_ENV_KEY}={value} (AL={al}) in {count} environment block(s)")
+    return new_content, count
+
+
+def rewrite_real(content, log):
+    """Remove forced acceptance so the verifier's real acceptance is used."""
+    new_content, count = _ENV_LINE_RE.subn("", content)
+    if count:
+        log(f"Removed {_ENV_KEY} from {count} environment block(s) for eval-only mode")
+    return new_content, count
+
+
+register("dynamo-trt", sys.modules[__name__])
+register("trt", sys.modules[__name__])

--- a/runners/test_synthetic_injectors.py
+++ b/runners/test_synthetic_injectors.py
@@ -1,0 +1,78 @@
+"""Tests for the framework-specific synthetic-acceptance injectors."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from synthetic_injectors import get_injector  # noqa: E402
+
+TRTLLM_RECIPE = """name: dynamo-agg-gb200-tp4-c20-b1-eagle3
+backend:
+  type: trtllm
+  aggregated_environment:
+    HF_HUB_OFFLINE: '1'
+    TRTLLM_ENABLE_PDL: '1'
+  trtllm_config:
+    aggregated:
+      speculative_config:
+        decoding_type: Eagle3
+        max_draft_len: 3
+        speculative_model: Inferact/MiniMax-M3-EAGLE3-GQA
+frontend:
+  type: dynamo
+"""
+
+
+def _noop(_msg):
+    pass
+
+
+def test_trtllm_registered_for_both_frameworks():
+    assert get_injector("dynamo-trt") is not None
+    assert get_injector("trt") is get_injector("dynamo-trt")
+
+
+def test_trtllm_rewrite_injects_al_minus_one_into_environment():
+    injector = get_injector("dynamo-trt")
+    new, count = injector.rewrite(TRTLLM_RECIPE, 2.78, _noop)
+    assert count == 1
+    assert "    TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS: '1.78'\n" in new
+    # Inserted directly under the environment header with the block's indentation.
+    header = new.index("aggregated_environment:\n")
+    assert new.index("TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS") > header
+    assert new.count("TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS") == 1
+
+
+def test_trtllm_rewrite_replaces_existing_value():
+    injector = get_injector("dynamo-trt")
+    recipe = TRTLLM_RECIPE.replace(
+        "    HF_HUB_OFFLINE: '1'\n",
+        "    HF_HUB_OFFLINE: '1'\n    TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS: '9'\n",
+    )
+    new, count = injector.rewrite(recipe, 3.02, _noop)
+    assert count == 1
+    assert "TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS: '2.02'" in new
+    assert "TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS: '9'" not in new
+
+
+def test_trtllm_rewrite_real_removes_forced_acceptance():
+    injector = get_injector("dynamo-trt")
+    injected, _ = injector.rewrite(TRTLLM_RECIPE, 2.78, _noop)
+    restored, count = injector.rewrite_real(injected, _noop)
+    assert count == 1
+    assert "TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS" not in restored
+    assert restored == TRTLLM_RECIPE
+
+
+def test_trtllm_rewrite_real_is_noop_without_forced_acceptance():
+    injector = get_injector("dynamo-trt")
+    restored, count = injector.rewrite_real(TRTLLM_RECIPE, _noop)
+    assert count == 0
+    assert restored == TRTLLM_RECIPE
+
+
+def test_trtllm_spec_tokens_from_recipe():
+    injector = get_injector("dynamo-trt")
+    assert injector.spec_tokens_from_recipe(TRTLLM_RECIPE) == 3
+    assert injector.spec_tokens_from_recipe("name: x\n") is None


### PR DESCRIPTION
## Description / 描述

- Add `minimaxm3-fp4-gb200-dynamo-trt-agentic-agg-mtp`: MiniMax-M3 NVFP4 served by TensorRT-LLM (`nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1`) behind the Dynamo frontend (`1.4.0.dev20260807`) on one GB200 node, aggregated TP4 with EAGLE3-GQA (3 draft tokens, committed golden acceptance length 2.78), 128 GiB per-rank host KV cache, one srt-slurm recipe per concurrency at 5, 10, 15, 20, 25, 30 and 40.
- Route `dynamo-trt` + `minimaxm3`/`fp4` in `runners/launch_gb200-nv.sh` (model alias `minimax-m3-nvfp4`) and pin NVIDIA/srt-slurm `v1.0.91`, which runs aggregated TRT-LLM workers under `numactl -m 0,1`.
- Add a TensorRT-LLM synthetic-acceptance injector (`runners/synthetic_injectors/trtllm.py`, frameworks `trt` and `dynamo-trt`): throughput runs get `TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS = AL - 1` in the worker environment, eval-only runs use real acceptance. The recipes carry no forced acceptance; the master entry sets `SYNTHETIC_ACCEPTANCE=true` / `SYNTHETIC_ACCEPTANCE_LENGTH=2.78`, matching the vLLM and SGLang AgentX configs.

- 新增 `minimaxm3-fp4-gb200-dynamo-trt-agentic-agg-mtp`：MiniMax-M3 NVFP4 由 TensorRT-LLM（`nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc23.post1`）在 Dynamo 前端（`1.4.0.dev20260807`）之后于单个 GB200 节点提供服务，聚合 TP4 + EAGLE3-GQA（3 个草稿 token，golden 接受长度 2.78），每 rank 128 GiB 主机 KV cache，并发 5、10、15、20、25、30、40 各一个 srt-slurm 配方。
- 在 `runners/launch_gb200-nv.sh` 中为 `dynamo-trt` + `minimaxm3`/`fp4` 添加路由（模型别名 `minimax-m3-nvfp4`），并固定 NVIDIA/srt-slurm `v1.0.91`（聚合 TRT-LLM worker 使用 `numactl -m 0,1`）。
- 新增 TensorRT-LLM 合成接受率注入器（`runners/synthetic_injectors/trtllm.py`，框架 `trt` 和 `dynamo-trt`）：吞吐运行在 worker 环境中设置 `TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS = AL - 1`，eval-only 运行使用真实接受率。配方本身不包含强制接受率，master 条目设置 `SYNTHETIC_ACCEPTANCE=true` / `SYNTHETIC_ACCEPTANCE_LENGTH=2.78`，与 vLLM 和 SGLang 的 AgentX 配置一致。

## Validation / 验证

Measured on the same GB200 runner class (`cluster:gb200-nv`) through the NVIDIA-internal InferenceMAX fork before filing here. Each point is a full 3600 s AgentX replay.

| conc | total tok/s per GPU | P90 interactivity (1 / ITL p90) | gsm8k exact match (eval-only, real acceptance) |
|---|---|---|---|
| 5 | 9245 | 258.8 | 0.955 |
| 10 | 17269 | 213.8 | 0.948 |
| 15 | 22325 | 164.0 | 0.953 |
| 20 | 34832 | 131.3 | 0.957 |
| 25 | 42067 | 106.9 | 0.958 |
| 30 | 46127 | 85.3 | 0.953 |
| 40 | 50971 | 64.2 | 0.961 |

- [x] All seven throughput jobs and all seven eval-only jobs passed (gsm8k threshold 0.90) / 七个吞吐作业和七个 eval-only 作业全部通过（gsm8k 阈值 0.90）
- [x] `generate_sweep_configs.py test-config` emits exactly seven agentic-coding rows with `SYNTHETIC_ACCEPTANCE=true` / `SYNTHETIC_ACCEPTANCE_LENGTH=2.78` / 精确 key 生成产生七个带合成接受率设置的配置
- [x] `utils/matrix_logic` test suite and `runners/test_synthetic_injectors.py` pass; `validate_perf_changelog.py` passes against `main` / 矩阵测试、注入器单元测试和变更日志验证通过
- [x] Recipes ran end to end through this launcher path at NVIDIA/srt-slurm v1.0.91 on the `gb200-nv` runner, and independently on an NVIDIA GB200 cluster (lyris) with matching throughput within 2% / 配方通过此启动路径在 srt-slurm v1.0.91 上于 `gb200-nv` runner 端到端运行，并在 NVIDIA GB200 集群（lyris）上独立复现，吞吐一致（2% 以内）

## Type of Change / 变更类型

- [x] New feature / 新功能
- [x] Configuration change / 配置变更

## Checklist / 检查清单

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
