### PR TITLE
[AgentX Power] collect Slurm power results and retain failure evidence / 保留失败证据

### DIFF
--- a/runners/slurm_utils.sh
+++ b/runners/slurm_utils.sh
@@ -161,6 +161,52 @@ copy_agentic_results() {
     echo "Copied $copied agentic result file(s)"
 }
 
+collect_agentic_power_results() {
+    local job_id="$1" logs_dir="$2" source_dir="$3" workspace="$4"
+    local result_filename="$5" producer_sha="$6"
+    shift 6
+    local rc=0 concurrency attempt
+    [[ "$#" -gt 0 ]] || return 1
+    mkdir -p "$logs_dir/power" || return 1
+    logs_dir="$(cd "$logs_dir" && pwd -P)" || return 1
+    workspace="$(cd "$workspace" && pwd -P)" || return 1
+
+    # Accounting can lag squeue removal; retry only missing or nonterminal rows.
+    for attempt in 1 2 3; do
+        echo "$attempt" > "$logs_dir/power/native-job-status-attempts.txt"
+        sacct -X -n -P -j "$job_id" --format=JobIDRaw,State,ExitCode \
+            > "$logs_dir/power/native-job-status.txt" \
+            2>> "$logs_dir/power/native-job-status.stderr" || true
+        if awk -F'|' -v job="$job_id" '
+            $1 == job && $2 !~ /^(PENDING|RUNNING|COMPLETING)$/ { found = 1 }
+            END { exit !found }
+        ' "$logs_dir/power/native-job-status.txt"; then
+            break
+        fi
+        if [[ "$attempt" != "3" ]]; then sleep 5; fi
+    done
+    if ! awk -F'|' -v job="$job_id" '
+        $1 == job { found = 1; if ($2 != "COMPLETED" || $3 != "0:0") failed = 1 }
+        END { exit (!found || failed) }
+    ' "$logs_dir/power/native-job-status.txt"; then
+        rc=1
+    fi
+    copy_agentic_results "$source_dir" "$workspace" "$result_filename" || rc=$?
+    for concurrency in "$@"; do
+        (
+            cd "$workspace" || exit 1
+            python3 -m infx.results.agentic.power_adapter \
+                --result-dir "$logs_dir/agentic/conc_${concurrency}" \
+                --agg-result "$workspace/${result_filename}_conc${concurrency}.json" \
+                --power-dir "$logs_dir/power" \
+                --logs-root "$logs_dir" \
+                --expected-producer-sha "$producer_sha" \
+                --require-power
+        ) || rc=$?
+    done
+    return "$rc"
+}
+
 copy_eval_artifacts() {
     local eval_dir="$1"
     local workspace="$2"

--- a/utils/test_gb300_power_official_contract.py
+++ b/utils/test_gb300_power_official_contract.py
@@ -1,6 +1,8 @@
 """Exercise launcher routing and exporter imports without Slurm or network access."""
 
 import os
+import json
+import sys
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
@@ -255,3 +257,54 @@ def test_gb300_dsv4_recipe_images_match_their_master_configs():
             assert recipe_path.is_file(), (key, config_file)
             recipe_image = yaml.safe_load(recipe_path.read_text())["model"]["container"]
             assert recipe_image == config["image"], (key, config_file)
+
+
+@pytest.mark.parametrize(
+    ("job_state", "concurrencies", "expected_rc"),
+    [("COMPLETED|0:0", [4], 0), ("FAILED|1:0", [4], 1), ("COMPLETED|0:0", [4, 8], 1)],
+)
+def test_agentx_collection_preserves_failed_jobs_and_incomplete_sweeps(
+    tmp_path, job_state, concurrencies, expected_rc,
+):
+    from utils.test_aggregate_power_multinode import build_package, RESULT_STEM
+
+    package = build_package(tmp_path)
+    result_dir = package.logs_root / "agentic/conc_4"
+    result_dir.mkdir(parents=True)
+    stem = "agentic_power_concurrency_4"
+    package.original_result.replace(result_dir / f"{stem}.json")
+    old_window = package.windows_dir / f"{RESULT_STEM}.json"
+    window = json.loads(old_window.read_text())
+    window.update(benchmark_type="custom", result_path=f"agentic/conc_4/{stem}.json")
+    old_window.unlink()
+    (package.windows_dir / f"{stem}.json").write_text(json.dumps(window))
+    manifest_path = package.power_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["expected_windows"] = [{"benchmark_type": "custom", "concurrency": 4}]
+    manifest["window_validations"][0].update(
+        benchmark_type="custom", window_file=f"windows/{stem}.json",
+    )
+    manifest_path.write_text(json.dumps(manifest))
+    source = tmp_path / "compute-workspace"
+    source.mkdir()
+    (source / "run_conc4.json").write_text(json.dumps({
+        "conc": 4, "disagg": True, "num_prefill_gpu": 2, "num_decode_gpu": 2,
+    }))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    env["PATH"] = f"{Path(sys.executable).parent}:{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "-c",
+         'source "$1"; export TEST_JOB_STATE="$2"; sacct() { printf "12345|%s\\n" "$TEST_JOB_STATE"; }; '
+         'shift 2; collect_agentic_power_results "$@"',
+         "bash", str(REPO_ROOT / "runners/slurm_utils.sh"), job_state,
+         "12345", str(package.logs_root), str(source), str(tmp_path),
+         "run", PRODUCER_PIN, *map(str, concurrencies)],
+        env=env, text=True, capture_output=True,
+    )
+    assert result.returncode == expected_rc, result.stdout + result.stderr
+    aggregate = json.loads((tmp_path / "run_conc4.json").read_text())
+    assert aggregate["power_valid"] == 1
+    assert aggregate["total_gpu_energy_j"] == 84000.0
+    assert (result_dir / "power_validation.json").is_file()
+    assert (package.power_dir / "native-job-status.txt").read_text() == f"12345|{job_state}\n"


### PR DESCRIPTION
## Description

**Superseded by #3043:** collector and B200 recipes are reviewed and validated together.

Add a shared Slurm result collector that preserves native job failures, stages available artifacts, and validates power for every requested concurrency through the existing adapter.

**Testing:** Existing 3 CPU tests and Bash syntax checks passed.

**Pending:** Hardware proof comes through downstream callers; this helper enables no recipes and needs no standalone GPU sweep.

<details>
<summary>中文</summary>

## 中文说明

**已由 #3043 替代：** 采集函数与 B200 配方统一评审和验证。

新增公共 Slurm 结果采集函数，保留原生任务失败状态、暂存可用产物，并通过现有适配器校验每个请求并发值的功耗。

**测试：** 已有 3 项 CPU 测试及 Bash 语法检查通过。

**待完成：** 硬件验证由下游调用方完成；此函数不启用配方，无需单独启动 GPU 扫描。

</details>

## Related Issue

Scope index and shared policy / 范围索引与共同规则: #3030.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Configuration change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [ ] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries** — Not applicable: uncalled helper; recipe enablement is downstream. / 不适用：尚无调用方，配方启用在下游 PR。
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New uncalled Bash helper and offline tests only; no change to live launch paths until downstream wiring.
> 
> **Overview**
> Adds **`collect_agentic_power_results`** in `slurm_utils.sh` as a shared post-Slurm collector for AgentX power runs. It polls **`sacct`** (with retries for accounting lag), writes native job status under `logs_dir/power`, sets a non-zero exit when the job did not finish **`COMPLETED`/`0:0`**, still copies available **`_conc*.json`** artifacts, and runs **`infx.results.agentic.power_adapter`** for each requested concurrency with **`--require-power`**.
> 
> A parametrized CPU test in **`test_gb300_power_official_contract.py`** stubs **`sacct`** and checks that failed jobs and incomplete multi-concurrency sweeps return the expected exit code while still aggregating power when artifacts exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b237ef7dd6ec153f559db3d27cc62dd256c6715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->