### PR TITLE
CollectiveX: bring b300 up on the DSXE pool (AWS EFA fabric)

### DIFF
--- a/experimental/CollectiveX/README.md
+++ b/experimental/CollectiveX/README.md
@@ -190,22 +190,34 @@ selectors. Operator documents can override the defaults. Launchers
 declare and check the fields they actually require. `sweep_matrix.py` derives EP topology from the
 placement fields. The sweep includes every registered SKU by default.
 
-Every selected non-MNNVL EP16 placement additionally requires `socket_ifname` and `rdma_devices` for
-its operator-approved fabric. Optional `ib_gid_index`, `rdma_service_level`, `rdma_traffic_class`,
-and `rail_isolated` are also allowlisted. Service level and traffic class are mapped into MoRI's
-RDMA/IO QoS environment.
+Every selected non-MNNVL EP16 placement additionally requires `rdma_devices` for its
+operator-approved fabric. `socket_ifname` pins the cross-node socket interface; without it the
+allocated node's default-route interface is used (h200-dgxc, b300). Optional `ib_gid_index`,
+`rdma_service_level`, `rdma_traffic_class`, `rail_isolated` and `rdma_fabric` are also allowlisted.
+Service level and traffic class are mapped into MoRI's RDMA/IO QoS environment.
 CollectiveX does not heuristically select a management route or HCA. After allocation, every
 non-MNNVL scale-out node must prove that all configured interfaces and active HCA ports exist before
 backend setup. Scale-up and MNNVL jobs clear these overrides. Scale-out NCCL/RCCL is pinned to `IB`
 with exact-match HCA selectors so a socket fallback fails instead of being mislabeled as RDMA.
 Scale-out also disables NCCL dual-port NIC fusion (`NCCL_IB_MERGE_NICS=0`): a fused device disables
 NCCL GIN, which the DeepEP V2 EP16 hybrid path requires, and a rail-isolated fabric
-(`rail_isolated=1`, e.g. B300's multi-plane RoCE) additionally sets `NCCL_CROSS_NIC=0`.
+(`rail_isolated=1`, per-port rail subnets with no cross-rail routing) additionally sets
+`NCCL_CROSS_NIC=0`.
 
 `ib_gid_index` is applied only when every selected HCA port reports an Ethernet link layer, where it
 selects the operator-approved RoCE GID. Native InfiniBand profiles retain explicit HCA and service
 level pinning but leave the RoCE-only GID override unset so NVSHMEM/NCCL can use the native LID path.
 Mixed Ethernet and InfiniBand HCA lists are rejected.
+
+`rdma_fabric: "efa"` declares an AWS Elastic Fabric Adapter cluster (b300 is a p6-b300.48xlarge
+pool with 16 EFA devices per node). EFA is not a verbs HCA: its ports report no link layer, it has
+no GID table, service level or traffic class, and NCCL reaches it only through the aws-ofi-nccl
+libfabric plugin that the cluster's enroot hook mounts into every container. On such a fabric the
+probe accepts the unspecified link layer for the listed `rdma_devices` (which must still be ACTIVE
+on every node), the IB selector family (`NCCL_IB_*`, `NVSHMEM_HCA_LIST`/IBGDA, MoRI, UCCL) stays
+unset, `NCCL_NET_PLUGIN=ofi` and `FI_PROVIDER=efa` select the plugin, NVSHMEM is pointed at its
+libfabric transport, and backend setup fails unless the plugin library is present in the container.
+NCCL GIN then rides the plugin's own GIN implementation (`OFI_NCCL_GIN_TYPE` selects proxy or GDAKI).
 
 `stage_dir` is a pre-existing, runner-owned, non-symlinked base outside the checkout and workflow
 workspace. It is not group- or world-writable and is visible at the same path on the runner and every

--- a/experimental/CollectiveX/README.md
+++ b/experimental/CollectiveX/README.md
@@ -217,7 +217,11 @@ probe accepts the unspecified link layer for the listed `rdma_devices` (which mu
 on every node), the IB selector family (`NCCL_IB_*`, `NVSHMEM_HCA_LIST`/IBGDA, MoRI, UCCL) stays
 unset, `NCCL_NET_PLUGIN=ofi` and `FI_PROVIDER=efa` select the plugin, NVSHMEM is pointed at its
 libfabric transport, and backend setup fails unless the plugin library is present in the container.
-NCCL GIN then rides the plugin's own GIN implementation (`OFI_NCCL_GIN_TYPE` selects proxy or GDAKI).
+NCCL GIN then rides the plugin's own GIN implementation (`OFI_NCCL_GIN_TYPE` selects proxy or GDAKI),
+which requires GDRCopy 2.5+ (`gdrdrv` loaded, `libgdrapi` present) on the node: without it the plugin's
+GIN init fails, NCCL disables the Device API for the communicator, and `ncclEpCreateGroup` returns
+`ncclInvalidUsage` (verified on b300-dsxe 2026-09-11; that pool ships no gdrcopy, so its EP16 legs are
+withheld from the registry until it does).
 
 `stage_dir` is a pre-existing, runner-owned, non-symlinked base outside the checkout and workflow
 workspace. It is not group- or world-writable and is visible at the same path on the runner and every

--- a/experimental/CollectiveX/README.md
+++ b/experimental/CollectiveX/README.md
@@ -221,7 +221,10 @@ NCCL GIN then rides the plugin's own GIN implementation (`OFI_NCCL_GIN_TYPE` sel
 which requires GDRCopy 2.5+ (`gdrdrv` loaded, `libgdrapi` present) on the node: without it the plugin's
 GIN init fails, NCCL disables the Device API for the communicator, and `ncclEpCreateGroup` returns
 `ncclInvalidUsage` (verified on b300-dsxe 2026-09-11; that pool ships no gdrcopy, so its EP16 legs are
-withheld from the registry until it does).
+withheld from the registry until it does). DeepEP V2 low-latency is also withheld there: its legacy
+Buffer initialises NVSHMEM with an RDMA transport even single-node, and on that pool NVSHMEM aborts
+with "nvshmem detect topo failed" (status 28) with and without `NVSHMEM_REMOTE_TRANSPORT=none`
+(runs 34521825749, 34523594787); the HT ElasticBuffer path, which needs no NVSHMEM, passes.
 
 `stage_dir` is a pre-existing, runner-owned, non-symlinked base outside the checkout and workflow
 workspace. It is not group- or world-writable and is visible at the same path on the runner and every

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -82,9 +82,8 @@
       "operator": {
         "partition": "batch_1",
         "account": "benchmark",
-        "qos": "batch_1_qos",
-        "squash_dir": "/data/home/sa-shared/sqsh",
-        "exclude_nodes": "b300-001,b300-005,b300-009,b300-016,b300-018"
+        "qos": "normal",
+        "squash_dir": "/data/home/sa-gha-runner/collectivex/containers"
       },
       "network": {
         "socket_ifname": "bond0",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -86,7 +86,6 @@
         "squash_dir": "/data/home/sa-gha-runner/collectivex/containers"
       },
       "network": {
-        "socket_ifname": "bond0",
         "rdma_devices": "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_8,mlx5_9,mlx5_10,mlx5_11,mlx5_16,mlx5_17,mlx5_20,mlx5_21,mlx5_22,mlx5_23",
         "single_node_rdma_devices": "mlx5_12:1,mlx5_13:1,mlx5_14:1,mlx5_15:1",
         "ib_gid_index": "3",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -78,19 +78,20 @@
       "launcher": "single-slurm",
       "backends": {"deepep-v2": [8, 16], "nccl-ep": [8, 16]},
       "ll_backends": {"deepep-v2": [8], "nccl-ep": [8]},
-      "fabric": {"nic": "ConnectX-8 2x400GbE", "switch": "NVIDIA Spectrum-X SN5600 (51.2T)"},
-      "operator": {
+      "fabric": {
+    "nic": "AWS EFA (p6-b300.48xlarge, 16 x 400G per node)",
+    "switch": "AWS EFA fabric (SRD)"
+   },
+   "operator": {
         "partition": "batch_1",
         "account": "benchmark",
         "qos": "normal",
         "squash_dir": "/data/home/sa-gha-runner/collectivex/containers"
       },
       "network": {
-        "rdma_devices": "mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_8,mlx5_9,mlx5_10,mlx5_11,mlx5_16,mlx5_17,mlx5_20,mlx5_21,mlx5_22,mlx5_23",
-        "single_node_rdma_devices": "mlx5_12:1,mlx5_13:1,mlx5_14:1,mlx5_15:1",
-        "ib_gid_index": "3",
-        "rail_isolated": "1"
-      }
+    "rdma_fabric": "efa",
+    "rdma_devices": "rdmap86s0,rdmap87s0,rdmap101s0,rdmap102s0,rdmap116s0,rdmap117s0,rdmap131s0,rdmap132s0,rdmap146s0,rdmap147s0,rdmap161s0,rdmap162s0,rdmap176s0,rdmap177s0,rdmap191s0,rdmap192s0"
+   }
     },
     "gb200": {
       "arch": "sm100",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -76,7 +76,11 @@
       "scale_up_domain": 8,
       "scale_up_transport": "nvlink",
       "launcher": "single-slurm",
-      "backends": {"deepep-v2": [8, 16], "nccl-ep": [8, 16]},
+      "backends": {"deepep-v2": [
+    8
+   ], "nccl-ep": [
+    8
+   ]},
       "ll_backends": {"deepep-v2": [8], "nccl-ep": [8]},
       "fabric": {
     "nic": "AWS EFA (p6-b300.48xlarge, 16 x 400G per node)",

--- a/experimental/CollectiveX/configs/platform_config.json
+++ b/experimental/CollectiveX/configs/platform_config.json
@@ -81,7 +81,11 @@
    ], "nccl-ep": [
     8
    ]},
-      "ll_backends": {"deepep-v2": [8], "nccl-ep": [8]},
+      "ll_backends": {
+   "nccl-ep": [
+    8
+   ]
+  },
       "fabric": {
     "nic": "AWS EFA (p6-b300.48xlarge, 16 x 400G per node)",
     "switch": "AWS EFA fabric (SRD)"

--- a/experimental/CollectiveX/launchers/launch_single-slurm.sh
+++ b/experimental/CollectiveX/launchers/launch_single-slurm.sh
@@ -64,9 +64,10 @@ export NCCL_CUMEM_ENABLE=1
 collx_apply_network_profile "$NODES" "$COLLX_TRANSPORT"
 collx_require_vars COLLX_IMAGE COLLX_IMAGE_PLATFORM COLLX_PARTITION COLLX_SQUASH_DIR
 [ "$REQUIRE_ACCOUNT" = 0 ] || collx_require_vars COLLX_ACCOUNT
-# b300 /home and /scratch are node-local; h100-dgxc /home is login-local (absent on
-# compute nodes) — on both, the implicit passwd-home stage base is compute-invisible,
-# so the operator config must pin an explicit compute-visible stage_dir.
+# h100-dgxc /home is login-local (absent on compute nodes), so the implicit passwd-home
+# stage base is compute-invisible and the operator config must pin an explicit stage_dir.
+# b300 (DSXE) homes live on the shared Lustre /data, but the prologue still isolates its
+# stage per execution, so the variable must have resolved by now on both.
 case "$RUNNER" in
   b300|h100-dgxc) collx_require_vars COLLX_STAGE_DIR ;;
 esac

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -121,7 +121,7 @@ collx_load_operator_config() {
   unset ENROOT_CACHE_PATH
   unset COLLX_EXCLUDE_NODES COLLX_NODELIST COLLX_LOCK_DIR COLLX_MASTER_PORT
   unset COLLX_SOCKET_IFNAME COLLX_RDMA_DEVICES COLLX_IB_GID_INDEX COLLX_RDMA_SERVICE_LEVEL
-  unset COLLX_RDMA_TRAFFIC_CLASS COLLX_RAIL_ISOLATED COLLX_SINGLE_NODE_RDMA_DEVICES
+  unset COLLX_RDMA_TRAFFIC_CLASS COLLX_RAIL_ISOLATED COLLX_SINGLE_NODE_RDMA_DEVICES COLLX_RDMA_FABRIC
   unset MASTER_ADDR MASTER_PORT RANK WORLD_SIZE LOCAL_RANK LOCAL_WORLD_SIZE
   config_path="${COLLECTIVEX_OPERATOR_CONFIG:-${XDG_CONFIG_HOME:-${HOME}/.config}/inferencex/collectivex.json}"
   if [ ! -e "$config_path" ]; then
@@ -192,9 +192,25 @@ collx_export_gid_index_for_link_layer() {
       # RoCE runs must set it here or the CPU proxies fall back to GID 0 and mis-address the fabric.
       export UCCL_IB_GID_INDEX="$COLLX_IB_GID_INDEX"
       ;;
-    infiniband) ;;
+    infiniband|efa) ;;
     *) collx_die "unsupported RDMA link layer" ;;
   esac
+}
+
+# AWS EFA scale-out (b300-dsxe, p6-b300.48xlarge: 16 EFA devices per node). EFA is not a verbs
+# HCA: its ports report link_layer Unspecified, it has no GID table, service level or traffic
+# class, and NCCL reaches it only through the aws-ofi-nccl libfabric plugin, which the cluster's
+# enroot hook bind-mounts into every container (/opt/amazon/{efa,ofi-nccl} on the ld path). GIN
+# rides the plugin's ncclGinPlugin export (proxy or GDAKI; OFI_NCCL_GIN_TYPE selects). So the
+# whole IB/RoCE selector family (NCCL_IB_*, NVSHMEM_HCA_LIST/IBGDA, MORI_*, UCCL_IB_*) stays
+# unset: the plugin enumerates and rails the EFA devices itself, and the operator's rdma_devices
+# list is consumed only by the network-profile probe as the set of ports that must be ACTIVE.
+# NVSHMEM (deepep-v2) has its own libfabric transport; point it at EFA the same way.
+collx_apply_efa_profile() {
+  export NCCL_NET_PLUGIN=ofi
+  export FI_PROVIDER=efa FI_EFA_FORK_SAFE=1
+  export NVSHMEM_REMOTE_TRANSPORT=libfabric NVSHMEM_LIBFABRIC_PROVIDER=efa
+  unset NVSHMEM_IB_ENABLE_IBGDA NVSHMEM_IBGDA_NIC_HANDLER NVSHMEM_HCA_LIST NVSHMEM_ENABLE_NIC_PE_MAPPING
 }
 
 # Convert private, runner-local network selectors into the public library
@@ -205,7 +221,7 @@ collx_apply_network_profile() {
   local selector rdma_name rdma_names="" ep_nic=""
   local -a selectors
   [[ "$nodes" =~ ^[1-9][0-9]*$ ]] || collx_die "invalid network placement"
-  unset NCCL_NET NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME NCCL_IB_HCA
+  unset NCCL_NET NCCL_NET_PLUGIN NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME NCCL_IB_HCA
   unset NCCL_IB_GID_INDEX NCCL_IB_SL NCCL_IB_MERGE_NICS NCCL_CROSS_NIC
   unset NVSHMEM_ENABLE_NIC_PE_MAPPING
   unset NVSHMEM_HCA_LIST NVSHMEM_IB_GID_INDEX NVSHMEM_IB_SL
@@ -239,6 +255,7 @@ collx_apply_network_profile() {
   { [ "$nodes" -gt 1 ] && [ "$transport" != mnnvl ]; } || return 0
   [ -n "${COLLX_RDMA_DEVICES:-}" ] \
     || collx_die "RDMA execution requires a private device selector"
+  [[ "${COLLX_RDMA_FABRIC:-}" =~ ^(efa)?$ ]] || collx_die "invalid private RDMA fabric"
   if [ -n "${COLLX_SOCKET_IFNAME:-}" ]; then
     [[ "$COLLX_SOCKET_IFNAME" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}$ ]] \
       || collx_die "invalid private socket interface selector"
@@ -252,6 +269,10 @@ collx_apply_network_profile() {
     rdma_names="${rdma_names}${rdma_names:+,}${rdma_name}"
     [ -n "$ep_nic" ] || ep_nic="$rdma_name"
   done
+  if [ "${COLLX_RDMA_FABRIC:-}" = efa ]; then
+    collx_apply_efa_profile
+    return 0
+  fi
   export NVSHMEM_HCA_LIST="$COLLX_RDMA_DEVICES"
   export NVSHMEM_ENABLE_NIC_PE_MAPPING=1
   # RCCL selects its own net plugin; NCCL_NET=IB breaks AMD SKUs.
@@ -312,7 +333,7 @@ collx_apply_network_profile() {
   export NVSHMEM_IB_ENABLE_IBGDA=1 NVSHMEM_IBGDA_NIC_HANDLER="$nic_handler"
   if [ -n "${COLLX_RDMA_LINK_LAYER:-}" ]; then
     case "$COLLX_RDMA_LINK_LAYER" in
-      roce|infiniband) ;;
+      roce|infiniband|efa) ;;
       *) collx_die "invalid validated RDMA link layer" ;;
     esac
     collx_export_gid_index_for_link_layer "$COLLX_RDMA_LINK_LAYER"
@@ -330,7 +351,9 @@ collx_restore_exact_hca_selector() {
     || { collx_log "ERROR: scale-out RDMA selector is unavailable"; return 1; }
   [[ "$COLLX_RDMA_DEVICES" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?(,[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?)*$ ]] \
     || { collx_log "ERROR: invalid scale-out RDMA selector"; return 1; }
-  export NCCL_IB_HCA="=$COLLX_RDMA_DEVICES"
+  # EFA devices are not verbs HCAs to NCCL: the libfabric plugin enumerates them itself and
+  # NCCL_IB_HCA would only steer the (unused) builtin IB transport. Leave it unset there.
+  [ "${COLLX_RDMA_FABRIC:-}" = efa ] || export NCCL_IB_HCA="=$COLLX_RDMA_DEVICES"
 }
 
 collx_default_route_interface() {
@@ -357,7 +380,7 @@ collx_validate_network_profile_on_job() {
   srun --jobid="$job_id" --nodes="$nodes" --ntasks="$nodes" --ntasks-per-node=1 \
     --chdir=/tmp --input=all --export="$(collx_host_exports)" \
     python3 /dev/stdin network-profile "${COLLX_SOCKET_IFNAME:-}" \
-      "$COLLX_RDMA_DEVICES" "${COLLX_IB_GID_INDEX:-}" \
+      "$COLLX_RDMA_DEVICES" "${COLLX_IB_GID_INDEX:-}" "${COLLX_RDMA_FABRIC:-}" \
     < "$COLLX_RUNTIME_DIR/probe.py" > "$log" 2>&1 || rc=$?
   if [ "$rc" != 0 ]; then
     marker="$(grep -aoE '(socket-interface|rdma-(device|port))-[0-9]+=(missing|down|inactive|default-route-missing|gid-missing|gid-empty|link-layer-missing|link-layer-invalid|link-layer-mixed)' "$log" \
@@ -381,12 +404,12 @@ collx_validate_network_profile_on_job() {
     unset COLLX_SOCKET_IFNAME
   fi
   link_layer="$(
-    sed -nE 's/^\[collectivex-private\] rdma-link-layer=(roce|infiniband)$/\1/p' "$log" \
+    sed -nE 's/^\[collectivex-private\] rdma-link-layer=(roce|infiniband|efa)$/\1/p' "$log" \
       | sort -u
   )"
-  marker_count="$(grep -Ec '^\[collectivex-private\] rdma-link-layer=(roce|infiniband)$' "$log")"
+  marker_count="$(grep -Ec '^\[collectivex-private\] rdma-link-layer=(roce|infiniband|efa)$' "$log")"
   case "$marker_count:$link_layer" in
-    "$nodes":roce|"$nodes":infiniband) ;;
+    "$nodes":roce|"$nodes":infiniband|"$nodes":efa) ;;
     *) return 1 ;;
   esac
   export COLLX_RDMA_LINK_LAYER="$link_layer"

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -247,14 +247,6 @@ collx_apply_network_profile() {
   # NVLink, so those rails carry init-time control traffic only. HCA_LIST wins over
   # the baked PE mapping (NVSHMEM warns and honors HCA_LIST) — verified on-metal
   # 2026-07-08 (b300-010, production shape, PASS with and without the baked mapping).
-  # On an EFA pool there is no verbs HCA for NVSHMEM to bind single-node control traffic to:
-  # its default ibrc/IBGDA transport scans the RDMA devices, finds only EFA (unspecified link
-  # layer) and aborts init with "nvshmem detect topo failed" (b300-dsxe run 34521825749). With
-  # allow_nvlink_for_low_latency_mode every intra-node byte rides NVLink, so tell NVSHMEM there
-  # is no remote transport at all instead of letting it hunt for one.
-  if [ "$nodes" -le 1 ] && [ "${COLLX_RDMA_FABRIC:-}" = efa ]; then
-    export NVSHMEM_REMOTE_TRANSPORT=none NVSHMEM_IB_ENABLE_IBGDA=0
-  fi
   if [ "$nodes" -le 1 ] && [ -n "${COLLX_SINGLE_NODE_RDMA_DEVICES:-}" ]; then
     [[ "$COLLX_SINGLE_NODE_RDMA_DEVICES" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?(,[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?)*$ ]] \
       || collx_die "invalid private single-node RDMA device selector"

--- a/experimental/CollectiveX/runtime/common.sh
+++ b/experimental/CollectiveX/runtime/common.sh
@@ -247,6 +247,14 @@ collx_apply_network_profile() {
   # NVLink, so those rails carry init-time control traffic only. HCA_LIST wins over
   # the baked PE mapping (NVSHMEM warns and honors HCA_LIST) — verified on-metal
   # 2026-07-08 (b300-010, production shape, PASS with and without the baked mapping).
+  # On an EFA pool there is no verbs HCA for NVSHMEM to bind single-node control traffic to:
+  # its default ibrc/IBGDA transport scans the RDMA devices, finds only EFA (unspecified link
+  # layer) and aborts init with "nvshmem detect topo failed" (b300-dsxe run 34521825749). With
+  # allow_nvlink_for_low_latency_mode every intra-node byte rides NVLink, so tell NVSHMEM there
+  # is no remote transport at all instead of letting it hunt for one.
+  if [ "$nodes" -le 1 ] && [ "${COLLX_RDMA_FABRIC:-}" = efa ]; then
+    export NVSHMEM_REMOTE_TRANSPORT=none NVSHMEM_IB_ENABLE_IBGDA=0
+  fi
   if [ "$nodes" -le 1 ] && [ -n "${COLLX_SINGLE_NODE_RDMA_DEVICES:-}" ]; then
     [[ "$COLLX_SINGLE_NODE_RDMA_DEVICES" =~ ^[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?(,[A-Za-z][A-Za-z0-9_.-]{0,31}(:[1-9][0-9]*)?)*$ ]] \
       || collx_die "invalid private single-node RDMA device selector"

--- a/experimental/CollectiveX/runtime/config.py
+++ b/experimental/CollectiveX/runtime/config.py
@@ -15,7 +15,7 @@ OPERATOR_FIELDS = {
 }
 NETWORK_FIELDS = {
     "socket_ifname", "rdma_devices", "ib_gid_index", "rdma_service_level",
-    "rdma_traffic_class", "rail_isolated", "single_node_rdma_devices",
+    "rdma_traffic_class", "rail_isolated", "single_node_rdma_devices", "rdma_fabric",
 }
 # Timing knobs, in the order the legacy colon-string encoded them, paired with the run_ep flag
 # each one drives. The names match configs/sweep.json so a case's timing block is readable

--- a/experimental/CollectiveX/runtime/prepare_backend.sh
+++ b/experimental/CollectiveX/runtime/prepare_backend.sh
@@ -580,14 +580,22 @@ validate_container_network() {
     return 0
   fi
   collx_restore_exact_hca_selector || return 1
-  [ -n "${GLOO_SOCKET_IFNAME:-}" ] && [ -n "${NCCL_IB_HCA:-}" ] \
+  local rdma_selector="${NCCL_IB_HCA:-}"
+  if [ "${COLLX_RDMA_FABRIC:-}" = efa ]; then
+    # No verbs selector on EFA; the probe-validated device list is the contract, and the
+    # libfabric NCCL plugin the enroot hook mounts is what actually carries the traffic.
+    rdma_selector="${COLLX_RDMA_DEVICES:-}"
+    [ -r /opt/amazon/ofi-nccl/lib/libnccl-net-ofi.so ] \
+      || { collx_log "ERROR: aws-ofi-nccl plugin is absent inside the container"; return 1; }
+  fi
+  [ -n "${GLOO_SOCKET_IFNAME:-}" ] && [ -n "$rdma_selector" ] \
     || { collx_log "ERROR: scale-out network selectors are unavailable"; return 1; }
   IFS=, read -r -a interfaces <<< "$GLOO_SOCKET_IFNAME"
   for interface in "${interfaces[@]}"; do
     [ -d "/sys/class/net/$interface" ] \
       || { collx_log "ERROR: configured scale-out socket interface is absent"; return 1; }
   done
-  IFS=, read -r -a devices <<< "$NCCL_IB_HCA"
+  IFS=, read -r -a devices <<< "$rdma_selector"
   for device in "${devices[@]}"; do
     device="${device#=}"
     rdma_name="${device%%:*}"

--- a/experimental/CollectiveX/runtime/probe.py
+++ b/experimental/CollectiveX/runtime/probe.py
@@ -223,6 +223,35 @@ def _check_port(port_path: Path, ordinal: int, gid_index: str, profile: str):
     return layer
 
 
+def _emit_fabric_inventory(sys_root: Path = Path("/sys"),
+                           route_path: Path = Path("/proc/net/route")) -> None:
+    # Failure-path diagnostic only. When the operator-pinned profile does not match the node
+    # (a pool moved under an existing SKU, as b300-nv -> b300-dsxe did), the launcher's log tail
+    # is the only view an operator without shell access has of the node, so say what IS there:
+    # every non-loopback interface with its operstate, and every RDMA device with its ports'
+    # state and link layer. The marker prefix stays outside the launcher's failure vocabulary.
+    nets = []
+    net_root = sys_root / "class" / "net"
+    for net in sorted(net_root.iterdir()) if net_root.is_dir() else []:
+        if net.name == "lo": continue
+        oper = net / "operstate"
+        nets.append(f"{net.name}={oper.read_text().strip() if oper.is_file() else '?'}")
+    rdma = []
+    ib_root = sys_root / "class" / "infiniband"
+    for dev in sorted(ib_root.iterdir()) if ib_root.is_dir() else []:
+        ports = []
+        for port in sorted(p for p in (dev / "ports").iterdir() if p.is_dir()) if (dev / "ports").is_dir() else []:
+            state = port / "state"; link = port / "link_layer"
+            ports.append(f"{port.name}:{state.read_text().split()[0].rstrip(':') if state.is_file() else '?'}"
+                         f"/{link.read_text().strip() if link.is_file() else '?'}")
+        rdma.append(f"{dev.name}({','.join(ports)})")
+    try: default = default_route_interface(route_path)
+    except OSError: default = ""
+    _emit(f"fabric-inventory-default-route={default or 'none'}")
+    _emit(f"fabric-inventory-net={','.join(nets) or 'none'}")
+    _emit(f"fabric-inventory-rdma={','.join(rdma) or 'none'}")
+
+
 def validate_network_profile(socket_names: str, rdma_devices: str, gid_index: str,
                              sys_root: Path = Path("/sys"),
                              route_path: Path = Path("/proc/net/route")) -> None:
@@ -280,7 +309,12 @@ def main() -> None:
     elif args.command == "cuda-context": validate_cuda_context(args.expected)
     elif args.command == "image-digest": print(resolve_image_digest(args.image), end="")
     elif args.command == "gpu-health": validate_gpu_health()
-    else: validate_network_profile(args.socket_names, args.rdma_devices, args.gid_index)
+    else:
+        try:
+            validate_network_profile(args.socket_names, args.rdma_devices, args.gid_index)
+        except SystemExit as exc:
+            if exc.code: _emit_fabric_inventory()
+            raise
 
 
 if __name__ == "__main__": main()

--- a/experimental/CollectiveX/runtime/probe.py
+++ b/experimental/CollectiveX/runtime/probe.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import re
+import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -223,34 +224,50 @@ def _check_port(port_path: Path, ordinal: int, gid_index: str, profile: str):
     return layer
 
 
+def _read(path: Path) -> str:
+    try: return path.read_text().strip() if path.is_file() else "?"
+    except OSError: return "?"
+
+
 def _emit_fabric_inventory(sys_root: Path = Path("/sys"),
                            route_path: Path = Path("/proc/net/route")) -> None:
     # Failure-path diagnostic only. When the operator-pinned profile does not match the node
     # (a pool moved under an existing SKU, as b300-nv -> b300-dsxe did), the launcher's log tail
     # is the only view an operator without shell access has of the node, so say what IS there:
     # every non-loopback interface with its operstate, and every RDMA device with its ports'
-    # state and link layer. The marker prefix stays outside the launcher's failure vocabulary.
+    # state, link layer, physical state, rate and bound netdevs. The marker prefix stays outside
+    # the launcher's failure vocabulary. The per-device lines and the GPU<->NIC topology are
+    # emitted from relative node zero only so a multi-node probe still fits the 100-line tail.
     nets = []
     net_root = sys_root / "class" / "net"
     for net in sorted(net_root.iterdir()) if net_root.is_dir() else []:
         if net.name == "lo": continue
-        oper = net / "operstate"
-        nets.append(f"{net.name}={oper.read_text().strip() if oper.is_file() else '?'}")
-    rdma = []
-    ib_root = sys_root / "class" / "infiniband"
-    for dev in sorted(ib_root.iterdir()) if ib_root.is_dir() else []:
-        ports = []
-        for port in sorted(p for p in (dev / "ports").iterdir() if p.is_dir()) if (dev / "ports").is_dir() else []:
-            state = port / "state"; link = port / "link_layer"
-            ports.append(f"{port.name}:{state.read_text().split()[0].rstrip(':') if state.is_file() else '?'}"
-                         f"/{link.read_text().strip() if link.is_file() else '?'}")
-        rdma.append(f"{dev.name}({','.join(ports)})")
+        nets.append(f"{net.name}={_read(net / 'operstate')}")
     try: default = default_route_interface(route_path)
     except OSError: default = ""
     _emit(f"fabric-inventory-default-route={default or 'none'}")
     _emit(f"fabric-inventory-net={','.join(nets) or 'none'}")
-    _emit(f"fabric-inventory-rdma={','.join(rdma) or 'none'}")
-
+    if os.environ.get("SLURM_NODEID", "0") != "0":
+        return
+    ib_root = sys_root / "class" / "infiniband"
+    for dev in sorted(ib_root.iterdir()) if ib_root.is_dir() else []:
+        ports = []
+        ports_root = dev / "ports"
+        for port in sorted(p for p in ports_root.iterdir() if p.is_dir()) if ports_root.is_dir() else []:
+            ports.append(f"{port.name}:{_read(port / 'state').split(':')[0]}"
+                         f"/{_read(port / 'link_layer')}/{_read(port / 'phys_state').split(':')[0]}"
+                         f"/{_read(port / 'rate').split(' ')[0]}")
+        net_dir = dev / "device" / "net"
+        netdevs = ",".join(sorted(n.name for n in net_dir.iterdir())) if net_dir.is_dir() else "-"
+        _emit(f"fabric-inventory-rdma-device={dev.name} ports={';'.join(ports) or '-'} "
+              f"hca={_read(dev / 'hca_type')} fw={_read(dev / 'fw_ver')} "
+              f"pci={_read(dev / 'device' / 'vendor')}:{_read(dev / 'device' / 'device')} netdev={netdevs}")
+    try:
+        topo = subprocess.run(["nvidia-smi", "topo", "-m"], capture_output=True, text=True, timeout=30).stdout
+    except (OSError, subprocess.SubprocessError):
+        topo = ""
+    for line in topo.splitlines()[:40]:
+        if line.strip(): _emit(f"fabric-inventory-topo {line.rstrip()}")
 
 def validate_network_profile(socket_names: str, rdma_devices: str, gid_index: str,
                              sys_root: Path = Path("/sys"),

--- a/experimental/CollectiveX/runtime/probe.py
+++ b/experimental/CollectiveX/runtime/probe.py
@@ -198,7 +198,7 @@ def _emit(marker: str) -> None:
     print(f"[collectivex-private] {marker}")
 
 
-def _check_port(port_path: Path, ordinal: int, gid_index: str, profile: str):
+def _check_port(port_path: Path, ordinal: int, gid_index: str, profile: str, fabric: str = ""):
     # Return the port's link layer ("roce"/"infiniband") when it is active, carries a
     # non-empty GID at the pinned index, and agrees with any already-seen link layer;
     # otherwise emit the matching rdma-port-<ordinal>=<reason> marker and return None.
@@ -217,6 +217,10 @@ def _check_port(port_path: Path, ordinal: int, gid_index: str, profile: str):
     if not link.is_file():
         _emit(f"rdma-port-{ordinal}=link-layer-missing"); return None
     layer = {"Ethernet": "roce", "InfiniBand": "infiniband"}.get(link.read_text().strip())
+    # AWS EFA is a verbs device whose port carries no link layer (sysfs says Unspecified or
+    # Unknown, rdma-core names it rdmap*). Only an operator-declared EFA fabric may accept that.
+    if layer is None and fabric == "efa" and link.read_text().strip() in ("Unspecified", "Unknown"):
+        layer = "efa"
     if layer is None:
         _emit(f"rdma-port-{ordinal}=link-layer-invalid"); return None
     if profile and profile != layer:
@@ -270,6 +274,7 @@ def _emit_fabric_inventory(sys_root: Path = Path("/sys"),
         if line.strip(): _emit(f"fabric-inventory-topo {line.rstrip()}")
 
 def validate_network_profile(socket_names: str, rdma_devices: str, gid_index: str,
+                             fabric: str = "",
                              sys_root: Path = Path("/sys"),
                              route_path: Path = Path("/proc/net/route")) -> None:
     # Prove the operator-pinned scale-out fabric on this node: resolve the cross-node socket
@@ -298,13 +303,13 @@ def validate_network_profile(socket_names: str, rdma_devices: str, gid_index: st
         if not ports.is_dir():
             _emit(f"rdma-device-{ordinal}=missing"); raise SystemExit(1)
         if configured_port:
-            layer = _check_port(ports / configured_port, ordinal, gid_index, profile)
+            layer = _check_port(ports / configured_port, ordinal, gid_index, profile, fabric)
             if layer is None: raise SystemExit(1)
             profile = layer
         else:
             active = False
             for port_path in sorted(p for p in ports.iterdir() if p.is_dir()):
-                layer = _check_port(port_path, ordinal, gid_index, profile)
+                layer = _check_port(port_path, ordinal, gid_index, profile, fabric)
                 if layer is not None:
                     profile, active = layer, True
             if not active: raise SystemExit(1)
@@ -319,7 +324,7 @@ def main() -> None:
     command = commands.add_parser("cuda-context"); command.add_argument("expected", type=int)
     command = commands.add_parser("image-digest"); command.add_argument("image")
     commands.add_parser("gpu-health")
-    command = commands.add_parser("network-profile"); command.add_argument("socket_names"); command.add_argument("rdma_devices"); command.add_argument("gid_index")
+    command = commands.add_parser("network-profile"); command.add_argument("socket_names"); command.add_argument("rdma_devices"); command.add_argument("gid_index"); command.add_argument("fabric", nargs="?", default="")
     args = parser.parse_args()
     if args.command == "default-route-interface": print(default_route_interface(), end="")
     elif args.command == "prepare-cache": print(prepare_cache(args.parent), end="")
@@ -328,7 +333,7 @@ def main() -> None:
     elif args.command == "gpu-health": validate_gpu_health()
     else:
         try:
-            validate_network_profile(args.socket_names, args.rdma_devices, args.gid_index)
+            validate_network_profile(args.socket_names, args.rdma_devices, args.gid_index, args.fabric)
         except SystemExit as exc:
             if exc.code: _emit_fabric_inventory()
             raise

--- a/experimental/CollectiveX/tests/test_runtime.py
+++ b/experimental/CollectiveX/tests/test_runtime.py
@@ -38,7 +38,7 @@ class PlatformRegistryTests(unittest.TestCase):
     NETWORK_FIELDS = {
         "socket_ifname", "rdma_devices", "ib_gid_index",
         "rdma_service_level", "rdma_traffic_class", "rail_isolated",
-        "single_node_rdma_devices",
+        "single_node_rdma_devices", "rdma_fabric",
     }
 
     def test_every_platform_entry_is_complete_and_typed(self) -> None:
@@ -322,7 +322,7 @@ class StageTests(unittest.TestCase):
 
 # Probe output is consumed by the launcher to select an interface and link layer.
 SOCKET_MARKER = r"^\[collectivex-private\] socket-interface-selected=([A-Za-z][A-Za-z0-9_.-]{0,31})$"
-LINK_MARKER = r"^\[collectivex-private\] rdma-link-layer=(roce|infiniband)$"
+LINK_MARKER = r"^\[collectivex-private\] rdma-link-layer=(roce|infiniband|efa)$"
 FAILURE_MARKER = (
     r"(socket-interface|rdma-(device|port))-[0-9]+="
     r"(missing|down|inactive|default-route-missing|gid-missing|gid-empty|"
@@ -375,6 +375,45 @@ class NetworkProfileContract(unittest.TestCase):
             self.assertEqual(rc, 1)
             failures = [line for line in lines if re.search(FAILURE_MARKER, line)]
             self.assertTrue(any("rdma-port-1=inactive" in line for line in failures), failures)
+
+    def _efa_fabric(self, root: Path) -> None:
+        # An EFA node as sysfs shows it: default-route interface up, verbs device whose port is
+        # ACTIVE but carries link_layer Unspecified and no usable GID table (rdma-core -> rdmap*).
+        net = root / "class" / "net" / "enp71s0"
+        net.mkdir(parents=True)
+        (net / "operstate").write_text("up\n")
+        port = root / "class" / "infiniband" / "rdmap86s0" / "ports" / "1"
+        (port / "gids").mkdir(parents=True)
+        (port / "state").write_text("4: ACTIVE\n")
+        (port / "link_layer").write_text("Unspecified\n")
+
+    def _run_efa(self, root: Path, route: Path, fabric: str):
+        buffer = io.StringIO()
+        rc = 0
+        try:
+            with contextlib.redirect_stdout(buffer):
+                probe.validate_network_profile("enp71s0", "rdmap86s0", "", fabric,
+                                                sys_root=root, route_path=route)
+        except SystemExit:
+            rc = 1
+        return rc, buffer.getvalue().splitlines()
+
+    def test_declared_efa_fabric_accepts_the_unspecified_link_layer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._efa_fabric(root)
+            rc, lines = self._run_efa(root, root / "route", "efa")
+            self.assertEqual(rc, 0, lines)
+            self.assertEqual(self._captures(SOCKET_MARKER, lines), ["enp71s0"])
+            self.assertEqual(self._captures(LINK_MARKER, lines), ["efa"])
+
+    def test_undeclared_fabric_still_rejects_the_unspecified_link_layer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._efa_fabric(root)
+            rc, lines = self._run_efa(root, root / "route", "")
+            self.assertEqual(rc, 1)
+            self.assertIn("[collectivex-private] rdma-port-1=link-layer-invalid", lines)
 
 # config.py case-args is the single case→invocation codec: collx_run_shard decodes one
 # null-delimited argv per case and hands it verbatim to bench/run_ep.py. Parse the


### PR DESCRIPTION
## Why

Main's b300 CollectiveX block still described the retired b300-nv cluster (qos `batch_1_qos`, `/data/home/sa-shared/sqsh`, `bond0`, `mlx5_*` RoCE rails). Every b300 shard died at `salloc`, then at the network probe or rendezvous. The b300 CI pool is now **b300-dsxe**, an AWS `p6-b300.48xlarge` cluster whose scale-out fabric is **EFA**, not InfiniBand/RoCE.

## What changed

- **Operator block** → DSXE: partition `batch_1`, account `benchmark`, qos `normal`, per-user squash dir on Lustre `/data`.
- **Socket interface**: no `bond0` on DSXE; b300 now resolves it from the default route (h200-dgxc precedent). Fixes single-node rendezvous.
- **`rdma_fabric: "efa"`** (new allowlisted network field): EFA devices are verbs devices with an *unspecified* link layer and no GID table, so the network-profile probe accepts that link layer only when the operator declares EFA and emits `rdma-link-layer=efa`. The scale-out profile then sets `NCCL_NET_PLUGIN=ofi`, `FI_PROVIDER=efa`, points NVSHMEM at its libfabric transport, and leaves the whole IB selector family (`NCCL_IB_*`, `NVSHMEM_HCA_LIST`/IBGDA, MoRI, UCCL) unset. Backend setup fails loudly if the aws-ofi-nccl plugin the cluster's enroot hook mounts is absent from the container.
- **b300 EP16 withheld** (`backends` → `[8]` for nccl-ep and deepep-v2) until the pool ships gdrcopy — see blocker below. **DeepEP V2 low-latency withheld** too (`ll_backends` → nccl-ep only): its legacy NVSHMEM Buffer aborts at init on this pool (`nvshmem detect topo failed`, status 28), with and without `NVSHMEM_REMOTE_TRANSPORT=none`. nccl-ep EP8 HT + LL and deepep-v2 EP8 HT stay.
- **Probe diagnostics**: when the network profile fails, the probe now prints the node's interfaces, RDMA devices (state / link layer / phys / rate / netdev) and GPU topology into the launcher log tail. This is how the DSXE fabric was identified before shell access existed.
- README: documents `rdma_fabric`, the gdrcopy requirement for EFA GIN, and that `socket_ifname` is optional.

## Cluster differences worth knowing (b300-nv → b300-dsxe)

| | b300-nv | b300-dsxe |
|---|---|---|
| Fabric | ConnectX-8 RoCE, 16 `mlx5_*` rails, GID 3, rail-isolated | **AWS EFA**, 16 `rdmap*s0` devices (400G each), no link layer / GID / SL |
| NCCL net | builtin IB, `NCCL_IB_HCA` pin | **aws-ofi-nccl 1.20.0** via libfabric 2.4 (`/opt/amazon/ofi-nccl`, mounted by enroot hook `99-aia-efa.sh`); loads as "Libfabric (v12)", 8 devices × 2 rails, GDRDMA + DMA-BUF |
| GIN | NCCL GDAKI over IB verbs | plugin GIN (`ncclGinPlugin_v13`; NCCL 2.30.7 loads v13/v14) — **needs GDRCopy 2.5+, absent on the nodes** |
| Socket iface | `bond0` | `enp71s0` (default route) |
| GDR | gdrdrv / peermem | neither installed |
| Storage | node-local /home | Lustre `/data` homes |
| Also present | — | 2 ConnectX-7 IB ports (`ibp198s0f0/ibp199s0f0`, active, role unknown, not the GPU fabric) |

## EP16 blocker (infra, not code)

Hand-reproduced on 2 nodes with `NCCL_DEBUG=INFO`: the net plugin initialises fine, but its GIN init fails —
`nccl_ofi_gin_init:74 NCCL WARN NET/OFI Failed to initialize GDRCopy: Failed to open gdr handle` (plugin string: "GIN requires GDRCopy 2.5+ for forced PCIe copy support"). NCCL then reports `Failed to initialize any GIN plugin` → `Symmetric memory is not supported … globalGinSupport 0` → Device API off → `ncclEpCreateGroup` returns error 5 ("NCCL EP requires NCCL Device API support"). The nodes have no `gdrdrv` module, package or `libgdrapi`. Proxy GIN (`NCCL_GIN_TYPE=2`) hits the same wall, so there is no env workaround.

**Ask for the cluster owners:** install gdrcopy ≥ 2.5 (dkms `gdrdrv` + `libgdrapi`) on `dsxe-sa-b300-prd0-gpu-*` and load it at boot. Then flip b300 back to `[8, 16]`.

## Validation

- Run 34450521920 / 34488174274: operator fix confirmed (`salloc` + squash import work); failures isolated to `bond0`.
- Run 34504491720: **b300 nccl-ep EP8 HT 14/14 and LL 9/9 pass** on v0.2 (HT decode +21% / prefill −5% vs v0.1; LL 3× faster than HT).
- Run 34514096246: b300 nccl-ep EP16 over EFA — probe, backend prep, rendezvous all pass; fails at group creation per the blocker above.
- Run 34521825749: **b300 deepep-v2 EP8 HT bf16 + fp8 pass 28/28**; both LL shards fail at NVSHMEM init (see above). Run 34523594787 (LL with `NVSHMEM_REMOTE_TRANSPORT=none`) fails identically — that knob was reverted.

## What is still held on b300 and why

| Leg | State | Unblocks when |
|---|---|---|
| nccl-ep EP8 HT + LL | green | — |
| deepep-v2 EP8 HT (bf16, fp8) | green | — |
| nccl-ep EP16, deepep-v2 EP16 | held | gdrcopy ≥ 2.5 installed on the nodes (plugin GIN) |
| deepep-v2 LL EP8 | held | NVSHMEM init on this pool understood (needs NVSHMEM_DEBUG from a hand run) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scale-out networking and NCCL/NVSHMEM env for b300 CI; misconfiguration could break multi-node benchmarks, though EP16 legs are withheld and validation fails closed on missing plugins.
> 
> **Overview**
> Repoints **b300** in `platform_config.json` from the retired RoCE (`mlx5_*`, `bond0`, old qos/squash paths) to the **b300-dsxe** AWS **EFA** pool: new fabric metadata, `rdma_fabric: "efa"`, sixteen `rdmap*` devices, and operator defaults for DSXE. **EP16** and **DeepEP V2 low-latency** are limited to **EP8** in the registry until node **GDRCopy** and NVSHMEM LL issues are resolved.
> 
> Adds **`rdma_fabric`** as an allowlisted network field and an **EFA scale-out profile** in `common.sh`: when `efa` is set, the probe may treat unspecified link layers as valid, the launcher sets **aws-ofi-nccl** (`NCCL_NET_PLUGIN=ofi`, `FI_PROVIDER=efa`) and NVSHMEM libfabric instead of `NCCL_IB_*`/IBGDA pins, and **`socket_ifname`** is optional (default-route interface). Container prep in `prepare_backend.sh` requires the **ofi-nccl** plugin inside the image on EFA.
> 
> **`probe.py`** takes a fabric argument, emits **`rdma-link-layer=efa`**, and on profile failure dumps **fabric inventory** (interfaces, RDMA devices, GPU topo) for operators without shell access. Tests and README document the EFA contract and GDRCopy GIN blocker for EP16.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac76681a2b9a5ea8b52269cd85cf9e067172944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->