### PR TITLE
Add GB300 DeepSeek V4.1 Flash P/D without KV offload / 新增无 KV 卸载的 GB300 P/D

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml
@@ -81,8 +81,6 @@ backend:
       max-num-batched-tokens: 8192
       long-prefill-token-threshold: 1024
       tokenizer-mode: "deepseek_v41"
-      tool-call-parser: "deepseek_v41"
-      enable-auto-tool-choice: true
       reasoning-parser: "deepseek_v41"
       engram-config: '{"cpu_offload":true}'
       gpu-memory-utilization: 0.90
@@ -106,8 +104,6 @@ backend:
       max-num-seqs: 8
       max-num-batched-tokens: 64
       tokenizer-mode: "deepseek_v41"
-      tool-call-parser: "deepseek_v41"
-      enable-auto-tool-choice: true
       reasoning-parser: "deepseek_v41"
       engram-config: '{"cpu_offload":true}'
       compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml
@@ -1,0 +1,184 @@
+# Use PR #2938's proven GB300 1P/1D shape with the DeepSeek-V4.1-Flash
+# runtime from PR #3017. KV stays GPU-resident except for direct NIXL P/D
+# transfer; there is no MooncakeStore prefix-cache tier.
+name: "dsv41flash-vllm-disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic"
+
+# GB300 AgentX DSpark5 topology: one DEP4 prefill worker feeds one DEP16
+# decode worker at concurrency 64, 128, or 256 through NIXL.
+
+model:
+  path: "deepseek-v4.1-flash"
+  container: "vllm/vllm-openai:deepseekv41-flash-0909"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4.1-Flash"
+  container:
+    image: "vllm/vllm-openai:deepseekv41-flash-0909"
+  frameworks:
+    dynamo: "1.4.0"
+
+dynamo:
+  wheel: "1.4.0"
+  install: true
+
+setup_script: vllm-container-deps.sh
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "gb300"
+  gpus_per_node: 4
+  het_jobs: false
+  spread_workers: false
+  prefill_nodes: 1
+  decode_nodes: 4
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 4
+  gpus_per_decode: 16
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "random"
+    router-session-affinity-ttl-secs: 900
+  env:
+    DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS: "3600"
+    DYN_TCP_CHANNEL_BUFFER: "128"
+    DYN_TCP_REQUEST_TIMEOUT: "60"
+
+backend:
+  type: vllm
+  connector: null
+  dp_launch_mode: per_node
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}}'
+      served-model-name: "deepseek-ai/DeepSeek-V4.1-Flash"
+      safetensors-load-strategy: "prefetch"
+      language-model-only: true
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 4
+      data-parallel-rpc-port: 13345
+      enable-cumem-allocator: true
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      max-model-len: 1048576
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      long-prefill-token-threshold: 1024
+      tokenizer-mode: "deepseek_v41"
+      tool-call-parser: "deepseek_v41"
+      enable-auto-tool-choice: true
+      reasoning-parser: "deepseek_v41"
+      engram-config: '{"cpu_offload":true}'
+      gpu-memory-utilization: 0.90
+      no-disable-hybrid-kv-cache-manager: true
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      numa-bind: true
+      numa-bind-nodes: [0, 0, 1, 1]
+    decode:
+      kv-transfer-config: '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}}'
+      served-model-name: "deepseek-ai/DeepSeek-V4.1-Flash"
+      safetensors-load-strategy: "prefetch"
+      language-model-only: true
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 16
+      data-parallel-rpc-port: 13345
+      enable-cumem-allocator: true
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      max-model-len: 1048576
+      max-num-seqs: 8
+      max-num-batched-tokens: 64
+      tokenizer-mode: "deepseek_v41"
+      tool-call-parser: "deepseek_v41"
+      enable-auto-tool-choice: true
+      reasoning-parser: "deepseek_v41"
+      engram-config: '{"cpu_offload":true}'
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      max-cudagraph-capture-size: 64
+      gpu-memory-utilization: 0.90
+      no-disable-hybrid-kv-cache-manager: true
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      numa-bind: true
+      numa-bind-nodes: [0, 0, 1, 1]
+  prefill_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    VLLM_V2_WARMUP_MAX_NUM_SEQS: "20"
+    VLLM_SERVER_DEV_MODE: "1"
+    VLLM_USE_V2_MODEL_RUNNER: "1"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    UCX_MEMTYPE_CACHE: "n"
+    UCX_NET_DEVICES: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+    UCX_TLS: "rc,cuda_copy"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RANDOMIZE_DP_DUMMY_INPUTS: "1"
+    NCCL_IB_HCA: "mlx5_0,mlx5_1,mlx5_2,mlx5_3"
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "0"
+    DG_JIT_CACHE_DIR: "/tmp/dg-cache-dsv41flash-gb300-1p1d-dep4-prefill-c256-{job_id}"
+  decode_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    VLLM_V2_WARMUP_MAX_NUM_SEQS: "20"
+    VLLM_SERVER_DEV_MODE: "1"
+    VLLM_USE_V2_MODEL_RUNNER: "1"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    UCX_MEMTYPE_CACHE: "n"
+    UCX_NET_DEVICES: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+    UCX_TLS: "rc,cuda_copy"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RANDOMIZE_DP_DUMMY_INPUTS: "1"
+    NCCL_IB_HCA: "mlx5_0,mlx5_1,mlx5_2,mlx5_3"
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "0"
+    DG_JIT_CACHE_DIR: "/tmp/dg-cache-dsv41flash-gb300-1p1d-dep16-decode-c256-{job_id}"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    # Avoid concurrent readers observing a mismatched mmap data/index pair.
+    AIPERF_DATASET_MMAP_CACHE_ENABLED: "false"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -10410,6 +10410,38 @@ dsv41flash-fp4-gb300-vllm-agentic-dspark:
       # Engram weights use UVA DRAM; the KV cache stays GPU-resident.
       - { tp: 4, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 64, 128] }
 
+dsv41flash-fp4-gb300-dynamo-vllm-agentic-dspark-disagg:
+  image: vllm/vllm-openai:deepseekv41-flash-0909
+  model: deepseek-ai/DeepSeek-V4.1-Flash
+  model-prefix: dsv41flash
+  runner: cluster:gb300-nv
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.4.0" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [64, 128, 256]
+        prefill:
+          num-worker: 1
+          tp: 4
+          ep: 4
+          dp-attn: true
+          additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=3.51"
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4.1-flash/agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml"
+        decode:
+          num-worker: 1
+          tp: 16
+          ep: 16
+          dp-attn: true
+
 # H200 AgentX arm for DeepSeek-V4.1-Flash. Upstream marks h200 verified and says
 # the GB200 NVL4 TP4 layout becomes TP8 on 8-GPU nodes, so this is TP8.
 # `precision: fp4` labels the checkpoint's MXFP4 routed experts, as on the

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -187,6 +187,14 @@ port if the preferred one is occupied. Serving, replay, metrics, and eval share
 that endpoint.
 The GB300 launcher allows 7200 seconds for engine readiness. In [run 34504969146](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34504969146), the Rust frontend exhausted its 3600-second deadline while the engine was still capturing graphs; model loading alone took 18–23 minutes. This extends startup time without changing the benchmark duration or decoding settings.
 
+`dsv41flash-fp4-gb300-dynamo-vllm-agentic-dspark-disagg` reuses that GB300
+image, model, 1M context, Engram UVA, and five-token DSpark configuration in a
+five-node 1P/1D deployment: one DEP4 prefill worker and one DEP16 decode worker
+at concurrency 64, 128, and 256. NIXL transfers KV directly from prefill to decode. The KV
+cache remains GPU-resident (`kv-offloading: none`); the recipe has no
+MooncakeStore configuration, external prefix-cache lookup, or DRAM KV pool.
+Throughput uses synthetic AL 3.51, while eval restores real block verification.
+
 GPU sweep and eval evidence is required before calling any recipe validated.
 
 Source: [upstream recipe](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash).

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -185,6 +185,13 @@ CUDA graph capture 覆盖并发数乘以六 token DSpark 验证块。launcher �
 
 GB300 launcher 将引擎就绪等待时间设为 7200 秒。在[运行 34504969146](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34504969146) 中，仅模型加载就耗时 18–23 分钟；Rust frontend 达到 3600 秒期限时，引擎仍在捕获 CUDA graph。此次仅延长启动等待时间，基准测试时长和解码设置保持不变。
 
+`dsv41flash-fp4-gb300-dynamo-vllm-agentic-dspark-disagg` 在五节点 1P/1D
+部署中复用该 GB300 镜像、模型、1M 上下文、Engram UVA 和五 token DSpark 配置：
+并发 64、128 和 256 下使用一个 DEP4 prefill worker 和一个 DEP16 decode worker。NIXL 将 KV
+从 prefill 直接传给 decode。KV cache 保持在 GPU 上（`kv-offloading: none`）；
+配方不包含 MooncakeStore 配置、外部 prefix-cache 查询或 DRAM KV 池。吞吐测试使用
+合成 AL 3.51，eval 则恢复真实 block 验证。
+
 来源：[上游配方](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash)。
 
 ### H200 上的 DeepSeek-V4.1-Flash DSpark

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7363,6 +7363,13 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2962
 
 - config-keys:
+    - dsv41flash-fp4-gb300-dynamo-vllm-agentic-dspark-disagg
+  description:
+    - "Add DeepSeek-V4.1-Flash GB300 AgentX 1P/1D with NIXL P/D transfer, GPU-resident KV, Engram UVA, DSpark5 synthetic AL 3.51 and concurrency 64, 128, 256"
+    - "新增 DeepSeek-V4.1-Flash GB300 AgentX 1P/1D：使用 NIXL P/D 传输、GPU 驻留 KV、Engram UVA、DSpark5 合成 AL 3.51 和并发 64、128、256"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+
+- config-keys:
     - dsv41flash-fp4-mi355x-vllm-agentic-dspark
   description:
     - "Pin AgentX to semianalysis_cc_traces_weka_062126, preventing the 256k corpus override"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7367,7 +7367,7 @@
   description:
     - "Add DeepSeek-V4.1-Flash GB300 AgentX 1P/1D with NIXL P/D transfer, GPU-resident KV, Engram UVA, DSpark5 synthetic AL 3.51 and concurrency 64, 128, 256"
     - "新增 DeepSeek-V4.1-Flash GB300 AgentX 1P/1D：使用 NIXL P/D 传输、GPU 驻留 KV、Engram UVA、DSpark5 合成 AL 3.51 和并发 64、128、256"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3036
 
 - config-keys:
     - dsv41flash-fp4-mi355x-vllm-agentic-dspark

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -37,7 +37,7 @@ mkdir -p "$DYNAMO_WHEELS_CACHE_HOST_PATH"
 
 export MODEL_PATH=$MODEL
 
-if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" ]]; then
+if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" ]]; then
     # Both direct and Dynamo-vLLM paths resolve the V4.1 Flash checkpoint from
     # the persistent shared HF cache. The alias must match model.path in the
     # checked-in P/D recipe.

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -37,9 +37,12 @@ mkdir -p "$DYNAMO_WHEELS_CACHE_HOST_PATH"
 
 export MODEL_PATH=$MODEL
 
-if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" && "${IS_MULTINODE:-false}" != "true" ]]; then
-    # Download the new checkpoint into the persistent shared HF cache.
+if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" ]]; then
+    # Both direct and Dynamo-vLLM paths resolve the V4.1 Flash checkpoint from
+    # the persistent shared HF cache. The alias must match model.path in the
+    # checked-in P/D recipe.
     export MODEL_PATH="$MODEL"
+    export SRT_SLURM_MODEL_PREFIX="deepseek-v4.1-flash"
 elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
     export SERVED_MODEL_NAME="deepseek-r1-fp4"
     export MODEL_PATH=/scratch/models/DeepSeek-R1-0528-NVFP4-v2
@@ -339,6 +342,9 @@ elif [[ "$IS_AGENTIC" == "1" ]]; then
     mkdir -p recipes/vllm/deepseek-v4/agentic || exit 1
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4/agentic" \
         recipes/vllm/deepseek-v4/agentic || exit 1
+    mkdir -p recipes/vllm/deepseek-v4.1-flash/agentic || exit 1
+    cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic" \
+        recipes/vllm/deepseek-v4.1-flash/agentic || exit 1
     mkdir -p recipes/vllm/minimax-m3/agentic || exit 1
     cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/minimax-m3/agentic" \
         recipes/vllm/minimax-m3/agentic || exit 1

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -41,7 +41,10 @@ if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" ]]; then
     # Both direct and Dynamo-vLLM paths resolve the V4.1 Flash checkpoint from
     # the persistent shared HF cache. The alias must match model.path in the
     # checked-in P/D recipe.
-    export MODEL_PATH="$MODEL"
+    DSV41_CACHE="$HF_HUB_CACHE_HOST_PATH/models--deepseek-ai--DeepSeek-V4.1-Flash"
+    DSV41_REVISION=$(cat "$DSV41_CACHE/refs/main") || exit 1
+    export MODEL_PATH="$DSV41_CACHE/snapshots/$DSV41_REVISION"
+    test -r "$MODEL_PATH/config.json" || { echo "Missing cached DeepSeek V4.1 Flash snapshot: $MODEL_PATH" >&2; exit 1; }
     export SRT_SLURM_MODEL_PREFIX="deepseek-v4.1-flash"
 elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
     export SERVED_MODEL_NAME="deepseek-r1-fp4"

--- a/runners/launch_gb300-nv.sh
+++ b/runners/launch_gb300-nv.sh
@@ -237,6 +237,10 @@ fi
 
 export ISL="$ISL"
 export OSL="$OSL"
+DSV41_BLOBS_MOUNT=""
+if [[ "$MODEL_PREFIX" == "dsv41flash" ]]; then
+    DSV41_BLOBS_MOUNT="  \"${DSV41_CACHE}/blobs\": \"/blobs\""
+fi
 
 echo "Cloning srt-slurm repository..."
 RUN_KEY=$(printf "%s" "${RESULT_FILENAME:-${RUNNER_NAME:-gb300-nv}}" | sha1sum | cut -c1-12)
@@ -526,6 +530,7 @@ srtctl_root: "${SRTCTL_ROOT}"
 default_mounts:
   "${AIPERF_MMAP_CACHE_HOST_PATH}": "/aiperf_mmap_cache"
   "${HF_HUB_CACHE_HOST_PATH}": "/hf_hub_cache"
+${DSV41_BLOBS_MOUNT}
   # Warm dynamo source-build cache (nested over the auto /configs mount) so the
   # hash-pinned install is a cache hit (pip-only, no apt/root) on every job.
   "${DYNAMO_WHEELS_CACHE_HOST_PATH}": "/configs/dynamo-wheels"

--- a/runners/test_dsv41flash_gb300_pd.py
+++ b/runners/test_dsv41flash_gb300_pd.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RECIPE = REPO_ROOT / (
+    "benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/"
+    "agentic/disagg-gb300-1p1d-dep4-dep16-c64-c256-dspark5-agentic.yaml"
+)
+
+
+def test_dsv41flash_pd_uses_nixl_without_external_kv_store() -> None:
+    recipe = yaml.safe_load(RECIPE.read_text())
+    assert recipe["model"] == {
+        "path": "deepseek-v4.1-flash",
+        "container": "vllm/vllm-openai:deepseekv41-flash-0909",
+        "precision": "fp4",
+    }
+    resources = recipe["resources"]
+    assert resources["prefill_nodes"] == 1
+    assert resources["decode_nodes"] == 4
+    assert resources["gpus_per_prefill"] == 4
+    assert resources["gpus_per_decode"] == 16
+
+    backend = recipe["backend"]
+    assert "mooncake_kv_store" not in backend
+    for role, expected_role in (("prefill", "kv_both"), ("decode", "kv_consumer")):
+        config = backend["vllm_config"][role]
+        transfer = json.loads(config["kv-transfer-config"])
+        assert transfer["kv_connector"] == "NixlConnector"
+        assert transfer["kv_role"] == expected_role
+        assert "connectors" not in transfer.get("kv_connector_extra_config", {})
+        assert config["engram-config"] == '{"cpu_offload":true}'
+        speculative = json.loads(config["speculative-config"])
+        assert speculative["method"] == "dspark"
+        assert speculative["num_speculative_tokens"] == 5
+        assert speculative["rejection_sample_method"] == "block"
+
+    raw = RECIPE.read_text().lower()
+    assert "mooncakestoreconnector" not in raw
+    assert "global_segment_size" not in raw


### PR DESCRIPTION
Add DeepSeek V4.1 Flash AgentX on GB300 as 1P/1D DEP4/DEP16 at concurrency 64, 128, and 256. It uses the PR #3017 image/runtime, Engram UVA, DSpark5 synthetic AL 3.51, NIXL P/D transfer, and GPU-resident KV with no MooncakeStore tier.

新增 GB300 DeepSeek V4.1 Flash AgentX 1P/1D DEP4/DEP16 配方，并发为 64、128、256。使用 PR #3017 的镜像与运行时、Engram UVA、DSpark5 合成 AL 3.51、NIXL P/D 传输；KV 驻留 GPU，不启用 MooncakeStore。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are benchmark recipes, registry docs, and GB300 launcher model-path/mount plumbing; no production serving or auth paths.
> 
> **Overview**
> Adds a **disaggregated GB300 AgentX** benchmark for **DeepSeek-V4.1-Flash**: five-node **1P/1D** (DEP4 prefill, DEP16 decode) with **NIXL** KV transfer, **GPU-resident KV** (no MooncakeStore / external prefix cache), **Engram UVA**, and **DSpark5** at concurrency **64, 128, and 256**. Throughput uses **synthetic AL 3.51**; eval keeps real block verification.
> 
> Registers **`dsv41flash-fp4-gb300-dynamo-vllm-agentic-dspark-disagg`** in the master config, documents it (EN/ZH), and records it in **`perf-changelog.yaml`**. The new srt-slurm recipe lives under **`benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/`**.
> 
> **`launch_gb300-nv.sh`** now resolves **all fp4 `dsv41flash`** runs (including Dynamo multinode) from the shared HF cache snapshot with alias **`deepseek-v4.1-flash`**, bind-mounts HF **blobs**, and overlays **v4.1-flash agentic** recipes into the pinned srt-slurm checkout. **`test_dsv41flash_gb300_pd.py`** asserts NIXL roles and absence of Mooncake / external KV store wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350ac5a136368d11baecac75a7c55a94f483937f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->