### PR TITLE
[Klaud Cold] Update dsr1-fp4-b300-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp4-b300-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1033,7 +1033,7 @@ dsv4-fp4-b200-vllm-mtp:
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4
 # B200 SGLang recipe as-is until B300-specific tuning is available.
 dsr1-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
   runner: b300


### PR DESCRIPTION
Update the `dsr1-fp4-b300-sglang` master image from `lmsysorg/sglang:v0.5.12-cu130` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, tag commit [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). The recipe script, model, TP4/EP4 and TP8/EP8 topologies, the 8k1k workload and the concurrency ranges are unchanged.

## Baseline

- **Published date:** 2026-05-22 (`benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`, `workflow-info?date=2026-05-22`, `evaluations?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`)
- **Old image:** `lmsysorg/sglang:v0.5.12-cu130` (digest `sha256:42194170546745092e74cd5f81ad32a7c6e944c7111fe7bf13588152277ff356`, tag commit [sgl-project/sglang@127b9e3](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624))
- **Workload / topology:** single-node B300, `nvidia/DeepSeek-R1-0528-FP4-V2`, SGLang NVFP4, no speculative decoding, fixed-seq-len 8k1k (ISL 8192 / OSL 1024), random dataset; TP4/EP4 at concurrency 1–128 and TP8/EP8 at concurrency 1–16
- **Producer:** [run 26306422380](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1) (head `6a4fe2a1272bcd6c9df8ea6539f593088ba90437`, changelog PR [#1534](https://github.com/SemiAnalysisAI/InferenceX/pull/1534)); benchmark result IDs 415336, 415396, 415329, 415327, 415351, 415385, 415354, 415324 (TP4/EP4) and 415300, 415295, 415373, 415293, 415285 (TP8/EP8). The run's overall conclusion is `failure` because one unrelated `dsr1-fp8-b200-sglang-mtp` job failed; every `dsr1-fp4-b300-sglang` benchmark and eval job succeeded.

| Shape | Conc | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| TP4/EP4 | 1 | 355.6 | 39.7 | 0.190 | 6.09 | 5.72 |
| TP4/EP4 | 2 | 605.0 | 67.9 | 0.242 | 7.09 | 6.91 |
| TP4/EP4 | 4 | 1045.5 | 116.3 | 0.228 | 8.17 | 7.67 |
| TP4/EP4 | 8 | 1651.0 | 185.6 | 0.253 | 10.27 | 9.82 |
| TP4/EP4 | 16 | 2400.5 | 266.0 | 0.492 | 14.17 | 13.33 |
| TP4/EP4 | 32 | 3321.2 | 371.4 | 0.734 | 20.37 | 19.48 |
| TP4/EP4 | 64 | 4495.5 | 498.7 | 1.057 | 30.56 | 29.21 |
| TP4/EP4 | 128 | 5661.9 | 627.1 | 1.560 | 48.76 | 46.37 |
| TP8/EP8 | 1 | 186.5 | 20.8 | 0.132 | 5.86 | 5.45 |
| TP8/EP8 | 2 | 329.9 | 37.0 | 0.165 | 6.55 | 6.34 |
| TP8/EP8 | 4 | 580.7 | 64.6 | 0.182 | 7.36 | 6.89 |
| TP8/EP8 | 8 | 968.2 | 108.8 | 0.195 | 8.78 | 8.30 |
| TP8/EP8 | 16 | 1497.8 | 166.0 | 0.384 | 11.32 | 10.69 |

- **Published eval:** gsm8k on TP4/EP4 at concurrency 64 (`em_strict` 0.9575 / `em_flexible` 0.9575, evaluation ID 6926) and concurrency 128 (`em_strict` 0.9545 / `em_flexible` 0.9560, evaluation ID 6922), same producer run, n = 1319 each. The public evaluations feed labels these rows `disagg: true`, which does not match the single-node aggregated recipe; the benchmark rows above carry the correct `disagg: false` identity.

---

将 `dsr1-fp4-b300-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.12-cu130` 升级到当前 SGLang 发布版 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，标签提交 [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。配方脚本、模型、TP4/EP4 与 TP8/EP8 拓扑、8k1k 工作负载以及并发范围均保持不变。

## 基线

- **发布日期：** 2026-05-22（`benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`，`workflow-info?date=2026-05-22`，`evaluations?model=DeepSeek-R1-0528&date=2026-05-22&exact=true`）
- **旧镜像：** `lmsysorg/sglang:v0.5.12-cu130`（摘要 `sha256:42194170546745092e74cd5f81ad32a7c6e944c7111fe7bf13588152277ff356`，标签提交 [sgl-project/sglang@127b9e3](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624)）
- **工作负载 / 拓扑：** 单节点 B300，`nvidia/DeepSeek-R1-0528-FP4-V2`，SGLang NVFP4，无投机解码，固定序列长度 8k1k（ISL 8192 / OSL 1024），随机数据集；TP4/EP4 并发 1–128，TP8/EP8 并发 1–16
- **数据来源：** [运行 26306422380](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1)（head `6a4fe2a1272bcd6c9df8ea6539f593088ba90437`，changelog PR [#1534](https://github.com/SemiAnalysisAI/InferenceX/pull/1534)）；基准结果 ID 415336、415396、415329、415327、415351、415385、415354、415324（TP4/EP4）与 415300、415295、415373、415293、415285（TP8/EP8）。该运行的总体结论为 `failure`，原因是一个无关的 `dsr1-fp8-b200-sglang-mtp` 任务失败；`dsr1-fp4-b300-sglang` 的全部基准与评测任务均成功。

| 拓扑 | 并发 | 总吞吐 tok/s/GPU | 输出吞吐 tok/s/GPU | TTFT 中位数 (s) | TPOT 中位数 (ms) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- | --- |
| TP4/EP4 | 1 | 355.6 | 39.7 | 0.190 | 6.09 | 5.72 |
| TP4/EP4 | 2 | 605.0 | 67.9 | 0.242 | 7.09 | 6.91 |
| TP4/EP4 | 4 | 1045.5 | 116.3 | 0.228 | 8.17 | 7.67 |
| TP4/EP4 | 8 | 1651.0 | 185.6 | 0.253 | 10.27 | 9.82 |
| TP4/EP4 | 16 | 2400.5 | 266.0 | 0.492 | 14.17 | 13.33 |
| TP4/EP4 | 32 | 3321.2 | 371.4 | 0.734 | 20.37 | 19.48 |
| TP4/EP4 | 64 | 4495.5 | 498.7 | 1.057 | 30.56 | 29.21 |
| TP4/EP4 | 128 | 5661.9 | 627.1 | 1.560 | 48.76 | 46.37 |
| TP8/EP8 | 1 | 186.5 | 20.8 | 0.132 | 5.86 | 5.45 |
| TP8/EP8 | 2 | 329.9 | 37.0 | 0.165 | 6.55 | 6.34 |
| TP8/EP8 | 4 | 580.7 | 64.6 | 0.182 | 7.36 | 6.89 |
| TP8/EP8 | 8 | 968.2 | 108.8 | 0.195 | 8.78 | 8.30 |
| TP8/EP8 | 16 | 1497.8 | 166.0 | 0.384 | 11.32 | 10.69 |

- **已发布评测：** TP4/EP4 并发 64 的 gsm8k（`em_strict` 0.9575 / `em_flexible` 0.9575，评测 ID 6926）与并发 128（`em_strict` 0.9545 / `em_flexible` 0.9560，评测 ID 6922），同一数据来源运行，各 n = 1319。公共评测接口将这些行标记为 `disagg: true`，与单节点聚合配方不符；上表基准行的 `disagg: false` 身份是正确的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
