### PR TITLE
Switch GLM-5.2 MI355X HiCache write policy to write_through

### DIFF
--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -89,9 +89,7 @@ if agentic_kv_offload_enabled; then
         # HICACHE_RATIO env-var override on nodes with more DRAM headroom.
         HICACHE_RATIO="${HICACHE_RATIO:-1.0}"
     fi
-    # write_through_selective skips DRAM writes for non-reusable KV blocks,
-    # reducing host-bus traffic without affecting the cache hit rate.
-    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through_selective}"
+    HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through}"
     HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-direct}"
     HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
     case "$KV_OFFLOAD_BACKEND" in

--- a/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/glm5.2_fp4_mi355x_sglang_mtp.sh
@@ -72,11 +72,10 @@ export SGLANG_OPT_USE_TOPK_V2=false
 #
 # Per-arm L2 ratio (sizing rationale below) applies to both backends unless
 # overridden via HICACHE_RATIO. TP arm (182.7 GB/rank device pool): the
-# agentic-coding corpus saturates any fixed DRAM pool at conc ≥ 10; ratio 1.5
-# (~2.9 TB pinned) is the safe default for cluster:mi355x-amds nodes (~3.0 TB
-# available DRAM per runners.yaml). ratio=2.5 (~4.8 TB) yields higher
-# throughput at conc 10-12 but exceeds physical DRAM on these nodes and must
-# be set via HICACHE_RATIO env-var override on nodes that can accommodate it.
+# agentic-coding corpus saturates any fixed DRAM pool at conc ≥ 10; ratio 1.0
+# (~453 GB pinned at TP4) is the default. Larger ratios trade DRAM headroom
+# for host-tier capacity and must be set via the HICACHE_RATIO env-var
+# override on nodes that can accommodate them.
 # The DP-attention arm (159.4 GB/rank) only runs at conc >= 32, where the host
 # tier just absorbs overflow - ratio 0.5 (~1.2 TB pinned, ~1.8 TB of load
 # headroom) at negligible hit-rate cost (ratio 1.5 OOMs the host mid-storm at
@@ -86,10 +85,9 @@ if agentic_kv_offload_enabled; then
     if [ "$DP_ATTENTION" = "true" ]; then
         HICACHE_RATIO="${HICACHE_RATIO:-0.5}"
     else
-        # ratio=1.5 (~2.9 TB pinned): safe default within the ~3.0 TB DRAM
-        # available on cluster:mi355x-amds nodes. Set HICACHE_RATIO=2.5 via
-        # env-var override for maximum throughput on nodes with >4 TB DRAM.
-        HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
+        # ratio=1.0 (~113 GB/rank, ~453 GB pinned at TP4). Raise via the
+        # HICACHE_RATIO env-var override on nodes with more DRAM headroom.
+        HICACHE_RATIO="${HICACHE_RATIO:-1.0}"
     fi
     # write_through_selective skips DRAM writes for non-reusable KV blocks,
     # reducing host-bus traffic without affecting the cache hit rate.


### PR DESCRIPTION
## What

Default `--hicache-write-policy` `write_through_selective` → `write_through`. Built on #3004 so the TP host-pool ratio stays **1.0**. Eval and sweep still share the same ratio-based sizing.

## Why

#3004 evals-only already passed at ratio 1.0 + `write_through_selective`: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34566241629

This PR is the write-policy A/B: same pool size, `write_through` (every KV write hits host). That is the remaining HiCache delta vs putting `write_through` back on #2900.

## Test plan

- [ ] Dispatch End-to-End Tests evals-only (no throughput sweep)
- [ ] `test-config --config-files configs/amd-master.yaml --config-keys glm5.2-fp4-mi355x-sglang-agentic-mtp --evals-only`
- [ ] Server stays up through GSM8K (no SIGKILL)
- [ ] Logs show `write_policy=write_through` and ratio 1.0 (~113 GB/rank)


Made with [Cursor](https://cursor.com)