### PR TITLE
[Klaud Cold] Update glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp SGLang image to v0.5.19-cu130 / 将 glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-1p4d-dep8-tp4-c48-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-1p4d-dep8-tp4-c48-mtp.yaml
@@ -8,10 +8,10 @@ identity:
     repo: nvidia/GLM-5.2-NVFP4
     revision: aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa
   container:
-    image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
+    image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   frameworks:
-    dynamo: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
-    sglang: nightly-dev-cu13-20260805-211ee642
+    dynamo: "1.5.0.dev20260910"
+    sglang: "0.5.19"
 resources:
   gpu_type: gb200
   gpus_per_node: 4
@@ -35,8 +35,8 @@ frontend:
     active-prefill-tokens-threshold: None
     active-prefill-tokens-threshold-frac: None
 dynamo:
-  hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
   install: true
+  wheel: "1.5.0.dev20260910"
 backend:
   type: sglang
   prefill_environment:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-1p6d-dep8-tp4-c45-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-1p6d-dep8-tp4-c45-mtp.yaml
@@ -8,10 +8,10 @@ identity:
     repo: nvidia/GLM-5.2-NVFP4
     revision: aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa
   container:
-    image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
+    image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   frameworks:
-    dynamo: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
-    sglang: nightly-dev-cu13-20260805-211ee642
+    dynamo: "1.5.0.dev20260910"
+    sglang: "0.5.19"
 resources:
   gpu_type: gb200
   gpus_per_node: 4
@@ -35,8 +35,8 @@ frontend:
     active-prefill-tokens-threshold: None
     active-prefill-tokens-threshold-frac: None
 dynamo:
-  hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
   install: true
+  wheel: "1.5.0.dev20260910"
 backend:
   type: sglang
   prefill_environment:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-2p1d-dep8-dep16-c128-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb200-fp4/agentic/disagg-gb200-2p1d-dep8-dep16-c128-mtp.yaml
@@ -8,10 +8,10 @@ identity:
     repo: nvidia/GLM-5.2-NVFP4
     revision: aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa
   container:
-    image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
+    image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   frameworks:
-    dynamo: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
-    sglang: nightly-dev-cu13-20260805-211ee642
+    dynamo: "1.5.0.dev20260910"
+    sglang: "0.5.19"
 resources:
   gpu_type: gb200
   gpus_per_node: 4
@@ -35,8 +35,8 @@ frontend:
     active-prefill-tokens-threshold: None
     active-prefill-tokens-threshold-frac: None
 dynamo:
-  hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
   install: true
+  wheel: "1.5.0.dev20260910"
 backend:
   type: sglang
   prefill_environment:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9198,7 +9198,7 @@ glm5.2-fp4-gb200-dynamo-sglang-agentic-disagg:
 # GLM-5.2 NVFP4 GB200 AgentX disaggregated variants use the committed
 # thinking-on golden acceptance length for two speculative tokens.
 glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: nvidia/GLM-5.2-NVFP4
   model-prefix: glm5.2
   runner: cluster:gb200-nv
@@ -9206,7 +9206,7 @@ glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp:
   framework: dynamo-sglang
   router:
     name: dynamo-router
-    version: 1.2.1
+    version: 1.5.0.dev20260910
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7145,3 +7145,11 @@
     - "Update SGLang image from lmsysorg/sglang:nightly-dev-cu13-20260907-30705c00 (2026-09-07 cu13 dev nightly, build commit sgl-project/sglang@30705c00) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-cu130 (digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T22:50:19Z)."
     - "The release image ships the same CUDA 13.0.3, FlashInfer 0.6.18 and sgl-kernel 0.4.6.post1 as the nightly. benchmarks/single_node/agentic/qwen3.5_fp8_h200_mtp.sh is unchanged: SGLANG_ENABLE_SPEC_V2 EAGLE MTP at 3 steps, golden acceptance length 3.39, flashinfer attention with allreduce fusion, fp8 quantization and fp8_e4m3 KV, HiCache kernel IO / page_first layout. TP8/EP1 DRAM HiCache concurrency 2 through 24 unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2966
+
+- config-keys:
+    - glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp
+  description:
+    - "Update the SGLang image from lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642 (2026-08-05 cu13 dev nightly, build commit sgl-project/sglang@211ee642) to the digest-pinned v0.5.19 release lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9 (build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T22:50:19Z)."
+    - "Move the three disaggregated recipes' Dynamo install from source commit 71eb001e17fa73c742f0afe1a6ed96836cb135fd to the ai-dynamo 1.5.0.dev20260910 wheel, which carries the ServerArgs.get_model_config()/use_mla_backend() compatibility shim for SGLang #36972 (ai-dynamo/dynamo#14234) and pins sglang==0.5.19 (ai-dynamo/dynamo#14151); align recipe identity.frameworks and the master router version to 1.5.0.dev20260910 / 0.5.19."
+    - "Topology, MTP settings, HiCache DRAM offload, NIXL KV transfer, concurrency 45/48/128 and NVIDIA/srt-slurm v1.0.50 are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2992


### PR DESCRIPTION
Refresh `glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp` from the SGLang `nightly-dev-cu13-20260805-211ee642` nightly to the digest-pinned `v0.5.19-cu130` release, moving the three disaggregated recipes' Dynamo install from source commit `71eb001e` to the `1.5.0.dev20260910` wheel that Dynamo pairs with SGLang 0.5.19.

## Baseline

- Published date: 2026-08-19 (`/api/v1/benchmarks?model=GLM-5.2&date=2026-08-19&exact=true`, `/api/v1/workflow-info?date=2026-08-19&benchmarkType=agentic_traces`, `/api/v1/evaluations?model=GLM-5.2&date=2026-08-19`)
- Old image: `lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642` (SGLang commit `211ee642`, 2026-08-05) with Dynamo built from source commit `71eb001e` and NVIDIA/srt-slurm `v1.0.50`. The published rows carry `router_version: 1.2.1` from the master metadata, which does not match the Dynamo source commit the recipes actually installed.
- Producer: [run 32207758126 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32207758126/attempts/2) at `6130a8b5b671be6fc9695e8d159197f2cd275482` (PR #2642 sweep, curve `2336`)
- Workload: GLM-5.2 NVFP4 on GB200, agentic-coding trace replay, native MTP (EAGLE, prefill 2 / decode 3 draft tokens, golden acceptance length 2.5), NIXL KV transfer, prefill HiCache DRAM offload; 1P6D (TP8/DEP8 prefill, 6×TP4 decode, 32 GPUs) at concurrency 45, 1P4D (TP8/DEP8 prefill, 4×TP4 decode, 24 GPUs) at concurrency 48, 2P1D (2×TP8/DEP8 prefill, DEP16 decode, 32 GPUs) at concurrency 128
- Source: [SGLang 211ee642…v0.5.19](https://github.com/sgl-project/sglang/compare/211ee642...0bcd822377da7b5718e674eaf9c870d349424dd1) (1509 commits), [SGLang #36972](https://github.com/sgl-project/sglang/pull/36972), [Dynamo #14234](https://github.com/ai-dynamo/dynamo/pull/14234), [Dynamo #14151](https://github.com/ai-dynamo/dynamo/pull/14151)

| Point | Output tok/s/GPU | Total tok/s/GPU | Median interactivity (tok/s/user) | Mean TTFT (s) | Mean TPOT (ms) | gsm8k (strict EM) |
| --- | --- | --- | --- | --- | --- | --- |
| 1P6D conc 45 (id 440078) | 56.96 | 8901.6 | 225.2 | 3.346 | 4.72 | 0.9568 (eval id 9501) |
| 1P4D conc 48 (id 440082) | 73.10 | 10499.0 | 204.9 | 6.815 | 5.22 | 0.9545 (eval id 9502) |
| 2P1D conc 128 (id 440079) | 137.32 | 16607.7 | 102.8 | 7.095 | 10.18 | 0.9401 (eval id 9503) |

- Power: N/A. The published rows contain no power metrics.
- Evals: the gsm8k scores above come from the same producer run. The current generator emits eval jobs for this family only under `--all-evals` or `--evals-only`; the default `test-config` matrix marks all three points `run-eval: false`.

---

将 `glm5.2-fp4-gb200-dynamo-sglang-agentic-mtp` 从 SGLang `nightly-dev-cu13-20260805-211ee642` 夜间构建更新到按摘要固定的 `v0.5.19-cu130` 正式版，并将三个分离式配方中的 Dynamo 安装方式从源码提交 `71eb001e` 切换为 Dynamo 与 SGLang 0.5.19 配套的 `1.5.0.dev20260910` wheel。

## 基线

- 发布日期：2026-08-19（`/api/v1/benchmarks?model=GLM-5.2&date=2026-08-19&exact=true`、`/api/v1/workflow-info?date=2026-08-19&benchmarkType=agentic_traces`、`/api/v1/evaluations?model=GLM-5.2&date=2026-08-19`）
- 旧镜像：`lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642`（SGLang 提交 `211ee642`，2026-08-05），Dynamo 从源码提交 `71eb001e` 构建，NVIDIA/srt-slurm `v1.0.50`。已发布数据中的 `router_version: 1.2.1` 来自主配置元数据，与配方实际安装的 Dynamo 源码提交不一致。
- 生产运行：[run 32207758126 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32207758126/attempts/2)，提交 `6130a8b5b671be6fc9695e8d159197f2cd275482`（PR #2642 的 sweep，曲线 `2336`）
- 工作负载：GB200 上的 GLM-5.2 NVFP4，agentic-coding 轨迹回放，原生 MTP（EAGLE，prefill 2 / decode 3 个草稿 token，黄金接受长度 2.5），NIXL KV 传输，prefill HiCache DRAM 卸载；1P6D（TP8/DEP8 prefill，6×TP4 decode，32 GPU）并发 45，1P4D（TP8/DEP8 prefill，4×TP4 decode，24 GPU）并发 48，2P1D（2×TP8/DEP8 prefill，DEP16 decode，32 GPU）并发 128
- 源码：[SGLang 211ee642…v0.5.19](https://github.com/sgl-project/sglang/compare/211ee642...0bcd822377da7b5718e674eaf9c870d349424dd1)（1509 个提交）、[SGLang #36972](https://github.com/sgl-project/sglang/pull/36972)、[Dynamo #14234](https://github.com/ai-dynamo/dynamo/pull/14234)、[Dynamo #14151](https://github.com/ai-dynamo/dynamo/pull/14151)

| 点位 | 输出 tok/s/GPU | 总 tok/s/GPU | 交互性中位数（tok/s/用户） | 平均 TTFT（秒） | 平均 TPOT（毫秒） | gsm8k（严格 EM） |
| --- | --- | --- | --- | --- | --- | --- |
| 1P6D 并发 45（id 440078） | 56.96 | 8901.6 | 225.2 | 3.346 | 4.72 | 0.9568（评测 id 9501） |
| 1P4D 并发 48（id 440082） | 73.10 | 10499.0 | 204.9 | 6.815 | 5.22 | 0.9545（评测 id 9502） |
| 2P1D 并发 128（id 440079） | 137.32 | 16607.7 | 102.8 | 7.095 | 10.18 | 0.9401（评测 id 9503） |

- 功耗：N/A。已发布数据中不包含功耗指标。
- 评测：上表 gsm8k 分数来自同一生产运行。当前生成器仅在 `--all-evals` 或 `--evals-only` 下为该配置族生成评测任务；默认 `test-config` 矩阵中三个点位均为 `run-eval: false`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
