### PR TITLE
Add B300 DSv4.1 Flash Mooncake offload / 新增 B300 Mooncake 卸载

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -150,6 +150,7 @@ Other offloading tiers, including NVMe KV cache offloading, are outside the init
 
 | Model architecture class | Prefix | Date added | Active scenarios | Deprecated scenarios |
 |---|---|---|---|---|
+| DeepSeek-V4.1-Flash | `dsv41flash` | 2026-09-10 | Agentic coding (DSpark, Engram UVA offload; GPU validation pending) | |
 | Qwen3.8-Flash-Next | `qwen3.8next` | 2026-08-26 ([#2742](https://github.com/SemiAnalysisAI/InferenceX/pull/2742)) | Agentic coding | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | Agentic coding (DSpark only) | Agentic coding non-DSpark arm (deprecated from day 0) |
 | GLM-5.2 | `glm5.2` | 2026-07-18 ([#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)) | Agentic coding (the non-MTP arm still runs while the MTP-only transition remains pending, as explained in the Deprecation Notice) | |

--- a/MODELS_zh.md
+++ b/MODELS_zh.md
@@ -150,6 +150,7 @@ InferenceX 支持 SGLang 和 vLLM 双方的维护者，并响应 AI 实验室和
 
 | 模型架构类别 | 前缀 | 加入日期 | 启用场景 | 已弃用场景 |
 |---|---|---|---|---|
+| DeepSeek-V4.1-Flash | `dsv41flash` | 2026-09-10 | Agentic coding（DSpark、Engram UVA 卸载；GPU 待验证） | |
 | Qwen3.8-Flash-Next | `qwen3.8next` | 2026-08-26（[#2742](https://github.com/SemiAnalysisAI/InferenceX/pull/2742)） | 智能体编码 | |
 | Kimi-K3 | `kimik3` | 2026-07-27 ([#2391](https://github.com/SemiAnalysisAI/InferenceX/pull/2391)) | 智能体编码（仅 DSpark） | 智能体编码非 DSpark 分支（自第 0 天起弃用） |
 | GLM-5.2 | `glm5.2` | 2026-07-18（[#2268](https://github.com/SemiAnalysisAI/InferenceX/pull/2268)） | 智能体编码（非 MTP 分支仍在运行，「仅 MTP」转换仍待执行，见弃用公告） | |

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -3421,13 +3421,15 @@ run_agentic_replay_and_write_outputs() (
 setup_agentic_mooncake() {
     require_agentic_kv_offload_backend mooncake || return 1
     check_env_vars GPU_COUNT RESULT_DIR MOONCAKE_HOST_RESERVE_GB
-    local per_rank_gb
-    per_rank_gb=$(python3 - "$TOTAL_CPU_DRAM_GB" "$GPU_COUNT" "$MOONCAKE_HOST_RESERVE_GB" <<'PYMCBUDGET'
+    local per_rank_bytes
+    per_rank_bytes=$(python3 - "$TOTAL_CPU_DRAM_GB" "$GPU_COUNT" "$MOONCAKE_HOST_RESERVE_GB" <<'PYMCBUDGET'
 import sys
 budget, ranks, reserved = map(int, sys.argv[1:])
 if ranks <= 0 or reserved < 0:
     raise SystemExit("Invalid Mooncake rank count or host-memory reservation")
-segment = (budget - reserved) // ranks - 4
+# Runner budgets use decimal GB; Mooncake's string GB suffix means GiB.
+# Pass integer bytes and account for the actual 4 GiB transfer buffer.
+segment = (budget - reserved) * 1_000_000_000 // ranks - 4 * 1024**3
 if segment <= 0:
     raise SystemExit("Host budget cannot fit model reservation, Mooncake buffers and KV segments")
 print(segment)
@@ -3445,7 +3447,7 @@ PYMCBUDGET
     MOONCAKE_MASTER_PORT=$(PORT=0; select_available_server_port; printf '%s' "$PORT") || return $?
     export MOONCAKE_CONFIG_PATH="$RESULT_DIR/mooncake_config.json"
     export PYTHONHASHSEED=0
-    python3 - "$MOONCAKE_CONFIG_PATH" "$MOONCAKE_MASTER_PORT" "$per_rank_gb" <<'PYMCCONFIG'
+    python3 - "$MOONCAKE_CONFIG_PATH" "$MOONCAKE_MASTER_PORT" "$per_rank_bytes" <<'PYMCCONFIG'
 import json
 import os
 import sys
@@ -3455,14 +3457,14 @@ with open(path, "w") as output:
         "mode": "embedded",
         "metadata_server": "P2PHANDSHAKE",
         "master_server_address": f"127.0.0.1:{port}",
-        "global_segment_size": f"{segment}GB",
-        "local_buffer_size": "4GB",
+        "global_segment_size": int(segment),
+        "local_buffer_size": 4 * 1024**3,
         "protocol": "rdma",
         "device_name": os.environ.get("MOONCAKE_DEVICE_NAME", ""),
         "enable_offload": False,
     }, output, indent=2)
 PYMCCONFIG
-    echo "Mooncake: ${per_rank_gb} GB per rank; ${MOONCAKE_HOST_RESERVE_GB} GB reserved for model host memory"
+    echo "Mooncake: ${per_rank_bytes} bytes per rank; ${MOONCAKE_HOST_RESERVE_GB} GB reserved for model host memory"
     mooncake_master --port="$MOONCAKE_MASTER_PORT" \
         --default_kv_lease_ttl=30s \
         --eviction_high_watermark_ratio=0.95 --eviction_ratio=0.1 \

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -22,6 +22,28 @@ INFERENCEX_REPO_ROOT="$(
 # nothing upstream set it.
 export PORT="${PORT:-8888}"
 
+# Opt-in for recipes running in the host network namespace. Probe the preferred
+# port on the compute node; fall back to an OS-selected port if it is occupied.
+# Call immediately before server launch and construct client URLs afterward.
+select_available_server_port() {
+    PORT=$(python3 - "${PORT:-8888}" <<'PYPORT'
+import errno
+import socket
+import sys
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    try:
+        sock.bind(("0.0.0.0", int(sys.argv[1])))
+    except OSError as exc:
+        if exc.errno != errno.EADDRINUSE:
+            raise
+        sock.bind(("0.0.0.0", 0))
+    print(sock.getsockname()[1])
+PYPORT
+    ) || return $?
+    export PORT
+}
+
 agentic_kv_offload_enabled() {
     if [[ -z "${KV_OFFLOADING+x}" || -z "$KV_OFFLOADING" ]]; then
         echo "Error: KV_OFFLOADING must be set for agentic benchmarks" >&2
@@ -3392,3 +3414,81 @@ run_agentic_replay_and_write_outputs() (
 
     validate_required_agentic_server_metrics "$result_dir"
 )
+
+# Start the upstream embedded Mooncake CPU KV tier. TOTAL_CPU_DRAM_GB is
+# the generated aggregate host budget; reserve model memory and rank buffers
+# before dividing the remaining segment capacity across GPU_COUNT ranks.
+setup_agentic_mooncake() {
+    require_agentic_kv_offload_backend mooncake || return 1
+    check_env_vars GPU_COUNT RESULT_DIR MOONCAKE_HOST_RESERVE_GB
+    local per_rank_gb
+    per_rank_gb=$(python3 - "$TOTAL_CPU_DRAM_GB" "$GPU_COUNT" "$MOONCAKE_HOST_RESERVE_GB" <<'PYMCBUDGET'
+import sys
+budget, ranks, reserved = map(int, sys.argv[1:])
+if ranks <= 0 or reserved < 0:
+    raise SystemExit("Invalid Mooncake rank count or host-memory reservation")
+segment = (budget - reserved) // ranks - 4
+if segment <= 0:
+    raise SystemExit("Host budget cannot fit model reservation, Mooncake buffers and KV segments")
+print(segment)
+PYMCBUDGET
+    ) || return $?
+
+    local package=mooncake-transfer-engine
+    if [[ "$(python3 -c 'import torch; print((torch.version.cuda or "").split(".")[0])')" == 13 ]]; then
+        package=mooncake-transfer-engine-cuda13
+    fi
+    agentic_pip_install --quiet --no-cache-dir --no-deps --force-reinstall "${package}==0.3.11.post1" || return $?
+    python3 -c 'from mooncake.store import MooncakeDistributedStore' || return $?
+
+    # A separate free port avoids arithmetic overflow and host-network collisions.
+    MOONCAKE_MASTER_PORT=$(PORT=0; select_available_server_port; printf '%s' "$PORT") || return $?
+    export MOONCAKE_CONFIG_PATH="$RESULT_DIR/mooncake_config.json"
+    export PYTHONHASHSEED=0
+    python3 - "$MOONCAKE_CONFIG_PATH" "$MOONCAKE_MASTER_PORT" "$per_rank_gb" <<'PYMCCONFIG'
+import json
+import os
+import sys
+path, port, segment = sys.argv[1:]
+with open(path, "w") as output:
+    json.dump({
+        "mode": "embedded",
+        "metadata_server": "P2PHANDSHAKE",
+        "master_server_address": f"127.0.0.1:{port}",
+        "global_segment_size": f"{segment}GB",
+        "local_buffer_size": "4GB",
+        "protocol": "rdma",
+        "device_name": os.environ.get("MOONCAKE_DEVICE_NAME", ""),
+        "enable_offload": False,
+    }, output, indent=2)
+PYMCCONFIG
+    echo "Mooncake: ${per_rank_gb} GB per rank; ${MOONCAKE_HOST_RESERVE_GB} GB reserved for model host memory"
+    mooncake_master --port="$MOONCAKE_MASTER_PORT" \
+        --default_kv_lease_ttl=30s \
+        --eviction_high_watermark_ratio=0.95 --eviction_ratio=0.1 \
+        > "$RESULT_DIR/mooncake_master.log" 2>&1 &
+    MOONCAKE_MASTER_PID=$!
+    local attempt
+    for attempt in {1..30}; do
+        if ! kill -0 "$MOONCAKE_MASTER_PID" 2>/dev/null; then
+            cat "$RESULT_DIR/mooncake_master.log" >&2
+            return 1
+        fi
+        if python3 - "$MOONCAKE_MASTER_PORT" <<'PYMCPING'
+import socket
+import sys
+try:
+    with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=1):
+        pass
+except OSError:
+    raise SystemExit(1)
+PYMCPING
+        then
+            OFFLOAD_ARGS=(--kv-transfer-config '{"kv_connector":"MooncakeStoreConnector","kv_role":"kv_both"}')
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Mooncake master did not become ready within 30 attempts" >&2
+    return 1
+}

--- a/benchmarks/single_node/agentic/dsv41flash_fp4_b300_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv41flash_fp4_b300_vllm_mtp.sh
@@ -1,0 +1,1 @@
+dsv41flash_fp4_vllm_mtp.sh

--- a/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
@@ -30,10 +30,14 @@ export VLLM_ENGINE_READY_TIMEOUT_S=7200
 export VLLM_USE_RUST_FRONTEND=1
 export PYTHONUNBUFFERED=1
 
-# Preserve the upstream scheduler defaults; size graph capture for the sweep.
+# Preserve scheduler concurrency; cap offload graphs to leave room for KV cache.
 NUM_SPEC_TOKENS=5
+CAPTURE_LIMIT=2048
+if [[ "${KV_OFFLOAD_BACKEND:-}" == mooncake ]]; then
+    CAPTURE_LIMIT=512
+fi
 CAPTURE_SIZE=1
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) && CAPTURE_SIZE < 2048 )); do
+while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) && CAPTURE_SIZE < CAPTURE_LIMIT )); do
     CAPTURE_SIZE=$((CAPTURE_SIZE * 2))
 done
 
@@ -49,6 +53,16 @@ MOONCAKE_MASTER_PID=""
 cleanup() {
     local rc=$?
     trap - EXIT INT TERM
+    if (( rc != 0 )) && [[ "${KV_OFFLOAD_BACKEND:-}" == mooncake ]]; then
+        # Preserve host OOM evidence that vLLM's generic "cancelled" error omits.
+        for memory_file in /proc/meminfo /sys/fs/cgroup/memory.events /sys/fs/cgroup/memory.current /sys/fs/cgroup/memory.max; do
+            if [[ -r "$memory_file" ]]; then
+                echo "Host memory diagnostic: $memory_file"
+                cat "$memory_file" || true
+            fi
+        done
+        [[ ! -f "$RESULT_DIR/mooncake_master.log" ]] || tail -n 80 "$RESULT_DIR/mooncake_master.log" || true
+    fi
     stop_background_process_tree "$SERVER_PID" "vLLM server" 60
     stop_background_process_tree "$MOONCAKE_MASTER_PID" "Mooncake master" 10
     exit "$rc"

--- a/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Native DeepSeek-V4.1-Flash DSpark and Engram UVA weight offload.
+# https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash
+source "$(dirname "$0")/../../benchmark_lib.sh"
+check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
+if [[ "${KV_OFFLOAD_BACKEND:-}" == mooncake ]]; then
+    require_agentic_kv_offload_backend mooncake
+else
+    require_agentic_kv_offload_none
+fi
+export GPU_COUNT="$TP"
+
+# Complete/resume partial downloads instead of trusting nonempty directories.
+if [[ -n "${MODEL_PATH:-}" && "$MODEL_PATH" != "$MODEL" ]]; then
+    hf download "$MODEL" --local-dir "$MODEL_PATH"
+else
+    hf download "$MODEL"
+    export MODEL_PATH="$MODEL"
+fi
+
+nvidia-smi
+export WEKA_LOADER_OVERRIDE=semianalysis_cc_traces_weka_062126
+resolve_trace_source
+install_agentic_deps
+mkdir -p "$RESULT_DIR"
+SERVER_LOG="$RESULT_DIR/server.log"
+export VLLM_ENGINE_READY_TIMEOUT_S=7200
+export VLLM_USE_RUST_FRONTEND=1
+export PYTHONUNBUFFERED=1
+
+# Preserve the upstream scheduler defaults; size graph capture for the sweep.
+NUM_SPEC_TOKENS=5
+CAPTURE_SIZE=1
+while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) && CAPTURE_SIZE < 2048 )); do
+    CAPTURE_SIZE=$((CAPTURE_SIZE * 2))
+done
+
+# Pyxis shares the host network; port 8888 can already belong to a host service.
+select_available_server_port
+export AIPERF_SERVER_URL="http://localhost:${PORT}"
+export AIPERF_SERVER_METRICS_URLS="${AIPERF_SERVER_URL}/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="vllm:"
+echo "Using vLLM endpoint ${AIPERF_SERVER_URL}"
+
+SERVER_PID=""
+MOONCAKE_MASTER_PID=""
+cleanup() {
+    local rc=$?
+    trap - EXIT INT TERM
+    stop_background_process_tree "$SERVER_PID" "vLLM server" 60
+    stop_background_process_tree "$MOONCAKE_MASTER_PID" "Mooncake master" 10
+    exit "$rc"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+# Engram uses about 189 GiB in aggregate; reserve 208 decimal GB.
+export MOONCAKE_HOST_RESERVE_GB=208
+OFFLOAD_ARGS=()
+if [[ "${KV_OFFLOAD_BACKEND:-}" == mooncake ]]; then
+    setup_agentic_mooncake
+fi
+
+# Golden AL: golden_al_distribution/dsv41flash_dspark.yaml, thinking_on, five draft tokens.
+# Accuracy evals keep real block rejection; throughput fixes acceptance to AL 3.51.
+if [[ "${EVAL_ONLY:-false}" == true ]]; then
+    SPEC_CONFIG='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+else
+    SPEC_CONFIG='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"synthetic","synthetic_acceptance_length":3.51,"enable_adaptive_verification":false}'
+fi
+VLLM_CMD=(
+    vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
+    --host 0.0.0.0 --port "$PORT" --tensor-parallel-size "$TP"
+    --language-model-only
+    --tokenizer-mode deepseek_v41
+    --tool-call-parser deepseek_v41 --enable-auto-tool-choice
+    --reasoning-parser deepseek_v41
+    --engram-config '{"cpu_offload":true}'
+    --speculative-config "$SPEC_CONFIG"
+    "${OFFLOAD_ARGS[@]}"
+    --max-model-len 1048576
+    --max-cudagraph-capture-size "$CAPTURE_SIZE"
+    --disable-uvicorn-access-log
+)
+printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
+printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
+"${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [[ "${EVAL_ONLY:-false}" == true ]]; then
+    run_eval --port "$PORT"
+else
+    build_replay_cmd "$RESULT_DIR"
+    run_agentic_replay_and_write_outputs "$RESULT_DIR"
+fi

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -10213,3 +10213,18 @@ glm5.1-fp8-b200-tilert-agentic:
           dp-attn: false
           additional-settings:
           - "DECODE_NODES=1"
+
+dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake:
+  image: vllm/vllm-openai:deepseekv41-flash-0909
+  model: deepseek-ai/DeepSeek-V4.1-Flash
+  model-prefix: dsv41flash
+  runner: cluster:b300-dsxe
+  precision: fp4
+  framework: vllm
+  multinode: false
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.60
+      search-space:
+      # Reserve host memory for Engram UVA tables before sizing Mooncake KV segments.
+      - { tp: 4, kv-offloading: dram, kv-offload-backend: { name: mooncake, version: "0.3.11.post1" }, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512] }

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -278,6 +278,8 @@ A configuration is ready for sweep only when the executable files agree, the exa
 
 `dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake` runs AgentX at TP4, with concurrency 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, full `semianalysis_cc_traces_weka_062126` traces and 1M context. It follows the [upstream embedded Mooncake recipe](https://github.com/vllm-project/recipes/blob/main/kv_store/kv_store_distributed_mooncake.yaml): `MooncakeStoreConnector`, `kv_both`, RDMA and one local metadata master. The helper pins Mooncake 0.3.11.post1 and selects the wheel for the image's CUDA major version.
 
-The generated host budget is 60% of the runner's allocated DRAM. Reserve 208 GB for Engram UVA tables and 4 GB of Mooncake transfer buffer per GPU, then divide the remainder into per-rank KV segments. `enable_offload: false` disables Mooncake's secondary storage tier; the embedded DRAM KV store remains enabled. Both server and master are cleaned up on exit.
+The generated host budget is 60% of the runner's allocated DRAM. Reserve 208 GB for Engram UVA tables and 4 GiB of Mooncake transfer buffer per GPU, then divide the remainder into per-rank KV segments. `enable_offload: false` disables Mooncake's secondary storage tier; the embedded DRAM KV store remains enabled. Both server and master are cleaned up on exit.
 
 Throughput keeps five-token DSpark at thinking-on golden synthetic AL 3.51 with adaptive verification disabled; eval uses real block verification. Startup allows 7200 seconds. H100 retains its 4096-token prefill-batch cap. Higher concurrencies are experimental and require GPU validation.
+
+Mooncake sizes are emitted as integer bytes so its binary `GB` parser cannot exceed the decimal host budget. Offload CUDA graphs capture at most 512 tokens; larger batches use the uncaptured path, retaining concurrency 512 and 1M context.

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -273,3 +273,11 @@ Stop before dispatching GPU work or claiming the configuration complete when any
 - YAML, Bash, strict schema, exact-key generation, launcher simulation, or recipe validation fails.
 
 A configuration is ready for sweep only when the executable files agree, the exact key generates, the runtime route exists, the changelog selects it, and all layer-specific checks above pass.
+
+## DeepSeek V4.1 Flash Mooncake on B300
+
+`dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake` runs AgentX at TP4, with concurrency 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, full `semianalysis_cc_traces_weka_062126` traces and 1M context. It follows the [upstream embedded Mooncake recipe](https://github.com/vllm-project/recipes/blob/main/kv_store/kv_store_distributed_mooncake.yaml): `MooncakeStoreConnector`, `kv_both`, RDMA and one local metadata master. The helper pins Mooncake 0.3.11.post1 and selects the wheel for the image's CUDA major version.
+
+The generated host budget is 60% of the runner's allocated DRAM. Reserve 208 GB for Engram UVA tables and 4 GB of Mooncake transfer buffer per GPU, then divide the remainder into per-rank KV segments. `enable_offload: false` disables Mooncake's secondary storage tier; the embedded DRAM KV store remains enabled. Both server and master are cleaned up on exit.
+
+Throughput keeps five-token DSpark at thinking-on golden synthetic AL 3.51 with adaptive verification disabled; eval uses real block verification. Startup allows 7200 seconds. H100 retains its 4096-token prefill-batch cap. Higher concurrencies are experimental and require GPU validation.

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -273,3 +273,11 @@ python -m pytest utils/matrix_logic/ -v
 - YAML、Bash、严格 schema、精确 key 生成、launcher 模拟或配方验证失败。
 
 只有当所有可执行文件一致、精确 key 能生成、运行时路由存在、changelog 能选择该 key，且以上各层检查全部通过时，配置才可以进入 sweep。
+
+## B300 上的 DeepSeek V4.1 Flash Mooncake
+
+`dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake` 以 TP4 运行 AgentX，并发为 1, 2, 4, 8, 16, 32, 64, 128, 256, 512，使用完整 `semianalysis_cc_traces_weka_062126` 轨迹和 1M 上下文。配方遵循[上游嵌入式 Mooncake 配置](https://github.com/vllm-project/recipes/blob/main/kv_store/kv_store_distributed_mooncake.yaml)：`MooncakeStoreConnector`、`kv_both`、RDMA 和单个本地 metadata master。helper 固定使用 Mooncake 0.3.11.post1，并按镜像的 CUDA 主版本选择 wheel。
+
+生成的主机内存预算为 runner 分配 DRAM 的 60%。先预留 208 GB 给 Engram UVA 表，并为每个 GPU 预留 4 GB Mooncake 传输缓冲区，再将剩余容量均分为各 rank 的 KV segment。`enable_offload: false` 关闭的是 Mooncake 的二级存储层，嵌入式 DRAM KV 存储仍然启用。退出时清理 server 和 master。
+
+吞吐测试保留五 token DSpark、thinking 开启时的黄金合成 AL 3.51，并关闭自适应验证；eval 使用真实块验证。启动等待期限为 7200 秒。H100 保留 4096 token 的 prefill batch 上限。更高并发属于实验配置，需通过 GPU 验证。

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -278,6 +278,8 @@ python -m pytest utils/matrix_logic/ -v
 
 `dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake` 以 TP4 运行 AgentX，并发为 1, 2, 4, 8, 16, 32, 64, 128, 256, 512，使用完整 `semianalysis_cc_traces_weka_062126` 轨迹和 1M 上下文。配方遵循[上游嵌入式 Mooncake 配置](https://github.com/vllm-project/recipes/blob/main/kv_store/kv_store_distributed_mooncake.yaml)：`MooncakeStoreConnector`、`kv_both`、RDMA 和单个本地 metadata master。helper 固定使用 Mooncake 0.3.11.post1，并按镜像的 CUDA 主版本选择 wheel。
 
-生成的主机内存预算为 runner 分配 DRAM 的 60%。先预留 208 GB 给 Engram UVA 表，并为每个 GPU 预留 4 GB Mooncake 传输缓冲区，再将剩余容量均分为各 rank 的 KV segment。`enable_offload: false` 关闭的是 Mooncake 的二级存储层，嵌入式 DRAM KV 存储仍然启用。退出时清理 server 和 master。
+生成的主机内存预算为 runner 分配 DRAM 的 60%。先预留 208 GB 给 Engram UVA 表，并为每个 GPU 预留 4 GiB Mooncake 传输缓冲区，再将剩余容量均分为各 rank 的 KV segment。`enable_offload: false` 关闭的是 Mooncake 的二级存储层，嵌入式 DRAM KV 存储仍然启用。退出时清理 server 和 master。
 
 吞吐测试保留五 token DSpark、thinking 开启时的黄金合成 AL 3.51，并关闭自适应验证；eval 使用真实块验证。启动等待期限为 7200 秒。H100 保留 4096 token 的 prefill batch 上限。更高并发属于实验配置，需通过 GPU 验证。
+
+Mooncake 容量以整数字节数传入，避免其二进制 `GB` 解析规则超出十进制主机内存预算。卸载模式的 CUDA graph 最多捕获 512 tokens；更大的 batch 使用非捕获路径，保留并发 512 和 1M 上下文。

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7162,3 +7162,9 @@
   description:
     - "Use the pinned SGLang nightly-dev-cu13-20260901-07c8f729 image with FlashInfer 0.6.18, which includes the BF16 TRTLLM MoE allocation fix for small-batch Blackwell execution. Model, TP8, HiCache, MTP settings and concurrency grid are unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2829
+
+- config-keys:
+    - dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake
+  description:
+    - "Add B300 DSv4.1 Flash embedded Mooncake DRAM KV offload, golden synthetic AL 3.51 and concurrency 1-512"
+  pr-link: TBD

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7168,3 +7168,9 @@
   description:
     - "Add B300 DSv4.1 Flash embedded Mooncake DRAM KV offload, golden synthetic AL 3.51 and concurrency 1-512"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2998
+
+- config-keys:
+    - dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake
+  description:
+    - "Correct Mooncake decimal host-memory budget using exact bytes and 4 GiB transfer buffers; cap offload CUDA graph capture at 512 tokens to preserve KV memory at high concurrency"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2998

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7167,4 +7167,4 @@
     - dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake
   description:
     - "Add B300 DSv4.1 Flash embedded Mooncake DRAM KV offload, golden synthetic AL 3.51 and concurrency 1-512"
-  pr-link: TBD
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2998

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -436,6 +436,13 @@ else
         CONTAINER_MOUNT_DIR=/workspace
     fi
 
+    # Keep all new AgentX runtime directories outside /workspace.
+    if [[ "$MODEL_PREFIX" == "dsv41flash" && "$FRAMEWORK" == "vllm" ]]; then
+        CONTAINER_MOUNT_DIR=/ix
+        export INFMAX_CONTAINER_WORKSPACE=/ix
+        export RESULT_DIR=/ix/results
+    fi
+
     import_squash_image "$IMAGE" "$SQUASH_FILE"
 
     export GPU_COUNT="${GPU_COUNT:-${TP:?TP must be set}}"

--- a/utils/evals/test_mooncake_setup.py
+++ b/utils/evals/test_mooncake_setup.py
@@ -65,9 +65,10 @@ def test_store_reserves_model_and_transfer_buffers(tmp_path: Path, budget: int) 
     result = run_setup(tmp_path, budget)
     assert result.returncode == 0, result.stderr
     config = json.loads((tmp_path / "mooncake_config.json").read_text())
-    # 40 model + 4 * (13 segment + 4 buffer) = 108 GB, with at most 1 GB unused.
-    assert config["global_segment_size"] == "13GB"
-    assert config["local_buffer_size"] == "4GB"
+    # Independently calculated byte budgets, including the 4 GiB buffers.
+    assert config["global_segment_size"] == {108: 12_705_032_704, 109: 12_955_032_704}[budget]
+    assert config["local_buffer_size"] == 4_294_967_296
+    assert 40_000_000_000 + 4 * (config["global_segment_size"] + config["local_buffer_size"]) <= budget * 1_000_000_000
     assert config["mode"] == "embedded"
     assert config["enable_offload"] is False
     assert config["protocol"] == "rdma"
@@ -90,3 +91,36 @@ def test_master_exit_prevents_serving(tmp_path: Path) -> None:
     assert result.returncode != 0
     assert "controlled master failure" in result.stderr
     assert not (tmp_path / "connector-args").exists()
+
+
+@pytest.mark.parametrize("concurrency,backend,expected", [(1, "mooncake", 8), (64, "mooncake", 512), (128, "mooncake", 512), (512, "mooncake", 512), (512, "", 2048)])
+@pytest.mark.parametrize("eval_only", ["false", "true"])
+def test_graph_capture_leaves_kv_budget(tmp_path: Path, concurrency: int, backend: str, expected: int, eval_only: str) -> None:
+    env = {**os.environ, "MODEL": "fixture", "TP": "4", "CONC": str(concurrency),
+           "KV_OFFLOADING": "dram" if backend else "none", "KV_OFFLOAD_BACKEND": backend,
+           "TOTAL_CPU_DRAM_GB": "541", "RESULT_DIR": str(tmp_path), "DURATION": "1", "EVAL_ONLY": eval_only, "PORT": "18888"}
+    result = subprocess.run(["bash", "-c", r"""
+source() { :; }
+check_env_vars() { :; }
+require_agentic_kv_offload_none() { :; }
+require_agentic_kv_offload_backend() { :; }
+setup_agentic_mooncake() { OFFLOAD_ARGS=(--kv-transfer-config '{}'); }
+hf() { :; }
+nvidia-smi() { :; }
+resolve_trace_source() { :; }
+install_agentic_deps() { :; }
+select_available_server_port() { :; }
+wait_for_server_ready() { wait "$SERVER_PID"; }
+stop_background_process_tree() { :; }
+build_replay_cmd() { :; }
+run_agentic_replay_and_write_outputs() { :; }
+run_eval() { :; }
+vllm() { command python3 -c 'import json,sys,os; json.dump(sys.argv[1:],open(os.environ["RESULT_DIR"]+"/args.json","w"))' "$@"; }
+builtin source "$1/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh"
+""", "bash", str(REPO_ROOT)], env=env, capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+    args = json.loads((tmp_path / "args.json").read_text())
+    assert int(args[args.index("--max-cudagraph-capture-size") + 1]) == expected
+    assert args[args.index("--max-model-len") + 1] == "1048576"
+    spec = json.loads(args[args.index("--speculative-config") + 1])
+    assert spec["rejection_sample_method"] == ("block" if eval_only == "true" else "synthetic")

--- a/utils/evals/test_mooncake_setup.py
+++ b/utils/evals/test_mooncake_setup.py
@@ -1,0 +1,92 @@
+"""Exercise the embedded store launcher without GPU or Mooncake dependencies."""
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_setup(tmp_path: Path, budget: int, master_failure: bool = False) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "KV_OFFLOADING": "dram",
+        "KV_OFFLOAD_BACKEND": "mooncake",
+        "TOTAL_CPU_DRAM_GB": str(budget),
+        "GPU_COUNT": "4",
+        "MOONCAKE_HOST_RESERVE_GB": "40",
+        "RESULT_DIR": str(tmp_path),
+        "MASTER_FAILURE": "1" if master_failure else "0",
+    }
+    return subprocess.run(
+        ["bash", "-c", r'''
+set -eo pipefail
+source "$1/benchmarks/benchmark_lib.sh"
+agentic_pip_install() { touch "$RESULT_DIR/install-called"; }
+python3() {
+    case "$*" in
+        *'import torch;'*) echo 13 ;;
+        *'from mooncake.store import'*) return 0 ;;
+        *) command python3 "$@" ;;
+    esac
+}
+mooncake_master() {
+    if [[ "$MASTER_FAILURE" == 1 ]]; then
+        echo "controlled master failure" >&2
+        return 17
+    fi
+    command python3 -c '
+import os, socket, sys, time
+port = int(next(arg.split("=", 1)[1] for arg in sys.argv[1:] if arg.startswith("--port=")))
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", port))
+    sock.listen()
+    conn, _ = sock.accept()
+    conn.close()
+    time.sleep(120)
+' "$@"
+}
+cleanup() {
+    stop_background_process_tree "${MOONCAKE_MASTER_PID:-}" "test master" 1
+}
+trap cleanup EXIT
+setup_agentic_mooncake
+printf '%s\n' "$PYTHONHASHSEED" > "$RESULT_DIR/hash-seed"
+printf '%s\n' "${OFFLOAD_ARGS[@]}" > "$RESULT_DIR/connector-args"
+''', "bash", str(REPO_ROOT)],
+        env=env, capture_output=True, text=True, timeout=15,
+    )
+
+
+@pytest.mark.parametrize("budget", [108, 109])
+def test_store_reserves_model_and_transfer_buffers(tmp_path: Path, budget: int) -> None:
+    result = run_setup(tmp_path, budget)
+    assert result.returncode == 0, result.stderr
+    config = json.loads((tmp_path / "mooncake_config.json").read_text())
+    # 40 model + 4 * (13 segment + 4 buffer) = 108 GB, with at most 1 GB unused.
+    assert config["global_segment_size"] == "13GB"
+    assert config["local_buffer_size"] == "4GB"
+    assert config["mode"] == "embedded"
+    assert config["enable_offload"] is False
+    assert config["protocol"] == "rdma"
+    assert 0 < int(config["master_server_address"].rsplit(":", 1)[1]) < 65536
+    flag, raw = (tmp_path / "connector-args").read_text().splitlines()
+    assert flag == "--kv-transfer-config"
+    assert json.loads(raw) == {"kv_connector": "MooncakeStoreConnector", "kv_role": "kv_both"}
+    assert (tmp_path / "hash-seed").read_text().strip() == "0"
+
+
+def test_insufficient_memory_fails_before_install(tmp_path: Path) -> None:
+    result = run_setup(tmp_path, 56)
+    assert result.returncode != 0
+    assert "Host budget cannot fit" in result.stderr
+    assert not (tmp_path / "install-called").exists()
+
+
+def test_master_exit_prevents_serving(tmp_path: Path) -> None:
+    result = run_setup(tmp_path, 108, master_failure=True)
+    assert result.returncode != 0
+    assert "controlled master failure" in result.stderr
+    assert not (tmp_path / "connector-args").exists()

--- a/utils/evals/test_run_eval_dispatch.py
+++ b/utils/evals/test_run_eval_dispatch.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -3231,3 +3232,27 @@ _cleanup_vendor_eval "$cleanup_dir"
     assert f"SELECTED_PYTHON=<{python_root / 'venv/bin/python'}>" in result.stdout
     assert "--prefix" not in result.stdout
     assert not python_root.exists()
+
+
+@pytest.mark.parametrize("occupied", [False, True])
+def test_select_available_server_port_avoids_an_existing_listener(occupied: bool) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("0.0.0.0", 0))
+        preferred = listener.getsockname()[1]
+        if occupied:
+            listener.listen()
+        else:
+            listener.close()
+        result = subprocess.run(
+            ["bash", "-c", 'source "$BENCHMARK_LIB"; select_available_server_port; '
+             'python3 -c \'import os; print(os.environ["PORT"])\''],
+            env={**os.environ, "BENCHMARK_LIB": str(BENCHMARK_LIB), "PORT": str(preferred)},
+            text=True, capture_output=True, check=True,
+        )
+        selected = int(result.stdout.strip())
+        if occupied:
+            assert selected != preferred
+        else:
+            assert selected == preferred
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+            server.bind(("0.0.0.0", selected))


### PR DESCRIPTION
Add B300 TP4 DSv4.1 Flash AgentX with embedded `MooncakeStoreConnector` DRAM KV offload, Engram UVA and golden synthetic AL 3.51. Concurrencies: **1, 2, 4, 8, 16, 32, 64, 128, 256, 512**. Uses full `semianalysis_cc_traces_weka_062126` traces. Host allocation reserves Engram and transfer buffers; eval keeps real verification. Follows the [upstream Mooncake recipe](https://github.com/vllm-project/recipes/blob/main/kv_store/kv_store_distributed_mooncake.yaml). Local matrix, launcher, serving-command and Mooncake setup tests pass; GPU validation pending.

新增 B300 TP4 DSv4.1 Flash AgentX，启用嵌入式 `MooncakeStoreConnector` DRAM KV 卸载、Engram UVA 和黄金合成 AL 3.51。并发：**1, 2, 4, 8, 16, 32, 64, 128, 256, 512**。使用完整 `semianalysis_cc_traces_weka_062126` 轨迹；主机内存分配预留 Engram 和传输缓冲区，eval 保留真实验证。遵循上述上游 Mooncake 配方。本地矩阵、launcher、服务命令和 Mooncake 启动测试通过，GPU 验证待完成。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New host-memory budgeting, Mooncake master lifecycle, and high-concurrency AgentX paths affect benchmark reliability; GPU validation is still pending.
> 
> **Overview**
> Adds **DeepSeek-V4.1-Flash** (`dsv41flash`) to the model matrix and wires a new B300 DSXE AgentX recipe: **`dsv41flash-fp4-b300-vllm-agentic-dspark-mooncake`** (TP4, fp4 vLLM, DSpark with golden synthetic AL 3.51, concurrency 1–512, 1M context, full `semianalysis_cc_traces_weka_062126`).
> 
> Shared benchmark plumbing gains **`select_available_server_port`** for host-network/Pyxis collisions and **`setup_agentic_mooncake`** to install Mooncake 0.3.11.post1, size per-rank KV segments from decimal host DRAM (Engram **208 GB** reserve + **4 GiB** buffers per GPU), start an embedded master, and pass **`MooncakeStoreConnector`** into vLLM. The new **`dsv41flash_fp4_vllm_mtp.sh`** recipe enables Engram UVA CPU offload, caps CUDA graph capture at **512** when Mooncake is on, and documents Mooncake failure diagnostics.
> 
> **`launch_b300-dsxe.sh`** mounts **`/ix`** for `dsv41flash` vLLM runs; docs/changelog entries describe the recipe. Unit tests cover Mooncake setup budgeting and port selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f7f317c29293e746ab5f3643cd0a768cfe0ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->