### PR TITLE
refactor: share result topology through infx / 通过 infx 共享结果拓扑逻辑

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,9 +209,10 @@ result = build_result(raw_benchmark, runtime_env)
 
 New formats should expose their own typed builder under `infx/results/`, accepting the inputs that format needs and returning a dictionary. Compose shared transformations as ordinary function calls; keep file discovery, environment defaults, error presentation, and serialization in the format's CLI adapter. Existing AgentX topology and request/server processing retain their own policies.
 
-Two helpers are shared by the current processing paths:
+The current processing paths share these helpers:
 
 - [`parse_component_metadata`](../infx/results/metadata.py) accepts a raw JSON value and diagnostic label. Callers select whether `version` is optional and whether invalid input raises `ValueError` or `SystemExit`, preserving their existing contracts.
+- [`Parallelism`](../infx/results/topology.py) shares GPU-count calculation, parallelism result fields, and normalization when there are no separate decode GPUs. Fixed-sequence results retain explicit allocation counts; AgentX derives counts from its workers. Each caller retains its environment defaults, validation order, errors, and throughput denominators.
 - [`with_power_metrics`](../infx/results/power/__init__.py) returns a copy with the supplied metric family replaced, removes stale validity reasons, and validates and rounds new metrics. Callers supply metric keys and schema version, then own artifact writes and validation sidecars. This allows another metric family to reuse the transformation without changing its implementation.
 
 Power telemetry engines also live in [`infx.results.power`](../infx/results/power/): `single_node.run` consumes GPU-monitor CSVs, while `multinode.run` validates srt-slurm artifact packages. They share benchmark-window parsing, per-device integration, aggregate replacement, and audit serialization through `common.py`, while retaining their own telemetry validation and failure policies. Fixed-sequence and AgentX adapters import these engines directly; new result formats can supply their benchmark window and token counts to the matching engine.

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -209,9 +209,10 @@ result = build_result(raw_benchmark, runtime_env)
 
 新增格式应在 `infx/results/` 下提供带类型标注的构建函数，接收该格式所需的输入并返回字典。通过普通函数调用组合共享转换；文件查找、环境默认值、错误呈现和序列化由该格式的 CLI 适配器负责。现有 AgentX 拓扑及请求和服务器指标处理保留各自的策略。
 
-当前处理路径共享两个辅助函数：
+当前处理路径共享以下辅助工具：
 
 - [`parse_component_metadata`](../infx/results/metadata.py) 接收原始 JSON 值和诊断标签。调用方选择 `version` 是否可省略，以及无效输入应抛出 `ValueError` 还是 `SystemExit`，从而保留现有契约。
+- [`Parallelism`](../infx/results/topology.py) 共享 GPU 数量计算、并行度结果字段，以及没有独立解码 GPU 时的字段规范化。固定序列结果继续使用显式分配的 GPU 数量，AgentX 则根据 worker 拓扑推导数量。各调用方保留自己的环境默认值、验证顺序、错误处理和吞吐量分母。
 - [`with_power_metrics`](../infx/results/power/__init__.py) 返回替换了指定指标族的副本，移除旧的有效性原因，并验证、舍入新指标。调用方提供指标键和模式版本，再自行写入工件及验证附属文件。其他指标族因此可以直接复用该转换，无需修改其实现。
 
 功耗遥测处理引擎也位于 [`infx.results.power`](../infx/results/power/)：`single_node.run` 读取 GPU 监控 CSV，`multinode.run` 验证 srt-slurm 工件包。两者通过 `common.py` 共享基准窗口解析、单设备能量积分、聚合结果替换及审计序列化，同时保留各自的遥测校验和失败策略。固定序列及 AgentX 适配器直接导入这些引擎；新结果格式可以将其基准窗口和 token 计数提供给匹配的引擎。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,7 +97,7 @@ Inspect the emitted values, not only the exit code or row count: config key, mod
 | --- | --- |
 | Matrix schema or generation | `python -m pytest utils/matrix_logic/ -v` |
 | Changelog content or PR gating | `python -m pytest utils/test_process_changelog.py utils/changelog_gate_tests/ -v` |
-| Result processing | `python -m pytest utils/test_process_result.py utils/test_aggregate_power.py utils/test_calc_success_rate.py -v` |
+| Result processing and topology | `python -m pytest utils/test_process_result.py utils/agentic/aggregation/test_process_agentic_result.py utils/test_aggregate_power.py utils/test_calc_success_rate.py -v` |
 | Eval dispatch, batching, or patches | `python -m pytest utils/evals/ -v` |
 | Eval collection | `python -m pytest utils/test_collect_eval_results.py -v` |
 | Sweep reuse or reusable artifacts | `python -m pytest utils/test_github.py utils/test_find_reusable_sweep_run.py utils/test_acknowledge_sweep_reuse.py utils/test_validate_reusable_sweep_artifacts.py -v` |

--- a/docs/testing_zh.md
+++ b/docs/testing_zh.md
@@ -97,7 +97,7 @@ uv run --no-project --exclude-newer PT12H --python 3.12 --with pydantic --with p
 | --- | --- |
 | 矩阵模式或生成 | `python -m pytest utils/matrix_logic/ -v` |
 | Changelog 内容或 PR 门禁 | `python -m pytest utils/test_process_changelog.py utils/changelog_gate_tests/ -v` |
-| 结果处理 | `python -m pytest utils/test_process_result.py utils/test_aggregate_power.py utils/test_calc_success_rate.py -v` |
+| 结果处理与拓扑 | `python -m pytest utils/test_process_result.py utils/agentic/aggregation/test_process_agentic_result.py utils/test_aggregate_power.py utils/test_calc_success_rate.py -v` |
 | 评测分发、批处理或补丁 | `python -m pytest utils/evals/ -v` |
 | 评测收集 | `python -m pytest utils/test_collect_eval_results.py -v` |
 | 扫描复用或可复用制品 | `python -m pytest utils/test_github.py utils/test_find_reusable_sweep_run.py utils/test_acknowledge_sweep_reuse.py utils/test_validate_reusable_sweep_artifacts.py -v` |

--- a/infx/results/fixed_sequence.py
+++ b/infx/results/fixed_sequence.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .metadata import parse_component_metadata
 from .power import ALL_POWER_METRIC_KEYS, POWER_METRIC_SCHEMA_VERSION, with_power_metrics
+from .topology import Parallelism, validate_parallelism
 
 
 _BASE_ENV_VARS = (
@@ -76,31 +77,24 @@ def build_result(benchmark: Mapping[str, Any], env: Mapping[str, str]) -> dict[s
         prefill_gpus = int(env['PREFILL_GPUS'])
         decode_gpus = int(env['DECODE_GPUS'])
         prefill_num_workers = int(env['PREFILL_NUM_WORKERS'])
-        prefill_tp = int(env['PREFILL_TP'])
-        prefill_pp = int(env.get('PREFILL_PP_SIZE', '1'))
-        prefill_dcp_size = int(env.get('PREFILL_DCP_SIZE', '1'))
-        prefill_pcp_size = int(env.get('PREFILL_PCP_SIZE', '1'))
-        prefill_ep = int(env['PREFILL_EP'])
+        prefill = Parallelism(
+            tp=int(env['PREFILL_TP']),
+            pp=int(env.get('PREFILL_PP_SIZE', '1')),
+            dcp_size=int(env.get('PREFILL_DCP_SIZE', '1')),
+            pcp_size=int(env.get('PREFILL_PCP_SIZE', '1')),
+            ep=int(env['PREFILL_EP']),
+        )
         prefill_dp_attn = env['PREFILL_DP_ATTN']
         decode_num_workers = int(env['DECODE_NUM_WORKERS'])
-        decode_tp = int(env['DECODE_TP'])
-        decode_pp = int(env.get('DECODE_PP_SIZE', '1'))
-        decode_dcp_size = int(env.get('DECODE_DCP_SIZE', '1'))
-        decode_pcp_size = int(env.get('DECODE_PCP_SIZE', '1'))
-        decode_ep = int(env['DECODE_EP'])
-        decode_dp_attn = env['DECODE_DP_ATTN']
-        worker_parallelism = (
-            prefill_pp,
-            prefill_dcp_size,
-            prefill_pcp_size,
-            decode_pp,
-            decode_dcp_size,
-            decode_pcp_size,
+        decode = Parallelism(
+            tp=int(env['DECODE_TP']),
+            pp=int(env.get('DECODE_PP_SIZE', '1')),
+            dcp_size=int(env.get('DECODE_DCP_SIZE', '1')),
+            pcp_size=int(env.get('DECODE_PCP_SIZE', '1')),
+            ep=int(env['DECODE_EP']),
         )
-        if any(value <= 0 for value in worker_parallelism):
-            raise ValueError(
-                "Multinode PP, DCP, and PCP sizes must be positive integers."
-            )
+        decode_dp_attn = env['DECODE_DP_ATTN']
+        validate_parallelism(prefill, decode)
 
         total_gpus = prefill_gpus + decode_gpus
         if total_gpus <= 0:
@@ -109,26 +103,14 @@ def build_result(benchmark: Mapping[str, Any], env: Mapping[str, str]) -> dict[s
             raise ValueError("Multinode results require at least one prefill GPU.")
 
         output_tput_denominator = decode_gpus if decode_gpus > 0 else total_gpus
-        output_decode_tp = decode_tp if decode_gpus > 0 else 0
-        output_decode_ep = decode_ep if decode_gpus > 0 else 0
-        output_decode_pp = decode_pp if decode_gpus > 0 else 1
-        output_decode_dcp_size = decode_dcp_size if decode_gpus > 0 else 1
-        output_decode_pcp_size = decode_pcp_size if decode_gpus > 0 else 1
+        decode = decode.for_decode(decode_gpus)
 
         multi_node_data = {
             'is_multinode': True,
-            'prefill_tp': prefill_tp,
-            'prefill_pp': prefill_pp,
-            'prefill_dcp_size': prefill_dcp_size,
-            'prefill_pcp_size': prefill_pcp_size,
-            'prefill_ep': prefill_ep,
+            **prefill.fields('prefill_'),
             'prefill_dp_attention': prefill_dp_attn,
             'prefill_num_workers': prefill_num_workers,
-            'decode_tp': output_decode_tp,
-            'decode_pp': output_decode_pp,
-            'decode_dcp_size': output_decode_dcp_size,
-            'decode_pcp_size': output_decode_pcp_size,
-            'decode_ep': output_decode_ep,
+            **decode.fields('decode_'),
             'decode_dp_attention': decode_dp_attn,
             'decode_num_workers': decode_num_workers,
             'num_prefill_gpu': prefill_gpus,
@@ -150,20 +132,19 @@ def build_result(benchmark: Mapping[str, Any], env: Mapping[str, str]) -> dict[s
         tp_size = int(env['TP'])
         ep_size = int(env['EP_SIZE'])
         dp_attention = env['DP_ATTENTION']
-        pp = int(env.get('PP_SIZE', '1'))
-        dcp_size = int(env.get('DCP_SIZE', '1'))
-        pcp_size = int(env.get('PCP_SIZE', '1'))
-        if pp <= 0 or dcp_size <= 0 or pcp_size <= 0:
-            raise ValueError("PP_SIZE, DCP_SIZE, and PCP_SIZE must be positive integers.")
-        num_gpus = tp_size * pp * pcp_size
+        parallelism = Parallelism(
+            tp=tp_size,
+            pp=int(env.get('PP_SIZE', '1')),
+            dcp_size=int(env.get('DCP_SIZE', '1')),
+            pcp_size=int(env.get('PCP_SIZE', '1')),
+            ep=ep_size,
+        )
+        validate_parallelism(parallelism)
+        num_gpus = parallelism.gpus_per_worker
 
         single_node_data = {
             'is_multinode': False,
-            'tp': tp_size,
-            'pp': pp,
-            'dcp_size': dcp_size,
-            'pcp_size': pcp_size,
-            'ep': ep_size,
+            **parallelism.fields(),
             'dp_attention': dp_attention,
             'tput_per_gpu': float(benchmark['total_token_throughput']) / num_gpus,
             'output_tput_per_gpu': float(benchmark['output_throughput']) / num_gpus,

--- a/infx/results/topology.py
+++ b/infx/results/topology.py
@@ -1,0 +1,48 @@
+"""Parallelism calculations shared by fixed-sequence and AgentX results.
+
+Callers own environment parsing, allocation counts, and validation order.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class Parallelism:
+    tp: int
+    pp: int = 1
+    dcp_size: int = 1
+    pcp_size: int = 1
+    ep: int = 1
+
+    @property
+    def gpus_per_worker(self) -> int:
+        """EP and DCP share GPUs; only TP, PP, and PCP multiply allocation."""
+        return self.tp * self.pp * self.pcp_size
+
+    def for_decode(self, num_gpus: int) -> Parallelism:
+        """An aggregate worker has no separate decode parallelism."""
+        return self if num_gpus > 0 else Parallelism(tp=0, ep=0)
+
+    def fields(self, prefix: str = "") -> dict[str, int]:
+        """Return fresh result fields in their existing serialization order."""
+        return {
+            f"{prefix}tp": self.tp,
+            f"{prefix}pp": self.pp,
+            f"{prefix}dcp_size": self.dcp_size,
+            f"{prefix}pcp_size": self.pcp_size,
+            f"{prefix}ep": self.ep,
+        }
+
+
+def validate_parallelism(
+    *layouts: Parallelism, error_type: type[BaseException] = ValueError,
+) -> None:
+    """Validate PP/DCP/PCP after the caller has parsed all its inputs."""
+    if any(size <= 0 for layout in layouts for size in (layout.pp, layout.dcp_size, layout.pcp_size)):
+        dimensions = (
+            "Multinode PP, DCP, and PCP sizes" if len(layouts) > 1
+            else "PP_SIZE, DCP_SIZE, and PCP_SIZE"
+        )
+        raise error_type(f"{dimensions} must be positive integers.")

--- a/utils/agentic/aggregation/process_agentic_result.py
+++ b/utils/agentic/aggregation/process_agentic_result.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from infx.results.metadata import parse_component_metadata
+from infx.results.topology import Parallelism, validate_parallelism
 
 from .aggregation_common import round_floats
 from .request_metrics import compute_request_metrics, load_aggregate, load_records_with_accounting
@@ -74,91 +75,57 @@ def _gpu_shape() -> tuple[dict[str, Any], int, int, int, str]:
     tp = env_int("TP", 1)
     ep = env_int("EP_SIZE", 1)
     dp_attention = os.environ.get("DP_ATTENTION", "false")
-    fields: dict[str, Any] = {}
-
     if not is_multinode:
-        pp = env_int("PP_SIZE", 1)
-        dcp_size = env_int("DCP_SIZE", 1)
-        pcp_size = env_int("PCP_SIZE", 1)
-        if pp <= 0 or dcp_size <= 0 or pcp_size <= 0:
-            raise SystemExit(
-                "PP_SIZE, DCP_SIZE, and PCP_SIZE must be positive integers."
-            )
-        fields.update({"pp": pp, "dcp_size": dcp_size, "pcp_size": pcp_size})
-        return fields, tp * pp * pcp_size, tp, ep, dp_attention
+        parallelism = Parallelism(
+            tp=tp, pp=env_int("PP_SIZE", 1), dcp_size=env_int("DCP_SIZE", 1),
+            pcp_size=env_int("PCP_SIZE", 1), ep=ep,
+        )
+        validate_parallelism(parallelism, error_type=SystemExit)
+        fields = {"pp": parallelism.pp, "dcp_size": parallelism.dcp_size, "pcp_size": parallelism.pcp_size}
+        return fields, parallelism.gpus_per_worker, tp, ep, dp_attention
 
     prefill_num_workers = env_int("PREFILL_NUM_WORKERS")
-    prefill_tp = env_int("PREFILL_TP")
-    prefill_pp = env_int("PREFILL_PP_SIZE", 1)
-    prefill_dcp_size = env_int("PREFILL_DCP_SIZE", 1)
-    prefill_pcp_size = env_int("PREFILL_PCP_SIZE", 1)
-    prefill_ep = env_int("PREFILL_EP", 1)
+    prefill = Parallelism(
+        tp=env_int("PREFILL_TP"), pp=env_int("PREFILL_PP_SIZE", 1),
+        dcp_size=env_int("PREFILL_DCP_SIZE", 1), pcp_size=env_int("PREFILL_PCP_SIZE", 1),
+        ep=env_int("PREFILL_EP", 1),
+    )
     prefill_dp_attention = os.environ.get("PREFILL_DP_ATTN", "false")
     decode_num_workers = env_int("DECODE_NUM_WORKERS")
-    decode_tp = env_int("DECODE_TP")
-    decode_pp = env_int("DECODE_PP_SIZE", 1)
-    decode_dcp_size = env_int("DECODE_DCP_SIZE", 1)
-    decode_pcp_size = env_int("DECODE_PCP_SIZE", 1)
-    decode_ep = env_int("DECODE_EP", 1)
-    decode_dp_attention = os.environ.get("DECODE_DP_ATTN", "false")
-    worker_parallelism = (
-        prefill_pp,
-        prefill_dcp_size,
-        prefill_pcp_size,
-        decode_pp,
-        decode_dcp_size,
-        decode_pcp_size,
+    decode = Parallelism(
+        tp=env_int("DECODE_TP"), pp=env_int("DECODE_PP_SIZE", 1),
+        dcp_size=env_int("DECODE_DCP_SIZE", 1), pcp_size=env_int("DECODE_PCP_SIZE", 1),
+        ep=env_int("DECODE_EP", 1),
     )
-    if any(value <= 0 for value in worker_parallelism):
-        raise SystemExit(
-            "Multinode PP, DCP, and PCP sizes must be positive integers."
-        )
+    decode_dp_attention = os.environ.get("DECODE_DP_ATTN", "false")
+    validate_parallelism(prefill, decode, error_type=SystemExit)
     prefill_hardware = os.environ.get("PREFILL_HARDWARE", "")
     decode_hardware = os.environ.get("DECODE_HARDWARE", "")
     if bool(prefill_hardware) != bool(decode_hardware):
         raise SystemExit(
             "PREFILL_HARDWARE and DECODE_HARDWARE must be specified together."
         )
-    num_prefill_gpu = prefill_num_workers * prefill_tp * prefill_pp * prefill_pcp_size
-    num_decode_gpu = decode_num_workers * decode_tp * decode_pp * decode_pcp_size
+    num_prefill_gpu = prefill_num_workers * prefill.gpus_per_worker
+    num_decode_gpu = decode_num_workers * decode.gpus_per_worker
     num_gpus = num_prefill_gpu + num_decode_gpu
-    # Aggregated configs set decode num-worker 0 (prefill+decode co-located on one
-    # worker), so there are no separate decode GPUs. Mirror process_result.py and drop
-    # the decode-side parallelism, so TP/EP and the per-GPU throughput denominator
-    # reflect the single aggregated worker instead of double-counting its GPUs.
-    if num_decode_gpu <= 0:
-        decode_tp = 0
-        decode_ep = 0
-        decode_pp = 1
-        decode_dcp_size = 1
-        decode_pcp_size = 1
-    tp = prefill_tp + decode_tp
-    ep = max(prefill_ep, decode_ep)
+    decode = decode.for_decode(num_decode_gpu)
+    tp = prefill.tp + decode.tp
+    ep = max(prefill.ep, decode.ep)
     dp_attention = (
         "true"
         if env_bool("PREFILL_DP_ATTN") or env_bool("DECODE_DP_ATTN")
         else "false"
     )
-    fields.update(
-        {
-            "prefill_num_workers": prefill_num_workers,
-            "prefill_tp": prefill_tp,
-            "prefill_pp": prefill_pp,
-            "prefill_dcp_size": prefill_dcp_size,
-            "prefill_pcp_size": prefill_pcp_size,
-            "prefill_ep": prefill_ep,
-            "prefill_dp_attention": prefill_dp_attention,
-            "num_prefill_gpu": num_prefill_gpu,
-            "decode_num_workers": decode_num_workers,
-            "decode_tp": decode_tp,
-            "decode_pp": decode_pp,
-            "decode_dcp_size": decode_dcp_size,
-            "decode_pcp_size": decode_pcp_size,
-            "decode_ep": decode_ep,
-            "decode_dp_attention": decode_dp_attention,
-            "num_decode_gpu": num_decode_gpu,
-        }
-    )
+    fields = {
+        "prefill_num_workers": prefill_num_workers,
+        **prefill.fields("prefill_"),
+        "prefill_dp_attention": prefill_dp_attention,
+        "num_prefill_gpu": num_prefill_gpu,
+        "decode_num_workers": decode_num_workers,
+        **decode.fields("decode_"),
+        "decode_dp_attention": decode_dp_attention,
+        "num_decode_gpu": num_decode_gpu,
+    }
     if prefill_hardware:
         fields["prefill_hw"] = prefill_hardware
         fields["decode_hw"] = decode_hardware

--- a/utils/agentic/aggregation/test_process_agentic_result.py
+++ b/utils/agentic/aggregation/test_process_agentic_result.py
@@ -794,6 +794,53 @@ def test_multinode_processor_rejects_one_sided_hardware(
         _gpu_shape()
 
 
+@pytest.mark.parametrize("env", [{}, {"PP_SIZE": "", "DCP_SIZE": "", "PCP_SIZE": ""}])
+def test_gpu_shape_defaults_empty_parallelism_to_one(monkeypatch, env):
+    monkeypatch.setattr(os, "environ", env)
+    assert _gpu_shape() == ({"pp": 1, "dcp_size": 1, "pcp_size": 1}, 1, 1, 1, "false")
+
+
+@pytest.mark.parametrize("decode_workers,expected_gpus,expected_decode", [
+    ("3", 78, (2, 11, 1, 9, 5)),
+    ("0", 48, (0, 0, 1, 1, 1)),
+])
+def test_gpu_shape_counts_workers_and_normalizes_absent_decode(
+    monkeypatch, decode_workers, expected_gpus, expected_decode,
+):
+    monkeypatch.setattr(os, "environ", {
+        "IS_MULTINODE": "true", "PREFILL_NUM_WORKERS": "2", "PREFILL_TP": "3",
+        "PREFILL_PP_SIZE": "2", "PREFILL_PCP_SIZE": "4", "PREFILL_DCP_SIZE": "7",
+        "PREFILL_EP": "8", "PREFILL_DP_ATTN": "YES", "DECODE_NUM_WORKERS": decode_workers,
+        "DECODE_TP": "2", "DECODE_EP": "11", "DECODE_PP_SIZE": "1",
+        "DECODE_DCP_SIZE": "9", "DECODE_PCP_SIZE": "5", "DECODE_DP_ATTN": "false",
+        "PREFILL_GPUS": "999", "DECODE_GPUS": "999",
+    })
+    fields, num_gpus, tp, ep, attention = _gpu_shape()
+    # Two 24-GPU prefill workers plus either three 10-GPU decode workers or
+    # no decode workers. EP and DCP do not allocate extra GPUs.
+    assert num_gpus == expected_gpus
+    assert fields["num_prefill_gpu"] == 48
+    assert fields["num_decode_gpu"] == (30 if decode_workers == "3" else 0)
+    assert tuple(fields[key] for key in ("decode_tp", "decode_ep", "decode_pp",
+                                        "decode_dcp_size", "decode_pcp_size")) == expected_decode
+    assert (tp, ep, attention) == ((5, 11, "true") if decode_workers == "3" else (3, 8, "true"))
+    assert fields["prefill_dp_attention"] == "YES"
+    assert fields["decode_dp_attention"] == "false"
+
+
+@pytest.mark.parametrize("env,error_type,message", [
+    ({"IS_MULTINODE": "true", "TP": "bad"}, ValueError, "invalid literal for int"),
+    ({"IS_MULTINODE": "true", "PREFILL_PP_SIZE": "0", "PREFILL_HARDWARE": "gpu"},
+     SystemExit, "Multinode PP, DCP, and PCP sizes must be positive integers."),
+    ({"IS_MULTINODE": "true", "DECODE_NUM_WORKERS": "0", "DECODE_PCP_SIZE": "0"},
+     SystemExit, "Multinode PP, DCP, and PCP sizes must be positive integers."),
+])
+def test_gpu_shape_preserves_parsing_and_validation_order(monkeypatch, env, error_type, message):
+    monkeypatch.setattr(os, "environ", env)
+    with pytest.raises(error_type, match=message):
+        _gpu_shape()
+
+
 def test_processor_surfaces_request_accounting(tmp_path: Path):
     result_dir = tmp_path / "results"
     artifact = result_dir / "aiperf_artifacts"

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -65,6 +65,64 @@ def test_result_builder_uses_explicit_readonly_inputs(single_node_env_vars, monk
     assert list(tmp_path.iterdir()) == []
 
 
+def test_multinode_explicit_gpu_counts_control_decode_fields_and_denominators(
+    multinode_env_vars, sample_benchmark_result,
+):
+    from infx.results.fixed_sequence import build_result
+
+    # Worker dimensions describe 48 prefill and 180 decode GPUs. The supplied
+    # allocation counts, 20 and 0, remain authoritative for this collector.
+    env = {**multinode_env_vars, "PREFILL_NUM_WORKERS": "2", "PREFILL_TP": "3",
+           "PREFILL_PP_SIZE": "2", "PREFILL_PCP_SIZE": "4", "DECODE_NUM_WORKERS": "3",
+           "DECODE_TP": "6", "DECODE_EP": "5", "DECODE_PP_SIZE": "2",
+           "DECODE_DCP_SIZE": "3", "DECODE_PCP_SIZE": "5", "DECODE_GPUS": "0"}
+    benchmark = {**sample_benchmark_result, "total_token_throughput": 600,
+                 "output_throughput": 400}
+    result = build_result(benchmark, env)
+    assert [result[key] for key in ("decode_tp", "decode_ep", "decode_pp",
+                                   "decode_dcp_size", "decode_pcp_size")] == [0, 0, 1, 1, 1]
+    assert result["decode_num_workers"] == 3
+    assert result["num_prefill_gpu"] == 20
+    assert result["num_decode_gpu"] == 0
+    assert result["tput_per_gpu"] == 30
+    assert result["input_tput_per_gpu"] == 10
+    assert result["output_tput_per_gpu"] == 20
+
+    result = build_result(benchmark, {**env, "DECODE_GPUS": "4"})
+    assert [result[key] for key in ("decode_tp", "decode_ep", "decode_pp",
+                                   "decode_dcp_size", "decode_pcp_size")] == [6, 5, 2, 3, 5]
+    assert result["tput_per_gpu"] == 25
+    assert result["output_tput_per_gpu"] == 100
+
+
+@pytest.mark.parametrize("overrides,message", [
+    ({"DECODE_HARDWARE": "", "PREFILL_TP": "invalid"},
+     "PREFILL_HARDWARE and DECODE_HARDWARE must be specified together."),
+    ({"PREFILL_PP_SIZE": "0", "DECODE_GPUS": "-20"},
+     "Multinode PP, DCP, and PCP sizes must be positive integers."),
+    ({"DECODE_PP_SIZE": "0", "DECODE_GPUS": "0"},
+     "Multinode PP, DCP, and PCP sizes must be positive integers."),
+])
+def test_multinode_topology_preserves_validation_order(
+    multinode_env_vars, sample_benchmark_result, overrides, message,
+):
+    from infx.results.fixed_sequence import build_result
+
+    with pytest.raises(ValueError) as error:
+        build_result(sample_benchmark_result, {**multinode_env_vars, **overrides})
+    assert str(error.value) == message
+
+
+@pytest.mark.parametrize("name", ["PP_SIZE", "DCP_SIZE", "PCP_SIZE"])
+def test_fixed_topology_rejects_empty_parallelism(
+    single_node_env_vars, sample_benchmark_result, name,
+):
+    from infx.results.fixed_sequence import build_result
+
+    with pytest.raises(ValueError, match="invalid literal for int"):
+        build_result(sample_benchmark_result, {**single_node_env_vars, name: ""})
+
+
 # =============================================================================
 # Test Fixtures - Based on real benchmark output structure
 # =============================================================================


### PR DESCRIPTION
Fixed-sequence and AgentX result builders duplicate parallelism fields, GPU arithmetic, and normalization when there are no separate decode GPUs. Put those shared rules in `infx.results.topology.Parallelism` so they can evolve together.

固定序列与 AgentX 结果构建函数重复实现了并行度字段、GPU 数量计算，以及没有独立解码 GPU 时的字段规范化。本次将这些共享规则集中到 `infx.results.topology.Parallelism`，便于统一维护。

Each caller retains its existing behavior: fixed-sequence results use explicit allocation counts, while AgentX derives counts from worker layouts. Environment parsing, empty-value defaults, validation order, exception types/messages, throughput denominators, JSON field order, and CLI entry points are preserved. The module uses only the standard library; production Python is four lines smaller overall. No recipe, benchmark execution, or workflow-policy changes.

各调用方保留现有行为：固定序列结果使用显式分配的 GPU 数量，AgentX 根据 worker 拓扑推导数量。环境变量解析、空值默认规则、验证顺序、异常类型与消息、吞吐量分母、JSON 字段顺序和 CLI 入口均保持不变。新增模块仅依赖标准库，生产 Python 代码总体减少 4 行；未修改 recipe、基准测试执行逻辑或工作流策略。

Validation against baseline `11e1ba1026b490b3ebf430fa724581f842f3272f`, using Python 3.12.13:

- Added 14 regression cases to existing tests. They passed against the original implementation before production edits, then passed after the refactor. Cases include hand-calculated worker counts, allocation overrides, zero-decode normalization, empty defaults, and competing invalid inputs.
- Ran the exact `Run pytest` step from `.github/workflows/test-process-result.yml` against both implementations with the same expanded tests: **306 passed before in 7.47s; 306 passed after in 7.90s**, including power integration and CLI tests.
- **6,704 differential comparisons matched** using the actual baseline source: 3,172 fixed-sequence builder cases, 3,172 AgentX topology cases, and 360 complete AgentX builder cases. Compared serialized results, numeric types, and exception types/messages across topology combinations and missing, empty, malformed, zero, negative, and large inputs.
- **48 CLI comparisons matched** against a git-archived baseline: artifact bytes, exit codes, stdout, and diagnostic text. Traceback source paths, code excerpts, and line numbers were excluded because extraction changes stack frames. `git diff --check` passed.

使用 Python 3.12.13，与基线 `11e1ba1026b490b3ebf430fa724581f842f3272f` 对比验证：

- 在现有测试中新增 14 个回归用例，先在修改生产代码前验证通过，再在重构后验证通过。覆盖手工计算的 worker GPU 数量、显式分配数量覆盖、无独立解码 GPU 时的规范化、空值默认规则，以及多个无效输入同时存在的情况。
- 对两个实现运行 `.github/workflows/test-process-result.yml` 中相同的 `Run pytest` 步骤，使用相同的扩展测试集：**改动前 306 项通过，耗时 7.47 秒；改动后 306 项通过，耗时 7.90 秒**，包含功耗集成与 CLI 测试。
- 使用真实基线源码完成 **6,704 次差分对比，全部一致**：3,172 个固定序列构建用例、3,172 个 AgentX 拓扑用例，以及 360 个完整 AgentX 结果构建用例。比较序列化结果、数值类型、异常类型和消息，覆盖拓扑组合及缺失、空值、格式错误、零、负数和大整数输入。
- 与 Git 归档基线进行 **48 次 CLI 对比，全部一致**，比较产物字节、退出码、标准输出和诊断文本。由于代码提取会改变堆栈，未比较 traceback 中的源文件路径、代码片段及行号。`git diff --check` 通过。

No differences were found for the covered inputs. These are local compatibility checks; no live GPU benchmark was run.

覆盖的输入中未发现行为差异。以上为本地兼容性验证，未运行真实 GPU 基准测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how benchmark aggregate JSON topology fields are computed for fixed-sequence and AgentX paths; behavior is intended to be identical but mistakes would affect per-GPU throughput and parallelism metadata ingested downstream.
> 
> **Overview**
> Introduces **`infx.results.topology.Parallelism`** so fixed-sequence and AgentX result builders share GPU-per-worker math, serialized TP/PP/DCP/PCP/EP fields, PP/DCP/PCP validation, and **zero-decode** normalization (`for_decode`) instead of duplicating that logic.
> 
> **`build_result`** in `infx/results/fixed_sequence.py` and **`_gpu_shape`** in `utils/agentic/aggregation/process_agentic_result.py` now construct `Parallelism` from env vars and call `validate_parallelism` (AgentX still uses `SystemExit` via `error_type`). Callers keep their own contracts: fixed-sequence still uses explicit `PREFILL_GPUS` / `DECODE_GPUS` for counts and throughput denominators; AgentX still derives GPU counts from workers × `gpus_per_worker`.
> 
> Docs (`architecture*.md`) document the helper; **`docs/testing*.md`** expands the focused pytest row to include `utils/agentic/aggregation/test_process_agentic_result.py`. New regression tests cover multinode decode normalization, validation order, and empty parallelism defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d0486f42c444d661dc55fd677e1fd3bfc435f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->