### PR TITLE
Add DSv4.1 Flash DSpark golden AL curve / 新增黄金 AL 曲线

### DIFF
--- a/golden_al_distribution/README.md
+++ b/golden_al_distribution/README.md
@@ -127,6 +127,7 @@ Before accepting an updated curve, reviewers should verify:
 | --- | --- | --- | --- |
 | DeepSeek V4 Pro | MTP | [`dsv4_mtp.yaml`](dsv4_mtp.yaml) | [27180633016](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27180633016) |
 | DeepSeek V4 Pro 0813 | DSpark (probabilistic draft) | [`dsv4-pro-0813-dspark.yaml`](dsv4-pro-0813-dspark.yaml) | [31742838308](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31742838308) |
+| DeepSeek V4.1 Flash | DSpark (probabilistic draft, block verify) | [`dsv41flash_dspark.yaml`](dsv41flash_dspark.yaml) | [34493175056](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34493175056) |
 | Qwen3.5 397B-A17B | MTP | [`qwen3.5_mtp.yaml`](qwen3.5_mtp.yaml) | [27317114007](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27317114007) |
 | Kimi K2.5 | EAGLE3 | [`kimik2.5_eagle3.yaml`](kimik2.5_eagle3.yaml) | [28122195822](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28122195822) |
 | Kimi K3 | DSpark | [`kimik3_dspark.yaml`](kimik3_dspark.yaml) | [30304797750](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30304797750) |
@@ -151,3 +152,5 @@ Before accepting an updated curve, reviewers should verify:
 - [InferenceX initial AL collector PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1650)
 - [InferenceX multi-model AL collectors PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1706)
 - [InferenceX multi-node synthetic-acceptance bring-up](https://github.com/SemiAnalysisAI/InferenceX/pull/1789)
+
+DeepSeek V4.1 Flash includes measured draft lengths 1–5 for thinking off/on. The same image rejected lengths 6–8 before serving in [run 34494319147](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34494319147); no AL values are assigned to those lengths.

--- a/golden_al_distribution/README_zh.md
+++ b/golden_al_distribution/README_zh.md
@@ -127,6 +127,7 @@ gh workflow run speedbench-al.yml \
 | --- | --- | --- | --- |
 | DeepSeek V4 Pro | MTP | [`dsv4_mtp.yaml`](dsv4_mtp.yaml) | [27180633016](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27180633016) |
 | DeepSeek V4 Pro 0813 | DSpark（概率采样草稿） | [`dsv4-pro-0813-dspark.yaml`](dsv4-pro-0813-dspark.yaml) | [31742838308](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31742838308) |
+| DeepSeek V4.1 Flash | DSpark（概率采样草稿 + 块验证） | [`dsv41flash_dspark.yaml`](dsv41flash_dspark.yaml) | [34493175056](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34493175056) |
 | Qwen3.5 397B-A17B | MTP | [`qwen3.5_mtp.yaml`](qwen3.5_mtp.yaml) | [27317114007](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/27317114007) |
 | Kimi K2.5 | EAGLE3 | [`kimik2.5_eagle3.yaml`](kimik2.5_eagle3.yaml) | [28122195822](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28122195822) |
 | Kimi K3 | DSpark | [`kimik3_dspark.yaml`](kimik3_dspark.yaml) | [30304797750](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30304797750) |
@@ -151,3 +152,5 @@ gh workflow run speedbench-al.yml \
 - [InferenceX 初始 AL 收集器 PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1650)
 - [InferenceX 多模型 AL 收集器 PR](https://github.com/SemiAnalysisAI/InferenceX/pull/1706)
 - [InferenceX 多节点合成接受验证](https://github.com/SemiAnalysisAI/InferenceX/pull/1789)
+
+DeepSeek V4.1 Flash 包含草稿长度 1–5 在 thinking 开关两种模式下的实测值。同一镜像在[运行 34494319147](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34494319147) 中于服务启动前拒绝长度 6–8，因此未为这些长度填写 AL 数值。

--- a/golden_al_distribution/dsv41flash_dspark.yaml
+++ b/golden_al_distribution/dsv41flash_dspark.yaml
@@ -1,0 +1,23 @@
+# Source GitHub Actions run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34493175056
+# Draft lengths 6-8 rejected by the image (no measured AL): https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34494319147
+# Acceptance Length (AL) measured with SPEED-Bench Qualitative coding.
+# model: deepseek-ai/DeepSeek-V4.1-Flash | image: vllm/vllm-openai:deepseekv41-flash-0909 | TP: 4
+# temperature: 1.0 | output_len: 4096
+# thinking_on chat_template_kwargs: {"thinking":true,"reasoning_effort":"high"}
+# thinking_off chat_template_kwargs: {"thinking":false}
+# method: dspark | draft_sample_method: probabilistic | rejection_sample_method: block
+# enable_adaptive_verification: false | engram cpu_offload: true
+# key = num_speculative_tokens; AL includes the target verification token.
+deepseek-v4.1-flash:
+  thinking_off:
+    1: 1.88
+    2: 2.62
+    3: 3.27
+    4: 3.73
+    5: 4.07
+  thinking_on:
+    1: 1.81
+    2: 2.43
+    3: 2.90
+    4: 3.26
+    5: 3.51


### PR DESCRIPTION
Commit the DSv4.1 Flash DSpark golden AL curve from [run 34493175056](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34493175056): B200 TP4, UVA offload, probabilistic/block sampling, adaptive verification off, SPEED-Bench coding, temperature 1.0, output length 4096, thinking off/on, draft lengths 1–5. YAML matches the artifact byte-for-byte after provenance comments; all 800 requests succeeded and all ten AL values were independently checked against counter deltas. Sampled outputs match the intended modes; 6–8 thinking-on outputs per cell reached the 4096-token cap before ending reasoning. [Lengths 6–8 failed config validation](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34494319147) and have no fabricated values. Follows #2460: data-only, `[skip-sweep]`; collector is #2964.

提交上述运行的 DSv4.1 Flash DSpark 黄金 AL：B200 TP4、UVA offload、probabilistic/block 采样、关闭 adaptive verification，SPEED-Bench coding、temperature 1.0、输出上限 4096，覆盖 thinking 开关与草稿长度 1–5。除来源注释外，YAML 与产物逐字节一致；800 个请求全部成功，十个 AL 均已根据 counter 差值独立复核。抽查输出符合预期模式；每个 thinking-on 单元有 6–8 个输出在结束推理前达到 4096 token 上限。长度 6–8 验证失败，未填写虚构数值。参照 #2460，仅提交数据，使用 `[skip-sweep]`；采集器为 #2964。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and benchmark reference data only; no runtime or auth changes.
> 
> **Overview**
> Adds a **golden acceptance-length (AL) curve** for **DeepSeek V4.1 Flash** with **DSpark** (probabilistic draft, block rejection), sourced from [Actions run 34493175056](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34493175056).
> 
> The new `dsv41flash_dspark.yaml` records mean AL for **draft lengths 1–5** under **thinking off** and **thinking on**, with metadata for the vLLM image, TP4, SPEED-Bench coding, and sampling settings. English and Chinese READMEs list the curve in the golden-curves table and note that **lengths 6–8 were not measured** because the same image failed config validation before serve ([run 34494319147](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34494319147)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a58c9cd7c9c3725fc4f942331d644906eb75ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->