### PR TITLE
AMD: MI355x: Lower the GLM-5.2 MI355X HiCache host-pool ratio from 1.5 to 1.0

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -72,11 +72,10 @@ export SGLANG_OPT_USE_TOPK_V2=false
 #
 # Per-arm L2 ratio (sizing rationale below) applies to both backends unless
 # overridden via HICACHE_RATIO. TP arm (182.7 GB/rank device pool): the
-# agentic-coding corpus saturates any fixed DRAM pool at conc ≥ 10; ratio 1.5
-# (~2.9 TB pinned) is the safe default for cluster:mi355x-amds nodes (~3.0 TB
-# available DRAM per runners.yaml). ratio=2.5 (~4.8 TB) yields higher
-# throughput at conc 10-12 but exceeds physical DRAM on these nodes and must
-# be set via HICACHE_RATIO env-var override on nodes that can accommodate it.
+# agentic-coding corpus saturates any fixed DRAM pool at conc ≥ 10; ratio 1.0
+# (~453 GB pinned at TP4) is the default. Larger ratios trade DRAM headroom
+# for host-tier capacity and must be set via the HICACHE_RATIO env-var
+# override on nodes that can accommodate them.
 # The DP-attention arm (159.4 GB/rank) only runs at conc >= 32, where the host
 # tier just absorbs overflow - ratio 0.5 (~1.2 TB pinned, ~1.8 TB of load
 # headroom) at negligible hit-rate cost (ratio 1.5 OOMs the host mid-storm at
@@ -86,10 +85,9 @@ if agentic_kv_offload_enabled; then
     if [ "$DP_ATTENTION" = "true" ]; then
         HICACHE_RATIO="${HICACHE_RATIO:-0.5}"
     else
-        # ratio=1.5 (~2.9 TB pinned): safe default within the ~3.0 TB DRAM
-        # available on cluster:mi355x-amds nodes. Set HICACHE_RATIO=2.5 via
-        # env-var override for maximum throughput on nodes with >4 TB DRAM.
-        HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
+        # ratio=1.0 (~113 GB/rank, ~453 GB pinned at TP4). Raise via the
+        # HICACHE_RATIO env-var override on nodes with more DRAM headroom.
+        HICACHE_RATIO="${HICACHE_RATIO:-1.0}"
     fi
     # write_through_selective skips DRAM writes for non-reusable KV blocks,
     # reducing host-bus traffic without affecting the cache hit rate.


### PR DESCRIPTION
## What

`--hicache-ratio 1.5` → `1.0` for the TP arm. The DP-attention arm stays at 0.5. **No change to the allocation logic**: eval and sweep still share the same ratio-based sizing.

## Why

Ratio is relative to the *device* KV pool. On `cluster:mi355x-amds` the TP4 device pool measured 127.90 GB/rank, so ratio 1.5 resolved to 169.73 GB/rank — **679 GB pinned across the 4 TP ranks**. Ratio 1.0 brings that to ~113 GB/rank, ~453 GB total.

The GSM8K eval for `glm5.2_tp4_conc12_kvdram-hicache_spec-mtp` was SIGKILLed mid-eval on `mi355x-amds_07` (`132625 Killed`) once `lm_eval` started touching those pinned pages: allocation and warmup succeeded, then the OOM killer fired on the first batch.

The host tier is also not paying for its size today, so the smaller pool is worth measuring on its own.

## Test plan

Eval-only dispatch of the AgentX config (no throughput sweep) to see whether the eval survives at ratio 1.0:

- [ ] `test-config --config-files configs/amd-master.yaml --config-keys glm5.2-fp4-mi355x-sglang-agentic-mtp --evals-only`
- [ ] Server stays up through GSM8K
- [ ] Host pool logs ~113 GB/rank