### PR TITLE
[Klaud Cold] Update dsr1-fp8-b300-sglang-mtp SGLang image to v0.5.19-cu130 / 将 dsr1-fp8-b300-sglang-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -1464,7 +1464,7 @@ dsr1-fp8-b200-sglang-mtp:
   # does not have a B300-specific recipe, so this config reuses the existing DSR1 FP8
   # B200 SGLang MTP recipe as-is until B300-specific tuning is available.
 dsr1-fp8-b300-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.15.post1-cu130
+  image: lmsysorg/sglang:v0.5.19-cu130
   model: deepseek-ai/DeepSeek-R1-0528
   model-prefix: dsr1
   runner: b300

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7408,3 +7408,10 @@
     - "Enable required power for the seven existing B200 Kimi-K3 recipes, use the pinned AgentX producer and shared collector, fix the exporter import URI, and record DCP8 with offload disabled to match the serving commands."
     - "启用 Kimi-K3 B200 实测功耗并修正 DCP 与 Offload 元数据。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3043
+
+- config-keys:
+    - dsr1-fp8-b300-sglang-mtp
+  description:
+    - "Update SGLang image from lmsysorg/sglang:v0.5.15.post1-cu130 (build commit sgl-project/sglang@0b3bb0cbe31873994c9f989fddfe2f87ca839fdd, CUDA 13.0.1, FlashInfer 0.6.12, sgl-kernel 0.4.4) to the v0.5.19 release image lmsysorg/sglang:v0.5.19-cu130 (Docker Hub digest sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9, build commit sgl-project/sglang@0bcd822377da7b5718e674eaf9c870d349424dd1, CUDA 13.0.3, FlashInfer 0.6.18, sgl-kernel 0.4.6.post1). Recipe flags unchanged."
+    - "将 SGLang 镜像从 lmsysorg/sglang:v0.5.15.post1-cu130 更新至 v0.5.19 发布镜像 lmsysorg/sglang:v0.5.19-cu130（Docker Hub 摘要 sha256:d6e7288627be…，构建提交 0bcd822）；配方参数保持不变。"
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3060


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.15.post1-cu130` to `lmsysorg/sglang:v0.5.19-cu130`.  
**Baseline:** 2026-07-25 · `lmsysorg/sglang:v0.5.15.post1-cu130`  
8k/1k · TP8/EP1 · Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-25&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-25)

| Concurrency | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| ---: | ---: | ---: | ---: | ---: |
| 1 | N/A | N/A | N/A | N/A |
| 2 | N/A | N/A | N/A | N/A |
| 4 | N/A | N/A | N/A | N/A |
| 8 | N/A | N/A | N/A | N/A |
| 16 | N/A | N/A | N/A | N/A |
| 32 | N/A | N/A | N/A | N/A |
| 64 | N/A | N/A | N/A | N/A |
| 128 | N/A | N/A | N/A | N/A |
| 256 | N/A | N/A | N/A | N/A |
| 512 | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

**Eval:** N/A

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.15.post1-cu130` 更新为 `lmsysorg/sglang:v0.5.19-cu130`。  
**基线：**2026-07-25 · `lmsysorg/sglang:v0.5.15.post1-cu130`  
8k/1k · TP8/EP1 · 平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-07-25&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-25)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->