### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-b200-sglang-mtp SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp8-b200-sglang-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1267,7 +1267,7 @@ qwen3.5-fp4-b200-sglang-mtp:
       - { tp: 2, ep: 2, conc-list: [16, 32, 64], spec-decoding: mtp }
 
 qwen3.5-fp8-b200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: cluster:b200-nscale

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7319,3 +7319,10 @@
     - "Resolve the requested H100 SGLang container instead of a hardcoded older image, and stop benchmark/eval clients when their ready server or required worker exits."
     - "H100 SGLang 使用所请求的容器而非硬编码旧镜像；已就绪的服务或必需工作进程退出后，停止其 benchmark/评测客户端。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3020
+
+- config-keys:
+    - qwen3.5-fp8-b200-sglang-mtp
+  description:
+    - "Update the Qwen3.5-397B-A17B-FP8 B200 SGLang MTP image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130. Model, TP8/TP4 EP1 topology, EAGLE MTP speculation, 8k1k workload, concurrency grid, launch flags and evals are unchanged."
+    - "将 Qwen3.5-397B-A17B-FP8 B200 SGLang MTP 镜像从 lmsysorg/sglang:v0.5.14-cu130 更新为 lmsysorg/sglang:v0.5.19-cu130。模型、TP8/TP4 EP1 拓扑、EAGLE MTP 投机解码、8k1k 工作负载、并发网格、启动参数与评测均保持不变。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3023


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.14-cu130` to `lmsysorg/sglang:v0.5.19-cu130`.  
**Baseline:** 2026-07-05 · `lmsysorg/sglang:v0.5.14-cu130`  
Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-05), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true)

| Point | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| --- | ---: | ---: | ---: | ---: |
| 8k/1k c4 TP8 EP1 f9f71f | N/A | N/A | N/A | N/A |
| 8k/1k c4 TP4 EP1 0b07f6 | N/A | N/A | N/A | N/A |
| 8k/1k c8 TP4 EP1 fba569 | N/A | N/A | N/A | N/A |
| 8k/1k c16 TP4 EP1 99abaf | N/A | N/A | N/A | N/A |
| 8k/1k c32 TP4 EP1 6c98f4 | N/A | N/A | N/A | N/A |
| 8k/1k c64 TP4 EP1 878d37 | N/A | N/A | N/A | N/A |
| 8k/1k c128 TP4 EP1 bafe0b | N/A | N/A | N/A | N/A |
| 8k/1k c256 TP4 EP1 d2d946 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

| Eval | Score ↑ | Samples |
| --- | ---: | ---: |
| gsm8k/em_strict · c64 | 96.66% | 1,319 |
| gsm8k/em_strict · c256 | 96.59% | 1,319 |

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.14-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130`。  
**基线：**2026-07-05 · `lmsysorg/sglang:v0.5.14-cu130`  
平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-05), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=Qwen-3.5-397B-A17B&date=2026-07-05&exact=true)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->