### PR TITLE
feat(config): add GLM-5.2 FP8 H200 AgentX 1P1D HiCache / 新增 GLM-5.2 FP8 H200 AgentX 1P1D HiCache 配置

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/agentic/disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/agentic/disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache.yaml
@@ -1,0 +1,167 @@
+name: "disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache"
+
+# 1P1D GLM-5.2 FP8 AgentX topology on H200 with EAGLE MTP and prefill-side
+# hierarchical KV cache. The decode-side KV cache remains GPU-resident.
+
+model:
+  path: "hf:zai-org/GLM-5.2-FP8"
+  container: "lmsysorg/sglang:v0.5.16-cu130"
+  precision: "fp8"
+
+dynamo:
+  install: true
+  wheel: "1.3.0.dev1"
+
+resources:
+  gpu_type: h200
+  gpus_per_node: 8
+  prefill_nodes: 1
+  decode_nodes: 1
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 8
+  gpus_per_decode: 8
+
+infra:
+  etcd_nats_dedicated_node: true
+  nats_max_payload_mb: 32
+
+frontend:
+  type: dynamo
+  nginx_session_affinity: true
+  nginx_session_affinity_header: X-Correlation-ID
+  env:
+    DYN_ROUTER_TEMPERATURE: "10000000"
+    PIP_BREAK_SYSTEM_PACKAGES: "1"
+  args:
+    router-mode: "kv"
+    router-reset-states: true
+    active-decode-blocks-threshold: "None"
+    active-prefill-tokens-threshold: "None"
+    active-prefill-tokens-threshold-frac: "None"
+
+backend:
+  type: sglang
+  prefill_environment:
+    HF_HOME: "/hf_hub_cache"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    PIP_BREAK_SYSTEM_PACKAGES: "1"
+    PYTHONUNBUFFERED: "1"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "900"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_OPT_USE_TOPK_V2: "1"
+    SGLANG_TIMEOUT_KEEP_ALIVE: "900"
+  decode_environment:
+    HF_HOME: "/hf_hub_cache"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    PIP_BREAK_SYSTEM_PACKAGES: "1"
+    PYTHONUNBUFFERED: "1"
+    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: "900"
+    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: "True"
+    SGLANG_OPT_USE_TOPK_V2: "1"
+    SGLANG_TIMEOUT_KEEP_ALIVE: "900"
+    SGLANG_SIMULATE_ACC_LEN: "3.78"
+    SGLANG_SIMULATE_ACC_METHOD: "match-expected"
+    SGLANG_SIMULATE_ACC_TOKEN_MODE: "real-draft-token"
+
+  sglang_config:
+    prefill:
+      host: 0.0.0.0
+      model-path: /model/
+      served-model-name: zai-org/GLM-5.2-FP8
+      trust-remote-code: true
+      tool-call-parser: glm47
+      reasoning-parser: glm45
+      tp-size: 8
+      ep-size: 1
+      attn-cp-size: 8
+      enable-prefill-cp: true
+      cp-strategy: interleave
+      enable-dsa-cache-layer-split: true
+      disaggregation-transfer-backend: mooncake
+      disaggregation-mode: prefill
+      kv-cache-dtype: fp8_e4m3
+      context-length: 1048576
+      max-total-tokens: 1048576
+      chunked-prefill-size: 32768
+      mem-fraction-static: 0.85
+      max-running-requests: 32
+      page-size: 64
+      enable-hierarchical-cache: true
+      hicache-size: 64
+      hicache-mem-layout: layer_first
+      hicache-io-backend: kernel
+      hicache-write-policy: write_back
+      speculative-algorithm: EAGLE
+      speculative-num-steps: 6
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 7
+      watchdog-timeout: 86400
+      stream-interval: 60
+      enable-metrics: true
+      enable-cache-report: true
+
+    decode:
+      host: 0.0.0.0
+      model-path: /model/
+      served-model-name: zai-org/GLM-5.2-FP8
+      trust-remote-code: true
+      tool-call-parser: glm47
+      reasoning-parser: glm45
+      tp-size: 8
+      dp-size: 8
+      ep-size: 1
+      enable-dp-attention: true
+      disaggregation-transfer-backend: mooncake
+      disaggregation-mode: decode
+      kv-cache-dtype: fp8_e4m3
+      dsa-decode-backend: flashmla_kv
+      context-length: 1048576
+      max-total-tokens: 1048576
+      mem-fraction-static: 0.85
+      max-running-requests: 200
+      page-size: 64
+      disable-radix-cache: true
+      speculative-algorithm: EAGLE
+      speculative-num-steps: 6
+      speculative-eagle-topk: 1
+      speculative-num-draft-tokens: 7
+      watchdog-timeout: 86400
+      stream-interval: 60
+      enable-metrics: true
+      enable-cache-report: true
+
+sbatch_directives:
+  mem: "0"
+
+srun_options:
+  mem: "0"
+  container-remap-root: ""
+
+telemetry:
+  enabled: true
+  provider: dcgm-power
+  default_frequency: 1.0
+  storage_subdir: power
+  required: true
+  startup_timeout_seconds: 120
+  request_timeout_seconds: 2
+  collector_join_timeout_seconds: 10
+  dcgm_exporter:
+    container_image: dcgm-exporter
+    port: 9401
+
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: /infmax-workspace
+    RESULT_DIR: /logs/agentic
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    AIPERF_REQUIRED_SERVER_METRIC_PREFIX: "sglang:"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9076,6 +9076,76 @@ glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-2p2d:
           ep: 1
           dp-attn: true
 
+# GLM-5.2 FP8 H200 AgentX with one prefill worker and one decode worker.
+# Prefill uses PCP8 and a host-DRAM-backed hierarchical KV cache; decode uses
+# TP8/DP8 with a GPU-resident KV cache. Both roles enable six-step EAGLE MTP.
+glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-1p1d-hicache:
+  image: lmsysorg/sglang:v0.5.16-cu130
+  model: zai-org/GLM-5.2-FP8
+  model-prefix: glm5.2
+  runner: cluster:h200-dgxc
+  precision: fp8
+  framework: dynamo-sglang
+  router: { name: dynamo-router, version: "1.3.0.dev1" }
+  kv-p2p-transfer: mooncake
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - dram-utilization: 0.80
+      search-space:
+      - spec-decoding: mtp
+        conc-list: [8]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 1
+          pcp-size: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/agentic/disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: true
+      - spec-decoding: mtp
+        conc-list: [12]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 1
+          pcp-size: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/agentic/disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: true
+      - spec-decoding: mtp
+        conc-list: [16]
+        kv-offloading: dram
+        kv-offload-backend: { name: hicache }
+        prefill:
+          num-worker: 1
+          tp: 1
+          pcp-size: 8
+          ep: 1
+          dp-attn: false
+          additional-settings:
+          - "CONFIG_FILE=recipes/sglang/glm5.2/agentic/disagg-h200-1p1d-pcp8-tp8-dp8-mtp6-hicache.yaml"
+        decode:
+          num-worker: 1
+          tp: 8
+          ep: 1
+          dp-attn: true
+
 # GLM-5.2 B300 NVFP4 AgentX with EAGLE/MTP speculative decoding, following the
 # AgentX speculative-decoding policy in MODELS.md. SGLang EAGLE runs off
 # GLM-5.2's built-in nextn head (num-steps 3,

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7311,3 +7311,12 @@
     - "Reserve 144 CPU cores for the GB300 single-node serving task"
     - "为 GB300 单节点服务任务预留 144 个 CPU 核心"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3017
+
+- config-keys:
+    - glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-1p1d-hicache
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Add a 1P1D GLM-5.2 FP8 H200 AgentX configuration with six-step EAGLE MTP."
+    - "Enable prefill-only hierarchical KV cache offload to host DRAM with the layer_first memory layout; keep decode KV cache GPU-resident."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7319,4 +7319,4 @@
   description:
     - "Add a 1P1D GLM-5.2 FP8 H200 AgentX configuration with six-step EAGLE MTP."
     - "Enable prefill-only hierarchical KV cache offload to host DRAM with the layer_first memory layout; keep decode KV cache GPU-resident."
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3021


### PR DESCRIPTION
## Description

Add a GLM-5.2 FP8 H200 AgentX disaggregated configuration with one prefill worker and one decode worker.

- Use PCP8 for prefill and TP8/DP8 for decode.
- Enable six-step EAGLE MTP with simulated acceptance pinned to the committed golden curve.
- Offload the prefill hierarchical KV cache to host DRAM using the `layer_first` layout and `write_back` policy.
- Keep the decode KV cache GPU-resident.
- Use `lmsysorg/sglang:v0.5.16-cu130`.

Validation:
- Exact-key matrix and committed changelog validation passed.
- All effective srt-slurm recipe variants passed dry-run validation.
- Public H200 launcher routing and image availability were verified.

Known follow-up before sweep: align the generated `nodes:N` scheduling demand with the recipe's dedicated NATS/etcd node.

## 中文说明

新增 GLM-5.2 FP8 H200 AgentX 分离式配置，包含一个 prefill worker 和一个 decode worker。

- prefill 使用 PCP8，decode 使用 TP8/DP8。
- 启用六步 EAGLE MTP，并将模拟接受长度固定到仓库中已提交的黄金曲线。
- prefill 侧分层 KV 缓存使用 `layer_first` 布局和 `write_back` 策略卸载到主机 DRAM。
- decode 侧 KV 缓存保持在 GPU 上。
- 使用 `lmsysorg/sglang:v0.5.16-cu130`。

验证：
- 精确配置键矩阵生成和已提交变更日志验证通过。
- 所有实际 srt-slurm 配方变体均通过 dry-run 验证。
- 已验证公开 H200 启动脚本路由和镜像可用性。

扫描前的已知后续事项：使生成的 `nodes:N` 调度需求包含配方专用的 NATS/etcd 节点。

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and recipe configuration only; no runtime application code changes.
> 
> **Overview**
> Adds a new **1P1D disaggregated AgentX benchmark** for **GLM-5.2 FP8 on H200** (Dynamo + SGLang), wired through a new srt-slurm recipe and a master config key `glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-1p1d-hicache`.
> 
> The recipe defines prefill **PCP8** with **host-DRAM hierarchical KV cache** (`layer_first`, `write_back`) and decode **TP8/DP8** with **GPU-resident** KV; both roles use **six-step EAGLE MTP**, Mooncake disagg transfer, and decode-side **simulated acceptance** pinned to AL 3.78. `nvidia-master.yaml` registers **agentic-coding** sweeps at concurrency **8, 12, and 16** (80% DRAM utilization, HiCache offload metadata). **`perf-changelog.yaml`** documents the new config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75eaddf4814a6f400b2f4aab25b4ec2c4c46c2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->