### PR TITLE
[PowerX] scope required power to selected 8k1k scenarios / 按所选 8k1k 场景要求功耗

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -368,7 +368,7 @@ jobs:
             decode-dp-attn: ${{ matrix.config.decode.dp-attn }}
             decode-additional-settings: ${{ toJson(matrix.config.decode.additional-settings) }}
             run-eval: false
-            require-power: ${{ inputs.require-power }}
+            require-power: ${{ inputs.require-power || (matrix.config['require-power'] == true && matrix.config['eval-only'] != true) }}
             power-producer-sha: ${{ inputs.power-producer-sha }}
             ref: ${{ inputs.ref }}
 
@@ -692,7 +692,7 @@ jobs:
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
             run-eval: false
-            require-power: ${{ inputs.require-power }}
+            require-power: ${{ inputs.require-power || (matrix.config['require-power'] == true && matrix.config['eval-only'] != true) }}
             ref: ${{ inputs.ref }}
 
     test-sweep-evals:

--- a/.github/workflows/run-sweep.yml
+++ b/.github/workflows/run-sweep.yml
@@ -413,6 +413,7 @@ jobs:
             klaud-run: &klaud-run ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'Klaud-Cold' && (startsWith(github.head_ref, 'klaud/auto-') || startsWith(github.head_ref, 'klaude/auto-')) }}
             exp-name: ${{ matrix.config.exp-name }}
             recipe-fingerprint: ${{ matrix.config['recipe-fingerprint'] || '' }}
+            require-power: ${{ matrix.config['require-power'] == true && matrix.config['eval-only'] != true }}
             isl: ${{ matrix.config.isl }}
             osl: ${{ matrix.config.osl }}
             max-model-len: ${{ matrix.config.max-model-len }}
@@ -474,6 +475,7 @@ jobs:
             kv-p2p-transfer: ${{ matrix.config['kv-p2p-transfer'] || '' }}
             exp-name: ${{ matrix.config.exp-name }}
             recipe-fingerprint: ${{ matrix.config['recipe-fingerprint'] || '' }}
+            require-power: ${{ matrix.config['require-power'] == true && matrix.config['eval-only'] != true }}
             conc-list: ${{ toJson(matrix.config.conc) }}
             spec-decoding: ${{ matrix.config.spec-decoding }}
             disagg: ${{ matrix.config.disagg }}
@@ -540,6 +542,7 @@ jobs:
             klaud-run: *klaud-run
             exp-name: ${{ matrix.config.exp-name }}
             recipe-fingerprint: ${{ matrix.config['recipe-fingerprint'] || '' }}
+            require-power: ${{ matrix.config['require-power'] == true && matrix.config['eval-only'] != true }}
             isl: ${{ matrix.config.isl }}
             osl: ${{ matrix.config.osl }}
             max-model-len: ${{ matrix.config.max-model-len }}

--- a/docs/configuration-procedures.md
+++ b/docs/configuration-procedures.md
@@ -88,6 +88,8 @@ Sources: [`configs/CONFIGS.md`](../configs/CONFIGS.md), [`validation.py`](../uti
 6. For srt-slurm, update recipe and master entry together. For llm-d, update the llm-d recipe/orchestration and master entry together.
 7. Append the trigger entry, generate only the affected key first, and inspect every emitted point.
 
+Fixed-sequence `8192/1024` scenarios may set `require-power: true` to opt into validated measured power. The matrix passes this flag to standard sweeps and manual E2E throughput jobs; eval-only and AgentX rows do not inherit it. Omit the field to preserve existing behavior. Enable it only alongside the corresponding runtime and result adapter, then qualify the complete selected scope.
+
 ## Register and set up a runner
 
 Setup source: [`utils/runner_setup/RUNNER_SETUP.md`](../utils/runner_setup/RUNNER_SETUP.md). Config source: [`configs/CONFIGS.md#runners`](../configs/CONFIGS.md#runners).

--- a/docs/configuration-procedures_zh.md
+++ b/docs/configuration-procedures_zh.md
@@ -88,6 +88,8 @@ STP（Single Token Prediction，单 Token 预测）是每次前向传播生成�
 6. srt-slurm 必须同时更新配方和主条目；llm-d 必须同时更新 llm-d 配方/编排和主条目。
 7. 追加触发条目，先只生成受影响的 key，并检查每个生成点。
 
+固定序列 `8192/1024` 场景可设置 `require-power: true`，要求经过验证的实测功耗。矩阵将此标记传递给标准 sweep 和手动 E2E 吞吐作业；eval-only 和 AgentX 行不继承该标记。省略此字段可保留现有行为。仅在对应 runtime 和结果适配器同时交付时启用，然后验证完整选定范围。
+
 ## 注册并设置 runner
 
 设置来源：[`utils/runner_setup/RUNNER_SETUP.md`](../utils/runner_setup/RUNNER_SETUP.md)。配置来源：[`configs/CONFIGS.md#runners`](../configs/CONFIGS.md#runners)。

--- a/infx/matrix/generate.py
+++ b/infx/matrix/generate.py
@@ -136,6 +136,7 @@ def smoke_entries(entries: list[dict]) -> list[dict]:
         if not row.get('run-eval'):
             continue
         row = {**row, 'eval-only': True}
+        row.pop(Fields.REQUIRE_POWER.value, None)
         if row.get('prefill') is not None:
             row['conc'] = [row['eval-conc']]
             row['eval-all-concs'] = False
@@ -808,6 +809,9 @@ def _fixed_sequence_entries(
     is_multinode = config.get(Fields.MULTINODE.value, False)
     disagg = config.get(Fields.DISAGG.value, False)
     isl, osl = sequence[Fields.ISL.value], sequence[Fields.OSL.value]
+    require_power = sequence.get(Fields.REQUIRE_POWER.value, False)
+    if require_power and (isl, osl) != (8192, 1024):
+        raise ValueError("require-power rollout supports only fixed-sequence 8192/1024")
     model_code = config[Fields.MODEL_PREFIX.value]
     spec_decoding = benchmark.get(Fields.SPEC_DECODING.value, "none")
     if is_multinode:
@@ -831,6 +835,8 @@ def _fixed_sequence_entries(
                 Fields.ISL.value: isl,
                 Fields.OSL.value: osl,
             }
+            if require_power:
+                entry[Fields.REQUIRE_POWER.value] = True
             if is_multinode:
                 entry.update({
                     Fields.SPEC_DECODING.value: spec_decoding,
@@ -1316,6 +1322,7 @@ def select_matrix_evals(
         rows = [row for row in rows if row.get(Fields.RUN_EVAL.value, False)]
         for row in rows:
             row[Fields.EVAL_ONLY.value] = True
+            row.pop(Fields.REQUIRE_POWER.value, None)
     return rows
 
 

--- a/infx/matrix/generate.py
+++ b/infx/matrix/generate.py
@@ -809,7 +809,7 @@ def _fixed_sequence_entries(
     is_multinode = config.get(Fields.MULTINODE.value, False)
     disagg = config.get(Fields.DISAGG.value, False)
     isl, osl = sequence[Fields.ISL.value], sequence[Fields.OSL.value]
-    require_power = sequence.get(Fields.REQUIRE_POWER.value, False)
+    require_power = sequence.get(Fields.REQUIRE_POWER.value, sequence.get("require_power", False))
     if require_power and (isl, osl) != (8192, 1024):
         raise ValueError("require-power rollout supports only fixed-sequence 8192/1024")
     model_code = config[Fields.MODEL_PREFIX.value]

--- a/infx/matrix/validation.py
+++ b/infx/matrix/validation.py
@@ -76,6 +76,7 @@ class Fields(Enum):
     NUM_NODES = 'num-nodes'
     NODE_COUNT = 'node-count'
     DURATION = 'duration'
+    REQUIRE_POWER = 'require-power'
 
     # Matrix entry fields
     CONC = 'conc'
@@ -168,6 +169,7 @@ class SingleNodeMatrixEntry(BaseModel):
     runner: str
     isl: int
     osl: int
+    require_power: bool = Field(default=False, alias=Fields.REQUIRE_POWER.value, strict=True)
     tp: int
     pp: int = Field(gt=0, strict=True)
     dcp_size: int = Field(alias=Fields.DCP_SIZE.value, gt=0, strict=True)
@@ -268,6 +270,7 @@ class MultiNodeMatrixEntry(BaseModel):
     node_count: int = Field(alias=Fields.NODE_COUNT.value, gt=0, strict=True)
     isl: int
     osl: int
+    require_power: bool = Field(default=False, alias=Fields.REQUIRE_POWER.value, strict=True)
     prefill: WorkerConfig
     decode: WorkerConfig
     conc: List[int]
@@ -629,6 +632,7 @@ class SingleNodeSeqLenConfig(BaseModel):
 
     isl: int
     osl: int
+    require_power: bool = Field(default=False, alias=Fields.REQUIRE_POWER.value, strict=True)
     search_space: List[SingleNodeSearchSpaceEntry] = Field(
         alias=Fields.SEARCH_SPACE.value)
 
@@ -639,6 +643,7 @@ class MultiNodeSeqLenConfig(BaseModel):
 
     isl: int
     osl: int
+    require_power: bool = Field(default=False, alias=Fields.REQUIRE_POWER.value, strict=True)
     search_space: List[MultiNodeSearchSpaceEntry] = Field(
         alias=Fields.SEARCH_SPACE.value)
 

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -3241,3 +3241,32 @@ class TestE2EConfigSplitting:
         output = split_e2e_configs([])
 
         assert output and all(rows == [] for rows in output.values())
+
+
+@pytest.mark.parametrize("multinode", [False, True])
+def test_require_power_is_scoped_to_one_fixed_sequence(multinode, sample_single_node_config,
+                                                       sample_multinode_config, sample_runner_config):
+    from infx.matrix.generate import expand_full_sweep, select_matrix_evals
+    from infx.matrix.validation import MultiNodeSeqLenConfig, SingleNodeSeqLenConfig
+
+    config = sample_multinode_config if multinode else sample_single_node_config
+    entry = next(iter(config.values()))
+    sequences = entry["scenarios"]["fixed-seq-len"]
+    if multinode:
+        sequences.append(copy.deepcopy(sequences[0]))
+        sequences[-1]["isl"] = 8192
+    before = expand_full_sweep(config, sample_runner_config)
+    assert all("require-power" not in row for row in before)
+    sequences[-1]["require-power"] = True
+    schema = MultiNodeSeqLenConfig if multinode else SingleNodeSeqLenConfig
+    schema.model_validate(sequences[-1])
+    after = expand_full_sweep(config, sample_runner_config)
+    assert len(before) == len(after)
+    for original, row in zip(before, after):
+        assert row == ({**original, "require-power": True} if original["isl"] == 8192 else original)
+    evals = select_matrix_evals(copy.deepcopy(after), mode="subset")
+    assert evals
+    assert all("require-power" not in row for row in evals)
+    sequences[0]["require-power"] = True
+    with pytest.raises(ValueError, match="only fixed-sequence 8192/1024"):
+        expand_full_sweep(config, sample_runner_config)

--- a/utils/matrix_logic/test_generate_sweep_configs.py
+++ b/utils/matrix_logic/test_generate_sweep_configs.py
@@ -3244,7 +3244,8 @@ class TestE2EConfigSplitting:
 
 
 @pytest.mark.parametrize("multinode", [False, True])
-def test_require_power_is_scoped_to_one_fixed_sequence(multinode, sample_single_node_config,
+@pytest.mark.parametrize("power_key", ["require-power", "require_power"])
+def test_require_power_is_scoped_to_one_fixed_sequence(multinode, power_key, sample_single_node_config,
                                                        sample_multinode_config, sample_runner_config):
     from infx.matrix.generate import expand_full_sweep, select_matrix_evals
     from infx.matrix.validation import MultiNodeSeqLenConfig, SingleNodeSeqLenConfig
@@ -3257,7 +3258,7 @@ def test_require_power_is_scoped_to_one_fixed_sequence(multinode, sample_single_
         sequences[-1]["isl"] = 8192
     before = expand_full_sweep(config, sample_runner_config)
     assert all("require-power" not in row for row in before)
-    sequences[-1]["require-power"] = True
+    sequences[-1][power_key] = True
     schema = MultiNodeSeqLenConfig if multinode else SingleNodeSeqLenConfig
     schema.model_validate(sequences[-1])
     after = expand_full_sweep(config, sample_runner_config)
@@ -3267,6 +3268,6 @@ def test_require_power_is_scoped_to_one_fixed_sequence(multinode, sample_single_
     evals = select_matrix_evals(copy.deepcopy(after), mode="subset")
     assert evals
     assert all("require-power" not in row for row in evals)
-    sequences[0]["require-power"] = True
+    sequences[0][power_key] = True
     with pytest.raises(ValueError, match="only fixed-sequence 8192/1024"):
         expand_full_sweep(config, sample_runner_config)


### PR DESCRIPTION
## Description

Add an opt-in measured-power requirement to individual fixed 8192/1024 scenarios and propagate it through standard sweeps and E2E jobs. Existing recipes, AgentX and eval-only behavior remain unchanged.

**Testing:** [Matrix CI](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34686797604) passed at `671b0c1e5`; two alias regressions failed before the fix, all four focused cases pass. No GPU run or recipe activation; runtime qualification and CODEOWNER approval remain required.

<details>
<summary>中文</summary>

为独立固定 8192/1024 场景增加可选的实测功耗要求，并贯通标准 sweep 和 E2E 作业。现有配方、AgentX 和 eval-only 行为保持不变。

**测试：** `671b0c1e5` 的矩阵 CI 通过；两个字段别名回归用例在修复前失败，修复后四个针对性用例全部通过。未运行 GPU 或启用配方；仍需各 runtime 资格验证与 CODEOWNER 审批。

</details>

## Related Issue

Shared prerequisite for #3027 runtime splits.

#3027 runtime 拆分的共享前置。

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Configuration change
- [x] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [ ] **For every change that can affect benchmark performance and every recipe addition or modification, I have appended a new entry to the physical end of `perf-changelog.yaml` and have not edited historical entries**
- [ ] **Before merging via reuse, an authorized maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) has commented `/reuse-sweep-run` on this PR**. Do this **only once there is a final full sweep that is all green with evals passing**, since after this comment the sweep label will no longer automatically kick off new sweeps. Remove and re-add the label to force one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix and generator changes only; eval-only and non-8k1k paths are explicitly excluded, with no auth or data-handling impact.
> 
> **Overview**
> Adds an **opt-in `require-power` flag** on fixed-sequence master YAML (validated and emitted only for **8192/1024** rows) so benchmark matrix jobs can request validated measured power without changing AgentX or default behavior.
> 
> The generator copies the flag onto throughput matrix rows, **strips it from eval-only** paths (`smoke`, subset/all eval modes), and rejects `require-power` on other sequence lengths. Pydantic schemas accept the field on sequence configs and matrix entries.
> 
> **CI wiring:** `run-sweep` and manual E2E throughput jobs pass `require-power` when the matrix row sets it and the job is not eval-only; E2E also honors the workflow input or per-row flag. Docs (EN/ZH) describe rollout constraints. Tests cover single/multi-node and both key spellings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671b0c1e534787749ebc7e7c56070953a963b569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->