### PR TITLE
[PowerX AMD] preserve telemetry through the measurement end / 保留完整窗口遥测

### DIFF
--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -373,13 +373,9 @@ _wait_for_amd_stop_coverage() {
     deadline=$(( target + timeout_s ))
     while :; do
         covered=$(_amd_monitor_min_covered_tick)
-        if [[ -z "$covered" ]]; then
-            # Non-epoch timestamps or an unusable stream: keep the legacy
-            # fixed tail so older amd-smi builds behave exactly as before.
-            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
-            return 0
-        fi
-        if [[ "$covered" -ge "$target" ]]; then
+        # The first usable row may arrive after stop begins. Keep the same
+        # deadline for empty or unsupported streams instead of stopping early.
+        if [[ -n "$covered" && "$covered" -ge "$target" ]]; then
             return 0
         fi
         if ! _background_process_is_running "$GPU_MONITOR_PID"; then

--- a/benchmarks/benchmark_lib.sh
+++ b/benchmarks/benchmark_lib.sh
@@ -153,8 +153,12 @@ unset _benchmark_caller
 # --------------------------------
 
 GPU_MONITOR_PID=""
+GPU_MONITOR_SOURCE_PID=""
+GPU_MONITOR_PIPE=""
 GPU_MONITOR_VENDOR=""
 GPU_MONITOR_INTERVAL=1
+# Bounded wait for AMD telemetry to cover a stop request; 0 skips the wait.
+AMD_MONITOR_STOP_TIMEOUT_S="${AMD_MONITOR_STOP_TIMEOUT_S:-30}"
 GPU_METRICS_CSV="${GPU_METRICS_CSV:-gpu_metrics.csv}"
 NVIDIA_GPU_MONITOR_QUERY="timestamp,index,power.draw,temperature.gpu,clocks.current.sm,clocks.current.memory,utilization.gpu,utilization.memory"
 export GPU_METRICS_CSV
@@ -196,8 +200,15 @@ start_gpu_monitor() {
         # Python; measured on MI355X: trailing ticks were lost at kill without it).
         # Pipe through awk to: skip preamble lines, keep first CSV header, skip repeated
         # headers, and flush every row so killing the pipe cannot discard buffered samples.
-        PYTHONUNBUFFERED=1 amd-smi metric -p -c -t -u -w "$interval" --csv 2>/dev/null \
-            | awk '/^timestamp,/{if(!h){print;h=1};next} h{print;fflush()}' > "$output" &
+        # Track both processes: killing only awk can leave amd-smi alive until
+        # its next write. Keep the FIFO beside this run's raw CSV, never shared.
+        GPU_MONITOR_PIPE="${output}.pipe.$$"
+        mkfifo "$GPU_MONITOR_PIPE" || return 1
+        PYTHONUNBUFFERED=1 amd-smi metric -p -c -t -u -w "$interval" --csv \
+            > "$GPU_MONITOR_PIPE" 2>/dev/null &
+        GPU_MONITOR_SOURCE_PID=$!
+        awk '/^timestamp,/{if(!h){print;h=1};next} h{print;fflush()}' \
+            < "$GPU_MONITOR_PIPE" > "$output" &
         GPU_MONITOR_PID=$!
         # Hardware energy-accumulator + identity snapshots; the end-side twin in
         # stop_gpu_monitor lets auditors cross-check the integrated energy
@@ -215,19 +226,21 @@ start_gpu_monitor() {
 # Stop the background GPU monitor and report file size.
 stop_gpu_monitor() {
     if [[ -n "$GPU_MONITOR_PID" ]] && kill -0 "$GPU_MONITOR_PID" 2>/dev/null; then
-        # benchmark_end_time_unix is recorded shortly before the benchmark
-        # process exits, so the stream must cover one more sample past it for
-        # deterministic boundary interpolation. NVIDIA appends a one-shot
-        # post-exit sample below; amd-smi one-shot CSV has no timestamp column,
-        # so the AMD path instead lets the watch stream emit final ticks before
-        # the kill. Two extra intervals: amd-smi stamps integer seconds, so a
-        # tick in the same second as the window end still fails bracketing —
-        # the stream needs a tick at the NEXT whole second (measured on MI355X:
-        # end=...153.325 vs last sample ...153.0).
+        # The aggregator requires, for every GPU, a usable sample stamped at or
+        # after the (fractional) benchmark window end, which is always <= the
+        # wall clock when this stop runs. NVIDIA appends a one-shot post-exit
+        # sample below; amd-smi one-shot CSV has no timestamp column, so the
+        # AMD path polls the output file until every GPU's watch stream shows
+        # a usable tick at the next whole second — amd-smi stamps integer
+        # seconds, so that tick strictly covers any fractional window end
+        # (measured on MI355X: end=...609.157 vs last sample ...605). Observing
+        # the file rather than sleeping also defeats pipe-buffer loss when the
+        # awk consumer is killed: covered rows are already on disk.
         if [[ "$GPU_MONITOR_VENDOR" == "amd" ]]; then
-            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
+            _wait_for_amd_stop_coverage
         fi
-        kill "$GPU_MONITOR_PID" 2>/dev/null
+        # The monitor may exit during the coverage wait; still finish cleanup.
+        kill "$GPU_MONITOR_PID" 2>/dev/null || true
         wait "$GPU_MONITOR_PID" 2>/dev/null || true
         case "$GPU_MONITOR_VENDOR" in
             nvidia)
@@ -249,6 +262,13 @@ stop_gpu_monitor() {
             echo "[GPU Monitor] Collected $lines rows -> $GPU_METRICS_CSV"
         fi
     fi
+    if [[ -n "$GPU_MONITOR_SOURCE_PID" ]]; then
+        kill "$GPU_MONITOR_SOURCE_PID" 2>/dev/null || true
+        wait "$GPU_MONITOR_SOURCE_PID" 2>/dev/null || true
+    fi
+    [[ -z "$GPU_MONITOR_PIPE" ]] || rm -f "$GPU_MONITOR_PIPE"
+    GPU_MONITOR_SOURCE_PID=""
+    GPU_MONITOR_PIPE=""
     GPU_MONITOR_PID=""
     GPU_MONITOR_VENDOR=""
 }
@@ -269,6 +289,109 @@ _repair_truncated_gpu_metrics_tail() {
         fi
     fi
     return 0
+}
+
+# Print the newest telemetry tick (whole epoch seconds) that EVERY observed
+# GPU has covered with a usable sample (numeric epoch timestamp, numeric
+# power > 0), or nothing when the stream holds no usable epoch-stamped row
+# (e.g. an amd-smi build emitting ISO timestamps). Column detection mirrors
+# _POWER_COL_RE/_POWER_EXCLUDE_RE/_GPU_INDEX_COL_RE in utils/aggregate_power.py.
+# POSIX awk only: the ROCm container images ship mawk/busybox awk.
+_amd_monitor_min_covered_tick() {
+    [[ -f "$GPU_METRICS_CSV" ]] || return 0
+    awk -F, '
+        NR == 1 {
+            for (i = 1; i <= NF; i++) {
+                name = tolower($i)
+                gsub(/^ +| +$/, "", name)
+                sub(/\r$/, "", name)
+                if (!power_col && name ~ /power/ && name !~ /limit|cap|max|min/)
+                    power_col = i
+                if (!gpu_col && name ~ /^(index|gpu|gpu_id|gpu_index|card|device)$/)
+                    gpu_col = i
+            }
+            next
+        }
+        !power_col || !gpu_col { next }
+        {
+            # amd-smi quotes list-valued cells that embed commas; neutralize
+            # them so the power cell keeps its header-relative position.
+            line = $0
+            sub(/\r$/, "", line)
+            if (line ~ /"/) {
+                n = split(line, seg, /"/)
+                line = ""
+                for (i = 1; i <= n; i++) {
+                    if (i % 2 == 0) gsub(/,/, ";", seg[i])
+                    line = line seg[i]
+                }
+            }
+            count = split(line, cell, /,/)
+            if (count < power_col || count < gpu_col) next
+            if (cell[1] !~ /^[0-9]+(\.[0-9]+)?$/) next
+            if (cell[power_col] !~ /^[0-9]+(\.[0-9]+)?$/) next
+            if (cell[power_col] + 0 <= 0) next
+            if (cell[gpu_col] == "") next
+            ts = cell[1] + 0
+            # Mirror _parse_timestamp in utils/aggregate_power.py: normalize
+            # millisecond epochs so a ms-stamping amd-smi build cannot
+            # trivially satisfy any second-scale stop target.
+            if (ts > 1e12) ts /= 1000
+            gpu = cell[gpu_col]
+            if (!(gpu in newest) || ts > newest[gpu])
+                newest[gpu] = ts
+        }
+        END {
+            have = 0
+            for (gpu in newest)
+                if (!have || newest[gpu] < min) { min = newest[gpu]; have = 1 }
+            if (have) printf "%d\n", min
+        }
+    ' "$GPU_METRICS_CSV" 2>/dev/null
+    return 0
+}
+
+# Block until every observed GPU has a usable tick at/after the first whole
+# second past stop entry, so any window end preceding the stop request is
+# bracketed on file. Bounded by AMD_MONITOR_STOP_TIMEOUT_S; always returns 0 —
+# on timeout or early monitor death it warns and lets aggregation attribute
+# the missing coverage (fail-safe, never fail-silent).
+_wait_for_amd_stop_coverage() {
+    local target deadline covered timeout_s
+    # A non-integer timeout (e.g. "30s") would abort the whole stop_gpu_monitor
+    # call under `set -e` at the arithmetic below, leaking the monitor process
+    # and skipping tail repair + the energy sidecar; fall back to the default.
+    timeout_s="${AMD_MONITOR_STOP_TIMEOUT_S:-30}"
+    if [[ ! "$timeout_s" =~ ^-?[0-9]+$ ]]; then
+        echo "[GPU Monitor] Warning: ignoring non-integer AMD_MONITOR_STOP_TIMEOUT_S='$timeout_s', using 30" >&2
+        timeout_s=30
+    fi
+    if [[ "$timeout_s" -le 0 ]]; then
+        return 0
+    fi
+    target=$(( $(date +%s) + 1 ))
+    deadline=$(( target + timeout_s ))
+    while :; do
+        covered=$(_amd_monitor_min_covered_tick)
+        if [[ -z "$covered" ]]; then
+            # Non-epoch timestamps or an unusable stream: keep the legacy
+            # fixed tail so older amd-smi builds behave exactly as before.
+            sleep $(( ${GPU_MONITOR_INTERVAL:-1} + 2 ))
+            return 0
+        fi
+        if [[ "$covered" -ge "$target" ]]; then
+            return 0
+        fi
+        if ! _background_process_is_running "$GPU_MONITOR_PID"; then
+            echo "[GPU Monitor] Warning: AMD monitor exited before covering the stop request (covered=$covered target=$target)" >&2
+            return 0
+        fi
+        if [[ "$(date +%s)" -ge "$deadline" ]]; then
+            echo "[GPU Monitor] Warning: AMD telemetry never covered the stop request within ${timeout_s}s (covered=$covered target=$target)" >&2
+            return 0
+        fi
+        sleep 1
+    done
 }
 
 # Write one best-effort amd-smi snapshot; remove the file rather than keep a
@@ -3284,9 +3407,15 @@ run_agentic_replay_and_write_outputs() (
     esac
 
     _stop_agentx_power_monitor() {
+        local mode="${1:-}"
         if [ "$agentx_monitor_stopped" = "0" ]; then
-            agentx_monitor_stopped=1
+            if [ "$mode" = "abort" ]; then
+                # A cancelled run's power validity is moot; skip the AMD
+                # coverage wait so signal teardown stays fast.
+                AMD_MONITOR_STOP_TIMEOUT_S=0
+            fi
             stop_gpu_monitor
+            agentx_monitor_stopped=1
         fi
     }
 
@@ -3330,10 +3459,11 @@ run_agentic_replay_and_write_outputs() (
         agentx_monitor_stopped=0
         # This function runs in a subshell, so these handlers cannot replace
         # launcher-owned traps. The stopped flag keeps explicit and signal/EXIT
-        # cleanup idempotent.
-        trap '_stop_agentx_power_monitor' EXIT
-        trap '_stop_agentx_power_monitor; exit 130' INT
-        trap '_stop_agentx_power_monitor; exit 143' TERM
+        # cleanup idempotent after stopping completes. If a signal interrupts
+        # the normal coverage wait, abort cleanup must still kill the monitor.
+        trap '_stop_agentx_power_monitor abort' EXIT
+        trap '_stop_agentx_power_monitor abort; exit 130' INT
+        trap '_stop_agentx_power_monitor abort; exit 143' TERM
     fi
 
     echo "$REPLAY_CMD" > "$result_dir/benchmark_command.txt"

--- a/docs/results-and-ingestion.md
+++ b/docs/results-and-ingestion.md
@@ -160,6 +160,11 @@ The aggregate artifact matches the `bmk_*` collection pattern and therefore also
 Server logs are separate `server_logs_<RESULT_FILENAME>` artifacts. The app uses the fully stripped suffix fallback so AgentX rows can find a server log even though the log artifact has no `agentic_` prefix.
 
 Ordinary single-node AgentX runs enable the shared GPU power monitor by default.
+AMD monitor shutdown waits for usable samples through the stop request, up to
+`AMD_MONITOR_STOP_TIMEOUT_S` (default 30 seconds), including when the first sample
+is delayed. Unsupported timestamps or missing samples reach the same deadline;
+aggregation still rejects an uncovered measurement window. AgentX cancellation
+skips this wait and preserves the available evidence.
 Their `power_audit_<RESULT_FILENAME>` artifact retains the raw telemetry, GPU
 identity, formal measurement window, timezone offset, and validation verdict
 from `results/`. Multinode runs retain the deployment telemetry under

--- a/docs/results-and-ingestion_zh.md
+++ b/docs/results-and-ingestion_zh.md
@@ -159,6 +159,9 @@ raw tree:           results/**, excluding inputs.json and profile_export_raw.jso
 服务器日志是单独的 `server_logs_<RESULT_FILENAME>` 工件。应用会使用完全移除前缀后的后缀作为回退，从而让 AgentX 记录找到不含 `agentic_` 前缀的日志工件。
 
 普通单节点 AgentX 提交默认启用共享 GPU 功耗监控。
+AMD 监控停止时等待有效采样覆盖停止请求，最长等待 `AMD_MONITOR_STOP_TIMEOUT_S`
+（默认 30 秒），首条采样延迟也适用。不支持的时间戳或缺失采样使用相同截止时间；
+聚合仍会拒绝未覆盖测量窗口的数据。AgentX 取消时跳过等待，并保留已有证据。
 `power_audit_<RESULT_FILENAME>` 工件保留 `results/` 中的原始遥测、GPU 身份、
 正式测量窗口、时区偏移和校验结果。多节点运行在同一审计工件中保留
 `LOGS/power/` 下的部署遥测，以及 `LOGS/agentic/` 下各并发的窗口和校验文件。

--- a/infx/results/power/single_node.py
+++ b/infx/results/power/single_node.py
@@ -9,7 +9,11 @@ Ordinary benchmark runs are best-effort: invalid telemetry is recorded in the
 aggregate and a validation sidecar, but does not fail the benchmark. Power
 studies can set ``REQUIRE_POWER=1`` to fail after those audit artifacts exist.
 The aggregate carries numeric ``power_valid`` (1/0) for metric ingestion; the
-sidecar is the canonical source for boolean validity and reason codes.
+sidecar is the canonical source for boolean validity and reason codes. Rows in
+the ingest band but outside the formal window whose power is missing,
+non-finite, or <= 0 are teardown noise: they are skipped and counted in the
+sidecar's ``boundary_degenerate_rows`` instead of poisoning validity or faking
+window bracketing.
 """
 
 from __future__ import annotations
@@ -22,7 +26,7 @@ import math
 import os
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
@@ -65,6 +69,10 @@ class PowerIntegration:
     per_gpu_max_sample_gap_s: dict[str, float]
     per_gpu_energy_j: dict[str, float]
     device_issues: dict[str, list[str]]
+    # Rows in the ingest band but outside the formal window whose power was
+    # missing/N-A/non-finite/<=0, skipped and counted per GPU; "unknown"
+    # buckets rows without a GPU identity.
+    boundary_degenerate_rows: dict[str, int] = field(default_factory=dict)
     avg_power_w: float | None = None
     p75_power_w: float | None = None
     p75_total_gpu_power_w: float | None = None
@@ -237,6 +245,7 @@ def _empty_integration(
     *,
     expected_num_gpus: int | None,
     reasons: list[str],
+    boundary_degenerate_rows: dict[str, int] | None = None,
 ) -> PowerIntegration:
     """Build an invalid integration result when no device data is available."""
     return PowerIntegration(
@@ -248,6 +257,7 @@ def _empty_integration(
         per_gpu_max_sample_gap_s={},
         per_gpu_energy_j={},
         device_issues={},
+        boundary_degenerate_rows=boundary_degenerate_rows or {},
     )
 
 
@@ -308,6 +318,7 @@ def integrate_power(
     # expose timestamps at lower resolution than their sampling cadence, so
     # duplicate-timestamp readings are averaged rather than treated as corrupt.
     raw_samples: dict[str, dict[float, list[float]]] = {}
+    boundary_degenerate: dict[str, int] = {}
     saw_missing_gpu_identity = False
     try:
         with csv_path.open("r", newline="", encoding="utf-8", errors="replace") as f:
@@ -348,6 +359,15 @@ def integrate_power(
 
                 power = _parse_power((row.get(power_col) or "").strip())
                 gpu_id = (row.get(gpu_col) or "").strip()
+                if (power is None or not math.isfinite(power) or power <= 0.0) and (
+                    timestamp < start_unix or timestamp > end_unix
+                ):
+                    # SMI teardown rows can carry N/A or 0 W cells: outside the
+                    # formal window they are counted, never used to satisfy
+                    # bracketing or to poison in-window validity.
+                    key = gpu_id or "unknown"
+                    boundary_degenerate[key] = boundary_degenerate.get(key, 0) + 1
+                    continue
                 if power is None:
                     _append_reason(reasons, "invalid_power_sample")
                     continue
@@ -364,6 +384,7 @@ def integrate_power(
         return _empty_integration(
             expected_num_gpus=expected_num_gpus,
             reasons=reasons,
+            boundary_degenerate_rows=boundary_degenerate,
         )
 
     if saw_missing_gpu_identity:
@@ -373,6 +394,7 @@ def integrate_power(
         return _empty_integration(
             expected_num_gpus=expected_num_gpus,
             reasons=reasons,
+            boundary_degenerate_rows=boundary_degenerate,
         )
 
     observed_gpu_ids = tuple(sorted(raw_samples, key=_gpu_sort_key))
@@ -450,6 +472,7 @@ def integrate_power(
         per_gpu_max_sample_gap_s=per_gpu_max_sample_gap_s,
         per_gpu_energy_j=per_gpu_energy_j,
         device_issues=device_issues,
+        boundary_degenerate_rows=boundary_degenerate,
         avg_power_w=avg_power_w,
         p75_power_w=p75_total / len(observed_gpu_ids) if p75_total is not None else None,
         p75_total_gpu_power_w=p75_total,
@@ -679,6 +702,7 @@ def _validation_payload(
         "per_gpu_max_sample_gap_s": integration.per_gpu_max_sample_gap_s,
         "per_gpu_energy_j": integration.per_gpu_energy_j,
         "device_issues": integration.device_issues,
+        "boundary_degenerate_rows": integration.boundary_degenerate_rows,
         "accumulator_check": accumulator_check,
         "metrics": audit_metrics(metrics),
     }

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7408,3 +7408,12 @@
     - "Retain the AMD monitor stream until it brackets the stop request, keep cancellation teardown bounded, and reject invalid samples inside the measured window while accounting for degenerate boundary rows."
     - "保留 AMD 功耗测量边界及诊断信息。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3041
+
+- config-keys:
+    - kimik3-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Keep the AMD stop deadline active while waiting for the first usable telemetry row; unsupported streams no longer sleep beyond the configured timeout."
+    - "等待首条有效 AMD 遥测时继续执行停止截止时间；不支持的采样流不再超出配置超时。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3041

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7399,3 +7399,12 @@
     - "Disable adaptive verification in the EVAL_ONLY DSpark config as well. It trims verification requests on device, which the ROCm DeepseekV4IndexerBackend does not support, so the eval-only engine refused to start (run 34651830283, c32). Evals keep real block rejection; throughput settings are unchanged."
     - "EVAL_ONLY 的 DSpark 配置同样关闭自适应验证：它会在设备端裁剪验证请求，而 ROCm 的 DeepseekV4IndexerBackend 不支持该操作，导致仅评测引擎拒绝启动（运行 34651830283，c32）。评测仍保留真实块拒绝采样；吞吐设置不变。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2962
+
+- config-keys:
+    - kimik3-fp4-mi355x-atom-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Retain the AMD monitor stream until it brackets the stop request, keep cancellation teardown bounded, and reject invalid samples inside the measured window while accounting for degenerate boundary rows."
+    - "保留 AMD 功耗测量边界及诊断信息。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3041

--- a/utils/agentic/aggregation/test_power_lifecycle.py
+++ b/utils/agentic/aggregation/test_power_lifecycle.py
@@ -657,7 +657,7 @@ done
     assert duration < 10
 
 
-def test_amd_stop_falls_back_to_fixed_tail_for_iso_timestamps(tmp_path: Path):
+def test_amd_stop_bounds_wait_for_iso_timestamps(tmp_path: Path):
     producer = """
 while :; do
     emit_row "$(date +%Y-%m-%dT%H:%M:%S)" 0 500
@@ -665,14 +665,27 @@ while :; do
 done
 """
     started = time.monotonic()
-    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30, interval=0)
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=1, interval=30)
     duration = time.monotonic() - started
 
     assert result.returncode == 0, result.stderr
-    assert "never covered the stop request" not in result.stdout + result.stderr
-    assert "exited before covering" not in result.stdout + result.stderr
-    pre, post = _stop_epochs(tmp_path)
-    # Non-epoch timestamps keep the legacy interval+2 fixed tail (one shot).
-    assert post - pre >= 2
-    assert duration < 10
+    assert "never covered the stop request" in result.stderr
+    assert "exited before covering" not in result.stderr
+    assert duration < 4
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_waits_for_delayed_first_sample(tmp_path: Path):
+    producer = """
+sleep 4
+while :; do
+    emit_row "$(date +%s)" 0 500
+    sleep 0.2
+done
+"""
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=8)
+
+    assert result.returncode == 0, result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
     _assert_producer_dead(tmp_path)

--- a/utils/agentic/aggregation/test_power_lifecycle.py
+++ b/utils/agentic/aggregation/test_power_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import os
 import re
@@ -278,7 +279,9 @@ source {str(BENCHMARK_LIB)!r}
 start_gpu_monitor() {{
     printf 'monitor-pid:%s\n' "${{BASHPID:-$$}}" >> {str(event_log)!r}
 }}
-stop_gpu_monitor() {{ printf 'monitor-stop\n' >> {str(event_log)!r}; }}
+stop_gpu_monitor() {{
+    printf 'monitor-stop:%s\n' "${{AMD_MONITOR_STOP_TIMEOUT_S:-unset}}" >> {str(event_log)!r}
+}}
 fake_replay() {{
     printf 'replay-ready\n' >> {str(event_log)!r}
     exec sleep 30
@@ -321,7 +324,355 @@ run_agentic_replay_and_write_outputs {str(result_dir)!r}
 
     assert proc.returncode == expected_rc, stderr
     events = _events(tmp_path)
-    assert events.count("monitor-stop") == 1
+    stop_events = [event for event in events if event.startswith("monitor-stop")]
+    # Signal teardown must stop exactly once, in abort mode: the coverage wait
+    # is skipped by setting AMD_MONITOR_STOP_TIMEOUT_S=0 before stopping.
+    assert stop_events == ["monitor-stop:0"]
     expected_parent_event = "parent-int" if sent_signal == signal.SIGINT else "parent-term"
     assert expected_parent_event in events
     assert events[-1] == "parent-exit"
+
+
+
+@pytest.mark.parametrize(
+    ("sent_signal", "expected_rc"),
+    [(signal.SIGINT, 130), (signal.SIGTERM, 143)],
+)
+def test_signal_during_amd_coverage_wait_stops_monitor(
+    tmp_path: Path, sent_signal: signal.Signals, expected_rc: int
+):
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    event_log = tmp_path / "events.log"
+    script = f"""
+source {str(BENCHMARK_LIB)!r}
+start_gpu_monitor() {{
+    GPU_METRICS_CSV="$2"
+    printf 'timestamp,gpu,socket_power\n1,0,500\n' > "$GPU_METRICS_CSV"
+    command sleep 60 >/dev/null 2>&1 &
+    GPU_MONITOR_PID=$!
+    GPU_MONITOR_VENDOR=amd
+    printf 'monitor:%s\nlifecycle:%s\n' "$GPU_MONITOR_PID" "${{BASHPID:-$(exec sh -c 'echo "$PPID"')}}" >> {str(event_log)!r}
+}}
+sleep() {{
+    printf 'coverage-wait\n' >> {str(event_log)!r}
+    command sleep "$@"
+}}
+_write_amd_smi_sidecar() {{ :; }}
+fake_replay() {{ :; }}
+trap 'printf "parent-exit\\n" >> {str(event_log)!r}' EXIT
+REPLAY_CMD=fake_replay
+ENABLE_AGENTX_POWER=1
+IS_MULTINODE=false
+AMD_MONITOR_STOP_TIMEOUT_S=30
+run_agentic_replay_and_write_outputs {str(result_dir)!r}
+exit $?
+"""
+    proc = subprocess.Popen(
+        ["bash", "-c", script],
+        env={**os.environ, "PATH": "/usr/bin:/bin"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            events = _events(tmp_path) if event_log.exists() else []
+            if "coverage-wait" in events:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("AMD coverage wait did not start")
+
+        pids = dict(event.split(":") for event in events if ":" in event)
+        # Signal only the lifecycle shell: signalling the whole group would
+        # kill the monitor directly and hide a broken cleanup handler.
+        os.kill(int(pids["lifecycle"]), sent_signal)
+        _, stderr = proc.communicate(timeout=5)
+        assert proc.returncode == expected_rc, stderr
+        assert _events(tmp_path)[-1] == "parent-exit"
+        with pytest.raises(ProcessLookupError):
+            os.kill(int(pids["monitor"]), 0)
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.communicate()
+
+
+# AMDSMI 26.2.0 `metric -p -c -t -u -w 1 --csv` header (order-faithful subset,
+# measured on MI355X; mirrors test_detect_columns_amd_watch_mode_real_header).
+_MI355X_WATCH_HEADER = (
+    "timestamp,gpu,gfx_activity,umc_activity,mm_activity,vcn_activity,"
+    "jpeg_activity,gfx_busy_inst_xcp_0,jpeg_busy_xcp_0,vcn_busy_xcp_0,"
+    "socket_power,gfx_voltage,soc_voltage,mem_voltage,throttle_status,"
+    "power_management,gfx_0_clk,mem_0_clk,edge,hotspot,mem"
+)
+
+# amd-smi quotes list-valued cells with embedded commas; the coverage helper
+# must keep the power cell at its header-relative position through them.
+_WATCH_ROW_FORMAT = (
+    "%s,%s,0,0,N/A,\"['N/A', 'N/A']\",\"['N/A', 'N/A']\",\"[0, 0]\","
+    "\"[0, 0]\",\"[0, 0]\",%s,N/A,N/A,N/A,N/A,ENABLED,1404,2000,N/A,40,25\\n"
+)
+
+
+def _bash_single_quote(text: str) -> str:
+    return "'" + text.replace("'", "'\\''") + "'"
+
+
+def _run_amd_stop(
+    tmp_path: Path,
+    *,
+    producer_script: str,
+    timeout_s: int | str,
+    interval: int = 1,
+    setup_script: str = "",
+) -> subprocess.CompletedProcess[str]:
+    """Run the real stop_gpu_monitor against a scripted AMD telemetry producer."""
+    csv_path = tmp_path / "gpu_metrics.csv"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    amd_smi = bin_dir / "amd-smi"
+    amd_smi.write_text("#!/bin/bash\nprintf 'gpu,total_energy_consumption\\n0,100.0\\n'\n")
+    amd_smi.chmod(0o755)
+    script = f"""
+set -e
+source {str(BENCHMARK_LIB)!r}
+GPU_METRICS_CSV={str(csv_path)!r}
+printf '%s\\n' {_bash_single_quote(_MI355X_WATCH_HEADER)} > "$GPU_METRICS_CSV"
+emit_row() {{
+    printf {_bash_single_quote(_WATCH_ROW_FORMAT)} "$1" "$2" "$3" >> "$GPU_METRICS_CSV"
+}}
+{setup_script}
+( {producer_script} ) &
+GPU_MONITOR_PID=$!
+printf '%s\\n' "$GPU_MONITOR_PID" > {str(tmp_path / "producer.pid")!r}
+GPU_MONITOR_VENDOR=amd
+GPU_MONITOR_INTERVAL={interval}
+AMD_MONITOR_STOP_TIMEOUT_S={timeout_s}
+date +%s > {str(tmp_path / "pre.txt")!r}
+stop_gpu_monitor
+date +%s > {str(tmp_path / "post.txt")!r}
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _min_covered_tick(csv_path: Path) -> int:
+    """Newest usable tick (numeric ts, power > 0) covered by every GPU."""
+    newest: dict[str, float] = {}
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            try:
+                timestamp = float((row.get("timestamp") or "").strip())
+                power = float((row.get("socket_power") or "").strip())
+            except ValueError:
+                continue
+            if timestamp > 1e12:  # millisecond epoch, mirror _parse_timestamp
+                timestamp /= 1000.0
+            gpu = (row.get("gpu") or "").strip()
+            if not gpu or power <= 0:
+                continue
+            newest[gpu] = max(newest.get(gpu, 0.0), timestamp)
+    assert newest, "no usable telemetry rows"
+    return int(min(newest.values()))
+
+
+def _stop_epochs(tmp_path: Path) -> tuple[int, int]:
+    pre = int((tmp_path / "pre.txt").read_text().strip())
+    post = int((tmp_path / "post.txt").read_text().strip())
+    return pre, post
+
+
+def _assert_producer_dead(tmp_path: Path) -> None:
+    producer_pid = int((tmp_path / "producer.pid").read_text().strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(producer_pid, 0)
+
+
+def test_amd_stop_waits_until_every_gpu_covers_stop_request(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    # Every GPU has a usable tick at/after the first whole second past stop
+    # entry, so any fractional window end before the stop is bracketed.
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_ignores_degenerate_rows_for_coverage(tmp_path: Path):
+    setup = """
+stale=$(( $(date +%s) - 30 ))
+emit_row "$stale" 0 500
+emit_row "$stale" 1 505
+"""
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 N/A
+    emit_row "$now" 1 N/A
+    sleep 0.2
+done
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script=producer,
+        timeout_s=2,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" in result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    assert post - pre >= 2
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_requires_coverage_per_gpu(tmp_path: Path):
+    setup = """
+stale=$(( $(date +%s) - 30 ))
+emit_row "$stale" 1 505
+"""
+    producer = """
+while :; do
+    emit_row "$(date +%s)" 0 500
+    sleep 0.2
+done
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script=producer,
+        timeout_s=2,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    # GPU 1 never covers the stop request, so min-over-GPUs coverage times out
+    # even though GPU 0 keeps producing fresh usable ticks.
+    assert "never covered the stop request" in result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    assert post - pre >= 2
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_preserves_outputs_when_monitor_exits_during_wait(tmp_path: Path):
+    setup = """
+emit_row 1 0 500
+sleep() {
+    # End the real producer on the first coverage poll without a timing race.
+    kill "$GPU_MONITOR_PID"
+    wait "$GPU_MONITOR_PID" 2>/dev/null || true
+}
+"""
+    result = _run_amd_stop(
+        tmp_path,
+        producer_script="exec /bin/sleep 60",
+        timeout_s=3,
+        setup_script=setup,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AMD monitor exited before covering the stop request" in result.stderr
+    assert (tmp_path / "gpu_metrics_energy_end.csv").read_text() == (
+        "gpu,total_energy_consumption\n0,100.0\n"
+    )
+    _stop_epochs(tmp_path)  # The caller continued after stop under set -e.
+    _assert_producer_dead(tmp_path)
+
+
+def test_amd_stop_survives_non_integer_timeout(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(date +%s)
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s="30s")
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    # A non-integer timeout must not unwind stop_gpu_monitor via a bash
+    # arithmetic error (which would leak the monitor and skip tail repair
+    # and the energy sidecar): it warns, falls back to 30, and still waits.
+    assert "ignoring non-integer AMD_MONITOR_STOP_TIMEOUT_S='30s'" in result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_normalizes_millisecond_epoch_timestamps(tmp_path: Path):
+    producer = """
+while :; do
+    now=$(( $(date +%s) * 1000 + 123 ))
+    emit_row "$now" 0 500
+    emit_row "$now" 1 505
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    # Raw millisecond epochs (~1.8e12) dwarf any second-scale target, so
+    # without normalization the poll would return
+    # instantly with zero tail coverage; mirrored _parse_timestamp
+    # normalization makes the poll wait for real coverage instead.
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    pre, _ = _stop_epochs(tmp_path)
+    assert _min_covered_tick(tmp_path / "gpu_metrics.csv") >= pre + 1
+    _assert_producer_dead(tmp_path)
+    assert duration < 10
+
+
+def test_amd_stop_falls_back_to_fixed_tail_for_iso_timestamps(tmp_path: Path):
+    producer = """
+while :; do
+    emit_row "$(date +%Y-%m-%dT%H:%M:%S)" 0 500
+    sleep 0.2
+done
+"""
+    started = time.monotonic()
+    result = _run_amd_stop(tmp_path, producer_script=producer, timeout_s=30, interval=0)
+    duration = time.monotonic() - started
+
+    assert result.returncode == 0, result.stderr
+    assert "never covered the stop request" not in result.stdout + result.stderr
+    assert "exited before covering" not in result.stdout + result.stderr
+    pre, post = _stop_epochs(tmp_path)
+    # Non-epoch timestamps keep the legacy interval+2 fixed tail (one shot).
+    assert post - pre >= 2
+    assert duration < 10
+    _assert_producer_dead(tmp_path)

--- a/utils/test_aggregate_power.py
+++ b/utils/test_aggregate_power.py
@@ -574,6 +574,201 @@ def test_run_rejects_malformed_telemetry_inside_window(
     assert audit["reasons"] == [expected_reason]
 
 
+
+# AMDSMI 26.2.0 `metric -p -c -t -u -w 1 --csv` header (order-faithful subset,
+# measured on MI355X; see test_detect_columns_amd_watch_mode_real_header).
+_MI355X_WATCH_HEADER = (
+    "timestamp,gpu,gfx_activity,umc_activity,mm_activity,vcn_activity,"
+    "jpeg_activity,gfx_busy_inst_xcp_0,jpeg_busy_xcp_0,vcn_busy_xcp_0,"
+    "socket_power,gfx_voltage,soc_voltage,mem_voltage,throttle_status,"
+    "power_management,gfx_0_clk,mem_0_clk,edge,hotspot,mem"
+)
+
+
+def _mi355x_watch_row(timestamp: int, gpu: int, socket_power: str) -> str:
+    """One data row in the shape captured from run 32433563482 (conc1):
+    integer-second epoch, quoted list cells with embedded commas, N/A cells,
+    and a trailing carriage return."""
+    return (
+        f"{timestamp},{gpu},0,0,N/A,\"['N/A', 'N/A', 'N/A', 'N/A']\","
+        "\"['N/A', 'N/A']\",\"[0, 0, 0, 0, 0, 0, 0, 0]\",\"[0, 0]\",\"[0, 0]\","
+        f"{socket_power},N/A,N/A,N/A,N/A,ENABLED,1404,2000,N/A,40,25\r"
+    )
+
+
+def test_integrate_power_skips_na_power_rows_outside_window(tmp_path: Path):
+    """N/A-power teardown rows past the window end are counted, not poisonous."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    for offset in range(-2, 13):
+        for gpu in range(2):
+            lines.append(f"{base + offset},{gpu},500.0,65")
+    for gpu in range(2):
+        lines.append(f"{base + 11},{gpu},N/A,65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is True
+    assert result.invalid_reasons == ()
+    assert result.boundary_degenerate_rows == {"0": 1, "1": 1}
+    assert result.total_gpu_energy_j == pytest.approx(10_000.0)
+
+
+def test_integrate_power_does_not_bracket_with_zero_power_tail(tmp_path: Path):
+    """A 0 W teardown row past the window end must not fake end bracketing.
+
+    Legacy behavior accepted the 0 W row as a valid boundary sample, corrupting
+    the end interpolation with a bogus value; this intentionally flips that
+    case to an explicit benchmark_window_not_bracketed failure."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    # Good rows stop at end-4; the only post-end sample per GPU has power 0.
+    for offset in range(-1, 7):
+        for gpu in range(2):
+            lines.append(f"{base + offset},{gpu},500.0,65")
+    for gpu in range(2):
+        lines.append(f"{base + 11},{gpu},0,65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is False
+    assert "benchmark_window_not_bracketed" in result.invalid_reasons
+    assert result.boundary_degenerate_rows == {"0": 1, "1": 1}
+
+
+def test_integrate_power_preserves_boundary_counts_without_usable_samples(tmp_path: Path):
+    csv = tmp_path / "gpu_metrics.csv"
+    csv.write_text(
+        "timestamp,gpu,socket_power\n"
+        "1699999999,0,N/A\n"
+        "1700000011,0,0\n"
+        "1700000011,1,N/A\n",
+        encoding="utf-8",
+    )
+
+    result = integrate_power(
+        csv,
+        start_unix=1_700_000_000,
+        end_unix=1_700_000_010,
+        expected_num_gpus=2,
+    )
+
+    assert result.power_valid is False
+    assert "no_usable_power_samples" in result.invalid_reasons
+    assert result.boundary_degenerate_rows == {"0": 2, "1": 1}
+
+
+def test_integrate_power_keeps_zero_power_semantics_inside_window(tmp_path: Path):
+    """Frozen legacy behavior: an in-window 0 W sample still integrates."""
+    csv = tmp_path / "gpu_metrics.csv"
+    base = 1_700_000_000.0
+    lines = ["timestamp,gpu,socket_power,temperature"]
+    for offset in range(-1, 12):
+        watts = "0.0" if offset == 5 else "500.0"
+        lines.append(f"{base + offset},0,{watts},65")
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=base,
+        end_unix=base + 10,
+        expected_num_gpus=1,
+    )
+
+    assert result.power_valid is True
+    assert result.invalid_reasons == ()
+    assert result.boundary_degenerate_rows == {}
+    # Trapezoids dip to 0 at t=5: 8 x 500 + 2 x 250 = 4500 J.
+    assert result.total_gpu_energy_j == pytest.approx(4_500.0)
+
+
+def test_run_writes_boundary_degenerate_rows_to_sidecar(tmp_path: Path):
+    base = 1_700_000_000.0
+    csv = tmp_path / "gpu_metrics.csv"
+    _write_constant_window_samples(
+        csv,
+        start=base,
+        end=base + 10,
+        watts_per_gpu=500.0,
+        num_gpus=2,
+    )
+    bench = tmp_path / "bench.json"
+    agg = tmp_path / "agg.json"
+    validation = tmp_path / "power_validation.json"
+    _write_bench_result(
+        bench,
+        start=base,
+        end=base + 10,
+        duration=10.0,
+        total_output=2_000,
+        total_input=10_000,
+    )
+    agg.write_text(json.dumps({"hw": "mi355x"}), encoding="utf-8")
+
+    exit_code = run(csv, bench, agg, expected_num_gpus=2, validation_result=validation)
+
+    assert exit_code == 0
+    audit = json.loads(validation.read_text())
+    # Present-and-empty for clean streams: readers can rely on the key.
+    assert audit["boundary_degenerate_rows"] == {}
+
+
+def test_integrate_power_regression_mi355x_integer_ticks_end_gap(tmp_path: Path):
+    """Run-32433563482 conc1 regression: amd-smi integer-second ticks stop 4 s
+    before the fractional aiperf window end (last tick 1787277605 vs end
+    ...609.157497), so bracketing fails and the producer-side telemetry loss is
+    attributed as benchmark_window_not_bracketed on every GPU.
+
+    The retrieved artifact's trailing rows all carry valid socket_power
+    (254-264 W) with N/A activity/voltage cells; the N/A- and 0-power teardown
+    rows appended past the window end are the documented synthetic degenerate
+    shapes, asserting they are counted rather than used for bracketing."""
+    csv = tmp_path / "gpu_metrics.csv"
+    start = 1_787_277_560.155891
+    end = 1_787_277_609.157497
+    last_tick = 1_787_277_605
+    powers = [259, 255, 263, 264, 256, 254, 259, 259]
+    lines = [_MI355X_WATCH_HEADER]
+    for tick in range(1_787_277_555, last_tick + 1):
+        for gpu in range(8):
+            lines.append(_mi355x_watch_row(tick, gpu, str(powers[gpu])))
+        # amd-smi watch mode emits a blank line between tick groups.
+        lines.append("")
+    for gpu in range(8):
+        lines.append(_mi355x_watch_row(1_787_277_610, gpu, "N/A"))
+    for gpu in range(8):
+        lines.append(_mi355x_watch_row(1_787_277_611, gpu, "0"))
+    csv.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = integrate_power(
+        csv,
+        start_unix=start,
+        end_unix=end,
+        expected_num_gpus=8,
+    )
+
+    assert result.power_valid is False
+    assert result.invalid_reasons == ("benchmark_window_not_bracketed",)
+    assert result.device_issues == {
+        str(gpu): ["benchmark_window_not_bracketed"] for gpu in range(8)
+    }
+    assert result.boundary_degenerate_rows == {str(gpu): 2 for gpu in range(8)}
+
+
 def test_run_patches_agg_with_power_and_joules(tmp_path: Path):
     base = 1_700_000_000.0
     csv = tmp_path / "gpu_metrics.csv"
@@ -1433,12 +1628,12 @@ def test_power_percentiles_uses_synchronized_total_not_device_percentiles(tmp_pa
 
 def test_power_percentiles_weights_time_and_clips_the_validated_window(tmp_path):
     csv_path = tmp_path / "power.csv"
-    # Dense readings near the high end must not bias a uniform linear ramp.
-    _write_amd_csv(csv_path, [(0, 0, 0), (1, 0, 100), (1.9, 0, 190), (2, 0, 200)])
+    # Dense readings must not bias the uniform 150-250 W ramp inside the window.
+    _write_amd_csv(csv_path, [(0, 0, 100), (1, 0, 200), (1.9, 0, 290), (2, 0, 300)])
     result = integrate_power(csv_path, start_unix=0.5, end_unix=1.5, expected_num_gpus=1)
     assert result.power_valid
-    assert result.p75_power_w == pytest.approx(125)
-    assert result.p90_power_w == pytest.approx(140)
+    assert result.p75_power_w == pytest.approx(225)
+    assert result.p90_power_w == pytest.approx(240)
 
 
 def test_power_percentiles_is_withheld_for_invalid_telemetry(tmp_path):

--- a/utils/test_process_result.py
+++ b/utils/test_process_result.py
@@ -5,6 +5,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -1148,8 +1149,13 @@ stop_gpu_monitor
             final_sample,
         ]
 
-    def test_stop_gpu_monitor_amd_waits_one_tick_and_snapshots_energy(self, tmp_path):
-        """AMD stop lets the watch stream bracket the window, then snapshots energy."""
+    def test_stop_gpu_monitor_amd_covers_stop_request_and_snapshots_energy(self, tmp_path):
+        """AMD stop returns once telemetry covers the stop entry, then snapshots energy.
+
+        A usable tick stamped past the stop request satisfies the coverage
+        poll on its first pass: the legacy fixed tail sleep never runs, the
+        stream is not mutated, and the end-side accumulator snapshot is
+        written."""
         fake_bin = tmp_path / "bin"
         fake_bin.mkdir()
         args_log = tmp_path / "amd_args.txt"
@@ -1161,7 +1167,8 @@ stop_gpu_monitor
         )
         fake_amd_smi.chmod(0o755)
         sleep_log = tmp_path / "sleep_args.txt"
-        contents = "timestamp,gpu,socket_power\n1785881113,0,238\n"
+        covered_tick = int(time.time()) + 30
+        contents = f"timestamp,gpu,socket_power\n{covered_tick},0,238\n"
         metrics = tmp_path / "gpu_metrics.csv"
         metrics.write_text(contents)
         benchmark_lib = Path(__file__).parents[1] / "benchmarks/benchmark_lib.sh"
@@ -1169,7 +1176,7 @@ stop_gpu_monitor
 source {str(benchmark_lib)!r}
 kill() {{ return 0; }}
 wait() {{ return 0; }}
-sleep() {{ printf '%s\\n' "$1" > {str(sleep_log)!r}; }}
+sleep() {{ printf '%s\\n' "$1" >> {str(sleep_log)!r}; }}
 GPU_MONITOR_PID=999
 GPU_MONITOR_VENDOR=amd
 GPU_MONITOR_INTERVAL=3
@@ -1190,7 +1197,8 @@ stop_gpu_monitor
         )
 
         assert result.returncode == 0, result.stderr
-        assert sleep_log.read_text().strip() == "5"
+        assert not sleep_log.exists()
+        assert "never covered the stop request" not in result.stderr
         assert metrics.read_text() == contents
         assert "metric -E --csv" in args_log.read_text()
         energy_end = tmp_path / "gpu_metrics_energy_end.csv"
@@ -1219,6 +1227,7 @@ sleep() {{ return 0; }}
 GPU_MONITOR_PID=999
 GPU_MONITOR_VENDOR=amd
 GPU_METRICS_CSV={str(metrics)!r}
+AMD_MONITOR_STOP_TIMEOUT_S=0
 stop_gpu_monitor
 """
         env = {


### PR DESCRIPTION
## Description

**Superseded by #3026:** AMD monitor fixes and validation travel together.

Keep AMD telemetry through the measurement end, handle delayed samples, bound cleanup, and retain invalid-boundary diagnostics.

**Testing:** 202 focused tests passed; delayed-sample regression failed before the fix. Bash/changelog checks passed.

**Pending:** MI355X hardware validation and the FIFO-startup review fix continue in #3026. No separate sweep is needed for this duplicate.

<details>
<summary>中文</summary>

## 中文说明

**由 #3026 接替：** AMD 监控修复与验证统一在该 PR 推进。

保留 AMD 遥测直到测量结束，处理延迟采样，限制清理等待，并保留无效边界行诊断。

**测试：** 202 项针对性测试通过；延迟采样回归测试在修复前失败。Bash/changelog 检查通过。

**待完成：** MI355X 硬件验证与 FIFO 启动问题的 review 修复继续在 #3026 完成。本重复范围无需单独运行 sweep。

</details>

## Related Issue

Scope index and shared policy / 范围索引与共同规则: #3030.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark teardown timing and power validity rules for AMD AgentX runs; mis-tuned timeouts could delay stops or mark windows invalid, but cancellation remains bounded and failures stay explicit in audits.
> 
> **Overview**
> Improves **AMD GPU power telemetry** so benchmark windows can be bracketed reliably and teardown noise does not corrupt validity.
> 
> **Monitor lifecycle (`benchmark_lib.sh`):** AMD `amd-smi` watch output now flows through a per-run FIFO with separate PIDs for the producer and `awk` consumer, so killing the parser does not leave `amd-smi` running or drop buffered rows. On stop, the fixed tail sleep is replaced by polling `gpu_metrics.csv` until every GPU has a usable tick (numeric epoch, power &gt; 0) at or after the next whole second, bounded by `AMD_MONITOR_STOP_TIMEOUT_S` (default 30s). AgentX **signal/EXIT cleanup** sets that timeout to **0** so cancellation stays fast while normal completion still waits for coverage.
> 
> **Aggregation (`infx/results/power/single_node.py`):** Rows in the ingest band but **outside** the formal window with missing, non-finite, or ≤0 W power are skipped for bracketing and integration and counted in audit **`boundary_degenerate_rows`** (e.g. N/A or 0 W teardown tails no longer fake end bracketing). In-window invalid samples are unchanged.
> 
> Docs, `perf-changelog.yaml`, and shell/Python tests cover the new stop behavior, abort path, and degenerate-boundary semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 942c0588788202eff984ef75f721dad97469d747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->