### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-mi325x-sglang SGLang ROCm image to v0.5.19-rocm720-mi30x / 将 qwen3.5-fp8-mi325x-sglang 的 SGLang ROCm 镜像更新至 v0.5.19-rocm720-mi30x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -171,7 +171,7 @@ dsr1-fp8-mi355x-sglang-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 64, spec-decoding: mtp }
 
 qwen3.5-fp8-mi325x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.19-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi325x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7145,3 +7145,10 @@
     - "Update SGLang image from lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, build commit sgl-project/sglang@30705c00) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T22:50:19Z)."
     - "The release image ships the same CUDA 13.0.3, FlashInfer 0.6.18 and sgl-kernel 0.4.6.post1 as the nightly. benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh is unchanged: SGLANG_ENABLE_SPEC_V2 EAGLE MTP at 3 steps, golden acceptance length 3.39, flashinfer attention with allreduce fusion, fp8 quantization and fp8_e4m3 KV, HiCache kernel IO / page_first layout. TP8/EP1 DRAM HiCache concurrency 2 through 24 unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2966
+
+- config-keys:
+    - qwen3.5-fp8-mi325x-sglang
+  description:
+    - "Update SGLang ROCm image from lmsysorg/sglang:v0.5.12-rocm720-mi30x (v0.5.12 release, build commit sgl-project/sglang@127b9e3283f7c2a43234b852ff5c9f1796d53624) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-rocm720-mi30x (digest sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T21:24:05Z)."
+    - "Both images build docker/rocm.Dockerfile stage gfx942-rocm720 on rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1; AITER moves from a6bb4993 to c16d44b9. benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi325x.sh is unchanged: aiter attention with allreduce fusion, radix cache disabled, mem-fraction-static 0.75; TP8 8k/1k concurrency 4 through 64 unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2988


### PR DESCRIPTION
Update the `qwen3.5-fp8-mi325x-sglang` master image from `lmsysorg/sglang:v0.5.12-rocm720-mi30x` to the SGLang v0.5.19 release image `lmsysorg/sglang:v0.5.19-rocm720-mi30x` (digest `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`, build commit [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). Model, precision, TP8 topology, 8k/1k workload, concurrency 4-64, launch script and eval policy are unchanged.

## Baseline

- Published: 2026-05-17, image `lmsysorg/sglang:v0.5.12-rocm720-mi30x` (build commit [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624))
- Identity: Qwen3.5-397B-A17B-FP8, MI325X, SGLang, FP8, no speculative decoding, aggregated single node, fixed-seq-len ISL 8192 / OSL 1024, TP8, concurrency 4/8/16/32/64
- Producer: [run 25980025185 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25980025185/attempts/2), head `ac2f8485ae6ca170182037c5375298f24cb7cd85`, changelog PR [#1430](https://github.com/SemiAnalysisAI/InferenceX/pull/1430)
- API queries: `/api/v1/workflow-info?date=2026-05-17`, `/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`, `/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`

| conc | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TPOT (ms) | median TTFT (ms) | median E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 281.2 | 31.3 | 14.76 | 852.4 | 14.28 |
| 8 | 486.1 | 54.6 | 17.08 | 832.2 | 16.64 |
| 16 | 790.8 | 87.6 | 21.28 | 870.9 | 20.24 |
| 32 | 1216.4 | 136.0 | 27.81 | 1018.4 | 26.61 |
| 64 | 1733.6 | 192.3 | 39.86 | 1285.7 | 38.14 |

Published eval (same producer run): gsm8k em_strict 0.9689 / em_flexible 0.9621 at concurrency 32 and 64. The published eval rows carry `disagg: true` metadata although the recipe is aggregated single-node; the run URL and config match this family, so the mismatch is noted here as a metadata quirk.

---

将 `qwen3.5-fp8-mi325x-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.12-rocm720-mi30x` 更新至 SGLang v0.5.19 发布镜像 `lmsysorg/sglang:v0.5.19-rocm720-mi30x`（digest `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`，构建提交 [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。模型、精度、TP8 拓扑、8k/1k 工作负载、并发 4-64、启动脚本和评测策略均保持不变。

## 基线

- 发布日期：2026-05-17，镜像 `lmsysorg/sglang:v0.5.12-rocm720-mi30x`（构建提交 [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624)）
- 身份：Qwen3.5-397B-A17B-FP8、MI325X、SGLang、FP8、无投机解码、单节点聚合部署、fixed-seq-len ISL 8192 / OSL 1024、TP8、并发 4/8/16/32/64
- 生产运行：[run 25980025185 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25980025185/attempts/2)，head `ac2f8485ae6ca170182037c5375298f24cb7cd85`，变更日志 PR [#1430](https://github.com/SemiAnalysisAI/InferenceX/pull/1430)
- API 查询：`/api/v1/workflow-info?date=2026-05-17`、`/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`、`/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`

| 并发 | 每 GPU 吞吐 (tok/s) | 每 GPU 输出吞吐 (tok/s) | TPOT 中位数 (ms) | TTFT 中位数 (ms) | E2E 中位数 (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 281.2 | 31.3 | 14.76 | 852.4 | 14.28 |
| 8 | 486.1 | 54.6 | 17.08 | 832.2 | 16.64 |
| 16 | 790.8 | 87.6 | 21.28 | 870.9 | 20.24 |
| 32 | 1216.4 | 136.0 | 27.81 | 1018.4 | 26.61 |
| 64 | 1733.6 | 192.3 | 39.86 | 1285.7 | 38.14 |

已发布评测（同一生产运行）：gsm8k em_strict 0.9689 / em_flexible 0.9621（并发 32 与 64）。已发布评测行的元数据标记为 `disagg: true`，但该配方为单节点聚合部署；运行链接与配置均与本家族匹配，此处仅作为元数据差异记录。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only container pin and changelog; no topology, script, or eval policy changes.
> 
> **Overview**
> Bumps the **`qwen3.5-fp8-mi325x-sglang`** recipe in `configs/amd-master.yaml` from SGLang **`v0.5.12-rocm720-mi30x`** to **`v0.5.19-rocm720-mi30x`**. Model, MI325X runner, FP8, TP8, and the fixed-seq-len 8k/1k concurrency 4–64 search space are unchanged.
> 
> Adds a **`perf-changelog.yaml`** entry for config key `qwen3.5-fp8-mi325x-sglang` documenting the image digest/build commit, shared ROCm 7.2 Docker base, AITER revision bump, and that the launch script `benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi325x.sh` is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395d2505b02b435fcce6d7c8f90a41f995084b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->