### PR TITLE
[Klaud Cold] Update glm5.2-fp8-mi325x-sglang-agentic-mtp SGLang ROCm image to v0.5.19-rocm720-mi30x / 将 glm5.2-fp8-mi325x-sglang-agentic-mtp 的 SGLang ROCm 镜像更新至 v0.5.19-rocm720-mi30x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -1547,7 +1547,7 @@ minimaxm3-fp8-mi300x-vllm-agentic-mtp:
 # GPU-resident-KV c1/c2/c3/c4/c5/c6/c8 curve from Actions run 29657732517
 # and enables EAGLE MTP with the committed thinking-on golden AL.
 glm5.2-fp8-mi325x-sglang-agentic-mtp:
-  image: lmsysorg/sglang:v0.5.16-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.19-rocm720-mi30x
   model: zai-org/GLM-5.2-FP8
   model-prefix: glm5.2
   runner: cluster:mi325x-amds

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7138,3 +7138,9 @@
     - "Pin vLLM nightly-9ea8f3ffc354901b740f0b31988900897b7221d7, Dynamo 1.5.0.dev20260908, and NVIDIA/srt-slurm d50ee7280c33d469df8708e363e23be2456e94fb."
     - "Use Dynamo-native MiniMax parsing, EAGLE3 with FlashInfer, FULL_AND_PIECEWISE CUDA graphs, and wait for the OpenAI chat route before AgentX trace replay."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2925
+
+- config-keys:
+    - glm5.2-fp8-mi325x-sglang-agentic-mtp
+  description:
+    - "Update the GLM-5.2 FP8 MI325X SGLang AgentX MTP image from lmsysorg/sglang:v0.5.16-rocm720-mi30x to the SGLang v0.5.19 release image lmsysorg/sglang:v0.5.19-rocm720-mi30x (AITER c16d44b9, torch 2.11.0+rocm7.2) while preserving the TP8/EP1, GPU-resident BF16 KV, TileLang DSA, 1M-context, EAGLE MTP topology and the c1/c2/c3/c4/c5/c6/c8 search space"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2980


### PR DESCRIPTION
Update the `glm5.2-fp8-mi325x-sglang-agentic-mtp` family image from `lmsysorg/sglang:v0.5.16-rocm720-mi30x` to the SGLang v0.5.19 release image `lmsysorg/sglang:v0.5.19-rocm720-mi30x` (Docker Hub digest `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`, pushed 2026-09-04). Model, precision, TP8/EP1 topology, EAGLE MTP settings, workloads and the recipe script are unchanged.

## Baseline

- **Published date:** 2026-08-08 (public API `workflow-info?date=2026-08-08&benchmarkType=agentic_traces` and `benchmarks?model=GLM-5.2&date=2026-08-08&exact=true&sequence=agentic-traces`)
- **Old image:** `lmsysorg/sglang:v0.5.16-rocm720-mi30x` (digest `sha256:80d04638deb64fac000fa565cb46e5d2f692173dc125a32a956014a6383ecaee`)
- **Workload / topology:** AgentX agentic-coding traces, single node 8xMI325X, TP8/EP1, GPU-resident BF16 KV, TileLang DSA, 1M context, EAGLE MTP (3 steps, top-k 1, 4 draft tokens), concurrency 1/2/3/4/5/6/8; no eval points in this family's matrix.
- **Producer:** [Actions run 31229823255](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31229823255) attempt 1, head `8c4d33868d6b10291cbc63dc399f4ad228535455`, changelog [#2528](https://github.com/SemiAnalysisAI/InferenceX/pull/2528).
- **Source:** old [sglang v0.5.16](https://github.com/sgl-project/sglang/tree/v0.5.16) (`fdebc938`), new [sglang v0.5.19](https://github.com/sgl-project/sglang/tree/v0.5.19) (`0bcd8223`); both built from `docker/rocm.Dockerfile` flavor `gfx942-rocm720` with `SGL_BRANCH` set to the release tag.

| conc | tput/GPU (tok/s) | output tok/s | median TTFT (s) | median TPOT (s) | median E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 1 | 688.24 | 26.08 | 2.134 | 0.0299 | 16.10 |
| 2 | 778.46 | 41.48 | 2.649 | 0.0340 | 26.01 |
| 3 | 813.03 | 52.96 | 1.626 | 0.0381 | 10.67 |
| 4 | 725.85 | 47.97 | 1.802 | 0.0366 | 9.58 |
| 5 | 537.28 | 40.21 | 6.458 | 0.0374 | 90.17 |
| 6 | 415.90 | 30.28 | 89.796 | 0.0566 | 202.36 |
| 8 | 360.81 | 18.15 | 206.810 | 0.1366 | 264.72 |

---

将 `glm5.2-fp8-mi325x-sglang-agentic-mtp` 配方的镜像从 `lmsysorg/sglang:v0.5.16-rocm720-mi30x` 更新为 SGLang v0.5.19 正式发布镜像 `lmsysorg/sglang:v0.5.19-rocm720-mi30x`（Docker Hub 摘要 `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`，2026-09-04 推送）。模型、精度、TP8/EP1 拓扑、EAGLE MTP 参数、工作负载与配方脚本均保持不变。

## 基线

- **发布日期：** 2026-08-08（公开 API `workflow-info?date=2026-08-08&benchmarkType=agentic_traces` 与 `benchmarks?model=GLM-5.2&date=2026-08-08&exact=true&sequence=agentic-traces`）
- **旧镜像：** `lmsysorg/sglang:v0.5.16-rocm720-mi30x`（摘要 `sha256:80d04638deb64fac000fa565cb46e5d2f692173dc125a32a956014a6383ecaee`）
- **工作负载 / 拓扑：** AgentX agentic-coding 轨迹回放，单节点 8xMI325X，TP8/EP1，GPU 常驻 BF16 KV，TileLang DSA，1M 上下文，EAGLE MTP（3 步、top-k 1、4 个草稿 token），并发度 1/2/3/4/5/6/8；该配方矩阵不含评测点。
- **生产运行：** [Actions run 31229823255](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31229823255) 第 1 次尝试，head `8c4d33868d6b10291cbc63dc399f4ad228535455`，变更日志 [#2528](https://github.com/SemiAnalysisAI/InferenceX/pull/2528)。
- **源码：** 旧 [sglang v0.5.16](https://github.com/sgl-project/sglang/tree/v0.5.16)（`fdebc938`），新 [sglang v0.5.19](https://github.com/sgl-project/sglang/tree/v0.5.19)（`0bcd8223`）；两者均由 `docker/rocm.Dockerfile` 的 `gfx942-rocm720` 变体构建，`SGL_BRANCH` 指向对应发布标签。

| 并发度 | 每 GPU 吞吐 (tok/s) | 输出 tok/s | TTFT 中位数 (s) | TPOT 中位数 (s) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- |
| 1 | 688.24 | 26.08 | 2.134 | 0.0299 | 16.10 |
| 2 | 778.46 | 41.48 | 2.649 | 0.0340 | 26.01 |
| 3 | 813.03 | 52.96 | 1.626 | 0.0381 | 10.67 |
| 4 | 725.85 | 47.97 | 1.802 | 0.0366 | 9.58 |
| 5 | 537.28 | 40.21 | 6.458 | 0.0374 | 90.17 |
| 6 | 415.90 | 30.28 | 89.796 | 0.0566 | 202.36 |
| 8 | 360.81 | 18.15 | 206.810 | 0.1366 | 264.72 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only container pin for a benchmark matrix; no serving logic, auth, or application code changes.
> 
> **Overview**
> Bumps the **GLM-5.2 FP8 MI325X AgentX MTP** benchmark recipe (`glm5.2-fp8-mi325x-sglang-agentic-mtp`) from `lmsysorg/sglang:v0.5.16-rocm720-mi30x` to **`lmsysorg/sglang:v0.5.19-rocm720-mi30x`**. Model, TP8/EP1, EAGLE MTP, agentic-coding scenario, and the concurrency **1–8** search space are unchanged.
> 
> Adds a matching **`perf-changelog.yaml`** entry (PR #2980) noting the image move and that topology/settings stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad243e0193906bc5c12f077f1240e59916aabb9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->