### PR TITLE
[Klaud Cold] Update dsr1-fp4-gb200-dynamo-sglang SGLang image to v0.5.19-cu130 / 将 dsr1-fp4-gb200-dynamo-sglang 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -2905,7 +2905,7 @@ dsr1-fp8-gb300-dynamo-sglang:
           dp-attn: true
 
 dsr1-fp4-gb200-dynamo-sglang:
-  image: "lmsysorg/sglang:v0.5.8-cu130"
+  image: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   model: nvidia/DeepSeek-R1-0528-NVFP4-v2
   model-prefix: dsr1
   runner: gb200


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.8-cu130` to `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`.  
**Baseline:** 2026-02-08 · `lmsysorg/sglang:v0.5.8-cu130`  
Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-08&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-02-08)

| Point | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| --- | ---: | ---: | ---: | ---: |
| 8k/1k c4 PTP4x1/DTP4x4 721805 | N/A | N/A | N/A | N/A |
| 8k/1k c8 PTP4x1/DTP4x4 234c8c | N/A | N/A | N/A | N/A |
| 8k/1k c512 PTP4x6/DTP48x1 e70f1b | N/A | N/A | N/A | N/A |
| 8k/1k c2048 PTP4x6/DTP48x1 31b164 | N/A | N/A | N/A | N/A |
| 8k/1k c4096 PTP4x6/DTP48x1 57a875 | N/A | N/A | N/A | N/A |
| 8k/1k c2048 PTP4x10/DTP32x1 5d6d23 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

**Eval:** N/A

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.8-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`。  
**基线：**2026-02-08 · `lmsysorg/sglang:v0.5.8-cu130`  
平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-02-08&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-02-08)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->
