### PR TITLE
[Klaud Cold] Update dsv4-fp4-b200-sglang-agentic-hicache-mtp SGLang image to v0.5.19-cu130 / 将 dsv4-fp4-b200-sglang-agentic-hicache-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -929,7 +929,7 @@ dsv4-fp4-b200-sglang:
       - { tp: 8, ep: 8, dp-attn: true, conc-start: 256, conc-end: 1024 }
 
 dsv4-fp4-b200-sglang-agentic-hicache-mtp:
-  image: lmsysorg/sglang:nightly-dev-20260827-20621aa1
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: deepseek-ai/DeepSeek-V4-Pro-0813
   model-prefix: dsv4
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7179,3 +7179,12 @@
   description:
     - "Use the pinned SGLang nightly-dev-cu13-20260901-07c8f729 image with FlashInfer 0.6.18, which includes the BF16 TRTLLM MoE allocation fix for small-batch Blackwell execution. Model, TP8, HiCache, MTP settings and concurrency grid are unchanged."
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2994
+
+- config-keys:
+    - dsv4-fp4-b200-sglang-agentic-hicache-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Update the B200 DeepSeek-V4-Pro-0813 SGLang AgentX image from lmsysorg/sglang:nightly-dev-20260827-20621aa1 (2026-08-27 dev nightly, sglang commit 20621aa1) to the lmsysorg/sglang:v0.5.19-cu130 release (Docker Hub digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, release commit 0bcd8223, published 2026-09-05). The release branch contains every commit of the pinned nightly."
+    - "benchmarks/single_node/agentic/dsv4_fp4_b200_sglang_mtp.sh is unchanged: DSpark block size 6 with one speculative step and seven draft tokens, golden synthetic acceptance length 3.77, HiCache ratio 2.75 for TP8 and 8 for DP-attention, W4A4 MXFP4 MegaMoE plus the FP4 indexer on the DP-attention path, and sglang-router 0.3.2 cache-aware routing; the search space and cluster:b200-nscale runner are unchanged. Between the two images every server flag and SGLANG_* variable used by the script keeps its definition; --enable-w4a4-mxfp4-megamoe now selects DeepGEMM's mxf4xmxf4 MMA type directly instead of exporting DG_USE_FP4_ACTS/DG_USE_MXF4_KIND, DeepGEMM moves from 0.1.5.post2 to 0.1.7 and FlashInfer from 0.6.17 to 0.6.18."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3012


### PR DESCRIPTION
Update the `dsv4-fp4-b200-sglang-agentic-hicache-mtp` image from the 2026-08-27 dev nightly `lmsysorg/sglang:nightly-dev-20260827-20621aa1` to the SGLang v0.5.19 release image `lmsysorg/sglang:v0.5.19-cu130` (Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`, pushed 2026-09-04). Model, DSpark speculative decoding, HiCache profiles, search space and runner are unchanged.

## Baseline

- **Published date:** 2026-09-08 (public dashboard API: `workflow-info?date=2026-09-08&benchmarkType=agentic_traces`, `benchmarks?model=DeepSeek-V4-Pro&date=2026-09-08&exact=true&sequence=agentic-traces`, `evaluations?model=DeepSeek-V4-Pro&date=2026-09-08`)
- **Old image:** `lmsysorg/sglang:nightly-dev-20260827-20621aa1` (sglang commit [`20621aa1`](https://github.com/sgl-project/sglang/commit/20621aa14bda7726a8a968f326198eac61717fef), 2026-08-27)
- **New image source:** [`v0.5.19`](https://github.com/sgl-project/sglang/releases/tag/v0.5.19) at [`0bcd8223`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1); the release is 317 commits ahead of and 0 behind the pinned nightly ([compare](https://github.com/sgl-project/sglang/compare/20621aa14bda7726a8a968f326198eac61717fef...0bcd822377da7b5718e674eaf9c870d349424dd1))
- **Workload / topology:** AgentX agentic-coding traces, DeepSeek-V4-Pro-0813 NVFP4, DSpark block 6 (1 step, 7 draft tokens), single node `cluster:b200-nscale`; TP8 no offload (c1-5), TP8 HiCache DRAM (c8-16), TP8/EP8/DP-attention HiCache DRAM with sglang-router 0.3.2 (c64-160)
- **Producer:** [run 33830419034 attempt 2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33830419034/attempts/2), head `874e8a66297b79ff38fcb9b608396c35430e24cd` (#2821)

| conc | KV offload | out tok/s/GPU | median TPOT ms | median TTFT ms | median E2E s |
| --- | --- | --- | --- | --- | --- |
| 1 | none | 17.6 | 3.36 | 830 | 3.74 |
| 2 | none | 20.6 | 3.36 | 509 | 2.29 |
| 3 | none | 25.7 | 3.49 | 523 | 2.24 |
| 4 | none | 27.4 | 3.58 | 518 | 2.34 |
| 5 | none | 30.7 | 3.70 | 474 | 3.07 |
| 8 | hicache | 48.9 | 4.39 | 491 | 2.76 |
| 10 | hicache | 59.0 | 4.80 | 531 | 3.00 |
| 16 | hicache | 81.3 | 5.95 | 552 | 3.24 |
| 64 | hicache DEP8 | 270.8 | 13.79 | 1770 | 9.04 |
| 96 | hicache DEP8 | 367.0 | 16.72 | 2512 | 13.11 |
| 128 | hicache DEP8 | 398.4 | 17.88 | 4234 | 17.54 |
| 160 | hicache DEP8 | 388.2 | 20.40 | 12649 | 27.17 |

- **Published eval:** gsm8k at c160 (DEP8 HiCache), em_strict 0.9666 / em_flexible 0.9659, n=1319 ([run 33830419034](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33830419034)). The published eval row labels the deployment `disagg: true`, which mismatches the single-node aggregated recipe; the run itself is the aggregated job.

---

将 `dsv4-fp4-b200-sglang-agentic-hicache-mtp` 的镜像从 2026-08-27 的开发 nightly `lmsysorg/sglang:nightly-dev-20260827-20621aa1` 更新至 SGLang v0.5.19 正式版镜像 `lmsysorg/sglang:v0.5.19-cu130`（Docker Hub digest `sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`，2026-09-04 推送）。模型、DSpark 投机解码、HiCache 配置、搜索空间与 runner 均保持不变。

## 基线

- **发布日期：** 2026-09-08（公开仪表盘 API：`workflow-info?date=2026-09-08&benchmarkType=agentic_traces`、`benchmarks?model=DeepSeek-V4-Pro&date=2026-09-08&exact=true&sequence=agentic-traces`、`evaluations?model=DeepSeek-V4-Pro&date=2026-09-08`）
- **旧镜像：** `lmsysorg/sglang:nightly-dev-20260827-20621aa1`（sglang 提交 [`20621aa1`](https://github.com/sgl-project/sglang/commit/20621aa14bda7726a8a968f326198eac61717fef)，2026-08-27）
- **新镜像来源：** [`v0.5.19`](https://github.com/sgl-project/sglang/releases/tag/v0.5.19)，提交 [`0bcd8223`](https://github.com/sgl-project/sglang/commit/0bcd822377da7b5718e674eaf9c870d349424dd1)；发布版本领先所固定 nightly 317 个提交、落后 0 个（[对比](https://github.com/sgl-project/sglang/compare/20621aa14bda7726a8a968f326198eac61717fef...0bcd822377da7b5718e674eaf9c870d349424dd1)）
- **负载 / 拓扑：** AgentX agentic-coding 轨迹回放，DeepSeek-V4-Pro-0813 NVFP4，DSpark block 6（1 步、7 个草稿 token），单节点 `cluster:b200-nscale`；TP8 无卸载（c1-5）、TP8 HiCache DRAM（c8-16）、TP8/EP8/DP-attention HiCache DRAM 配 sglang-router 0.3.2（c64-160）
- **生产运行：** [run 33830419034 第 2 次尝试](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33830419034/attempts/2)，head `874e8a66297b79ff38fcb9b608396c35430e24cd`（#2821）

| 并发 | KV 卸载 | 输出 tok/s/GPU | 中位 TPOT ms | 中位 TTFT ms | 中位 E2E s |
| --- | --- | --- | --- | --- | --- |
| 1 | 无 | 17.6 | 3.36 | 830 | 3.74 |
| 2 | 无 | 20.6 | 3.36 | 509 | 2.29 |
| 3 | 无 | 25.7 | 3.49 | 523 | 2.24 |
| 4 | 无 | 27.4 | 3.58 | 518 | 2.34 |
| 5 | 无 | 30.7 | 3.70 | 474 | 3.07 |
| 8 | hicache | 48.9 | 4.39 | 491 | 2.76 |
| 10 | hicache | 59.0 | 4.80 | 531 | 3.00 |
| 16 | hicache | 81.3 | 5.95 | 552 | 3.24 |
| 64 | hicache DEP8 | 270.8 | 13.79 | 1770 | 9.04 |
| 96 | hicache DEP8 | 367.0 | 16.72 | 2512 | 13.11 |
| 128 | hicache DEP8 | 398.4 | 17.88 | 4234 | 17.54 |
| 160 | hicache DEP8 | 388.2 | 20.40 | 12649 | 27.17 |

- **已发布评测：** c160（DEP8 HiCache）gsm8k，em_strict 0.9666 / em_flexible 0.9659，n=1319（[run 33830419034](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33830419034)）。已发布评测行将部署标记为 `disagg: true`，与单节点聚合配方不符；该运行本身是聚合作业。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only Docker pin plus changelog; no application code or benchmark script edits in the diff.
> 
> **Overview**
> Pins **`dsv4-fp4-b200-sglang-agentic-hicache-mtp`** to the release image **`lmsysorg/sglang:v0.5.19-cu130`**, replacing the **`nightly-dev-20260827-20621aa1`** dev build. Model, agentic-coding search space, HiCache/MTP/DSpark benchmark recipe, and **`cluster:b200-nscale`** runner are unchanged.
> 
> Adds a **`perf-changelog.yaml`** entry for this config key noting the image swap and that the benchmark script flags stay the same while the container bumps **DeepGEMM** (0.1.5.post2 → 0.1.7), **FlashInfer** (0.6.17 → 0.6.18), and routes **W4A4 MXFP4 MegaMoE** through **`--enable-w4a4-mxfp4-megamoe`** instead of **`DG_USE_FP4_ACTS` / `DG_USE_MXF4_KIND`** env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da239a6585566fec56766c7185ecd22e147616af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->