### PR TITLE
[Klaud Cold] Update dsr1-fp4-b200-dynamo-sglang-mtp SGLang image to v0.5.19-cu130 with Dynamo wheel 1.5.0.dev20260910 / 将 dsr1-fp4-b200-dynamo-sglang-mtp 的 SGLang 镜像更新至 v0.5.19-cu130 并搭配 Dynamo wheel 1.5.0.dev20260910

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-1p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-2p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-3p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-4p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-5p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
@@ -9,7 +9,7 @@
 name: b200-fp4-dsr1_8k1k_mtp_4p1d_c2048
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: fp4
 resources:
   gpu_type: b200
@@ -22,7 +22,7 @@ resources:
 frontend:
   type: dynamo
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 backend:
   prefill_environment: &env

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-5d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-3d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-1d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  wheel: "1.5.0.dev20260910"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "auto"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3990,13 +3990,13 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: true
 
 dsr1-fp4-b200-dynamo-sglang-mtp:
-  image: "lmsysorg/sglang:v0.5.12.post1"
+  image: "lmsysorg/sglang:v0.5.19-cu130"
   model: deepseek-r1-fp4
   model-prefix: dsr1
   runner: cluster:b200-nscale
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "5b4bc1dd70965017a737c71b19db5a0aeaa88727" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260910" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true


### PR DESCRIPTION
Refresh the `dsr1-fp4-b200-dynamo-sglang-mtp` disaggregated MTP family from `lmsysorg/sglang:v0.5.12.post1` to the current SGLang release `lmsysorg/sglang:v0.5.19-cu130`, switching its coupled Dynamo install from the source hash `5b4bc1dd` (1.3.0, pinned to SGLang 0.5.12) to the published `ai-dynamo` wheel `1.5.0.dev20260910` (pinned to SGLang 0.5.19) in the nine recipe YAMLs and the master `router.version`. Model, precision, topologies, MTP settings, workloads and concurrency points are unchanged.

## Baseline

- Published date: 2026-07-08 (Single-turn 8k/1k, DeepSeek-R1-0528 FP4, B200, dynamo-sglang, MTP, disaggregated, NIXL)
- Old image: `lmsysorg/sglang:v0.5.12.post1` (Docker Hub manifest digest `sha256:ceaf8b16e02d165143633ac228bbb994a05fe77d7e0526cf035ae4bbf4eacc36`, identical to `v0.5.12.post1-cu130`), Dynamo source hash `5b4bc1dd70965017a737c71b19db5a0aeaa88727`
- Producer run: [28916523710](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28916523710/attempts/1), head `e0e00cdeb11e580bb6cd0e9fbe92b6a3ef7f3671`, changelog PR [#2113](https://github.com/SemiAnalysisAI/InferenceX/pull/2113)
- API queries: `/api/v1/workflow-info?date=2026-07-08`, `/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-08&exact=true&sequence=8k%2F1k` (rows filtered to framework=dynamo-sglang, precision=fp4, spec_method=mtp, disagg=true, isl=8192, osl=1024), `/api/v1/evaluations?model=DeepSeek-R1-0528&date=2026-07-08`
- Topology / concurrency (13 points; tput = total tok/s per GPU, out = output tok/s per GPU, median TTFT in s, median TPOT in ms):

| Topology (P / D) | Conc | tput/GPU | out/GPU | TTFT | TPOT |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1P tp4 / 5D tp8 (low-lat) | 4 | 191.2 | 23.4 | 0.745 | 3.32 |
| 1P tp4 / 5D tp8 (low-lat) | 8 | 366.0 | 45.3 | 0.858 | 3.67 |
| 1P tp4 / 5D tp8 (low-lat) | 16 | 648.2 | 79.0 | 0.920 | 4.00 |
| 1P tp4 / 5D tp8 (low-lat) | 32 | 950.5 | 116.9 | 2.087 | 4.62 |
| 1P tp4 / 3D tp8 (low-lat) | 32 | 1382.7 | 180.4 | 1.458 | 5.77 |
| 1P tp4 / 3D tp8 (low-lat) | 64 | 1527.9 | 197.7 | 6.689 | 6.11 |
| 1P tp4 / 1D tp8 (low-lat) | 32 | 2281.4 | 382.6 | 1.172 | 9.36 |
| 1P dep4 / 1D dep8 (MTP2) | 512 | 3944.2 | 657.3 | 79.222 | 10.98 |
| 2P dep4 / 1D dep8 (MTP2) | 768 | 5838.0 | 1296.8 | 54.615 | 13.51 |
| 3P dep4 / 1D dep8 (MTP2) | 1024 | 6963.5 | 1934.5 | 44.133 | 17.63 |
| 4P dep4 / 1D dep8 (MTP2) | 512 | 7343.4 | 2447.6 | 5.181 | 20.00 |
| 4P dep4 / 1D dep8 (c2048 tune) | 2048 | 8534.8 | 2847.2 | 60.718 | 21.72 |
| 5P dep4 / 1D dep8 (MTP2) | 2048 | 8242.6 | 3208.1 | 48.389 | 26.27 |

- Published evals (gsm8k `em_strict`, n=1319, same producer run): 1P/5D c32 0.9568, 1P/3D c64 0.9553, 1P/1D c32 0.9553, 1P/1D dep c512 0.9575, 2P/1D c768 0.9530, 3P/1D c1024 0.9522, 4P/1D c512 0.9538, 4P/1D c2048 0.9545, 5P/1D c2048 0.9530
- Source links: SGLang [v0.5.12.post1](https://github.com/sgl-project/sglang/tree/v0.5.12.post1) → [v0.5.19](https://github.com/sgl-project/sglang/tree/v0.5.19); Dynamo [5b4bc1dd](https://github.com/ai-dynamo/dynamo/commit/5b4bc1dd70965017a737c71b19db5a0aeaa88727) → wheel [ai-dynamo 1.5.0.dev20260910](https://pypi.org/project/ai-dynamo/1.5.0.dev20260910/); srt-slurm launcher pin [a98738de](https://github.com/NVIDIA/srt-slurm/commit/a98738de9b2233459b5456e9ed71af09ce893f92) (unchanged)

---

将 `dsr1-fp4-b200-dynamo-sglang-mtp` 分离式 MTP 系列的镜像从 `lmsysorg/sglang:v0.5.12.post1` 更新至当前 SGLang 发布版 `lmsysorg/sglang:v0.5.19-cu130`，并在九个 recipe YAML 与主配置的 `router.version` 中，将配套的 Dynamo 安装源从源码哈希 `5b4bc1dd`（1.3.0，绑定 SGLang 0.5.12）切换为已发布的 `ai-dynamo` wheel `1.5.0.dev20260910`（绑定 SGLang 0.5.19）。模型、精度、拓扑、MTP 设置、负载与并发点均保持不变。

## 基线

- 发布日期：2026-07-08（单轮 8k/1k，DeepSeek-R1-0528 FP4，B200，dynamo-sglang，MTP，分离式，NIXL）
- 旧镜像：`lmsysorg/sglang:v0.5.12.post1`（Docker Hub manifest 摘要 `sha256:ceaf8b16e02d165143633ac228bbb994a05fe77d7e0526cf035ae4bbf4eacc36`，与 `v0.5.12.post1-cu130` 相同），Dynamo 源码哈希 `5b4bc1dd70965017a737c71b19db5a0aeaa88727`
- 生产运行：[28916523710](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28916523710/attempts/1)，head `e0e00cdeb11e580bb6cd0e9fbe92b6a3ef7f3671`，changelog PR [#2113](https://github.com/SemiAnalysisAI/InferenceX/pull/2113)
- API 查询：`/api/v1/workflow-info?date=2026-07-08`，`/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-08&exact=true&sequence=8k%2F1k`（按 framework=dynamo-sglang、precision=fp4、spec_method=mtp、disagg=true、isl=8192、osl=1024 过滤），`/api/v1/evaluations?model=DeepSeek-R1-0528&date=2026-07-08`
- 拓扑 / 并发：共 13 个点，数值见上表（tput = 每 GPU 总 tok/s，out = 每 GPU 输出 tok/s，TTFT 中位数单位秒，TPOT 中位数单位毫秒）
- 已发布评测（gsm8k `em_strict`，n=1319，同一生产运行）：1P/5D c32 0.9568，1P/3D c64 0.9553，1P/1D c32 0.9553，1P/1D dep c512 0.9575，2P/1D c768 0.9530，3P/1D c1024 0.9522，4P/1D c512 0.9538，4P/1D c2048 0.9545，5P/1D c2048 0.9530
- 源码链接：SGLang [v0.5.12.post1](https://github.com/sgl-project/sglang/tree/v0.5.12.post1) → [v0.5.19](https://github.com/sgl-project/sglang/tree/v0.5.19)；Dynamo [5b4bc1dd](https://github.com/ai-dynamo/dynamo/commit/5b4bc1dd70965017a737c71b19db5a0aeaa88727) → wheel [ai-dynamo 1.5.0.dev20260910](https://pypi.org/project/ai-dynamo/1.5.0.dev20260910/)；srt-slurm 启动器固定提交 [a98738de](https://github.com/NVIDIA/srt-slurm/commit/a98738de9b2233459b5456e9ed71af09ce893f92)（未变）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
