### PR TITLE
[Klaud Cold] Update glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-2p2d SGLang image to v0.5.19-cu130 / 将 glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-2p2d 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/agentic/disagg-h200-2p2d-pcp8-tp8-dp8-mtp.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/glm5.2/agentic/disagg-h200-2p2d-pcp8-tp8-dp8-mtp.yaml
@@ -7,12 +7,16 @@ name: "disagg-h200-2p2d-pcp8-tp8-dp8-mtp"
 
 model:
   path: "hf:zai-org/GLM-5.2-FP8"
-  container: "lmsysorg/sglang:v0.5.16-cu130"
+  container: "lmsysorg/sglang:v0.5.19-cu130"
   precision: "fp8"
 
+# Dynamo 1.3.0.dev1 imports sglang.srt.server_args_config_parser at worker
+# startup; SGLang v0.5.19 moved that module under sglang.srt.utils
+# (sgl-project/sglang#36681). 1.5.0.dev20260910 imports the new path and pins
+# sglang==0.5.19.
 dynamo:
   install: true
-  wheel: "1.3.0.dev1"
+  wheel: "1.5.0.dev20260910"
 
 slurm:
   time_limit: "8:00:00"
@@ -40,7 +44,7 @@ frontend:
     PIP_BREAK_SYSTEM_PACKAGES: "1"
   args:
     router-mode: "kv"
-    router-reset-states: true
+    # --router-reset-states was removed from the Dynamo 1.5 frontend.
     active-decode-blocks-threshold: "None"
     active-prefill-tokens-threshold: "None"
     active-prefill-tokens-threshold-frac: "None"

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9168,13 +9168,13 @@ qwen3.5-fp8-gb300-dynamo-sglang:
 # PCP8/TP8-DP8 topology and c8/c12/c16 curve from Actions run 30133535261 while
 # enabling native EAGLE MTP with golden AL and GPU-resident decode KV cache.
 glm5.2-fp8-h200-dynamo-sglang-agentic-mtp-2p2d:
-  image: lmsysorg/sglang:v0.5.16-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: zai-org/GLM-5.2-FP8
   model-prefix: glm5.2
   runner: cluster:h200-dgxc
   precision: fp8
   framework: dynamo-sglang
-  router: { name: dynamo-router, version: "1.3.0.dev1" }
+  router: { name: dynamo-router, version: "1.5.0.dev20260910" }
   kv-p2p-transfer: mooncake
   multinode: true
   disagg: true


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.16-cu130` to `lmsysorg/sglang:v0.5.19-cu130`.  
**Baseline:** 2026-08-25 · `lmsysorg/sglang:v0.5.16-cu130`  
AgentX · PTP1x2/DTP8x2 · Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=GLM-5.2&date=2026-08-25&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-25), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations)

| Concurrency | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| ---: | ---: | ---: | ---: | ---: |
| 8 | N/A | N/A | N/A | N/A |
| 12 | N/A | N/A | N/A | N/A |
| 16 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

| Eval | Score ↑ | Samples |
| --- | ---: | ---: |
| gsm8k/em_strict · c16 | 94.92% | 1,319 |

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.16-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130`。  
**基线：**2026-08-25 · `lmsysorg/sglang:v0.5.16-cu130`  
AgentX · PTP1x2/DTP8x2 · 平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=GLM-5.2&date=2026-08-25&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-08-25), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->
