### PR TITLE
[AgentX B300] recover Kimi-K3 image and draft storage / 恢复镜像与草稿存储

### DIFF
--- a/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
+++ b/benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh
@@ -60,9 +60,11 @@ if [[ -n "${MODEL_PATH:-}" ]]; then
         hf download "$MODEL" --local-dir "$MODEL_PATH"
     fi
     DRAFT_MODEL_PATH="${WRITABLE_MODELS_DIR:-/data/models}/${DRAFT_MODEL##*/}"
-    if [[ ! -d "$DRAFT_MODEL_PATH" || -z "$(ls -A "$DRAFT_MODEL_PATH" 2>/dev/null)" ]]; then
+    # Other sweep cells share this directory; nonempty may mean a download
+    # is still in progress. Let HF validate/resume cached files under one lock.
+    mkdir -p "$(dirname "$DRAFT_MODEL_PATH")"
+    flock -w "${MODEL_DOWNLOAD_LOCK_TIMEOUT:-21600}" "${DRAFT_MODEL_PATH}.download.lock" \
         hf download "$DRAFT_MODEL" --local-dir "$DRAFT_MODEL_PATH"
-    fi
 else
     hf download "$MODEL"
     export MODEL_PATH="$MODEL"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1485,9 +1485,9 @@ kimik3-fp4-b300-vllm-agentic-dspark:
   # kimik3_dspark_probabilistic_sample_method_block_rejection_sample_method.yaml),
   # and EVAL_ONLY switches to real block verification.
   #
-  # The image carries the Kimi-K3 DCP, DSpark-under-DCP and Mooncake-hybrid
-  # changes (vllm-project/vllm agentx-k3 @ 5894fdf).
-  image: vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-5894fdf
+  # Kimi-K3 runtime from vllm-project/vllm @ 3696c772aae308f2420a8f307b0971e6986c4818.
+  # This replaces the unavailable 5894fdf build; new results use a new runtime baseline.
+  image: vllm/vllm-openai:nightly-dev-x86_64-cu13-3696c77
   model: moonshotai/Kimi-K3
   model-prefix: kimik3
   runner: cluster:b300-dsxe
@@ -9995,8 +9995,8 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-mooncake-dcp8-agg:
 # section 5): the single worker serves both phases, so no P/D KV transfer.
 # Serving is DIRECT vllm serve (srt-slurm frontend.type: vllm), not the dynamo
 # worker entrypoint -- framework stays dynamo-vllm for launcher routing only.
-# DCP8 over a2a with the direct symmetric-memory kernels, Mooncake DRAM KV
-# offload, and DSpark speculation sized per concurrency: 7 draft tokens (golden
+# DCP8 over a2a with the direct symmetric-memory kernels and DSpark
+# speculation sized per concurrency: 7 draft tokens (golden
 # AL 3.84) through conc 14, where the decode batch is small enough that deeper
 # speculation pays; 4 draft tokens (AL 3.36) at conc 24/48; and no speculation
 # at conc 96, where the batch already saturates the two nodes.

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9995,8 +9995,8 @@ kimik3-fp4-gb300-dynamo-vllm-agentic-mooncake-dcp8-agg:
 # section 5): the single worker serves both phases, so no P/D KV transfer.
 # Serving is DIRECT vllm serve (srt-slurm frontend.type: vllm), not the dynamo
 # worker entrypoint -- framework stays dynamo-vllm for launcher routing only.
-# DCP8 over a2a with the direct symmetric-memory kernels and DSpark
-# speculation sized per concurrency: 7 draft tokens (golden
+# DCP8 over a2a with the direct symmetric-memory kernels, Mooncake DRAM KV
+# offload, and DSpark speculation sized per concurrency: 7 draft tokens (golden
 # AL 3.84) through conc 14, where the decode batch is small enough that deeper
 # speculation pays; 4 draft tokens (AL 3.36) at conc 24/48; and no speculation
 # at conc 96, where the batch already saturates the two nodes.

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -112,6 +112,11 @@ The runner-name prefix is load-bearing: workflow routing uses `launch_${RUNNER_N
 6. Verify every runner is **Idle** in [repository runner settings](https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners) before adding it to sweep traffic.
 7. Verify launcher mounts for `_work`, HF cache, staged weights, and squash images from a compute node. Root containers must not leave root-owned files in the shared workspace.
 
+The B300 DSXE Kimi-K3 AgentX path mounts its pre-staged target under
+`/scratch/models` and separately exports and mounts `WRITABLE_MODELS_DIR` for
+DSpark weights. Keep the draft directory on that persistent mount when reusing
+the serving container; the read-only target mount cannot hold the draft.
+
 ## Register an srt-slurm recipe
 
 Mapping source: [`benchmarks/multi_node/srt-slurm-recipes/RECIPES.md`](../benchmarks/multi_node/srt-slurm-recipes/RECIPES.md). Checked-in recipes: [`benchmarks/multi_node/srt-slurm-recipes/`](../benchmarks/multi_node/srt-slurm-recipes/).

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -116,6 +116,9 @@ The B300 DSXE Kimi-K3 AgentX path mounts its pre-staged target under
 `/scratch/models` and separately exports and mounts `WRITABLE_MODELS_DIR` for
 DSpark weights. Keep the draft directory on that persistent mount when reusing
 the serving container; the read-only target mount cannot hold the draft.
+Concurrent cells serialize draft staging with a per-model lock. Each cell lets
+`hf download` validate or resume the existing cache before serving; a nonempty
+directory is not a completion signal.
 
 ## Register an srt-slurm recipe
 

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -115,6 +115,8 @@ runner 名称前缀是关键契约：workflow 通过 `launch_${RUNNER_NAME%%_*}.
 B300 DSXE 的 Kimi-K3 AgentX 路径在 `/scratch/models` 下挂载预置目标模型，
 另行导出并挂载 `WRITABLE_MODELS_DIR` 以保存 DSpark 权重。复用服务容器时，
 草稿模型目录应保留在该持久化挂载中；只读目标模型挂载无法保存草稿模型。
+并发任务通过模型专用锁串行准备草稿权重。每个任务在启动服务前由 `hf download`
+校验或续传现有缓存；目录非空不代表下载完成。
 
 ## 注册 srt-slurm 配方
 

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -112,6 +112,10 @@ runner 名称前缀是关键契约：workflow 通过 `launch_${RUNNER_NAME%%_*}.
 6. 将 runner 加入 sweep 流量前，在[仓库 runner 设置页](https://github.com/SemiAnalysisAI/InferenceX/settings/actions/runners)确认每个 runner 都是 **Idle**。
 7. 从计算节点验证 launcher 对 `_work`、HF cache、预置权重和 squash 镜像的挂载。root 容器不得在共享 workspace 留下 root 所有的文件。
 
+B300 DSXE 的 Kimi-K3 AgentX 路径在 `/scratch/models` 下挂载预置目标模型，
+另行导出并挂载 `WRITABLE_MODELS_DIR` 以保存 DSpark 权重。复用服务容器时，
+草稿模型目录应保留在该持久化挂载中；只读目标模型挂载无法保存草稿模型。
+
 ## 注册 srt-slurm 配方
 
 映射来源：[`benchmarks/multi_node/srt-slurm-recipes/RECIPES.md`](../benchmarks/multi_node/srt-slurm-recipes/RECIPES.md)。检入的配方：[`benchmarks/multi_node/srt-slurm-recipes/`](../benchmarks/multi_node/srt-slurm-recipes/)。

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7405,8 +7405,8 @@
   scenario-type:
     - agentic-coding
   description:
-    - "Replace unavailable vLLM build 5894fdf with 3696c77 and route the existing Kimi-K3 recipe to B300 DSXE. This establishes a new runtime baseline."
-    - "恢复 Kimi-K3 B300 镜像与集群路由。"
+    - "Replace unavailable vLLM build 5894fdf with 3696c77 for the existing Kimi-K3 B300 DSXE route. This establishes a new runtime baseline."
+    - "将现有 Kimi-K3 B300 DSXE 路径不可用的 vLLM 镜像 5894fdf 更换为 3696c77，建立新的运行时基线。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040
 
 - config-keys:

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7408,3 +7408,12 @@
     - "Replace unavailable vLLM build 5894fdf with 3696c77 and route the existing Kimi-K3 recipe to B300 DSXE. This establishes a new runtime baseline."
     - "恢复 Kimi-K3 B300 镜像与集群路由。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040
+
+- config-keys:
+    - kimik3-fp4-b300-vllm-agentic-dspark
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Mount and export the persistent writable model root for Kimi-K3 DSpark weights alongside the pre-staged target on B300 DSXE."
+    - "在 B300 DSXE 上为 Kimi-K3 DSpark 权重挂载并导出持久化可写模型目录，与预加载目标模型一同使用。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7399,3 +7399,12 @@
     - "Disable adaptive verification in the EVAL_ONLY DSpark config as well. It trims verification requests on device, which the ROCm DeepseekV4IndexerBackend does not support, so the eval-only engine refused to start (run 34651830283, c32). Evals keep real block rejection; throughput settings are unchanged."
     - "EVAL_ONLY 的 DSpark 配置同样关闭自适应验证：它会在设备端裁剪验证请求，而 ROCm 的 DeepseekV4IndexerBackend 不支持该操作，导致仅评测引擎拒绝启动（运行 34651830283，c32）。评测仍保留真实块拒绝采样；吞吐设置不变。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2962
+
+- config-keys:
+    - kimik3-fp4-b300-vllm-agentic-dspark
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Replace unavailable vLLM build 5894fdf with 3696c77 and route the existing Kimi-K3 recipe to B300 DSXE. This establishes a new runtime baseline."
+    - "恢复 Kimi-K3 B300 镜像与集群路由。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7417,3 +7417,12 @@
     - "Mount and export the persistent writable model root for Kimi-K3 DSpark weights alongside the pre-staged target on B300 DSXE."
     - "在 B300 DSXE 上为 Kimi-K3 DSpark 权重挂载并导出持久化可写模型目录，与预加载目标模型一同使用。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040
+
+- config-keys:
+    - kimik3-fp4-b300-vllm-agentic-dspark
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Serialize shared Kimi-K3 DSpark downloads and validate or resume the cached draft before each cell starts serving."
+    - "串行执行共享 Kimi-K3 DSpark 下载，在每个任务启动服务前校验或续传草稿缓存。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3040

--- a/runners/launch_b300-dsxe.sh
+++ b/runners/launch_b300-dsxe.sh
@@ -482,6 +482,15 @@ else
         "$GITHUB_WORKSPACE:$CONTAINER_MOUNT_DIR"
         "$MODEL_MOUNT_DIR:$MODEL_MOUNT_DIR"
     )
+    if [[ "$MODEL_PREFIX" == "kimik3" && "$FRAMEWORK" == "vllm" && "${IS_AGENTIC:-0}" == "1" ]]; then
+        # The pre-staged target is read-only; DSpark needs the writable,
+        # persistent model root as a separate mount.
+        mkdir -p "$WRITABLE_MODELS_DIR"
+        export WRITABLE_MODELS_DIR
+        if [[ "$MODEL_MOUNT_DIR" != "$WRITABLE_MODELS_DIR" ]]; then
+            CONTAINER_MOUNTS+=("$WRITABLE_MODELS_DIR:$WRITABLE_MODELS_DIR")
+        fi
+    fi
     CONTAINER_MOUNTS_ARG=$(IFS=,; printf '%s' "${CONTAINER_MOUNTS[*]}")
 
     srun --jobid="$JOB_ID" \

--- a/runners/test_kimik3_b300.py
+++ b/runners/test_kimik3_b300.py
@@ -1,5 +1,8 @@
 import json
+import os
+import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -43,3 +46,86 @@ def test_b300_staged_target_keeps_kimi_draft_in_persistent_mount(
     else:
         assert serve["draft_root"] is None
         assert "/data/home/sa-gha-runner/models" not in mounts
+
+
+@pytest.mark.parametrize("first_exit", [0, 23])
+def test_kimi_shared_draft_waits_for_download_completion(tmp_path: Path, first_exit: int) -> None:
+    cache = tmp_path / "models"
+    cache.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "config.json").write_text("{}")
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    hf = binaries / "hf"
+    hf.write_text('''#!/usr/bin/env python3
+import os, pathlib, sys, time
+root = pathlib.Path(os.environ["TEST_ROOT"])
+draft = pathlib.Path(sys.argv[-1])
+draft.mkdir(exist_ok=True)
+(draft / "config.json").write_text("{}")
+(root / (os.environ["CELL"] + ".started")).touch()
+while not (root / "release").exists():
+    time.sleep(0.01)
+if os.environ["CELL"] == "first" and os.environ["FIRST_EXIT"] != "0":
+    raise SystemExit(int(os.environ["FIRST_EXIT"]))
+(draft / "weights.safetensors").write_text("complete")
+''')
+    hf.chmod(0o755)
+    smi = binaries / "nvidia-smi"
+    smi.write_text('''#!/usr/bin/env python3
+import os, pathlib
+complete = pathlib.Path(os.environ["WRITABLE_MODELS_DIR"], "Kimi-K3-DSpark", "weights.safetensors").is_file()
+pathlib.Path(os.environ["TEST_ROOT"], os.environ["CELL"] + ".serving").touch()
+raise SystemExit(77 if complete else 66)
+''')
+    smi.chmod(0o755)
+    lock = binaries / "flock"
+    native_flock = shutil.which("flock")
+    lock.write_text(f'''#!/usr/bin/env python3
+import fcntl, os, pathlib, subprocess, sys
+pathlib.Path(os.environ["TEST_ROOT"], os.environ["CELL"] + ".locking").touch()
+if {native_flock!r}:
+    raise SystemExit(subprocess.run([{native_flock!r}, *sys.argv[1:]]).returncode)
+# macOS lacks the Linux CLI; use the same OS advisory lock for this fixture.
+with open(sys.argv[3], "a") as handle:
+    fcntl.flock(handle, fcntl.LOCK_EX)
+    raise SystemExit(subprocess.run(sys.argv[4:]).returncode)
+''')
+    lock.chmod(0o755)
+    env = {
+        **os.environ, "PATH": f"{binaries}:{os.environ['PATH']}",
+        "FIRST_EXIT": str(first_exit), "TEST_ROOT": str(tmp_path), "MODEL": "moonshotai/Kimi-K3", "TP": "8", "CONC": "1",
+        "KV_OFFLOADING": "dram", "KV_OFFLOAD_BACKEND": "mooncake", "TOTAL_CPU_DRAM_GB": "1024", "DURATION": "1",
+        "RESULT_DIR": str(tmp_path / "result"), "MODEL_PATH": str(target),
+        "WRITABLE_MODELS_DIR": str(cache), "DRAFT_MODEL": "Inferact/Kimi-K3-DSpark",
+    }
+    command = ["bash", str(REPO_ROOT / "benchmarks/single_node/agentic/kimik3_fp4_b300_vllm_mtp.sh")]
+    processes = []
+    try:
+        first = subprocess.Popen(command, env={**env, "CELL": "first"}, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        processes.append(first)
+        deadline = time.monotonic() + 5
+        while not (tmp_path / "first.started").exists():
+            assert first.poll() is None, "first downloader exited before the barrier"
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        second = subprocess.Popen(command, env={**env, "CELL": "second"}, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        processes.append(second)
+        deadline = time.monotonic() + 5
+        while not any((tmp_path / f"second.{stage}").exists() for stage in ("locking", "started", "serving")):
+            assert second.poll() is None, "second cell exited before staging"
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        assert not (tmp_path / "second.serving").exists(), "another cell accepted the nonempty partial draft"
+        assert not (tmp_path / "second.started").exists(), "downloaders must serialize"
+        (tmp_path / "release").touch()
+        assert first.wait(timeout=5) == (first_exit or 77)
+        assert second.wait(timeout=5) == 77
+        assert (tmp_path / "second.started").exists()
+    finally:
+        (tmp_path / "release").touch()
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+            process.wait()

--- a/runners/test_kimik3_b300.py
+++ b/runners/test_kimik3_b300.py
@@ -1,0 +1,45 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("model_prefix", ["kimik3", "dsv4"])
+def test_b300_staged_target_keeps_kimi_draft_in_persistent_mount(
+    tmp_path: Path, model_prefix: str,
+) -> None:
+    log = tmp_path / "launch.jsonl"
+    result = subprocess.run(
+        ["bash", "-c", '''
+        mkdir() { :; }
+        unsquashfs() { return 0; }
+        salloc() { echo 'salloc: Granted job allocation 123' >&2; }
+        scancel() { :; }
+        srun() {
+            python3 -c 'import json,os,sys; open(sys.argv[1], "a").write(json.dumps({"args":sys.argv[2:], "draft_root":os.environ.get("WRITABLE_MODELS_DIR")})+"\\n")' "$SRUN_LOG" "$@"
+        }
+        unset WRITABLE_MODELS_DIR
+        export MODEL_PREFIX="$3" PRECISION=fp4 FRAMEWORK=vllm
+        export MODEL=moonshotai/Kimi-K3 IS_MULTINODE=false
+        export SPEC_DECODING=mtp TP=8 RUNNER_NAME=b300-test IS_AGENTIC=1
+        export SCENARIO_SUBDIR=agentic/ EXP_NAME="${MODEL_PREFIX}_tp8_conc1"
+        export IMAGE=vllm/test:fixture GITHUB_WORKSPACE="$1" SRUN_LOG="$2"
+        cd "$GITHUB_WORKSPACE"
+        source runners/launch_b300-dsxe.sh
+        ''', "bash", str(REPO_ROOT), str(log), model_prefix],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    serve = json.loads(log.read_text().splitlines()[-1])
+    mounts = next(arg for arg in serve["args"] if arg.startswith("--container-mounts="))
+    assert "/scratch/models:/scratch/models" in mounts
+    if model_prefix == "kimik3":
+        draft_root = serve["draft_root"]
+        assert draft_root
+        assert f"{draft_root}:{draft_root}" in mounts
+    else:
+        assert serve["draft_root"] is None
+        assert "/data/home/sa-gha-runner/models" not in mounts


### PR DESCRIPTION
## Description

Replace unavailable Kimi-K3 vLLM build `5894fdf` with `3696c77`, establishing a new B300 runtime baseline. Persist DSpark weights and serialize cached downloads so concurrent cells cannot serve partial drafts.

**Testing:** Four launcher/download tests passed, including concurrent staging and failed-download propagation; regressions failed before fixes. Matrix, changelog, and Bash checks passed.

**Blocked:** DSXE EFA conflicts with launcher RoCE assumptions; related same-image CI reports `IBVERBS_PRIVATE_34`. Hardware qualification remains pending.

<details>
<summary>中文</summary>

## 中文说明

将不可用的 Kimi-K3 vLLM 镜像 `5894fdf` 替换为 `3696c77`，建立新的 B300 运行时基线。持久保存 DSpark 权重并串行校验或续传缓存，避免并发任务使用未完成的草稿模型。

**测试：** 四项启动器与下载测试通过，包括并发准备和下载失败传播；回归测试在修复前失败。矩阵、changelog 和 Bash 检查通过。

**阻塞：** DSXE EFA 与启动器的 RoCE 假设冲突；同镜像的相关 CI 报错 `IBVERBS_PRIVATE_34`。硬件资格验证仍待完成。

</details>

## Related Issue

Scope index and shared policy / 范围索引与共同规则: #3030.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark container image baseline and B300 launcher mounts for a live recipe; incorrect mounts could break Kimi-K3 agentic runs but scope is limited to that path.
> 
> **Overview**
> Restores the **Kimi-K3 B300 DSXE agentic-dspark** recipe by swapping the unavailable vLLM image **`5894fdf`** for **`3696c77`** in `nvidia-master.yaml`, with matching **perf-changelog** entries noting a new runtime baseline.
> 
> For **agentic Kimi-K3 + vLLM** on B300 DSXE, `launch_b300-dsxe.sh` now **exports `WRITABLE_MODELS_DIR`** and adds a **second container mount** when the read-only staged target (`/scratch/models`) differs from the persistent draft root, so DSpark weights can survive container reuse. English and Chinese **host-setup docs** describe this split.
> 
> Adds **`runners/test_kimik3_b300.py`** to assert kimik3 gets the writable mount and draft env while other prefixes (e.g. dsv4) do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6eee72dc75d7ab06624ca361483f29ce3b917a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->