### PR TITLE
refactor: centralize eval result selection in infx / 将评测结果选择集中到 infx

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,7 +236,7 @@ Test builders with small, independently worked examples and read-only inputs. Fo
 
 For eval-only jobs, throughput output is not required. The workflow instead requires at least one `results*.json`. For jobs marked to run eval, uploads may contain `meta_env.json`, `results*.json`, `sample*.jsonl`, SWE-bench predictions and reports, and trajectory files. [`utils/evals/validate_scores.py`](../utils/evals/validate_scores.py) checks produced eval scores.
 
-[`infx.results.evals`](../infx/results/evals.py) provides `extract_metrics` for loaded eval JSON and `build_rows` for collector output. Both accept explicit inputs without file I/O or input mutation. The builder applies metadata defaults and primary-score precedence, retaining failed evaluations as diagnostic rows. The CLI owns file discovery, concurrency selection, reporting, and artifact writes.
+[`infx.results.evals`](../infx/results/evals.py) provides `extract_metrics` for loaded eval JSON and `build_rows` for collector output. Both accept explicit inputs without file I/O or input mutation. The builder applies metadata defaults and primary-score precedence, retaining failed evaluations as diagnostic rows. The CLI owns file discovery, concurrency eligibility, reporting, and artifact writes.
 
 ```python
 from infx.results.evals import build_rows
@@ -244,7 +244,7 @@ from infx.results.evals import build_rows
 rows = build_rows(raw_eval, metadata, source="eval_job/results.json")
 ```
 
-The collector and reusable-artifact validator share format recognition, concurrency suffix parsing, result ordering, metric-family classification, and numeric validity rules. Filename timestamps and legacy mtimes use epoch nanoseconds, with filenames breaking ties. Reuse retains its stricter structural checks and checks every applicable primary metric; the collector keeps the last configured value per metric family for reporting. Recognizing a format does not imply that its results are valid or reusable.
+The collector and reusable-artifact validator share format recognition, concurrency suffix parsing, result selection, metric-family classification, and numeric validity rules. `select_latest_result` selects the latest candidate overall or for a specified concurrency; `select_latest_results` also supports selecting one candidate per concurrency in numeric order. These helpers receive candidate paths; callers retain their discovery and eligibility rules. Filename timestamps and legacy mtimes use epoch nanoseconds, with filenames breaking ties. Reuse retains its stricter structural checks and checks every applicable primary metric; the collector keeps the last configured value per metric family for reporting. Recognizing a format does not imply that its results are valid or reusable.
 
 Agentic throughput jobs have a different contract. They validate AIPerf output with [`utils/agentic/validation/validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py), upload an aggregate `bmk_agentic_<suffix>` artifact, and upload the raw `agentic_<suffix>` sibling containing trace-replay material. InferenceX-app pairs those siblings by their shared suffix. Agentic eval-only jobs follow the eval output contract instead and do not require a throughput result.
 

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -236,7 +236,7 @@ result = build_result(records, profile, server_metrics, runtime_env,
 
 对于仅评测作业，不要求吞吐量输出。工作流改为要求至少存在一个 `results*.json`。对于标记为运行评测的作业，上传内容可能包含 `meta_env.json`、`results*.json`、`sample*.jsonl`、SWE-bench 预测和报告以及轨迹文件。[`utils/evals/validate_scores.py`](../utils/evals/validate_scores.py) 会检查生成的评测分数。
 
-[`infx.results.evals`](../infx/results/evals.py) 提供 `extract_metrics`，用于解析已加载的评测 JSON，并提供 `build_rows`，用于构建收集器输出。两者均接收显式输入，不执行文件 I/O，也不修改输入。构建函数应用元数据默认值和主分数优先级，并将失败评测保留为诊断行。CLI 负责文件查找、并发数选择、报告输出和工件写入。
+[`infx.results.evals`](../infx/results/evals.py) 提供 `extract_metrics`，用于解析已加载的评测 JSON，并提供 `build_rows`，用于构建收集器输出。两者均接收显式输入，不执行文件 I/O，也不修改输入。构建函数应用元数据默认值和主分数优先级，并将失败评测保留为诊断行。CLI 负责文件查找、并发数资格筛选、报告输出和工件写入。
 
 ```python
 from infx.results.evals import build_rows
@@ -244,7 +244,7 @@ from infx.results.evals import build_rows
 rows = build_rows(raw_eval, metadata, source="eval_job/results.json")
 ```
 
-收集器和可复用工件验证器共享格式识别、并发数后缀解析、结果排序、指标族分类及数值有效性规则。文件名时间戳和旧格式文件的修改时间统一使用 Unix 纪元纳秒数，时间相同时按文件名排序。复用验证保留更严格的结构检查，并验证所有适用的主指标；收集器则保留每个指标族中最后配置的值用于报告。识别出格式并不意味着结果有效或可复用。
+收集器和可复用工件验证器共享格式识别、并发数后缀解析、结果选择、指标族分类及数值有效性规则。`select_latest_result` 从全部候选中或指定并发数的候选中选择最新结果；`select_latest_results` 还支持为每个并发数选择一个候选，并按并发数的数值顺序返回。这些辅助函数接收候选路径，调用方仍保留各自的文件查找和资格筛选规则。文件名时间戳和旧格式文件的修改时间统一使用 Unix 纪元纳秒数，时间相同时按文件名排序。复用验证保留更严格的结构检查，并验证所有适用的主指标；收集器则保留每个指标族中最后配置的值用于报告。识别出格式并不意味着结果有效或可复用。
 
 智能体吞吐量作业采用不同的契约。它们使用 [`utils/agentic/validation/validate_agentic_result.py`](../utils/agentic/validation/validate_agentic_result.py) 验证 AIPerf 输出，上传聚合的 `bmk_agentic_<suffix>` 工件，并上传包含追踪重放材料的原始 `agentic_<suffix>` 同级工件。InferenceX-app 通过它们共享的后缀对这些同级工件进行配对。智能体仅评测作业改为遵循评测输出契约，不要求吞吐量结果。
 

--- a/infx/results/evals.py
+++ b/infx/results/evals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import re
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,38 @@ def result_order(path: Path) -> tuple[int, str]:
         except ValueError:
             pass
     return path.stat().st_mtime_ns, path.name
+
+
+def select_latest_result(
+    paths: Iterable[Path], *, concurrency: int | None = None,
+) -> Path | None:
+    """Select from recognized candidates, optionally for one concurrency.
+
+    Return None when no candidate matches. Discovery and result-content
+    validation belong to the caller; legacy ordering may read file mtimes.
+    """
+    candidates = (
+        path for path in paths
+        if concurrency is None or result_concurrency(path.name) == concurrency
+    )
+    return max(candidates, key=result_order, default=None)
+
+
+def select_latest_results(paths: Iterable[Path], *, batched: bool = False) -> list[Path]:
+    """Select one result, or one per suffixed concurrency in numeric order."""
+    if not batched:
+        latest = select_latest_result(paths)
+        return [latest] if latest is not None else []
+
+    latest_by_conc: dict[int, Path] = {}
+    for path in paths:
+        conc = result_concurrency(path.name)
+        if conc is None:
+            continue
+        current = latest_by_conc.get(conc)
+        if current is None or result_order(path) > result_order(current):
+            latest_by_conc[conc] = path
+    return [latest_by_conc[conc] for conc in sorted(latest_by_conc)]
 
 
 _SCORE_NAMES = {"strict": "em_strict", "accuracy": "accuracy", "flex": "em_flexible"}

--- a/utils/collect_eval_results.py
+++ b/utils/collect_eval_results.py
@@ -11,6 +11,7 @@ if not __package__:
 
 from infx.results.evals import (
     EVAL_RESULT_FORMAT, as_int, build_row, build_rows, is_eval_result, result_order,
+    select_latest_results,
 )
 from infx.results.evals import result_concurrency as _result_concurrency
 
@@ -92,20 +93,7 @@ def detect_lm_eval_jsons(d: Path, batched: bool = False) -> List[Path]:
         if is_eval_result(data):
             lm_paths.append(p)
 
-    if not lm_paths:
-        return []
-    if not batched:
-        return [max(lm_paths, key=result_order)]
-
-    latest_by_conc: Dict[int, Path] = {}
-    for path in lm_paths:
-        conc = result_concurrency(path)
-        if conc is None:
-            continue
-        current = latest_by_conc.get(conc)
-        if current is None or result_order(path) > result_order(current):
-            latest_by_conc[conc] = path
-    return [latest_by_conc[conc] for conc in sorted(latest_by_conc)]
+    return select_latest_results(lm_paths, batched=batched)
 
 
 def pct(x: Any) -> str:

--- a/utils/test_collect_eval_results.py
+++ b/utils/test_collect_eval_results.py
@@ -18,7 +18,27 @@ from collect_eval_results import (
 )
 from evals.kimi_vendor_eval import RESULT_FORMAT as KIMI_VENDOR_RESULT_FORMAT
 from evals.minimax_provider_eval import RESULT_FORMAT as MINIMAX_RESULT_FORMAT
-from infx.results.evals import build_rows, extract_metrics
+from infx.results.evals import (
+    build_rows, extract_metrics, select_latest_result, select_latest_results,
+)
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_result_selection_accepts_empty_candidates(batched: bool) -> None:
+    assert select_latest_results(iter(()), batched=batched) == []
+
+
+def test_result_selection_filters_concurrency_before_ordering(tmp_path: Path) -> None:
+    chosen = tmp_path / "results_2026-06-27T01-00-00_conc4.json"
+    other = tmp_path / "results_2026-06-28T01-00-00_conc8.json"
+    missing = tmp_path / "results_legacy_conc16.json"
+    # Timestamped candidates do not require stat; the legacy candidate does.
+    assert select_latest_result(iter([other, missing, chosen]), concurrency=4) == chosen
+    assert select_latest_result([other, missing, chosen], concurrency=32) is None
+    with pytest.raises(FileNotFoundError):
+        select_latest_result([missing], concurrency=16)
+    # Batch collection can retain an uncontested candidate without ranking it.
+    assert select_latest_results([missing], batched=True) == [missing]
 
 
 def test_build_rows_uses_explicit_inputs_and_preserves_them(tmp_path: Path, monkeypatch) -> None:
@@ -302,6 +322,30 @@ def test_collector_discovers_custom_names_but_not_metadata_or_nested_files(
     nested.mkdir()
     _write_lm_eval_result(nested / "results.json", 0.5)
     assert detect_lm_eval_jsons(tmp_path) == [custom]
+
+
+@pytest.mark.parametrize("batched,expected_names", [
+    (False, ["custom_2026-06-27T02-00-00.json"]),
+    (True, [
+        "results_2026-06-27T01-00-00_conc0.json",
+        "results_2026-06-27T01-00-00_conc0004_2.json",
+        "results_2026-06-27T01-00-00_conc16.json",
+    ]),
+])
+def test_collector_selects_retries_and_orders_concurrencies(
+    tmp_path: Path, batched: bool, expected_names: list[str],
+) -> None:
+    for name in (
+        "results_2026-06-27T01-00-00_conc16.json",
+        "custom_2026-06-27T02-00-00.json",
+        "results_2026-06-27T01-00-00_conc0004_2.json",
+        "results_2026-06-27T01-00-00_conc0004_10.json",
+        "results_2026-06-27T01-00-00_conc0.json",
+        "results_2026-06-27T00-00-00_conc4.json",
+    ):
+        _write_lm_eval_result(tmp_path / name, 0.75)
+
+    assert [path.name for path in detect_lm_eval_jsons(tmp_path, batched)] == expected_names
 
 
 def test_collector_cli_runs_outside_checkout(tmp_path: Path) -> None:

--- a/utils/test_validate_reusable_sweep_artifacts.py
+++ b/utils/test_validate_reusable_sweep_artifacts.py
@@ -794,6 +794,26 @@ def test_eval_validation_rejects_malformed_batch_metadata(
         assert any(expected in error for error in errors), errors
 
 
+def test_reuse_reports_unexpected_results_before_missing_concurrency(tmp_path: Path) -> None:
+    from validate_reusable_sweep_artifacts import raw_eval_key_rows
+
+    write_raw_batched_eval_artifact(tmp_path, [16, 4])
+    artifact = tmp_path / "eval_gptoss_8k1k_batch"
+    (artifact / "results_test_conc4.json").unlink()
+    for name in ("results_test.json", "results_test_conc8.json"):
+        (artifact / name).write_text(json.dumps(raw_eval_result()))
+
+    rows, errors = raw_eval_key_rows(tmp_path)
+
+    assert len(rows) == 1
+    prefix = "raw eval artifact 'eval_gptoss_8k1k_batch'"
+    assert set(errors[:-1]) == {
+        f"{prefix} has batched result 'results_test.json' without a concurrency suffix",
+        f"{prefix} has result 'results_test_conc8.json' for unexpected concurrency 8",
+    }
+    assert errors[-1] == f"{prefix} has no recognized eval result for concurrency 4"
+
+
 def test_fixed_sequence_validation_accepts_unique_source_rows(tmp_path: Path) -> None:
     results = tmp_path / "results_bmk"
     results.mkdir()

--- a/utils/validate_reusable_sweep_artifacts.py
+++ b/utils/validate_reusable_sweep_artifacts.py
@@ -17,6 +17,7 @@ if not __package__:
 
 from infx.results.evals import (
     is_eval_result, is_valid_effective_count, is_valid_score, metric_family,
+    select_latest_result,
 )
 from infx.results.evals import result_concurrency as _result_concurrency
 from infx.results.evals import result_order as _result_order
@@ -531,19 +532,14 @@ def raw_eval_key_rows(
                     )
 
         for _, conc in contributions:
-            candidates = [
-                path
-                for path in result_paths
-                if not batched or _result_concurrency(path.name) == conc
-            ]
+            latest = select_latest_result(result_paths, concurrency=conc)
             conc_label = f" for concurrency {conc}" if conc is not None else ""
-            if not candidates:
+            if latest is None:
                 errors.append(
                     f"raw eval artifact {artifact_dir.name!r} has no "
                     f"recognized eval result{conc_label}"
                 )
                 continue
-            latest = max(candidates, key=_result_order)
             result_error = _raw_result_error(latest)
             if result_error is not None:
                 errors.append(
@@ -801,19 +797,14 @@ def _eval_winners(artifacts_dir: Path) -> dict[tuple[Any, ...], Path]:
         tuple[tuple[int, str], str, Path],
     ] = {}
     for artifact_dir in raw_eval_artifact_dirs(artifacts_dir):
-        contributions, _, batched = _raw_dir_contributions(artifact_dir)
+        contributions, _, _ = _raw_dir_contributions(artifact_dir)
         result_paths = _recognized_eval_result_paths(
             artifact_dir.glob("results*.json")
         )
         for key, key_conc in contributions:
-            candidates = [
-                path
-                for path in result_paths
-                if not batched or _result_concurrency(path.name) == key_conc
-            ]
-            if not candidates:
+            latest = select_latest_result(result_paths, concurrency=key_conc)
+            if latest is None:
                 continue
-            latest = max(candidates, key=_result_order)
             candidate = (_result_order(latest), artifact_dir.name, latest)
             current = best.get(key)
             if current is None or candidate[:2] > current[:2]:


### PR DESCRIPTION
## Description / 说明

The eval collector, reuse validator, and deduper each implemented latest-result selection. Move that responsibility into `infx.results.evals`: `select_latest_result` selects overall or for a specified concurrency, and `select_latest_results` supports batch collection in numeric concurrency order. Preserve caller-specific discovery, eligibility, strict validation, diagnostics, pruning, and existing CLI/import interfaces.

评测收集器、复用验证器和去重逻辑原先分别实现最新结果选择。本次将这项职责集中到 `infx.results.evals`：`select_latest_result` 选择整体或指定并发数的最新结果，`select_latest_results` 支持按并发数数值顺序收集批量结果。保留各调用方的文件查找、资格筛选、严格验证、诊断、裁剪逻辑及现有 CLI/导入接口。

The separate entrypoints retain the existing candidate-evaluation order and filesystem-error behavior. Caller code shrinks by 21 lines; production source is net +12 lines including the typed APIs and their documentation. English and Chinese architecture notes are synchronized.

两个入口保留现有候选求值顺序和文件系统错误行为。调用方代码减少 21 行；计入带类型的 API 及其文档后，生产代码净增加 12 行。英文和中文架构说明已同步更新。

## Validation / 验证

- 134 compatibility tests pass before and after; the final targeted suite passes all 137 tests, including three new API cases. / 修改前后均通过 134 项兼容性测试；最终针对性测试共 137 项全部通过，包括三项新 API 用例。
- 1,460 reuse-artifact and 249 collector comparisons, plus 103 paired CLI invocations, found zero differences in selections, outputs, diagnostics, errors, and filesystem effects. / 1,460 组复用产物对照、249 组收集器对照及 103 组 CLI 对照中，选择结果、输出、诊断、错误和文件系统影响均无差异。
- Independent regressions cover retry ties, numeric concurrency order, missing/unexpected suffixes, empty candidates, and legacy stat-error boundaries. Three deliberate selection mutations were detected. / 独立回归测试覆盖重试结果排序相同、并发数数值排序、缺少或异常后缀、空候选及旧格式文件 stat 错误边界；检出了三种故意注入的选择错误。
- Relevant CI test command: **670 passed in 5.47s** on Python 3.12. Isolated package-import smoke and `git diff --check` also pass. / 相关 CI 测试命令在 Python 3.12 下 **670 项通过，耗时 5.47 秒**；隔离环境下的包导入冒烟检查和 `git diff --check` 也通过。

## Scope / 范围

Internal refactor with no benchmark execution, recipe, result-schema, or permission-policy changes. No performance-changelog entry or GPU sweep is needed.

仅内部重构，不改动基准测试执行、配方、结果模式或权限策略，无需性能变更日志条目或 GPU 扫描。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared selection rules for eval aggregates and reuse validation; behavior is intended to be identical but mistakes would affect which eval rows are collected or accepted.
> 
> **Overview**
> **Centralizes** duplicated “pick the latest eval `results*.json`” logic into `infx.results.evals`: **`select_latest_result`** (overall or per concurrency) and **`select_latest_results`** (single winner or one per concurrency in numeric order).
> 
> The eval collector’s `detect_lm_eval_jsons` and the reusable-sweep validator/deduper paths now call these helpers instead of local `max(..., key=result_order)` / batched grouping. **Discovery, eligibility, and stricter reuse validation stay in each caller**; only ordering and concurrency filtering move shared.
> 
> English and Chinese architecture notes document the new APIs. Tests add coverage for empty candidates, concurrency filtering, retry ordering, and reuse diagnostics when unexpected/missing suffixed results coexist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a382ad1fee2dc48d6cd5a79729b7fe0b442556d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->