### PR TITLE
[Klaud Cold] Update dsr1-fp8-mi300x-sglang SGLang ROCm image to v0.5.19-rocm700-mi30x / 将 dsr1-fp8-mi300x-sglang 的 SGLang ROCm 镜像更新至 v0.5.19-rocm700-mi30x

### DIFF
--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -63,7 +63,7 @@ dsr1-fp4-mi355x-atom-mtp:
       - { tp: 8, conc-start: 4, conc-end: 256, spec-decoding: mtp }
 
 dsr1-fp8-mi300x-sglang:
-  image: lmsysorg/sglang:v0.5.12-rocm700-mi30x
+  image: lmsysorg/sglang:v0.5.19-rocm700-mi30x@sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: mi300x

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7399,3 +7399,10 @@
     - "Disable adaptive verification in the EVAL_ONLY DSpark config as well. It trims verification requests on device, which the ROCm DeepseekV4IndexerBackend does not support, so the eval-only engine refused to start (run 34651830283, c32). Evals keep real block rejection; throughput settings are unchanged."
     - "EVAL_ONLY 的 DSpark 配置同样关闭自适应验证：它会在设备端裁剪验证请求，而 ROCm 的 DeepseekV4IndexerBackend 不支持该操作，导致仅评测引擎拒绝启动（运行 34651830283，c32）。评测仍保留真实块拒绝采样；吞吐设置不变。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/2962
+
+- config-keys:
+    - dsr1-fp8-mi300x-sglang
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.12-rocm700-mi30x to lmsysorg/sglang:v0.5.19-rocm700-mi30x (digest sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58, sgl-project/sglang commit 0bcd822377da7b5718e674eaf9c870d349424dd1, AITER c16d44b93a528b2a4bfd6d8d3409116d465872a9); recipe script, TP8 topology, 8k/1k concurrency points and default evals unchanged."
+    - "将 SGLang 镜像从 lmsysorg/sglang:v0.5.12-rocm700-mi30x 更新为 lmsysorg/sglang:v0.5.19-rocm700-mi30x（摘要 sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58，sgl-project/sglang 提交 0bcd822377da7b5718e674eaf9c870d349424dd1，AITER c16d44b93a528b2a4bfd6d8d3409116d465872a9）；配方脚本、TP8 拓扑、8k/1k 并发点与默认评测均保持不变。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3048


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.12-rocm700-mi30x` to `lmsysorg/sglang:v0.5.19-rocm700-mi30x@sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58`.  
**Baseline:** 2026-05-18 · `lmsysorg/sglang:v0.5.12-rocm700-mi30x`  
8k/1k · TP8/EP1 · Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-18&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-05-18), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations)

| Concurrency | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| ---: | ---: | ---: | ---: | ---: |
| 4 | N/A | N/A | N/A | N/A |
| 8 | N/A | N/A | N/A | N/A |
| 16 | N/A | N/A | N/A | N/A |
| 32 | N/A | N/A | N/A | N/A |
| 64 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

| Eval | Score ↑ | Samples |
| --- | ---: | ---: |
| gsm8k/em_strict · c32 | 95.45% | 1,319 |
| gsm8k/em_strict · c64 | 95.07% | 1,319 |

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.12-rocm700-mi30x` 更新为 `lmsysorg/sglang:v0.5.19-rocm700-mi30x@sha256:590a815c128d7d5c83ef771ad768c9f8be82f64f7d0dbd98dc7b9f085b268a58`。  
**基线：**2026-05-18 · `lmsysorg/sglang:v0.5.12-rocm700-mi30x`  
8k/1k · TP8/EP1 · 平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-05-18&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-05-18), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
