### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-h200-sglang-mtp SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp8-h200-sglang-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1790,7 +1790,7 @@ qwen3.5-fp8-h200-sglang:
       - { tp: 8, ep: 8, conc-start: 4, conc-end: 64 }
 
 qwen3.5-fp8-h200-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.14-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: h200

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7338,3 +7338,10 @@
     - "Resolve the requested H100 SGLang container instead of a hardcoded older image, and stop benchmark/eval clients when their ready server or required worker exits."
     - "H100 SGLang 使用所请求的容器而非硬编码旧镜像；已就绪的服务或必需工作进程退出后，停止其 benchmark/评测客户端。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3020
+
+- config-keys:
+    - qwen3.5-fp8-h200-sglang-mtp
+  description:
+    - "Update the Qwen3.5-397B-A17B-FP8 H200 SGLang MTP image from lmsysorg/sglang:v0.5.14-cu130 to lmsysorg/sglang:v0.5.19-cu130. Model, TP8/EP8 topology, EAGLE MTP speculation, 8k1k workload, concurrency grid, launch flags and evals are unchanged."
+    - "将 Qwen3.5-397B-A17B-FP8 H200 SGLang MTP 镜像从 lmsysorg/sglang:v0.5.14-cu130 更新为 lmsysorg/sglang:v0.5.19-cu130。模型、TP8/EP8 拓扑、EAGLE MTP 投机解码、8k1k 负载、并发网格、启动参数与评测均保持不变。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3032


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.14-cu130` to `lmsysorg/sglang:v0.5.19-cu130`.  
**Baseline:** 2026-07-04 · `lmsysorg/sglang:v0.5.14-cu130`  
8k/1k · TP8/EP8 · Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-04)

| Concurrency | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| ---: | ---: | ---: | ---: | ---: |
| 4 | N/A | N/A | N/A | N/A |
| 8 | N/A | N/A | N/A | N/A |
| 16 | N/A | N/A | N/A | N/A |
| 32 | N/A | N/A | N/A | N/A |
| 64 | N/A | N/A | N/A | N/A |
| 128 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

**Eval:** N/A

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.14-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130`。  
**基线：**2026-07-04 · `lmsysorg/sglang:v0.5.14-cu130`  
8k/1k · TP8/EP8 · 平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-04&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-04)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->
