### PR TITLE
[Klaud Cold] Update qwen3.5-fp4-b300-sglang SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp4-b300-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1313,7 +1313,7 @@ qwen3.5-fp8-b300-sglang:
       - { tp: 4, ep: 1, conc-start: 4, conc-end: 256 }
 
 qwen3.5-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/Qwen3.5-397B-A17B-NVFP4-V2
   model-prefix: qwen3.5
   runner: b300


### PR DESCRIPTION
Bump the `qwen3.5-fp4-b300-sglang` master image from `lmsysorg/sglang:v0.5.14-cu130` to `lmsysorg/sglang:v0.5.19-cu130` (digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`). Model (`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`), TP4/EP1 and TP2/EP2 topologies, the 8k/1k fixed-seq-len workload and the launch script `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_b300.sh` are unchanged.

## Baseline

- Published date: 2026-08-10, image `lmsysorg/sglang:v0.5.14-cu130` (digest `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`)
- Workload: single_turn fixed-seq-len ISL 8192 / OSL 1024, B300 single node, SGLang, FP4, no speculative decoding, TP4/EP1 and TP2/EP2, concurrency 4-128 (12 points)
- Producer run: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30506346629/attempts/1 (head `99e3a3fdaee4f2822ff43442509915f9a3a1bae0`, changelog keys include `qwen3.5-fp4-b300-sglang`); curve snapshot `curve_workflow_run_id` 2287 is a logical ID, not the producer
- API queries: `GET /api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-08-10&exact=true&sequence=8k/1k`, `GET /api/v1/workflow-info?date=2026-08-10`, `GET /api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-08-10`
- Old engine source: sgl-project/sglang tag `v0.5.14` = https://github.com/sgl-project/sglang/commit/49e384ce9d304648e9959666ecb8ce8cd98d0deb (image label `ai.sglang.build.commit` matches)
- New engine source: sgl-project/sglang tag `v0.5.19` = https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1 (image label `ai.sglang.build.commit` matches); release notes https://github.com/sgl-project/sglang/releases/tag/v0.5.19

| TP/EP | Conc | tput/GPU (tok/s) | output tput/GPU (tok/s) | mean TPOT (ms) | mean TTFT (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| TP4/EP1 | 4 | 1542.9 | 171.6 | 5.43 | 251.5 |
| TP4/EP1 | 8 | 2460.6 | 276.6 | 6.78 | 311.1 |
| TP4/EP1 | 16 | 3751.0 | 415.6 | 8.88 | 438.4 |
| TP4/EP1 | 32 | 5515.1 | 616.7 | 11.96 | 645.9 |
| TP4/EP1 | 64 | 7467.5 | 828.5 | 17.83 | 1061.1 |
| TP4/EP1 | 128 | 9627.6 | 1066.4 | 27.83 | 1577.7 |
| TP2/EP2 | 4 | 2613.0 | 290.7 | 6.43 | 270.1 |
| TP2/EP2 | 8 | 4184.7 | 470.4 | 8.01 | 337.1 |
| TP2/EP2 | 16 | 6184.1 | 685.2 | 10.79 | 524.9 |
| TP2/EP2 | 32 | 8641.7 | 966.4 | 15.32 | 799.6 |
| TP2/EP2 | 64 | 11835.9 | 1313.1 | 22.60 | 1248.8 |
| TP2/EP2 | 128 | 15214.3 | 1685.2 | 35.28 | 1909.5 |

Published default evals (gsm8k, same run):

| TP/EP | Conc | gsm8k em_strict | flexible-extract | n_eff |
| --- | ---: | ---: | ---: | ---: |
| TP4/EP1 | 64 | 0.9636 | 0.9492 | 1319 |
| TP4/EP1 | 128 | 0.9682 | 0.9606 | 1319 |
| TP2/EP2 | 64 | 0.9651 | 0.9568 | 1319 |
| TP2/EP2 | 128 | 0.9659 | 0.9560 | 1319 |

---

将 `qwen3.5-fp4-b300-sglang` 主配置镜像从 `lmsysorg/sglang:v0.5.14-cu130` 更新至 `lmsysorg/sglang:v0.5.19-cu130`（摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`）。模型（`nvidia/Qwen3.5-397B-A17B-NVFP4-V2`）、TP4/EP1 与 TP2/EP2 拓扑、8k/1k 固定序列长度工作负载以及启动脚本 `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_b300.sh` 均保持不变。

## 基线

- 发布日期：2026-08-10，镜像 `lmsysorg/sglang:v0.5.14-cu130`（摘要 `sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`）
- 工作负载：single_turn 固定序列长度 ISL 8192 / OSL 1024，B300 单节点，SGLang，FP4，无投机解码，TP4/EP1 与 TP2/EP2，并发 4-128（共 12 个点）
- 生产运行：https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30506346629/attempts/1（head `99e3a3fdaee4f2822ff43442509915f9a3a1bae0`）；`curve_workflow_run_id` 2287 是逻辑曲线快照 ID，不是生产运行 ID
- API 查询：见上方英文部分
- 旧引擎源码：sgl-project/sglang 标签 `v0.5.14` = 提交 49e384ce（与镜像标签 `ai.sglang.build.commit` 一致）
- 新引擎源码：sgl-project/sglang 标签 `v0.5.19` = 提交 0bcd8223（与镜像标签 `ai.sglang.build.commit` 一致）

基线基准数值与已发布 gsm8k 评测见上方英文表格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
