### PR TITLE
[Klaud Cold] Update glm5.2-fp4-gb300-dynamo-sglang-agentic-disagg SGLang image to v0.5.19-cu130 / 将 glm5.2-fp4-gb300-dynamo-sglang-agentic-disagg 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb300-fp4/agentic/glm5.2-agentx.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/gb300-fp4/agentic/glm5.2-agentx.yaml
@@ -4,6 +4,9 @@ base:
     path: glm-5.2-fp4
     container: dynamo-sglang
     precision: fp4
+  identity:
+    container:
+      image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   resources:
     gpu_type: gb300
     gpus_per_node: 4
@@ -21,8 +24,8 @@ base:
       active-prefill-tokens-threshold-frac: None
       router-session-affinity-ttl-secs: 3600
   dynamo:
-    hash: 71eb001e17fa73c742f0afe1a6ed96836cb135fd
     install: true
+    wheel: "1.5.0.dev20260910"
   backend:
     type: sglang
     prefill_environment:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9352,13 +9352,13 @@ glm5.2-fp4-gb300-dynamo-sglang-agentic-agg:
           additional-settings:
           - "CONFIG_FILE=recipes/sglang/glm5.2/gb300-fp4/agentic/glm5.2-agentx-agg.yaml"
 glm5.2-fp4-gb300-dynamo-sglang-agentic-disagg:
-  image: lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: nvidia/GLM-5.2-NVFP4
   model-prefix: glm5.2
   runner: cluster:gb300-nv
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "71eb001e17fa73c742f0afe1a6ed96836cb135fd" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260910" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642` to `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`.  
**Baseline:** 2026-08-16 · `lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642`  
Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=GLM-5.2&date=2026-08-16&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-16), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=GLM-5.2&date=2026-08-16)

| Point | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| --- | ---: | ---: | ---: | ---: |
| AgentX c48 PTP4x1/DTP4x2 aa1d55 | N/A | N/A | N/A | N/A |
| AgentX c48 PTP4x1/DTP4x4 e7eb7f | N/A | N/A | N/A | N/A |
| AgentX c45 PTP4x1/DTP4x6 de72ee | N/A | N/A | N/A | N/A |
| AgentX c128 PTP8x2/DTP16x1 8f3efc | N/A | N/A | N/A | N/A |
| AgentX c192 PTP8x2/DTP16x1 404052 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

| Eval | Score ↑ | Samples |
| --- | ---: | ---: |
| gsm8k/em_strict · c48 | 95.15% | 1,319 |
| gsm8k/em_strict · c48 | 95.45% | 1,319 |
| gsm8k/em_strict · c45 | 95.3% | 1,319 |
| gsm8k/em_strict · c128 | 94.01% | 1,319 |
| gsm8k/em_strict · c192 | 94.47% | 1,319 |

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642` 更新为 `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`。  
**基线：**2026-08-16 · `lmsysorg/sglang:nightly-dev-cu13-20260805-211ee642`  
平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=GLM-5.2&date=2026-08-16&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-16), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=GLM-5.2&date=2026-08-16)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->
