### PR TITLE
[Klaud Cold] Update dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg vLLM image to v0.29.0 / 将 dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg 的 vLLM 镜像更新至 v0.29.0

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml
@@ -6,14 +6,14 @@ name: "svf-vllm-agg-gb200-tp8-c4-mtp2-agentic"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.2.1"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c4-mtp2-agentic.yaml
@@ -120,7 +120,11 @@ backend:
       block-size: 256
       compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64],"mode":0}'
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
-      gpu-memory-utilization: 0.94
+      # vLLM v0.29.0 profiles only 3.8 GiB of peak activation and hands the
+      # rest to the KV cache; keep headroom for the lazily allocated sparse
+      # indexer logits workspace (VLLM_SPARSE_INDEXER_MAX_LOGITS_MB) that
+      # OOMed at 0.94 on the first long AgentX prefill.
+      gpu-memory-utilization: 0.90
       stream-interval: 10
       no-disable-hybrid-kv-cache-manager: true
       tokenizer-mode: "deepseek_v4"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c8-mtp2-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c8-mtp2-agentic.yaml
@@ -6,14 +6,14 @@ name: "svf-vllm-agg-gb200-tp8-c8-mtp2-agentic"
 
 model:
   path: "deepseek-v4-pro"
-  container: "vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f"
+  container: "vllm/vllm-openai:v0.29.0"
   precision: "fp4"
 
 identity:
   model:
     repo: "deepseek-ai/DeepSeek-V4-Pro"
   container:
-    image: "vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f"
+    image: "vllm/vllm-openai:v0.29.0"
   frameworks:
     dynamo: "1.2.1"
 

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c8-mtp2-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic/agg-gb200-tp8-c8-mtp2-agentic.yaml
@@ -119,7 +119,11 @@ backend:
       block-size: 256
       compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96,100,104,108,112,116,120,124,128],"mode":0}'
       speculative-config: '{"method":"mtp","num_speculative_tokens":3}'
-      gpu-memory-utilization: 0.94
+      # vLLM v0.29.0 profiles only 3.8 GiB of peak activation and hands the
+      # rest to the KV cache; keep headroom for the lazily allocated sparse
+      # indexer logits workspace (VLLM_SPARSE_INDEXER_MAX_LOGITS_MB) that
+      # OOMed at 0.94 on the first long AgentX prefill.
+      gpu-memory-utilization: 0.90
       stream-interval: 10
       no-disable-hybrid-kv-cache-manager: true
       tokenizer-mode: "deepseek_v4"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -8497,7 +8497,7 @@ dsv4-fp4-gb300-dynamo-vllm-agentic-mtp-disagg:
 # mtp2 keys/recipe files so the existing GB200 AgentX MTP recipes above are
 # untouched.
 dsv4-fp4-gb200-dynamo-vllm-agentic-mtp2-agg:
-  image: vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f
+  image: vllm/vllm-openai:v0.29.0
   model: deepseek-ai/DeepSeek-V4-Pro
   model-prefix: dsv4
   runner: cluster:gb200-nv


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update vLLM image from `vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f` to `vllm/vllm-openai:v0.29.0`.  
**Baseline:** 2026-08-18 · `vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f`  
AgentX · PTP8x1/DTP8x0 · Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-08-18&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-18)

| Concurrency | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| ---: | ---: | ---: | ---: | ---: |
| 1 | N/A | N/A | N/A | N/A |
| 4 | N/A | N/A | N/A | N/A |
| 8 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

**Eval:** N/A

<details>
<summary>中文</summary>

**目标：**将 vLLM 镜像从 `vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f` 更新为 `vllm/vllm-openai:v0.29.0`。  
**基线：**2026-08-18 · `vllm/vllm-openai:nightly-dev-arm64-cu13.0.1-426e59f`  
AgentX · PTP8x1/DTP8x0 · 平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-V4-Pro&date=2026-08-18&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-18)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->
