### PR TITLE
[Klaud Cold] Try TEP4 and DEP4 for DeepSeek V4.1 Flash AgentX on B300 / 在 B300 上尝试 DeepSeek V4.1 Flash AgentX 的 TEP4 与 DEP4

### DIFF
--- a/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
@@ -77,6 +77,13 @@ fi
 PARALLEL_ARGS=(--tensor-parallel-size "$TP")
 if [[ "$DP_ATTENTION" == "true" ]]; then
     PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+    # Under DEP every rank's expert layer sees the tokens dispatched from all
+    # DP ranks, so the TRT-LLM FP4 MoE workspace is larger than under TP. With
+    # the image default of 0.92 the autotuner warmup died 4.45 GiB short after
+    # the KV cache was sized (run 34655656558, DEP4 c64); reserve headroom and
+    # let the allocator grow segments instead of fragmenting.
+    PARALLEL_ARGS+=(--gpu-memory-utilization 0.85)
+    export PYTORCH_ALLOC_CONF=expandable_segments:True
 fi
 if [[ "$EP_SIZE" -gt 1 ]]; then
     PARALLEL_ARGS+=(--enable-expert-parallel)

--- a/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/dsv41flash_fp4_vllm_mtp.sh
@@ -8,6 +8,13 @@ check_env_vars MODEL TP CONC KV_OFFLOADING TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 require_agentic_kv_offload_none
 export GPU_COUNT="$TP"
 
+# Parallelism arms. The matrix always sets EP_SIZE and DP_ATTENTION; stand-alone
+# runs default to the pure-TP recipe. TEP keeps TP attention and shards the
+# routed experts (--enable-expert-parallel). DEP runs one attention rank per
+# GPU (--data-parallel-size TP) behind vllm-router with session affinity.
+EP_SIZE="${EP_SIZE:-1}"
+DP_ATTENTION="${DP_ATTENTION:-false}"
+
 # Complete/resume partial downloads instead of trusting nonempty directories.
 if [[ -n "${MODEL_PATH:-}" && "$MODEL_PATH" != "$MODEL" ]]; then
     hf download "$MODEL" --local-dir "$MODEL_PATH"
@@ -21,21 +28,42 @@ resolve_trace_source
 install_agentic_deps
 mkdir -p "$RESULT_DIR"
 SERVER_LOG="$RESULT_DIR/server.log"
+ROUTER_LOG="$RESULT_DIR/router.log"
 export VLLM_ENGINE_READY_TIMEOUT_S="${VLLM_ENGINE_READY_TIMEOUT_S:-3600}"
 export VLLM_USE_RUST_FRONTEND=1
 export PYTHONUNBUFFERED=1
 
 # Preserve the upstream scheduler defaults; size graph capture for the sweep.
+# Each DEP rank sees about CONC/TP sequences; capture for twice that so
+# consistent-hash imbalance across ranks still lands on captured graphs.
 NUM_SPEC_TOKENS=5
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    CAPTURE_TARGET=$(( 2 * ((CONC + TP - 1) / TP) * (1 + NUM_SPEC_TOKENS) ))
+else
+    CAPTURE_TARGET=$(( CONC * (1 + NUM_SPEC_TOKENS) ))
+fi
 CAPTURE_SIZE=1
-while (( CAPTURE_SIZE < CONC * (1 + NUM_SPEC_TOKENS) && CAPTURE_SIZE < 2048 )); do
+while (( CAPTURE_SIZE < CAPTURE_TARGET && CAPTURE_SIZE < 2048 )); do
     CAPTURE_SIZE=$((CAPTURE_SIZE * 2))
 done
 
 # Pyxis shares the host network; port 8888 can already belong to a host service.
 select_available_server_port
+VLLM_BACKEND_PORT="$PORT"
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    # vllm-router fronts the DP ranks on PORT and expands the one HTTP backend
+    # into one logical worker per rank. Bind every turn of a conversation to
+    # the same rank by mapping AIPerf's correlation ID to X-Session-ID.
+    VLLM_BACKEND_PORT=$((PORT + 1))
+    VLLM_ROUTER_VERSION=0.1.14
+    VLLM_ROUTER_METRICS_PORT=$((PORT + 10000))
+    export AIPERF_HTTP_X_SESSION_ID_FROM_CORRELATION_ID=1
+    agentic_pip_install --quiet "vllm-router==$VLLM_ROUTER_VERSION"
+fi
 export AIPERF_SERVER_URL="http://localhost:${PORT}"
-export AIPERF_SERVER_METRICS_URLS="${AIPERF_SERVER_URL}/metrics"
+# AIPerf scrapes the public endpoint's /metrics on its own; under DEP that is the
+# router, so name the engine endpoint explicitly (deduplicated for pure TP).
+export AIPERF_SERVER_METRICS_URLS="http://localhost:${VLLM_BACKEND_PORT}/metrics"
 export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="vllm:"
 echo "Using vLLM endpoint ${AIPERF_SERVER_URL}"
 
@@ -46,9 +74,16 @@ if [[ "${EVAL_ONLY:-false}" == true ]]; then
 else
     SPEC_CONFIG='{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"synthetic","synthetic_acceptance_length":3.51,"enable_adaptive_verification":false}'
 fi
+PARALLEL_ARGS=(--tensor-parallel-size "$TP")
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    PARALLEL_ARGS=(--tensor-parallel-size 1 --data-parallel-size "$TP")
+fi
+if [[ "$EP_SIZE" -gt 1 ]]; then
+    PARALLEL_ARGS+=(--enable-expert-parallel)
+fi
 VLLM_CMD=(
     vllm serve "$MODEL_PATH" --served-model-name "$MODEL"
-    --host 0.0.0.0 --port "$PORT" --tensor-parallel-size "$TP"
+    --host 0.0.0.0 --port "$VLLM_BACKEND_PORT" "${PARALLEL_ARGS[@]}"
     --language-model-only
     --tokenizer-mode deepseek_v41
     --tool-call-parser deepseek_v41 --enable-auto-tool-choice
@@ -63,7 +98,21 @@ printf '%q ' "${VLLM_CMD[@]}" | tee "$RESULT_DIR/vllm_command.txt"
 printf '\n' | tee -a "$RESULT_DIR/vllm_command.txt"
 "${VLLM_CMD[@]}" > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
-wait_for_server_ready --port "$PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+wait_for_server_ready --port "$VLLM_BACKEND_PORT" --server-log "$SERVER_LOG" --server-pid "$SERVER_PID"
+
+if [[ "$DP_ATTENTION" == "true" ]]; then
+    echo "Starting vllm-router on port $PORT for $TP DP ranks..."
+    vllm-router \
+        --worker-urls "http://localhost:$VLLM_BACKEND_PORT" \
+        --policy consistent_hash \
+        --intra-node-data-parallel-size "$TP" \
+        --host 0.0.0.0 --port "$PORT" \
+        --prometheus-host 127.0.0.1 --prometheus-port "$VLLM_ROUTER_METRICS_PORT" \
+        --request-timeout-secs 14400 \
+        --disable-retries > "$ROUTER_LOG" 2>&1 &
+    ROUTER_PID=$!
+    wait_for_server_ready --port "$PORT" --server-log "$ROUTER_LOG" --server-pid "$ROUTER_PID"
+fi
 
 if [[ "${EVAL_ONLY:-false}" == true ]]; then
     run_eval --port "$PORT"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -10379,6 +10379,11 @@ dsv41flash-fp4-b300-vllm-agentic-dspark:
       search-space:
       # Engram weights use UVA DRAM; the KV cache stays GPU-resident.
       - { tp: 4, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 64, 128] }
+      # TEP4: TP attention, routed experts sharded across the 4 GPUs (--enable-expert-parallel).
+      - { tp: 4, ep: 4, kv-offloading: none, spec-decoding: mtp, conc-list: [32, 64, 128] }
+      # DEP4: one attention rank per GPU (--data-parallel-size 4) behind vllm-router
+      # consistent-hash session affinity; experts sharded as in TEP4.
+      - { tp: 4, ep: 4, dp-attn: true, kv-offloading: none, spec-decoding: mtp, conc-list: [32, 64, 128], router: { name: vllm-router, version: "0.1.14" } }
 
 dsv41flash-fp4-b200-vllm-agentic-dspark:
   image: vllm/vllm-openai:deepseekv41-flash-0909

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -178,7 +178,7 @@ weights determine the recipe's `precision: fp4` label.
 
 The GPU-specific entry points share the text-only serving script, `deepseek_v41` tokenizer and
 parsers, 1M context, and the shared AgentX trace replay, power, metrics, and eval
-helpers. Concurrency is 1–128. Model-runner selection and scheduler batching follow the
+helpers. Concurrency is 1–128 at TP4. On B300 the TP4 grid is joined by TEP4 (`ep: 4`, `--enable-expert-parallel`) and DEP4 (`dp-attn: true`, `--data-parallel-size 4` behind vllm-router 0.1.14 consistent-hash session affinity, engine on `PORT+1`) arms at concurrency 32–128; the shared script gates both on `EP_SIZE` and `DP_ATTENTION`, so every other row still serves the pure TP4 command. Model-runner selection and scheduler batching follow the
 official single-node TP recipe defaults; graph capture covers concurrency times
 the six-token DSpark verification block. The launchers mount the repository at `/ix` for this recipe so
 AgentX runtime directories are not created under `/workspace`. Launcher-specific model paths and persistent caches are reused.

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -178,7 +178,7 @@ weights determine the recipe's `precision: fp4` label.
 
 The GPU-specific entry points share the text-only serving script, `deepseek_v41` tokenizer and
 parsers, 1M context, and the shared AgentX trace replay, power, metrics, and eval
-helpers. Concurrency is 1–128 at TP4. On B300 the TP4 grid is joined by TEP4 (`ep: 4`, `--enable-expert-parallel`) and DEP4 (`dp-attn: true`, `--data-parallel-size 4` behind vllm-router 0.1.14 consistent-hash session affinity, engine on `PORT+1`) arms at concurrency 32–128; the shared script gates both on `EP_SIZE` and `DP_ATTENTION`, so every other row still serves the pure TP4 command. Model-runner selection and scheduler batching follow the
+helpers. Concurrency is 1–128 at TP4. On B300 the TP4 grid is joined by TEP4 (`ep: 4`, `--enable-expert-parallel`) and DEP4 (`dp-attn: true`, `--data-parallel-size 4` behind vllm-router 0.1.14 consistent-hash session affinity, engine on `PORT+1`, `--gpu-memory-utilization 0.85` because the TRT-LLM FP4 MoE autotuner warmup OOMs at the image default under DP) arms at concurrency 32–128; the shared script gates both on `EP_SIZE` and `DP_ATTENTION`, so every other row still serves the pure TP4 command. Model-runner selection and scheduler batching follow the
 official single-node TP recipe defaults; graph capture covers concurrency times
 the six-token DSpark verification block. The launchers mount the repository at `/ix` for this recipe so
 AgentX runtime directories are not created under `/workspace`. Launcher-specific model paths and persistent caches are reused.

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -177,7 +177,7 @@ llm-d 不是 srt-slurm 路径：InferenceX 自己持有 Slurm allocation，并�
 专家权重为 MXFP4，因此配方标记为 `precision: fp4`。
 
 各 GPU 入口共用纯文本服务脚本，使用 `deepseek_v41` tokenizer 和解析器、1M 上下文，
-以及共享的 AgentX 轨迹回放、功耗、指标和 eval helper。并发范围为 1–128。模型 runner 选择和调度批处理沿用官方单节点 TP 配方的默认值；
+以及共享的 AgentX 轨迹回放、功耗、指标和 eval helper。TP4 的并发范围为 1–128。B300 在 TP4 网格之外新增 TEP4（`ep: 4`、`--enable-expert-parallel`）和 DEP4（`dp-attn: true`、`--data-parallel-size 4`，由 vllm-router 0.1.14 一致性哈希保证会话亲和，引擎监听 `PORT+1`）分支，并发 32–128；共享脚本按 `EP_SIZE` 与 `DP_ATTENTION` 门控，其余各行仍执行纯 TP4 命令。模型 runner 选择和调度批处理沿用官方单节点 TP 配方的默认值；
 CUDA graph capture 覆盖并发数乘以六 token DSpark 验证块。launcher 都为该配方将仓库挂载到 `/ix`，避免在 `/workspace`
 下创建 AgentX 运行目录。沿用各 launcher 的模型路径和持久化缓存。配方在计算节点探测服务端口，首选端口被占用时选择可用端口，
 服务、回放、指标和 eval 共用同一端点。所有配方都必须获得 GPU sweep 和 eval

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -177,7 +177,7 @@ llm-d 不是 srt-slurm 路径：InferenceX 自己持有 Slurm allocation，并�
 专家权重为 MXFP4，因此配方标记为 `precision: fp4`。
 
 各 GPU 入口共用纯文本服务脚本，使用 `deepseek_v41` tokenizer 和解析器、1M 上下文，
-以及共享的 AgentX 轨迹回放、功耗、指标和 eval helper。TP4 的并发范围为 1–128。B300 在 TP4 网格之外新增 TEP4（`ep: 4`、`--enable-expert-parallel`）和 DEP4（`dp-attn: true`、`--data-parallel-size 4`，由 vllm-router 0.1.14 一致性哈希保证会话亲和，引擎监听 `PORT+1`）分支，并发 32–128；共享脚本按 `EP_SIZE` 与 `DP_ATTENTION` 门控，其余各行仍执行纯 TP4 命令。模型 runner 选择和调度批处理沿用官方单节点 TP 配方的默认值；
+以及共享的 AgentX 轨迹回放、功耗、指标和 eval helper。TP4 的并发范围为 1–128。B300 在 TP4 网格之外新增 TEP4（`ep: 4`、`--enable-expert-parallel`）和 DEP4（`dp-attn: true`、`--data-parallel-size 4`，由 vllm-router 0.1.14 一致性哈希保证会话亲和，引擎监听 `PORT+1`，并设置 `--gpu-memory-utilization 0.85`，因为 DP 下 TRT-LLM FP4 MoE 自动调优预热在镜像默认值下会 OOM）分支，并发 32–128；共享脚本按 `EP_SIZE` 与 `DP_ATTENTION` 门控，其余各行仍执行纯 TP4 命令。模型 runner 选择和调度批处理沿用官方单节点 TP 配方的默认值；
 CUDA graph capture 覆盖并发数乘以六 token DSpark 验证块。launcher 都为该配方将仓库挂载到 `/ix`，避免在 `/workspace`
 下创建 AgentX 运行目录。沿用各 launcher 的模型路径和持久化缓存。配方在计算节点探测服务端口，首选端口被占用时选择可用端口，
 服务、回放、指标和 eval 共用同一端点。所有配方都必须获得 GPU sweep 和 eval

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7344,4 +7344,4 @@
   description:
     - "Add B300 TEP4 and DEP4 AgentX arms at concurrency 32, 64 and 128 alongside the unchanged TP4 grid: TEP4 shards the routed experts with --enable-expert-parallel; DEP4 runs data-parallel attention (--data-parallel-size 4) behind vllm-router 0.1.14 consistent-hash session affinity. The shared DSpark script gates both on EP_SIZE and DP_ATTENTION, so the existing TP4 rows on every SKU serve the same command as before."
     - "为 B300 新增 TEP4 与 DEP4 AgentX 分支（并发 32、64、128），TP4 网格保持不变：TEP4 通过 --enable-expert-parallel 切分路由专家；DEP4 以 --data-parallel-size 4 运行数据并行注意力，并由 vllm-router 0.1.14 一致性哈希保证会话亲和。共享 DSpark 脚本按 EP_SIZE 与 DP_ATTENTION 门控，各 SKU 现有 TP4 行的服务命令与以前完全一致。"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3028

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7338,3 +7338,10 @@
     - "Resolve the requested H100 SGLang container instead of a hardcoded older image, and stop benchmark/eval clients when their ready server or required worker exits."
     - "H100 SGLang 使用所请求的容器而非硬编码旧镜像；已就绪的服务或必需工作进程退出后，停止其 benchmark/评测客户端。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3020
+
+- config-keys:
+    - dsv41flash-fp4-b300-vllm-agentic-dspark
+  description:
+    - "Add B300 TEP4 and DEP4 AgentX arms at concurrency 32, 64 and 128 alongside the unchanged TP4 grid: TEP4 shards the routed experts with --enable-expert-parallel; DEP4 runs data-parallel attention (--data-parallel-size 4) behind vllm-router 0.1.14 consistent-hash session affinity. The shared DSpark script gates both on EP_SIZE and DP_ATTENTION, so the existing TP4 rows on every SKU serve the same command as before."
+    - "为 B300 新增 TEP4 与 DEP4 AgentX 分支（并发 32、64、128），TP4 网格保持不变：TEP4 通过 --enable-expert-parallel 切分路由专家；DEP4 以 --data-parallel-size 4 运行数据并行注意力，并由 vllm-router 0.1.14 一致性哈希保证会话亲和。共享 DSpark 脚本按 EP_SIZE 与 DP_ATTENTION 门控，各 SKU 现有 TP4 行的服务命令与以前完全一致。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/XXX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7342,6 +7342,6 @@
 - config-keys:
     - dsv41flash-fp4-b300-vllm-agentic-dspark
   description:
-    - "Add B300 TEP4 and DEP4 AgentX arms at concurrency 32, 64 and 128 alongside the unchanged TP4 grid: TEP4 shards the routed experts with --enable-expert-parallel; DEP4 runs data-parallel attention (--data-parallel-size 4) behind vllm-router 0.1.14 consistent-hash session affinity. The shared DSpark script gates both on EP_SIZE and DP_ATTENTION, so the existing TP4 rows on every SKU serve the same command as before."
-    - "为 B300 新增 TEP4 与 DEP4 AgentX 分支（并发 32、64、128），TP4 网格保持不变：TEP4 通过 --enable-expert-parallel 切分路由专家；DEP4 以 --data-parallel-size 4 运行数据并行注意力，并由 vllm-router 0.1.14 一致性哈希保证会话亲和。共享 DSpark 脚本按 EP_SIZE 与 DP_ATTENTION 门控，各 SKU 现有 TP4 行的服务命令与以前完全一致。"
+    - "Add B300 TEP4 and DEP4 AgentX arms at concurrency 32, 64 and 128 alongside the unchanged TP4 grid: TEP4 shards the routed experts with --enable-expert-parallel; DEP4 runs data-parallel attention (--data-parallel-size 4) behind vllm-router 0.1.14 consistent-hash session affinity with --gpu-memory-utilization 0.85 and expandable allocator segments, because the TRT-LLM FP4 MoE autotuner warmup ran out of memory at the image default (run 34655656558). The shared DSpark script gates both on EP_SIZE and DP_ATTENTION, so the existing TP4 rows on every SKU serve the same command as before."
+    - "为 B300 新增 TEP4 与 DEP4 AgentX 分支（并发 32、64、128），TP4 网格保持不变：TEP4 通过 --enable-expert-parallel 切分路由专家；DEP4 以 --data-parallel-size 4 运行数据并行注意力，并由 vllm-router 0.1.14 一致性哈希保证会话亲和，并设置 --gpu-memory-utilization 0.85 与可扩展分配器段，因为在镜像默认值下 TRT-LLM FP4 MoE 自动调优预热会内存不足（运行 34655656558）。共享 DSpark 脚本按 EP_SIZE 与 DP_ATTENTION 门控，各 SKU 现有 TP4 行的服务命令与以前完全一致。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3028


### PR DESCRIPTION
## Summary

Adds two experimental parallelism arms to `dsv41flash-fp4-b300-vllm-agentic-dspark` for mid-to-high concurrency, alongside the unchanged TP4 grid that passed 1–128 in the merged #2958 sweep:

- **TEP4** (`tp: 4, ep: 4`): TP attention, routed experts sharded across the 4 GPUs via `--enable-expert-parallel`. Concurrency 32, 64, 128.
- **DEP4** (`tp: 4, ep: 4, dp-attn: true`): one attention rank per GPU (`--tensor-parallel-size 1 --data-parallel-size 4`) plus expert parallel, fronted by `vllm-router` 0.1.14 with `consistent_hash` session affinity (AIPerf correlation ID mapped to `X-Session-ID`); engine on `PORT+1`, router on `PORT`. Concurrency 32, 64, 128.

Both arms come from the upstream recipe's `compatible_strategies` (`single_node_tep`, `single_node_dep`). The shared `dsv41flash_fp4_vllm_mtp.sh` gates the new behaviour on the matrix-supplied `EP_SIZE` / `DP_ATTENTION` env vars, so every existing TP4 row on B200/B300/GB200/GB300/H200 still serves the exact same command. DEP graph capture is sized per rank (twice `CONC/TP` verification blocks).

Changes: shared DSpark script, B300 master-config rows, perf-changelog entry, and the EN/ZH configuration docs.

## Validation

- `bash -n` on the script; matrix generation for the key yields 14 jobs (8 TP4 + 3 TEP4 + 3 DEP4) with the expected `ep` / `dp-attn` / `router` fields.
- Dry run of the argument construction for TP4 / TEP4 / DEP4 at conc 1, 32 and 128.
- `pytest runners/test_dsv41flash_*.py utils/matrix_logic`: 306 passed.
- GPU evidence: this PR's `full-sweep-fail-fast` sweep (pending).

## Risks

- Engram `cpu_offload` under DP is untested upstream: each DP rank may pin its own copy of the ~189 GiB Engram tables (~756 GiB host DRAM at DEP4). The B300 nodes have the headroom, but this is what the sweep is for.
- If DEP4 fails early, the fail-fast label cancels the rest of the matrix; TEP4 and TP4 results from the same run are still valid evidence.

## 摘要

为 `dsv41flash-fp4-b300-vllm-agentic-dspark` 新增两条面向中高并发的实验性并行分支，TP4 网格（已在 #2958 的 sweep 中通过并发 1–128）保持不变：

- **TEP4**（`tp: 4, ep: 4`）：TP 注意力，路由专家通过 `--enable-expert-parallel` 切分到 4 张 GPU。并发 32、64、128。
- **DEP4**（`tp: 4, ep: 4, dp-attn: true`）：每张 GPU 一个注意力 rank（`--tensor-parallel-size 1 --data-parallel-size 4`）并启用专家并行，前置 `vllm-router` 0.1.14 的 `consistent_hash` 会话亲和（AIPerf correlation ID 映射为 `X-Session-ID`）；引擎监听 `PORT+1`，router 监听 `PORT`。并发 32、64、128。

两条分支均来自上游配方的 `compatible_strategies`（`single_node_tep`、`single_node_dep`）。共享脚本 `dsv41flash_fp4_vllm_mtp.sh` 按矩阵提供的 `EP_SIZE` / `DP_ATTENTION` 环境变量门控新行为，因此 B200/B300/GB200/GB300/H200 上现有的 TP4 行仍执行完全相同的命令。DEP 的 CUDA graph capture 按每个 rank 计算（`CONC/TP` 验证块的两倍）。

改动：共享 DSpark 脚本、B300 master-config 行、perf-changelog 条目，以及中英文配置文档。

## 验证

- 脚本 `bash -n`；该 key 的矩阵生成得到 14 个 job（8 个 TP4 + 3 个 TEP4 + 3 个 DEP4），`ep` / `dp-attn` / `router` 字段符合预期。
- 对 TP4 / TEP4 / DEP4 在并发 1、32、128 下的参数构造做了 dry run。
- `pytest runners/test_dsv41flash_*.py utils/matrix_logic`：306 通过。
- GPU 证据：本 PR 的 `full-sweep-fail-fast` sweep（进行中）。

## 风险

- DP 下的 Engram `cpu_offload` 上游未验证：每个 DP rank 可能各自固定一份约 189 GiB 的 Engram 表（DEP4 约 756 GiB 主机内存）。B300 节点有余量，但这正是需要 sweep 验证的地方。
- 若 DEP4 早期失败，fail-fast 标签会取消矩阵中其余任务；同一 run 中的 TEP4 与 TP4 结果仍是有效证据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new vLLM parallelism and vllm-router serving paths with DEP-specific GPU memory limits; Engram CPU offload per DP rank is experimental and could stress host DRAM during sweeps.
> 
> **Overview**
> Adds **TEP4** and **DEP4** experimental AgentX sweep arms for `dsv41flash-fp4-b300-vllm-agentic-dspark` at concurrency 32–128, while the existing TP4 grid (1–128) stays unchanged.
> 
> The shared `dsv41flash_fp4_vllm_mtp.sh` now branches on matrix `EP_SIZE` / `DP_ATTENTION`: **TEP4** keeps TP attention and adds `--enable-expert-parallel`; **DEP4** runs `--tensor-parallel-size 1 --data-parallel-size 4` (plus EP when configured), lowers `--gpu-memory-utilization` to 0.85 with expandable PyTorch segments, sizes CUDA graph capture per DP rank, and fronts the engine with **vllm-router** 0.1.14 (`consistent_hash`, AIPerf correlation → `X-Session-ID`, engine on `PORT+1`). Metrics scraping targets the engine endpoint explicitly under DEP.
> 
> `configs/nvidia-master.yaml`, `perf-changelog.yaml`, and EN/ZH configuration docs document the new search-space rows and router metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f4da13e4a36ea5eb02713c80c992f0d9d9c388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->