### PR TITLE
[Klaud Cold] Update dsr1-fp8-h200-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp8-h200-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1541,7 +1541,7 @@ dsr1-fp8-b200-trt-mtp:
       - { tp: 8, ep: 1, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-h200-sglang:
-  image: lmsysorg/sglang:v0.5.12-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7179,3 +7179,9 @@
   description:
     - "Use the pinned SGLang nightly-dev-cu13-20260901-07c8f729 image with FlashInfer 0.6.18, which includes the BF16 TRTLLM MoE allocation fix for small-batch Blackwell execution. Model, TP8, HiCache, MTP settings and concurrency grid are unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2994
+
+- config-keys:
+    - dsr1-fp8-h200-sglang
+  description:
+    - "Update the DeepSeek-R1-0528 FP8 H200 SGLang image from v0.5.12-cu130 to v0.5.19-cu130. Model, TP8 topology, 8k1k workload, concurrency grid, launch flags and evals are unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3010


### PR DESCRIPTION
Update the `dsr1-fp8-h200-sglang` master image from `lmsysorg/sglang:v0.5.12-cu130` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub index digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, build commit [`0bcd822`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). Model, TP8 topology, 8k1k workload, concurrency grid, launch flags and evals are unchanged.

## Baseline

- **Published date:** 2026-05-17, old image `lmsysorg/sglang:v0.5.12-cu130` (build commit [`127b9e3`](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624))
- **Identity:** DeepSeek-R1-0528, H200, SGLang, FP8, no speculative decoding, single node, TP8 EP1, Single-turn 8k1k, `random-range-ratio` dataset, concurrency 4 / 8 / 16 / 32 / 64
- **Producer:** [run 25980019087 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25980019087/attempts/2) ("Update dsr1-fp8-h200-sglang SGLang image to v0.5.12-cu130", PR [#1423](https://github.com/SemiAnalysisAI/InferenceX/pull/1423), head `aa2df953`); the same curve is still the latest published data for this family as of 2026-09-11
- **API queries:** `/api/v1/workflow-info?date=2026-05-17`, `/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-17&exact=true`, `/api/v1/evaluations?model=DeepSeek-R1-0528&date=2026-05-17&exact=true`

| Conc | Result ID | Total tok/s/GPU | Output tok/s/GPU | Median TTFT (s) | Median TPOT (ms) | Median E2E (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 4 | 409933 | 387.6 | 43.1 | 0.312 | 10.98 | 10.32 |
| 8 | 409937 | 607.9 | 68.3 | 0.314 | 13.93 | 13.23 |
| 16 | 409940 | 847.3 | 93.9 | 0.330 | 20.22 | 19.01 |
| 32 | 409935 | 1082.1 | 121.0 | 0.348 | 32.01 | 29.96 |
| 64 | 409941 | 1360.9 | 151.0 | 0.690 | 50.70 | 47.70 |

- **Evals (gsm8k, n = 1319, same producer run):** concurrency 32 `em_strict` 0.9583 / `em_flexible` 0.9606 (ID 6394); concurrency 64 `em_strict` 0.9583 / `em_flexible` 0.9621 (ID 6395). The published eval rows carry `disagg=true` while the benchmark rows carry `disagg=false` for the same run; treated as an identity-metadata quirk, not a different deployment.

---

将 `dsr1-fp8-h200-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.12-cu130` 更新至当前 SGLang 发行版 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub 索引摘要 `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，构建提交 [`0bcd822`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。模型、TP8 拓扑、8k1k 工作负载、并发网格、启动参数与评测均保持不变。

## 基线

- **发布日期：** 2026-05-17，旧镜像 `lmsysorg/sglang:v0.5.12-cu130`（构建提交 [`127b9e3`](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624)）
- **身份：** DeepSeek-R1-0528，H200，SGLang，FP8，无投机解码，单节点，TP8 EP1，单轮 8k1k，`random-range-ratio` 数据集，并发 4 / 8 / 16 / 32 / 64
- **生产运行：** [运行 25980019087 第 2 次尝试](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25980019087/attempts/2)（"Update dsr1-fp8-h200-sglang SGLang image to v0.5.12-cu130"，PR [#1423](https://github.com/SemiAnalysisAI/InferenceX/pull/1423)，head `aa2df953`）；截至 2026-09-11，该曲线仍是本家族最新的已发布数据
- **API 查询：** `/api/v1/workflow-info?date=2026-05-17`、`/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-17&exact=true`、`/api/v1/evaluations?model=DeepSeek-R1-0528&date=2026-05-17&exact=true`

| 并发 | 结果 ID | 总吞吐 tok/s/GPU | 输出吞吐 tok/s/GPU | TTFT 中位数 (s) | TPOT 中位数 (ms) | 端到端中位数 (s) |
| --- | --- | --- | --- | --- | --- | --- |
| 4 | 409933 | 387.6 | 43.1 | 0.312 | 10.98 | 10.32 |
| 8 | 409937 | 607.9 | 68.3 | 0.314 | 13.93 | 13.23 |
| 16 | 409940 | 847.3 | 93.9 | 0.330 | 20.22 | 19.01 |
| 32 | 409935 | 1082.1 | 121.0 | 0.348 | 32.01 | 29.96 |
| 64 | 409941 | 1360.9 | 151.0 | 0.690 | 50.70 | 47.70 |

- **评测（gsm8k，n = 1319，同一生产运行）：** 并发 32 `em_strict` 0.9583 / `em_flexible` 0.9606（ID 6394）；并发 64 `em_strict` 0.9583 / `em_flexible` 0.9621（ID 6395）。已发布的评测行标记为 `disagg=true`，而同一运行的基准行为 `disagg=false`；视为身份元数据的差异，而非不同的部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Docker image pin and changelog; no runtime code, auth, or workload definition changes.
> 
> **Overview**
> Bumps the **`dsr1-fp8-h200-sglang`** master benchmark config from **`lmsysorg/sglang:v0.5.12-cu130`** to **`lmsysorg/sglang:v0.5.19-cu130`**. DeepSeek-R1-0528 on H200 (FP8, SGLang), TP8 topology, 8k/1k scenario, concurrency sweep, launch flags, and evals are **unchanged**—only the container image tag moves forward.
> 
> Adds a matching **`perf-changelog.yaml`** entry for **`dsr1-fp8-h200-sglang`** documenting the image update (PR #3010).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f207db02fbb7d8016d1aca9c67907b5e674dc915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->