### PR TITLE
Add B200 DeepSeek V4.1 Flash P/D without KV offload / 新增无 KV 卸载的 B200 P/D

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
@@ -81,8 +81,6 @@ backend:
       max-num-batched-tokens: 8192
       long-prefill-token-threshold: 1024
       tokenizer-mode: "deepseek_v41"
-      tool-call-parser: "deepseek_v41"
-      enable-auto-tool-choice: true
       reasoning-parser: "deepseek_v41"
       engram-config: '{"cpu_offload":true}'
       gpu-memory-utilization: 0.90
@@ -106,8 +104,6 @@ backend:
       max-num-seqs: 8
       max-num-batched-tokens: 64
       tokenizer-mode: "deepseek_v41"
-      tool-call-parser: "deepseek_v41"
-      enable-auto-tool-choice: true
       reasoning-parser: "deepseek_v41"
       engram-config: '{"cpu_offload":true}'
       compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
@@ -1,0 +1,184 @@
+# Use PR #2938's proven B200 1P/1D shape with the DeepSeek-V4.1-Flash
+# runtime from PR #3017. KV stays GPU-resident except for direct NIXL P/D
+# transfer; there is no MooncakeStore prefix-cache tier.
+name: "dsv41flash-vllm-disagg-b200-1p1d-dep4-dep16-c64-c256-dspark5-agentic"
+
+# B200 AgentX DSpark5 topology: one DEP8 prefill worker feeds one DEP16
+# decode worker at concurrency 64, 128, or 256 through NIXL.
+
+model:
+  path: "deepseek-v4.1-flash"
+  container: "vllm/vllm-openai:deepseekv41-flash-0909"
+  precision: "fp4"
+
+identity:
+  model:
+    repo: "deepseek-ai/DeepSeek-V4.1-Flash"
+  container:
+    image: "vllm/vllm-openai:deepseekv41-flash-0909"
+  frameworks:
+    dynamo: "1.4.0"
+
+dynamo:
+  wheel: "1.4.0"
+  install: true
+
+setup_script: vllm-container-deps.sh
+
+slurm:
+  time_limit: "8:00:00"
+
+health_check:
+  max_attempts: 2160
+  interval_seconds: 10
+
+resources:
+  gpu_type: "b200"
+  gpus_per_node: 8
+  het_jobs: false
+  spread_workers: false
+  prefill_nodes: 1
+  decode_nodes: 2
+  prefill_workers: 1
+  decode_workers: 1
+  gpus_per_prefill: 8
+  gpus_per_decode: 16
+
+infra:
+  etcd_nats_dedicated_node: false
+  nats_max_payload_mb: 32
+
+frontend:
+  type: dynamo
+  enable_multiple_frontends: false
+  args:
+    router-mode: "random"
+    router-session-affinity-ttl-secs: 900
+  env:
+    DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS: "3600"
+    DYN_TCP_CHANNEL_BUFFER: "128"
+    DYN_TCP_REQUEST_TIMEOUT: "60"
+
+backend:
+  type: vllm
+  connector: null
+  dp_launch_mode: per_node
+  vllm_config:
+    prefill:
+      kv-transfer-config: '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}}'
+      served-model-name: "deepseek-ai/DeepSeek-V4.1-Flash"
+      safetensors-load-strategy: "prefetch"
+      language-model-only: true
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 8
+      data-parallel-rpc-port: 13345
+      enable-cumem-allocator: true
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      max-model-len: 1048576
+      max-num-seqs: 256
+      max-num-batched-tokens: 8192
+      long-prefill-token-threshold: 1024
+      tokenizer-mode: "deepseek_v41"
+      tool-call-parser: "deepseek_v41"
+      enable-auto-tool-choice: true
+      reasoning-parser: "deepseek_v41"
+      engram-config: '{"cpu_offload":true}'
+      gpu-memory-utilization: 0.90
+      no-disable-hybrid-kv-cache-manager: true
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      numa-bind: true
+      numa-bind-nodes: [0, 0, 0, 0, 1, 1, 1, 1]
+    decode:
+      kv-transfer-config: '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail","kv_buffer_device":"cuda","kv_connector_extra_config":{"enforce_handshake_compat":false,"enable_cross_layers_blocks":false}}'
+      served-model-name: "deepseek-ai/DeepSeek-V4.1-Flash"
+      safetensors-load-strategy: "prefetch"
+      language-model-only: true
+      tensor-parallel-size: 1
+      pipeline-parallel-size: 1
+      data-parallel-size: 16
+      data-parallel-rpc-port: 13345
+      enable-cumem-allocator: true
+      enable-expert-parallel: true
+      enable-ep-weight-filter: true
+      max-model-len: 1048576
+      max-num-seqs: 8
+      max-num-batched-tokens: 64
+      tokenizer-mode: "deepseek_v41"
+      tool-call-parser: "deepseek_v41"
+      enable-auto-tool-choice: true
+      reasoning-parser: "deepseek_v41"
+      engram-config: '{"cpu_offload":true}'
+      compilation-config: '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}'
+      max-cudagraph-capture-size: 64
+      gpu-memory-utilization: 0.90
+      no-disable-hybrid-kv-cache-manager: true
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      numa-bind: true
+      numa-bind-nodes: [0, 0, 0, 0, 1, 1, 1, 1]
+  prefill_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    VLLM_V2_WARMUP_MAX_NUM_SEQS: "20"
+    VLLM_SERVER_DEV_MODE: "1"
+    VLLM_USE_V2_MODEL_RUNNER: "1"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    UCX_MEMTYPE_CACHE: "n"
+    UCX_NET_DEVICES: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+    UCX_TLS: "rc,cuda_copy"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RANDOMIZE_DP_DUMMY_INPUTS: "1"
+    NCCL_IB_HCA: "mlx5_0,mlx5_1,mlx5_2,mlx5_3"
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "0"
+    DG_JIT_CACHE_DIR: "/tmp/dg-cache-dsv41flash-b200-1p1d-dep8-prefill-c256-{job_id}"
+  decode_environment:
+    HF_HUB_CACHE: "/hf_hub_cache"
+    HUGGINGFACE_HUB_CACHE: "/hf_hub_cache"
+    TRANSFORMERS_CACHE: "/hf_hub_cache"
+    VLLM_ENGINE_READY_TIMEOUT_S: "3600"
+    VLLM_RPC_TIMEOUT: "600000"
+    VLLM_LOG_STATS_INTERVAL: "1"
+    VLLM_V2_WARMUP_MAX_NUM_SEQS: "20"
+    VLLM_SERVER_DEV_MODE: "1"
+    VLLM_USE_V2_MODEL_RUNNER: "1"
+    VLLM_ALLREDUCE_USE_SYMM_MEM: "0"
+    UCX_MEMTYPE_CACHE: "n"
+    UCX_NET_DEVICES: "mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1"
+    UCX_TLS: "rc,cuda_copy"
+    NCCL_CUMEM_ENABLE: "1"
+    NCCL_MNNVL_ENABLE: "1"
+    NCCL_NVLS_ENABLE: "1"
+    VLLM_RANDOMIZE_DP_DUMMY_INPUTS: "1"
+    NCCL_IB_HCA: "mlx5_0,mlx5_1,mlx5_2,mlx5_3"
+    VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "0"
+    DG_JIT_CACHE_DIR: "/tmp/dg-cache-dsv41flash-b200-1p1d-dep16-decode-c256-{job_id}"
+
+sbatch_directives:
+  cpus-per-task: "144"
+  mem: "0"
+
+srun_options:
+  container-remap-root: ""
+
+benchmark:
+  type: custom
+  command: bash /infmax-workspace/benchmarks/multi_node/agentic_srt.sh
+  env:
+    INFMAX_CONTAINER_WORKSPACE: "/infmax-workspace"
+    RESULT_DIR: "/logs/agentic"
+    PORT: "8000"
+    IS_MULTINODE: "true"
+    AIPERF_USE_DYNAMO_CONV_AWARE_ROUTING: "0"
+    AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID: "true"
+    # Avoid concurrent readers observing a mismatched mmap data/index pair.
+    AIPERF_DATASET_MMAP_CACHE_ENABLED: "false"
+    AIPERF_DATASET_MMAP_CACHE_DIR: "/aiperf_mmap_cache"
+    HF_HUB_CACHE: "/hf_hub_cache"
+    WEKA_LOADER_OVERRIDE: "semianalysis_cc_traces_weka_062126"

--- a/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml
@@ -87,7 +87,7 @@ backend:
       engram-config: '{"cpu_offload":true}'
       gpu-memory-utilization: 0.90
       no-disable-hybrid-kv-cache-manager: true
-      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"synthetic","synthetic_acceptance_length":3.51,"enable_adaptive_verification":false}'
       numa-bind: true
       numa-bind-nodes: [0, 0, 0, 0, 1, 1, 1, 1]
     decode:
@@ -114,7 +114,7 @@ backend:
       max-cudagraph-capture-size: 64
       gpu-memory-utilization: 0.90
       no-disable-hybrid-kv-cache-manager: true
-      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"block","enable_adaptive_verification":true}'
+      speculative-config: '{"method":"dspark","num_speculative_tokens":5,"draft_sample_method":"probabilistic","rejection_sample_method":"synthetic","synthetic_acceptance_length":3.51,"enable_adaptive_verification":false}'
       numa-bind: true
       numa-bind-nodes: [0, 0, 0, 0, 1, 1, 1, 1]
   prefill_environment:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -10395,6 +10395,34 @@ dsv41flash-fp4-b200-vllm-agentic-dspark:
       # Engram weights use UVA DRAM; the KV cache stays GPU-resident.
       - { tp: 4, kv-offloading: none, spec-decoding: mtp, conc-list: [1, 2, 4, 8, 16, 32, 64, 128] }
 
+dsv41flash-fp4-b200-dynamo-vllm-agentic-dspark-disagg:
+  image: vllm/vllm-openai:deepseekv41-flash-0909
+  model: deepseek-ai/DeepSeek-V4.1-Flash
+  model-prefix: dsv41flash
+  runner: cluster:b200-nscale
+  precision: fp4
+  framework: dynamo-vllm
+  router: { name: dynamo-router, version: "1.4.0" }
+  kv-p2p-transfer: nixl
+  multinode: true
+  disagg: true
+  scenarios:
+    agentic-coding:
+    - search-space:
+      - spec-decoding: mtp
+        kv-offloading: none
+        conc-list: [64, 128, 256]
+        prefill:
+          num-worker: 1
+          tp: 8
+          ep: 8
+          dp-attn: true
+          additional-settings:
+          - "SYNTHETIC_ACCEPTANCE=true"
+          - "SYNTHETIC_ACCEPTANCE_LENGTH=3.51"
+          - "CONFIG_FILE=recipes/vllm/deepseek-v4.1-flash/agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml"
+        decode: { num-worker: 1, tp: 16, ep: 16, dp-attn: true }
+
 dsv41flash-fp4-gb300-vllm-agentic-dspark:
   image: vllm/vllm-openai:deepseekv41-flash-0909
   model: deepseek-ai/DeepSeek-V4.1-Flash

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -191,6 +191,11 @@ GPU sweep and eval evidence is required before calling any recipe validated.
 
 Source: [upstream recipe](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash).
 
+The B200 P/D key `dsv41flash-fp4-b200-dynamo-vllm-agentic-dspark-disagg`
+uses one DEP8 prefill worker and one DEP16 decode worker on three nodes at
+concurrency 64, 128, and 256. NIXL performs direct P/D KV transfer; KV remains
+GPU-resident and no MooncakeStore tier is configured.
+
 ### DeepSeek-V4.1-Flash DSpark on H200
 
 `dsv41flash-fp4-h200-vllm-agentic-dspark` is the H200 AgentX arm of the

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -187,6 +187,10 @@ GB300 launcher 将引擎就绪等待时间设为 7200 秒。在[运行 345049691
 
 来源：[上游配方](https://recipes.vllm.ai/deepseek-ai/DeepSeek-V4.1-Flash)。
 
+B200 P/D 配置 `dsv41flash-fp4-b200-dynamo-vllm-agentic-dspark-disagg`
+在三个节点上使用一个 DEP8 prefill worker 和一个 DEP16 decode worker，并发为
+64、128、256。NIXL 执行直接 P/D KV 传输；KV 保持在 GPU 上，不配置 MooncakeStore。
+
 ### H200 上的 DeepSeek-V4.1-Flash DSpark
 
 `dsv41flash-fp4-h200-vllm-agentic-dspark` 是 DeepSeek-V4.1-Flash 配方的 H200 AgentX

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7363,6 +7363,13 @@
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2962
 
 - config-keys:
+    - dsv41flash-fp4-b200-dynamo-vllm-agentic-dspark-disagg
+  description:
+    - "Add B200 DeepSeek-V4.1-Flash AgentX 1P/1D with NIXL transfer, GPU-resident KV and concurrency 64, 128, 256"
+    - "新增 B200 DeepSeek-V4.1-Flash AgentX 1P/1D：使用 NIXL 传输、GPU 驻留 KV 和并发 64、128、256"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+
+- config-keys:
     - dsv41flash-fp4-mi355x-vllm-agentic-dspark
   description:
     - "Pin AgentX to semianalysis_cc_traces_weka_062126, preventing the 256k corpus override"

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7367,7 +7367,7 @@
   description:
     - "Add B200 DeepSeek-V4.1-Flash AgentX 1P/1D with NIXL transfer, GPU-resident KV and concurrency 64, 128, 256"
     - "新增 B200 DeepSeek-V4.1-Flash AgentX 1P/1D：使用 NIXL 传输、GPU 驻留 KV 和并发 64、128、256"
-  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/0
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3039
 
 - config-keys:
     - dsv41flash-fp4-mi355x-vllm-agentic-dspark

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -332,6 +332,10 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
         DEFAULT_MOUNTS_BLOCK="default_mounts:
   ${AIPERF_MMAP_CACHE_HOST_PATH}: /aiperf_mmap_cache
   ${HF_HUB_CACHE_HOST_PATH}: /hf_hub_cache"
+        if [[ "$MODEL_PREFIX" == "dsv41flash" ]]; then
+            DEFAULT_MOUNTS_BLOCK+="
+  ${DSV41_CACHE}/blobs: /blobs"
+        fi
     fi
 
     # Create srtslurm.yaml for srtctl (used by both frameworks)

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -17,8 +17,9 @@ set -x
 # portability, but we resolve to pre-staged paths here to avoid repeated
 # downloading on every Nscale node. Runs for both single-node and multinode
 # launches.
-if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" && "$IS_MULTINODE" != "true" ]]; then
+if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" ]]; then
     export MODEL_PATH="$MODEL"
+    export SRT_SLURM_MODEL_PREFIX="deepseek-v4.1-flash"
     export HF_HUB_CACHE_HOST_PATH="/data/home/sa-shared/gharunners/hf-hub-cache"
     mkdir -p "$HF_HUB_CACHE_HOST_PATH"
 elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
@@ -187,6 +188,12 @@ if [[ "$IS_MULTINODE" == "true" ]]; then
         git checkout aflowers/vllm-gb200-v0.20.0
         mkdir -p recipes/vllm/deepseek-v4
         cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4" recipes/vllm/deepseek-v4
+    elif [[ "$IS_AGENTIC" == "1" && $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "dsv41flash" ]]; then
+        git clone --branch v1.0.36 --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR" || exit 1
+        cd "$SRT_REPO_DIR" || exit 1
+        mkdir -p recipes/vllm/deepseek-v4.1-flash/agentic
+        cp -rT "$GITHUB_WORKSPACE/benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/agentic" \
+            recipes/vllm/deepseek-v4.1-flash/agentic
     elif [[ $FRAMEWORK == "dynamo-vllm" && $MODEL_PREFIX == "kimik2.6" && $PRECISION == "fp4" ]]; then
         git clone --branch main --single-branch https://github.com/NVIDIA/srt-slurm.git "$SRT_REPO_DIR"
         cd "$SRT_REPO_DIR" || exit 1

--- a/runners/launch_b200-nscale-compat.sh
+++ b/runners/launch_b200-nscale-compat.sh
@@ -17,11 +17,14 @@ set -x
 # portability, but we resolve to pre-staged paths here to avoid repeated
 # downloading on every Nscale node. Runs for both single-node and multinode
 # launches.
-if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" && "$FRAMEWORK" == "vllm" ]]; then
-    export MODEL_PATH="$MODEL"
+if [[ "$MODEL_PREFIX" == "dsv41flash" && "$PRECISION" == "fp4" ]]; then
     export SRT_SLURM_MODEL_PREFIX="deepseek-v4.1-flash"
     export HF_HUB_CACHE_HOST_PATH="/data/home/sa-shared/gharunners/hf-hub-cache"
     mkdir -p "$HF_HUB_CACHE_HOST_PATH"
+    DSV41_CACHE="$HF_HUB_CACHE_HOST_PATH/models--deepseek-ai--DeepSeek-V4.1-Flash"
+    DSV41_REVISION=$(cat "$DSV41_CACHE/refs/main") || exit 1
+    export MODEL_PATH="$DSV41_CACHE/snapshots/$DSV41_REVISION"
+    test -r "$MODEL_PATH/config.json" || { echo "Missing cached DeepSeek V4.1 Flash snapshot: $MODEL_PATH" >&2; exit 1; }
 elif [[ $MODEL_PREFIX == "dsr1" && $PRECISION == "fp4" ]]; then
     export MODEL_PATH="/scratch/models/DeepSeek-R1-0528-NVFP4-v2"
     export SRT_SLURM_MODEL_PREFIX="dsr1"

--- a/runners/test_dsv41flash_b200_pd.py
+++ b/runners/test_dsv41flash_b200_pd.py
@@ -36,7 +36,9 @@ def test_dsv41flash_pd_uses_nixl_without_external_kv_store() -> None:
         speculative = json.loads(config["speculative-config"])
         assert speculative["method"] == "dspark"
         assert speculative["num_speculative_tokens"] == 5
-        assert speculative["rejection_sample_method"] == "block"
+        assert speculative["rejection_sample_method"] == "synthetic"
+        assert speculative["synthetic_acceptance_length"] == 3.51
+        assert speculative["enable_adaptive_verification"] is False
 
     raw = RECIPE.read_text().lower()
     assert "mooncakestoreconnector" not in raw

--- a/runners/test_dsv41flash_b200_pd.py
+++ b/runners/test_dsv41flash_b200_pd.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RECIPE = REPO_ROOT / (
+    "benchmarks/multi_node/srt-slurm-recipes/vllm/deepseek-v4.1-flash/"
+    "agentic/disagg-b200-1p1d-dep8-dep16-c64-c256-dspark5-agentic.yaml"
+)
+
+
+def test_dsv41flash_pd_uses_nixl_without_external_kv_store() -> None:
+    recipe = yaml.safe_load(RECIPE.read_text())
+    assert recipe["model"] == {
+        "path": "deepseek-v4.1-flash",
+        "container": "vllm/vllm-openai:deepseekv41-flash-0909",
+        "precision": "fp4",
+    }
+    resources = recipe["resources"]
+    assert resources["prefill_nodes"] == 1
+    assert resources["decode_nodes"] == 2
+    assert resources["gpus_per_prefill"] == 8
+    assert resources["gpus_per_decode"] == 16
+
+    backend = recipe["backend"]
+    assert "mooncake_kv_store" not in backend
+    for role, expected_role in (("prefill", "kv_both"), ("decode", "kv_consumer")):
+        config = backend["vllm_config"][role]
+        transfer = json.loads(config["kv-transfer-config"])
+        assert transfer["kv_connector"] == "NixlConnector"
+        assert transfer["kv_role"] == expected_role
+        assert "connectors" not in transfer.get("kv_connector_extra_config", {})
+        assert config["engram-config"] == '{"cpu_offload":true}'
+        speculative = json.loads(config["speculative-config"])
+        assert speculative["method"] == "dspark"
+        assert speculative["num_speculative_tokens"] == 5
+        assert speculative["rejection_sample_method"] == "block"
+
+    raw = RECIPE.read_text().lower()
+    assert "mooncakestoreconnector" not in raw
+    assert "global_segment_size" not in raw


### PR DESCRIPTION
Add DeepSeek V4.1 Flash AgentX on B200 as 1P/1D DEP8/DEP16 at concurrency 64, 128, and 256. Uses Engram UVA, DSpark5 synthetic AL 3.51, NIXL P/D transfer, and GPU-resident KV without MooncakeStore.

新增 B200 DeepSeek V4.1 Flash AgentX 1P/1D DEP8/DEP16 配方，并发为 64、128、256。使用 Engram UVA、DSpark5 合成 AL 3.51、NIXL P/D 传输；KV 驻留 GPU，不启用 MooncakeStore。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches B200 Nscale multinode launcher model-path and mount behavior for all dsv41flash fp4 jobs, plus a new disaggregated serving recipe; scope is benchmark infra rather than production serving.
> 
> **Overview**
> Adds **B200 multinode AgentX** for DeepSeek-V4.1-Flash as **1 prefill (DEP8) / 1 decode (DEP16)** with **NIXL** prefill–decode KV transfer, **GPU-resident KV** (no MooncakeStore), and **DSpark5** throughput settings (synthetic acceptance length **3.51**).
> 
> Registers master key `dsv41flash-fp4-b200-dynamo-vllm-agentic-dspark-disagg` on `cluster:b200-nscale` for agentic-coding at concurrency **64, 128, 256**, pointing at the new srt-slurm recipe. Documents the topology in EN/ZH configuration procedures and records the key in `perf-changelog.yaml`.
> 
> Updates **`launch_b200-nscale-compat.sh`** so all **dsv41flash fp4** runs resolve a staged HF snapshot (not only single-node vllm), clone **srt-slurm v1.0.36** and copy the deepseek-v4.1-flash agentic recipes for **agentic + dynamo-vllm**, and bind **HF hub blobs** for agentic dsv41flash. Adds **`test_dsv41flash_b200_pd.py`** to lock NIXL roles and absence of MooncakeStore in the recipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a18af8923454381d1d497df2b726b25a9470bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->