### PR TITLE
Revert "fix: size the GLM-5.2 MI355X eval HiCache pool absolutely (#2983)"

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -91,15 +91,6 @@ if agentic_kv_offload_enabled; then
         # env-var override for maximum throughput on nodes with >4 TB DRAM.
         HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
     fi
-    # GSM8K never fills the agentic host pool; ratio 1.5 OOMs the TP4 DRAM share.
-    if [ "${EVAL_ONLY:-false}" = "true" ]; then
-        HICACHE_EVAL_SIZE_GB="${HICACHE_EVAL_SIZE_GB:-16}"
-        HICACHE_POOL_ARGS=(--hicache-size "$HICACHE_EVAL_SIZE_GB")
-        HICACHE_POOL_DESC="size=${HICACHE_EVAL_SIZE_GB} GB/rank (eval-only)"
-    else
-        HICACHE_POOL_ARGS=(--hicache-ratio "$HICACHE_RATIO" --hicache-size 0)
-        HICACHE_POOL_DESC="ratio=$HICACHE_RATIO"
-    fi
     # write_through_selective skips DRAM writes for non-reusable KV blocks,
     # reducing host-bus traffic without affecting the cache hit rate.
     HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through_selective}"
@@ -107,10 +98,10 @@ if agentic_kv_offload_enabled; then
     HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
     case "$KV_OFFLOAD_BACKEND" in
         hicache)
-            echo "HiCache (GPU+host DRAM only): $HICACHE_POOL_DESC, write_policy=$HICACHE_WRITE_POLICY, io_backend=$HICACHE_IO_BACKEND, mem_layout=$HICACHE_MEM_LAYOUT"
+            echo "HiCache (GPU+host DRAM only): ratio=$HICACHE_RATIO, write_policy=$HICACHE_WRITE_POLICY, io_backend=$HICACHE_IO_BACKEND, mem_layout=$HICACHE_MEM_LAYOUT"
             CACHE_ARGS=(
                 --enable-hierarchical-cache
-                "${HICACHE_POOL_ARGS[@]}"
+                --hicache-ratio "$HICACHE_RATIO"
                 --hicache-write-policy "$HICACHE_WRITE_POLICY"
                 --hicache-io-backend "$HICACHE_IO_BACKEND"
                 --hicache-mem-layout "$HICACHE_MEM_LAYOUT"
@@ -141,10 +132,11 @@ EOF
             MOONCAKE_MASTER_PID=$!
             sleep 2
             kill -0 "$MOONCAKE_MASTER_PID"
-            echo "HiCache+Mooncake: $HICACHE_POOL_DESC, l3_per_rank=${L3_PER_RANK_GB} GB, dram_budget=${TOTAL_CPU_DRAM_GB} GB"
+            echo "HiCache+Mooncake: ratio=$HICACHE_RATIO, l3_per_rank=${L3_PER_RANK_GB} GB, dram_budget=${TOTAL_CPU_DRAM_GB} GB"
             CACHE_ARGS=(
                 --enable-hierarchical-cache
-                "${HICACHE_POOL_ARGS[@]}"
+                --hicache-ratio "$HICACHE_RATIO"
+                --hicache-size 0
                 --hicache-write-policy "$HICACHE_WRITE_POLICY"
                 --hicache-io-backend "$HICACHE_IO_BACKEND"
                 --hicache-mem-layout "$HICACHE_MEM_LAYOUT"


### PR DESCRIPTION
Reverts #2983 (merge commit a5f23f4).

The HiCache pool sizing change was a workaround for a symptom, not the cause. The node runs one job at a time under `--exclusive`, so the shared-DRAM-budget explanation in #2983 does not hold, and it does not explain why only the eval path was crashing. The GSM8K crash is believed to be the SGLang EAGLE bug fixed upstream in sgl-project/sglang#38318, so the recipe change should not carry forward.

Discussed in #ext-amd-sw-engineering-semianalysis; Bryan Shan agreed to revert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark script-only change; restores prior HiCache CLI flags with no production runtime impact.
> 
> **Overview**
> Reverts the **eval-only HiCache pool workaround** from #2983 in the GLM-5.2 MI355X agentic benchmark launcher.
> 
> When `agentic_kv_offload_enabled` is on, **both** `hicache` and `mooncake` paths again always pass **`--hicache-ratio`** (with DP vs TP defaults unchanged) instead of switching to a fixed **`--hicache-size`** (16 GB default) when `EVAL_ONLY=true`. The Mooncake arm again sets **`--hicache-size 0`** alongside the ratio. Logging no longer uses `HICACHE_POOL_DESC` and always reports `ratio=$HICACHE_RATIO`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c849424f2cb800f5f611d0aabb92ad42516715a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->