### PR TITLE
[Klaud Cold] Update dsr1-fp4-b200-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp4-b200-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -860,7 +860,7 @@ dsr1-fp8-b300-dynamo-trt:
           ep: 8
           dp-attn: true
 dsr1-fp4-b200-sglang:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7162,3 +7162,10 @@
   description:
     - "Use the pinned SGLang nightly-dev-cu13-20260901-07c8f729 image with FlashInfer 0.6.18, which includes the BF16 TRTLLM MoE allocation fix for small-batch Blackwell execution. Model, TP8, HiCache, MTP settings and concurrency grid are unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2829
+
+- config-keys:
+    - dsr1-fp4-b200-sglang
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.16-cu130 (build commit sgl-project/sglang@fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1, CUDA 13.0.1, FlashInfer 0.6.14, sgl-kernel 0.4.5) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, CUDA 13.0.3, FlashInfer 0.6.18, sgl-kernel 0.4.6.post1)."
+    - "benchmarks/single_node/fixed_seq_len/dsr1_fp4_b200.sh is unchanged: nvidia/DeepSeek-R1-0528-FP4-V2 with modelopt_fp4, trtllm_mla attention, flashinfer_trtllm MoE, fp8_e4m3 KV cache, TP4/EP1 concurrency 1-32 and TP4/EP4 DP-attention concurrency 64-256 on the 8k1k workload."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2989


### PR DESCRIPTION
Update the `dsr1-fp4-b200-sglang` master image from `lmsysorg/sglang:v0.5.16-cu130` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, build commit [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1) = tag [v0.5.19](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)). Model, TP4/EP1 and TP4/EP4 DP-attention topologies, the 8k1k workload, concurrency ranges and `benchmarks/single_node/fixed_seq_len/dsr1_fp4_b200.sh` are unchanged.

## Baseline

- **Published date:** 2026-08-06 (`workflow-info?date=2026-08-06`; `benchmarks?model=DeepSeek-R1-0528&date=2026-08-06&exact=true&sequence=8k/1k`, filtered to hardware `b200`, framework `sglang`, precision `fp4`, spec `none`, non-disagg, ISL/OSL 8192/1024; `evaluations?model=DeepSeek-R1-0528&date=2026-08-06&exact=true`)
- **Old image:** `lmsysorg/sglang:v0.5.16-cu130` (Docker Hub digest `sha256:7b6a35df9839fd593a94a1eaee82d7777f472225d9f3ad1f8a2e0cb2bd1785d0`, build commit [sgl-project/sglang@fdebc93](https://github.com/sgl-project/sglang/commit/fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1) = tag `v0.5.16`, CUDA 13.0.1, FlashInfer 0.6.14, sgl-kernel 0.4.5)
- **Workload / topology:** single-node B200 (`cluster:b200-nscale`), `nvidia/DeepSeek-R1-0528-FP4-V2`, SGLang NVFP4, no speculative decoding, fixed-seq-len 8k1k (ISL 8192 / OSL 1024), random dataset; TP4/EP1 at concurrency 1–32 and TP4/EP4 DP-attention at concurrency 64–256 (9 points)
- **Producer:** all 9 points come from [run 30952773184 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30952773184/attempts/1) (head `d4363bd7fd5bda1391d2d0a46d834cecc363c0d6`, changelog PR [#2492](https://github.com/SemiAnalysisAI/InferenceX/pull/2492)); benchmark result IDs 438719 … (curve snapshot `curve_workflow_run_id` 2261 is a logical snapshot, not the producer)
- **Published evals:** N/A — the evaluations feed has no gsm8k row for this identity dated 2026-08-06; the newest published gsm8k for this identity is 2026-03-28 on an older image and is not comparable

| Point | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TPOT (ms) | median TTFT (ms) |
| --- | --- | --- | --- | --- |
| TP4/EP1 c1 | 389.7 | 43.5 | 5.52 | 207 |
| TP4/EP1 c2 | 672.2 | 75.4 | 6.37 | 245 |
| TP4/EP1 c4 | 1134.2 | 126.2 | 7.48 | 245 |
| TP4/EP1 c8 | 1778.0 | 199.9 | 9.49 | 269 |
| TP4/EP1 c16 | 2558.7 | 283.5 | 13.27 | 494 |
| TP4/EP1 c32 | 3428.7 | 383.4 | 19.75 | 769 |
| TP4/EP4 DPA c64 | 4603.2 | 510.7 | 29.73 | 857 |
| TP4/EP4 DPA c128 | 6249.9 | 692.3 | 44.39 | 831 |
| TP4/EP4 DPA c256 | 7955.2 | 884.2 | 66.38 | 4092 |

---

将 `dsr1-fp4-b200-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.16-cu130` 更新至当前 SGLang 发布版 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，构建提交 [sgl-project/sglang@0bcd822](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1) = 标签 [v0.5.19](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)）。模型、TP4/EP1 与 TP4/EP4 DP-attention 拓扑、8k1k 工作负载、并发范围以及 `benchmarks/single_node/fixed_seq_len/dsr1_fp4_b200.sh` 均保持不变。

## 基线

- **发布日期：** 2026-08-06（`workflow-info?date=2026-08-06`；`benchmarks?model=DeepSeek-R1-0528&date=2026-08-06&exact=true&sequence=8k/1k`，按硬件 `b200`、框架 `sglang`、精度 `fp4`、无投机解码、非分离式、ISL/OSL 8192/1024 过滤；`evaluations?model=DeepSeek-R1-0528&date=2026-08-06&exact=true`）
- **旧镜像：** `lmsysorg/sglang:v0.5.16-cu130`（Docker Hub 摘要 `sha256:7b6a35df9839fd593a94a1eaee82d7777f472225d9f3ad1f8a2e0cb2bd1785d0`，构建提交 [sgl-project/sglang@fdebc93](https://github.com/sgl-project/sglang/commit/fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1) = 标签 `v0.5.16`，CUDA 13.0.1，FlashInfer 0.6.14，sgl-kernel 0.4.5）
- **工作负载 / 拓扑：** 单节点 B200（`cluster:b200-nscale`），`nvidia/DeepSeek-R1-0528-FP4-V2`，SGLang NVFP4，无投机解码，固定序列长度 8k1k（ISL 8192 / OSL 1024），随机数据集；TP4/EP1 并发 1–32，TP4/EP4 DP-attention 并发 64–256（共 9 个点）
- **生产运行：** 全部 9 个点均来自 [run 30952773184 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30952773184/attempts/1)（head `d4363bd7fd5bda1391d2d0a46d834cecc363c0d6`，changelog PR [#2492](https://github.com/SemiAnalysisAI/InferenceX/pull/2492)）；曲线快照 `curve_workflow_run_id` 2261 仅为逻辑快照，不是生产运行
- **已发布评测：** N/A —— 评测接口中没有该配置在 2026-08-06 的 gsm8k 记录；该配置最新的已发布 gsm8k 为 2026-03-28、基于更旧镜像，不可比较

| 点位 | 每 GPU 吞吐 (tok/s) | 每 GPU 输出吞吐 (tok/s) | TPOT 中位数 (ms) | TTFT 中位数 (ms) |
| --- | --- | --- | --- | --- |
| TP4/EP1 c1 | 389.7 | 43.5 | 5.52 | 207 |
| TP4/EP1 c2 | 672.2 | 75.4 | 6.37 | 245 |
| TP4/EP1 c4 | 1134.2 | 126.2 | 7.48 | 245 |
| TP4/EP1 c8 | 1778.0 | 199.9 | 9.49 | 269 |
| TP4/EP1 c16 | 2558.7 | 283.5 | 13.27 | 494 |
| TP4/EP1 c32 | 3428.7 | 383.4 | 19.75 | 769 |
| TP4/EP4 DPA c64 | 4603.2 | 510.7 | 29.73 | 857 |
| TP4/EP4 DPA c128 | 6249.9 | 692.3 | 44.39 | 831 |
| TP4/EP4 DPA c256 | 7955.2 | 884.2 | 66.38 | 4092 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and changelog-only change; no benchmark script or topology edits, only a pinned container image version update.
> 
> **Overview**
> Bumps the **`dsr1-fp4-b200-sglang`** perf config container image from **`lmsysorg/sglang:v0.5.16-cu130`** to **`lmsysorg/sglang:v0.5.19-cu130`** in `configs/nvidia-master.yaml`. The new image brings CUDA 13.0.3, FlashInfer 0.6.18, and sgl-kernel 0.4.6.post1 (vs 13.0.1 / 0.6.14 / 0.4.5 on the old tag).
> 
> A matching **`perf-changelog.yaml`** entry records the digest, build commit, and states that model, B200 topology (TP4/EP1 and TP4/EP4 DP-attention), 8k1k fixed-seq-len grid, and `benchmarks/single_node/fixed_seq_len/dsr1_fp4_b200.sh` are unchanged—so this is a runtime refresh for comparable re-benchmarking only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f8f98fa258680daf485f6d6b60084eb961d24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->