### PR TITLE
[Klaud Cold] Update dsr1-fp4-b200-dynamo-sglang-mtp SGLang image to v0.5.19 / 将 dsr1-fp4-b200-dynamo-sglang-mtp 的 SGLang 镜像更新至 v0.5.19

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-1p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_1p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-1p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-2p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-2p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_2p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-3p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_3p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-3p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-4p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-4p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_4p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-5p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
@@ -92,7 +92,7 @@ backend:
       expert-parallel-size: 4
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2
@@ -123,7 +123,7 @@ backend:
       expert-parallel-size: 8
       enable-dp-attention: true
       enable-dp-lm-head: true
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 2

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp2_throughput_5p1d.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp2-throughput-5p-dep4-1d-dep8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
@@ -22,7 +22,7 @@ resources:
 frontend:
   type: dynamo
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 backend:
   prefill_environment: &env

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_4p1d_c2048.yaml
@@ -9,7 +9,7 @@
 name: b200-fp4-dsr1_8k1k_mtp_4p1d_c2048
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: fp4
 resources:
   gpu_type: b200
@@ -22,7 +22,7 @@ resources:
 frontend:
   type: dynamo
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 backend:
   prefill_environment: &env

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-5d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-5d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-3d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-3d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
@@ -91,7 +91,7 @@ backend:
       tensor-parallel-size: 4
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3
@@ -120,7 +120,7 @@ backend:
       tensor-parallel-size: 8
       expert-parallel-size: 1
       enable-dp-attention: false
-      fp4-gemm-backend: "flashinfer_trtllm"
+      fp4-gemm-backend: "flashinfer_cutedsl"
       disaggregation-transfer-backend: nixl
       speculative-algorithm: "EAGLE"
       speculative-num-steps: 3

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-1d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "5b4bc1dd70965017a737c71b19db5a0aeaa88727"
+  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
   install: true
 
 frontend:
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "dsr1"
-  container: "lmsysorg/sglang:v0.5.12.post1"
+  container: "lmsysorg/sglang:v0.5.19"
   precision: "fp4"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/dsr1/b200-fp4/8k1k/disagg/mtp/8k1k_mtp_lowlat_2.yaml
@@ -6,7 +6,7 @@ name: "b200-fp4-mtp-low-latency-1p-tp4-1d-tp8"
 # layout (sglang/<model>/<hw>-<precision>/<seq>/disagg/<variant>/...).
 
 dynamo:
-  hash: "4a205cb356c9a1882ed8cda8980404026b52173a"
+  version: "1.5.0.dev20260910"
   install: true
 
 frontend:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3996,7 +3996,7 @@ dsr1-fp4-b200-dynamo-sglang-mtp:
   runner: cluster:b200-nscale
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "4a205cb356c9a1882ed8cda8980404026b52173a" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260910" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -3990,13 +3990,13 @@ dsr1-fp8-b200-dynamo-sglang-mtp:
           dp-attn: true
 
 dsr1-fp4-b200-dynamo-sglang-mtp:
-  image: "lmsysorg/sglang:v0.5.12.post1"
+  image: "lmsysorg/sglang:v0.5.19"
   model: deepseek-r1-fp4
   model-prefix: dsr1
   runner: cluster:b200-nscale
   precision: fp4
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "5b4bc1dd70965017a737c71b19db5a0aeaa88727" }
+  router: { name: dynamo-router, version: "4a205cb356c9a1882ed8cda8980404026b52173a" }
   kv-p2p-transfer: nixl
   multinode: true
   disagg: true

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7338,3 +7338,10 @@
     - "Resolve the requested H100 SGLang container instead of a hardcoded older image, and stop benchmark/eval clients when their ready server or required worker exits."
     - "H100 SGLang 使用所请求的容器而非硬编码旧镜像；已就绪的服务或必需工作进程退出后，停止其 benchmark/评测客户端。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3020
+
+- config-keys:
+    - dsr1-fp4-b200-dynamo-sglang-mtp
+  description:
+    - "Update the DeepSeek-R1 FP4 B200 dynamo-sglang MTP disagg image from lmsysorg/sglang:v0.5.12.post1 to lmsysorg/sglang:v0.5.19; install Dynamo from the PyPI nightly 1.5.0.dev20260910 (pins sglang 0.5.19) instead of the hash-pinned source build, and switch --fp4-gemm-backend from flashinfer_trtllm to flashinfer_cutedsl because the v0.5.19 trtllm weight path skips the SM100 shared-experts SwiGLU fusion weights. Model, topology, MoE runner backend, speculation, workload, points and evals are unchanged."
+    - "将 DeepSeek-R1 FP4 B200 dynamo-sglang MTP 分离式镜像从 lmsysorg/sglang:v0.5.12.post1 更新为 lmsysorg/sglang:v0.5.19；Dynamo 改为从 PyPI nightly 1.5.0.dev20260910（固定 sglang 0.5.19）安装以替代哈希固定源码构建，并将 --fp4-gemm-backend 从 flashinfer_trtllm 改为 flashinfer_cutedsl，因为 v0.5.19 的 trtllm 权重路径跳过 SM100 共享专家 SwiGLU 融合权重。模型、拓扑、MoE runner 后端、投机解码、工作负载、点位与评测保持不变。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3034


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.12.post1` to `lmsysorg/sglang:v0.5.19`.  
**Baseline:** 2026-07-08 · `lmsysorg/sglang:v0.5.12.post1`  
Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-08&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-08)

| Point | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| --- | ---: | ---: | ---: | ---: |
| 8k/1k c4 PTP4x1/DTP8x5 cfdd8f | N/A | N/A | N/A | N/A |
| 8k/1k c8 PTP4x1/DTP8x5 79fe9e | N/A | N/A | N/A | N/A |
| 8k/1k c16 PTP4x1/DTP8x5 c150a9 | N/A | N/A | N/A | N/A |
| 8k/1k c32 PTP4x1/DTP8x5 c8b50d | N/A | N/A | N/A | N/A |
| 8k/1k c32 PTP4x1/DTP8x3 93ffe9 | N/A | N/A | N/A | N/A |
| 8k/1k c64 PTP4x1/DTP8x3 e14bf8 | N/A | N/A | N/A | N/A |
| 8k/1k c32 PTP4x1/DTP8x1 cfc4f3 | N/A | N/A | N/A | N/A |
| 8k/1k c512 PTP4x1/DTP8x1 523c3b | N/A | N/A | N/A | N/A |
| 8k/1k c768 PTP4x2/DTP8x1 e29707 | N/A | N/A | N/A | N/A |
| 8k/1k c1024 PTP4x3/DTP8x1 3906a6 | N/A | N/A | N/A | N/A |
| 8k/1k c512 PTP4x4/DTP8x1 bcc0ce | N/A | N/A | N/A | N/A |
| 8k/1k c2048 PTP4x5/DTP8x1 47ce4d | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

**Eval:** N/A

12/13 points shown; remaining rows are in the baseline report.

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.12.post1` 更新为 `lmsysorg/sglang:v0.5.19`。  
**基线：**2026-07-08 · `lmsysorg/sglang:v0.5.12.post1`  
平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-08&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-08)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->