### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-mi300x-sglang SGLang ROCm image to v0.5.19-rocm720-mi30x / 将 qwen3.5-fp8-mi300x-sglang 的 SGLang ROCm 镜像更新至 v0.5.19-rocm720-mi30x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -412,7 +412,7 @@ qwen3.5-fp4-mi355x-sglang-disagg:
           - "DECODE_MTP_SIZE=0"
 
 qwen3.5-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm720-mi30x
+  image: lmsysorg/sglang:v0.5.19-rocm720-mi30x
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7286,3 +7286,10 @@
   description:
     - "Use thinking-on golden synthetic AL 3.51 for five-token DSpark throughput; disable adaptive verification and retain real verification for evals"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2974
+
+- config-keys:
+    - qwen3.5-fp8-mi300x-sglang
+  description:
+    - "Update SGLang ROCm image from lmsysorg/sglang:v0.5.12-rocm720-mi30x (v0.5.12 release, build commit sgl-project/sglang@127b9e3283f7c2a43234b852ff5c9f1796d53624) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-rocm720-mi30x (digest sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, Docker Hub last pushed 2026-09-04T21:24:05Z)."
+    - "Both images build docker/rocm.Dockerfile stage gfx942-rocm720 on rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1; AITER moves from a6bb4993 to c16d44b9 and Triton stays at 42270451. benchmarks/single_node/fixed_seq_len/qwen3.5_fp8_mi300x.sh is unchanged: aiter attention with allreduce fusion, radix cache disabled, mem-fraction-static 0.75; TP8 8k/1k concurrency 4 through 64 and the gsm8k eval policy unchanged."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3011


### PR DESCRIPTION
Update the `qwen3.5-fp8-mi300x-sglang` master image from `lmsysorg/sglang:v0.5.12-rocm720-mi30x` to the SGLang v0.5.19 release image `lmsysorg/sglang:v0.5.19-rocm720-mi30x` (digest `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`, build commit [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)). Model, precision, TP8 topology, 8k/1k workload, concurrency 4-64, launch script and eval policy are unchanged.

## Baseline

- Published: 2026-05-17, image `lmsysorg/sglang:v0.5.12-rocm720-mi30x` (build commit [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624))
- Identity: Qwen3.5-397B-A17B-FP8, MI300X, SGLang, FP8, no speculative decoding, aggregated single node, fixed-seq-len ISL 8192 / OSL 1024, TP8, concurrency 4/8/16/32/64
- Producer: [run 25984517560 attempt 4](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25984517560/attempts/4), head `020e70d34a5d8a7f8487dba020159c48c2f7b39f`, changelog PR [#1427](https://github.com/SemiAnalysisAI/InferenceX/pull/1427)
- API queries: `/api/v1/workflow-info?date=2026-05-17`, `/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`, `/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`

| conc | tput/GPU (tok/s) | output tput/GPU (tok/s) | median TPOT (ms) | median TTFT (ms) | median E2E (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 271.0 | 30.1 | 15.04 | 1104.4 | 14.76 |
| 8 | 457.3 | 51.4 | 17.96 | 1154.6 | 17.65 |
| 16 | 735.7 | 81.5 | 22.69 | 1101.3 | 21.65 |
| 32 | 1097.5 | 122.7 | 30.70 | 1354.6 | 29.64 |
| 64 | 1562.9 | 173.4 | 43.84 | 1501.2 | 42.19 |

Published eval (same producer run): gsm8k em_strict 0.9644 / em_flexible 0.9560 at concurrency 32 and em_strict 0.9674 / em_flexible 0.9613 at concurrency 64. The published eval rows carry `disagg: true` metadata although the recipe is aggregated single-node; the run URL and config match this family, so the mismatch is noted here as a metadata quirk.

---

将 `qwen3.5-fp8-mi300x-sglang` 的主配置镜像从 `lmsysorg/sglang:v0.5.12-rocm720-mi30x` 更新至 SGLang v0.5.19 发布镜像 `lmsysorg/sglang:v0.5.19-rocm720-mi30x`（digest `sha256:a0ffcdd013af6d79c9b7c4348c42b14a79a48f6c43dd3ca0235ec3802da45f75`，构建提交 [sgl-project/sglang@0bcd8223](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)）。模型、精度、TP8 拓扑、8k/1k 工作负载、并发 4-64、启动脚本和评测策略均保持不变。

## 基线

- 发布日期：2026-05-17，镜像 `lmsysorg/sglang:v0.5.12-rocm720-mi30x`（构建提交 [sgl-project/sglang@127b9e32](https://github.com/sgl-project/sglang/commit/127b9e3283f7c2a43234b852ff5c9f1796d53624)）
- 身份：Qwen3.5-397B-A17B-FP8、MI300X、SGLang、FP8、无投机解码、单节点聚合部署、fixed-seq-len ISL 8192 / OSL 1024、TP8、并发 4/8/16/32/64
- 生产运行：[run 25984517560 attempt 4](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/25984517560/attempts/4)，head `020e70d34a5d8a7f8487dba020159c48c2f7b39f`，变更日志 PR [#1427](https://github.com/SemiAnalysisAI/InferenceX/pull/1427)
- API 查询：`/api/v1/workflow-info?date=2026-05-17`、`/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`、`/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-05-17&exact=true`

| 并发 | 每 GPU 吞吐 (tok/s) | 每 GPU 输出吞吐 (tok/s) | TPOT 中位数 (ms) | TTFT 中位数 (ms) | E2E 中位数 (s) |
| --- | --- | --- | --- | --- | --- |
| 4 | 271.0 | 30.1 | 15.04 | 1104.4 | 14.76 |
| 8 | 457.3 | 51.4 | 17.96 | 1154.6 | 17.65 |
| 16 | 735.7 | 81.5 | 22.69 | 1101.3 | 21.65 |
| 32 | 1097.5 | 122.7 | 30.70 | 1354.6 | 29.64 |
| 64 | 1562.9 | 173.4 | 43.84 | 1501.2 | 42.19 |

已发布评测（同一生产运行）：gsm8k 并发 32 下 em_strict 0.9644 / em_flexible 0.9560，并发 64 下 em_strict 0.9674 / em_flexible 0.9613。已发布评测行的元数据标记为 `disagg: true`，但该配方为单节点聚合部署；运行链接与配置均与本家族匹配，此处仅作为元数据差异记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field image pin for one benchmark config; workload topology and scripts are explicitly unchanged, so risk is limited to SGLang runtime behavior drift on re-benchmark.
> 
> **Overview**
> Bumps the **`qwen3.5-fp8-mi300x-sglang`** master recipe’s SGLang ROCm container from **`lmsysorg/sglang:v0.5.12-rocm720-mi30x`** to **`lmsysorg/sglang:v0.5.19-rocm720-mi30x`**. Model, MI300X runner, FP8, TP8, fixed-seq-len 8k/1k, concurrency 4–64, launch script, and eval policy are **unchanged**—only the pinned inference image moves forward (SGLang v0.5.19 build; changelog notes AITER revision update on the same ROCm 7.2 / gfx942 stack).
> 
> Adds a **`perf-changelog.yaml`** entry for config key `qwen3.5-fp8-mi300x-sglang` documenting the image transition (digests, build commits, stack parity) and linking PR #3011.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05cbdeef33489c20df437bca8a0e47f8f4d10436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->