### PR TITLE
[Klaud Cold] Update dsr1-fp4-b300-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp4-b300-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1033,7 +1033,7 @@ dsv4-fp4-b200-vllm-mtp:
 # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP4
 # B200 SGLang recipe as-is until B300-specific tuning is available.
 dsr1-fp4-b300-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: nvidia/DeepSeek-R1-0528-FP4-V2
   model-prefix: dsr1
   runner: b300


### PR DESCRIPTION
Refresh the `dsr1-fp4-b300-sglang` master image from `lmsysorg/sglang:v0.5.12-cu130` to the `v0.5.19` release image `lmsysorg/sglang:v0.5.19-cu130` (manifest digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, build commit [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). Model, TP4/EP4 and TP8/EP8 topologies, concurrency ranges, the 8k/1k workload, launch script and evals are unchanged.

## Baseline

- **Published date:** 2026-05-22 (`GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true&sequence=8k/1k`, `GET /api/v1/workflow-info?date=2026-05-22`, `GET /api/v1/evaluations?date=2026-05-22`)
- **Old image:** `lmsysorg/sglang:v0.5.12-cu130` (build commit [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624), tag `v0.5.12`)
- **Workload / topology:** DeepSeek-R1-0528 NVFP4 (`nvidia/DeepSeek-R1-0528-FP4-V2`), B300 single node, SGLang, single-turn fixed 8192/1024, no speculative decoding; TP4/EP4 at concurrency 1-128 and TP8/EP8 at concurrency 1-16 (13 points)
- **Producer:** [run 26306422380 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1) (all 13 points; the run's overall conclusion is `failure` because other matrices in that sweep failed, while these B300 FP4 points were ingested)
- **Source:** [SGLang v0.5.12...v0.5.19](https://github.com/sgl-project/sglang/compare/v0.5.12...v0.5.19), [v0.5.19 release notes](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)

| Topology | Conc | Tput/GPU (tok/s) | Output tput/GPU (tok/s) | Median TTFT (s) | Median TPOT (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| TP4/EP4 | 1 | 355.6 | 39.7 | 0.190 | 6.09 |
| TP4/EP4 | 2 | 605.0 | 67.9 | 0.242 | 7.09 |
| TP4/EP4 | 4 | 1045.5 | 116.3 | 0.228 | 8.17 |
| TP4/EP4 | 8 | 1651.0 | 185.6 | 0.253 | 10.27 |
| TP4/EP4 | 16 | 2400.5 | 266.0 | 0.492 | 14.17 |
| TP4/EP4 | 32 | 3321.2 | 371.4 | 0.734 | 20.37 |
| TP4/EP4 | 64 | 4495.5 | 498.7 | 1.057 | 30.56 |
| TP4/EP4 | 128 | 5661.9 | 627.1 | 1.560 | 48.76 |
| TP8/EP8 | 1 | 186.5 | 20.8 | 0.132 | 5.86 |
| TP8/EP8 | 2 | 329.9 | 37.0 | 0.165 | 6.55 |
| TP8/EP8 | 4 | 580.7 | 64.6 | 0.182 | 7.36 |
| TP8/EP8 | 8 | 968.3 | 108.9 | 0.195 | 8.78 |
| TP8/EP8 | 16 | 1497.8 | 166.0 | 0.384 | 11.32 |

**Published evals (gsm8k, 2026-05-22, TP4/EP4):** conc 64 `em_strict` 0.9575 / `em_flexible` 0.9575; conc 128 `em_strict` 0.9545 / `em_flexible` 0.9560. The evaluations feed labels these rows `disagg: true` with 16 prefill/decode GPUs, which does not match the single-node TP4 aggregated recipe; scores are kept as the baseline values with that mismatch noted.

---

将 `dsr1-fp4-b300-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.12-cu130` 更新至 `v0.5.19` 发布版镜像 `lmsysorg/sglang:v0.5.19-cu130`（manifest 摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，构建提交 [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。模型、TP4/EP4 与 TP8/EP8 拓扑、并发范围、8k/1k 工作负载、启动脚本和评测均保持不变。

## 基线

- **发布日期：** 2026-05-22（`GET /api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-22&exact=true&sequence=8k/1k`、`GET /api/v1/workflow-info?date=2026-05-22`、`GET /api/v1/evaluations?date=2026-05-22`）
- **旧镜像：** `lmsysorg/sglang:v0.5.12-cu130`（构建提交 [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624)，标签 `v0.5.12`）
- **工作负载 / 拓扑：** DeepSeek-R1-0528 NVFP4（`nvidia/DeepSeek-R1-0528-FP4-V2`），B300 单节点，SGLang，单轮固定 8192/1024，无投机解码；TP4/EP4 并发 1-128 与 TP8/EP8 并发 1-16（共 13 个点）
- **生产运行：** [run 26306422380 attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26306422380/attempts/1)（全部 13 个点；该运行整体结论为 `failure`，原因是同一扫描中的其他矩阵失败，而这些 B300 FP4 点已被正常入库）
- **源码：** [SGLang v0.5.12...v0.5.19](https://github.com/sgl-project/sglang/compare/v0.5.12...v0.5.19)、[v0.5.19 发布说明](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)

| 拓扑 | 并发 | 每 GPU 吞吐 (tok/s) | 每 GPU 输出吞吐 (tok/s) | TTFT 中位数 (s) | TPOT 中位数 (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| TP4/EP4 | 1 | 355.6 | 39.7 | 0.190 | 6.09 |
| TP4/EP4 | 2 | 605.0 | 67.9 | 0.242 | 7.09 |
| TP4/EP4 | 4 | 1045.5 | 116.3 | 0.228 | 8.17 |
| TP4/EP4 | 8 | 1651.0 | 185.6 | 0.253 | 10.27 |
| TP4/EP4 | 16 | 2400.5 | 266.0 | 0.492 | 14.17 |
| TP4/EP4 | 32 | 3321.2 | 371.4 | 0.734 | 20.37 |
| TP4/EP4 | 64 | 4495.5 | 498.7 | 1.057 | 30.56 |
| TP4/EP4 | 128 | 5661.9 | 627.1 | 1.560 | 48.76 |
| TP8/EP8 | 1 | 186.5 | 20.8 | 0.132 | 5.86 |
| TP8/EP8 | 2 | 329.9 | 37.0 | 0.165 | 6.55 |
| TP8/EP8 | 4 | 580.7 | 64.6 | 0.182 | 7.36 |
| TP8/EP8 | 8 | 968.3 | 108.9 | 0.195 | 8.78 |
| TP8/EP8 | 16 | 1497.8 | 166.0 | 0.384 | 11.32 |

**已发布评测（gsm8k，2026-05-22，TP4/EP4）：** 并发 64 `em_strict` 0.9575 / `em_flexible` 0.9575；并发 128 `em_strict` 0.9545 / `em_flexible` 0.9560。评测数据源将这些行标记为 `disagg: true` 且预填充/解码各 16 GPU，与单节点 TP4 聚合配方不一致；分数仍作为基线保留，并在此注明该不一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
