### PR TITLE
refactor: retain eval winners during reuse deduplication / 复用去重时保留已选评测结果

### DIFF
--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -1395,16 +1395,21 @@ def test_eval_dedupe_leaves_invalid_suite_for_validation(
     assert any("invalid eval_suite" in error for error in errors)
 
 
-def test_dedupe_uses_winning_legacy_result_mtime_for_aggregate(
-    tmp_path: Path,
+@pytest.mark.parametrize("newer_name,older_ns", [
+    ("results_a.json", 1_000_000_000),
+    ("results_c.json", 2_000_000_000),
+])
+def test_dedupe_uses_winning_legacy_result_for_aggregate(
+    tmp_path: Path, newer_name: str, older_ns: int,
 ) -> None:
     artifact_name = "eval_minimaxm3_conc4096_b300-nv_retry"
-    _dd_write_legacy_raw(tmp_path, artifact_name, 4096, "a")
+    _dd_write_legacy_raw(tmp_path, artifact_name, 4096, None)
     artifact_dir = tmp_path / artifact_name
     older = artifact_dir / "results_b.json"
     older.write_text(json.dumps(raw_eval_result()))
-    newer = artifact_dir / "results_a.json"
-    os.utime(older, ns=(1_000_000_000, 1_000_000_000))
+    newer = artifact_dir / newer_name
+    newer.write_text(json.dumps(raw_eval_result()))
+    os.utime(older, ns=(older_ns, older_ns))
     os.utime(newer, ns=(2_000_000_000, 2_000_000_000))
     _dd_write_aggregate(
         tmp_path,
@@ -1416,7 +1421,7 @@ def test_dedupe_uses_winning_legacy_result_mtime_for_aggregate(
             ),
             _dd_agg_row(
                 4096,
-                f"eval_results/{artifact_name}/results_a.json",
+                f"eval_results/{artifact_name}/{newer_name}",
                 0.9,
             ),
         ],
@@ -1429,3 +1434,72 @@ def test_dedupe_uses_winning_legacy_result_mtime_for_aggregate(
     )
     assert [row["em_strict"] for row in rows] == [0.9]
     assert validate_eval_artifacts(tmp_path) == []
+
+
+@pytest.mark.parametrize("separator", ["/", "\\"])
+def test_dedupe_breaks_ties_by_directory_then_aggregate_location(
+    tmp_path: Path, separator: str,
+) -> None:
+    # Equal result timestamps and filenames choose the last directory name;
+    # repeated rows for that file choose the last aggregate filename and index.
+    stamp = "2026-06-27T01-00-00.000000"
+    for name in ("eval_retry_z", "eval_retry_a"):
+        _dd_write_legacy_raw(tmp_path, name, 16, stamp)
+    source = separator.join(["eval_results", "eval_retry_z", f"results_{stamp}.json"])
+    first = _dd_write_aggregate(tmp_path, [
+        _dd_agg_row(16, f"eval_results/eval_retry_a/results_{stamp}.json", 0.1),
+        _dd_agg_row(16, source, 0.2),
+    ])
+    last = first.with_name("z.json")
+    chosen = _dd_agg_row(16, source, 0.4)
+    last.write_text(json.dumps([_dd_agg_row(16, source, 0.3), chosen]))
+
+    assert dedupe_reran_evals(tmp_path) == [
+        "agg_eval_all.json: kept 0 of 2 eval row(s)",
+        "z.json: kept 1 of 2 eval row(s)",
+        "removed superseded raw eval dir 'eval_retry_a'",
+    ]
+    assert json.loads(first.read_text()) == []
+    assert json.loads(last.read_text()) == [chosen]
+    assert not (tmp_path / "eval_retry_a").exists()
+    assert (tmp_path / "eval_retry_z" / f"results_{stamp}.json").is_file()
+    assert validate_eval_artifacts(tmp_path) == []
+    assert dedupe_reran_evals(tmp_path) == []
+
+
+def test_dedupe_selects_result_files_per_batched_concurrency(tmp_path: Path) -> None:
+    name = "eval_retry_batch"
+    _dd_write_legacy_raw(tmp_path, name, 0, None)
+    meta = {**_dd_meta(0), "eval_concs": [16, 32], "completed_eval_concs": [16, 32]}
+    meta_path = tmp_path / name / "meta_env.json"
+    meta_path.write_text(json.dumps(meta))
+    rows = []
+    for conc, suffix, mtime, score in (
+        (16, "a", 10, 0.1), (16, "b", 20, 0.6),
+        (32, "a", 20, 0.9), (32, "b", 10, 0.2),
+    ):
+        path = tmp_path / name / f"results_{suffix}_conc{conc}.json"
+        path.write_text(json.dumps(raw_eval_result(score)))
+        os.utime(path, (mtime, mtime))
+        rows.append(_dd_agg_row(conc, f"eval_results/{name}/{path.name}", score))
+    aggregate = _dd_write_aggregate(tmp_path, rows)
+    raw_bytes = {path: path.read_bytes() for path in (tmp_path / name).iterdir()}
+
+    assert dedupe_reran_evals(tmp_path) == ["agg_eval_all.json: kept 2 of 4 eval row(s)"]
+    assert [row["em_strict"] for row in json.loads(aggregate.read_text())] == [0.6, 0.9]
+    assert {path: path.read_bytes() for path in (tmp_path / name).iterdir()} == raw_bytes
+    assert validate_eval_artifacts(tmp_path) == []
+
+
+def test_dedupe_leaves_rows_without_the_selected_result_filename(tmp_path: Path) -> None:
+    name = "eval_retry"
+    _dd_write_legacy_raw(tmp_path, name, 16, "latest")
+    aggregate = _dd_write_aggregate(tmp_path, [
+        _dd_agg_row(16, f"eval_results/{name}/results_old.json", 0.1),
+        _dd_agg_row(16, f"eval_results/{name}/results_other.json", 0.9),
+    ])
+    before = aggregate.read_bytes()
+
+    assert dedupe_reran_evals(tmp_path) == []
+    assert aggregate.read_bytes() == before
+    assert any("duplicate" in error for error in validate_eval_artifacts(tmp_path))

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -779,8 +779,8 @@ def _source_names_raw_dir(source: Any, artifact_name: str) -> bool:
     return artifact_name in re.split(r"[\\/]+", str(source or ""))
 
 
-def _eval_winners(artifacts_dir: Path) -> dict[tuple[Any, ...], str]:
-    """Pick structurally valid, aggregate-backed latest raw results."""
+def _eval_winners(artifacts_dir: Path) -> dict[tuple[Any, ...], Path]:
+    """Retain the selected result path for each valid, aggregate-backed identity."""
     aggregate_sources: dict[tuple[Any, ...], list[Any]] = {}
     aggregate_dir = artifacts_dir / "eval_results_all"
     for path in sorted(aggregate_dir.glob("*.json")):
@@ -819,7 +819,7 @@ def _eval_winners(artifacts_dir: Path) -> dict[tuple[Any, ...], str]:
             if current is None or candidate[:2] > current[:2]:
                 best[key] = candidate
 
-    winners: dict[tuple[Any, ...], str] = {}
+    winners: dict[tuple[Any, ...], Path] = {}
     for key, (_, artifact_name, path) in best.items():
         if _raw_result_error(path) is not None:
             continue
@@ -827,12 +827,12 @@ def _eval_winners(artifacts_dir: Path) -> dict[tuple[Any, ...], str]:
             _source_names_raw_dir(source, artifact_name)
             for source in aggregate_sources.get(key, [])
         ):
-            winners[key] = artifact_name
+            winners[key] = path
     return winners
 
 
 def _dedupe_eval_aggregate(
-    artifacts_dir: Path, winners: dict[tuple[Any, ...], str]
+    artifacts_dir: Path, winners: dict[tuple[Any, ...], Path]
 ) -> list[str]:
     """Keep one aggregate row per winning identity across all aggregate files."""
     eval_dir = artifacts_dir / "eval_results_all"
@@ -862,25 +862,6 @@ def _dedupe_eval_aggregate(
         path: set(range(len(data)))
         for path, data in loaded.items()
     }
-    winner_result_names: dict[tuple[Any, ...], str] = {}
-    for key, artifact_name in winners.items():
-        artifact_dir = artifacts_dir / artifact_name
-        contributions, _, batched = _raw_dir_contributions(artifact_dir)
-        conc = next(
-            (candidate_conc for candidate_key, candidate_conc in contributions
-             if candidate_key == key),
-            None,
-        )
-        candidates = [
-            path
-            for path in _recognized_eval_result_paths(
-                artifact_dir.glob("results*.json")
-            )
-            if not batched or _result_concurrency(path.name) == conc
-        ]
-        if candidates:
-            winner_result_names[key] = max(candidates, key=_result_order).name
-
     for key, entries in groups.items():
         artifact_key = key[:-1]
         winner = winners.get(artifact_key)
@@ -889,16 +870,15 @@ def _dedupe_eval_aggregate(
         matching = [
             entry
             for entry in entries
-            if _source_names_raw_dir(entry[2].get("source"), winner)
+            if _source_names_raw_dir(entry[2].get("source"), winner.parent.name)
         ]
-        winner_result_name = winner_result_names.get(artifact_key)
         exact_matching = [
             entry
             for entry in matching
             if re.split(
                 r"[\\/]+",
                 str(entry[2].get("source") or ""),
-            )[-1] == winner_result_name
+            )[-1] == winner.name
         ]
         if not exact_matching:
             continue
@@ -928,7 +908,7 @@ def _dedupe_eval_aggregate(
 
 
 def _prune_raw_eval_dir(
-    artifact_dir: Path, winners: dict[tuple[Any, ...], str]
+    artifact_dir: Path, winners: dict[tuple[Any, ...], Path]
 ) -> Optional[str]:
     """Drop a raw dir's identities that a newer dir supersedes."""
     contributions, meta, batched = _raw_dir_contributions(artifact_dir)
@@ -938,7 +918,7 @@ def _prune_raw_eval_dir(
 
     def superseded(key: tuple[Any, ...]) -> bool:
         winner = winners.get(key)
-        return winner is not None and winner != name
+        return winner is not None and winner.parent.name != name
 
     if not batched:
         if superseded(contributions[0][0]):


### PR DESCRIPTION
## Description / 说明

Reuse artifact deduplication selected the winning raw result, discarded its filename, then reread metadata and result JSONs to select it again. Retain the selected `Path` through aggregate cleanup and raw-artifact pruning, removing 20 net production lines. Commands, public function signatures, winner ordering, validation gates, diagnostics, and retained/deleted artifacts keep their existing behavior.

复用产物去重原先选出获胜的原始结果后丢弃文件名，再次读取元数据和结果 JSON 来重新选择。本次将已选中的 `Path` 传递给聚合结果清理和原始产物裁剪逻辑，生产代码净减少 20 行。命令、公共函数签名、选择顺序、校验条件、诊断信息及产物保留/删除行为保持不变。

## Validation / 验证

- 131 targeted validator/collector tests pass before and after; the new/expanded cases exercise tied results, aggregate row selection, Windows source paths, batched concurrency, and missing selected filenames. / 修改前后均通过 131 项针对性校验与收集测试；新增及扩展用例覆盖结果排序相同、聚合行选择、Windows 路径、批量并发和缺少所选文件名的情况。
- 1,460 paired artifact-tree comparisons against the original implementation and 68 paired CLI invocations found zero differences in results, errors, diagnostics, or filesystem effects. These include malformed inputs and persistent filesystem failures. / 对原实现进行了 1,460 组产物目录对照和 68 组 CLI 对照，结果、错误、诊断及文件系统影响均无差异，覆盖了格式错误的输入和持续的文件系统故障。
- Three isolated wrong-winner/pruning mutations are caught by the new behavioral assertions. / 新行为断言能检出三种独立注入的结果选择或裁剪错误。
- The relevant workflow's full local test command passes on Python 3.12; `git diff --check` passes. / 相关工作流的完整本地测试命令在 Python 3.12 下通过；`git diff --check` 通过。

## Scope / 范围

Internal refactor only; no benchmark execution, recipe, or performance changes, so no performance-changelog entry or GPU sweep is needed. Existing documentation remains accurate.

仅内部重构，不改动基准测试执行、配方或性能，因此无需性能变更日志条目或 GPU 扫描。现有文档仍然准确。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal dedupe refactor in eval artifact validation with expanded tests and reported parity checks; public CLI and dedupe outcomes are intended to be unchanged.
> 
> **Overview**
> **Eval reuse deduplication** no longer picks a winning raw directory name and then re-scans `meta_env.json` and `results*.json` to recover the same result file during aggregate cleanup. `_eval_winners` now maps each identity to the chosen **`Path`**, and `_dedupe_eval_aggregate` / `_prune_raw_eval_dir` match aggregate `source` paths and supersession using `winner.name` and `winner.parent.name`, deleting the redundant winner-filename recomputation block.
> 
> Tests are broadened: parametrized legacy winner selection, tie-breaking by directory name then aggregate file/index (including `\` sources), per-concurrency winner files in batched dirs without touching raw bytes, and a no-op when no aggregate row names the selected result filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee6e3db508cf3a8c33428811bb3f5d2e068282c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->