### PR TITLE
[Klaud Cold] Update qwen3.5-fp8-gb200-dynamo-sglang-mtp SGLang image to v0.5.19-cu130 / 将 qwen3.5-fp8-gb200-dynamo-sglang-mtp 的 SGLang 镜像更新至 v0.5.19-cu130

### DIFF
--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_lowlat_0.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_lowlat_1.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_0.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_0.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_1.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_1.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_2.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_2.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_3.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_3.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_4.yaml
+++ b/benchmarks/multi_node/srt-slurm-recipes/sglang/qwen3.5/gb200-fp8/8k1k/disagg/mtp/8k1k_mtp_maxtpt_4.yaml
@@ -17,7 +17,7 @@ frontend:
 
 model:
   path: "qwen3.5-fp8"
-  container: "lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3"
+  container: "lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9"
   precision: "fp8"
 
 resources:

--- a/configs/nvidia-master.yaml
+++ b/configs/nvidia-master.yaml
@@ -9727,7 +9727,7 @@ glm5.2-fp4-gb300-dynamo-trt-agentic-disagg-mtp:
           dp-attn: true
 
 qwen3.5-fp8-gb200-dynamo-sglang-mtp:
-  image: lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3
+  image: lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9
   model: Qwen/Qwen3.5-397B-A17B-FP8
   model-prefix: qwen3.5
   runner: gb200


### PR DESCRIPTION
<!-- klaud-baseline-body -->
**Goal:** Update SGLang image from `lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3` to `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`.  
**Baseline:** 2026-07-26 · `lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`  
Mean latency · Sources: [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-26&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-26), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=Qwen-3.5-397B-A17B)

| Point | Total tok/s/GPU ↑ | Output tok/s/GPU ↑ | TTFT ms ↓ | TPOT ms ↓ |
| --- | ---: | ---: | ---: | ---: |
| 8k/1k c1 PTP4x1/DTP4x1 8d0bb5 | N/A | N/A | N/A | N/A |
| 8k/1k c2 PTP4x1/DTP4x1 89da6c | N/A | N/A | N/A | N/A |
| 8k/1k c8 PTP4x1/DTP4x1 a6ee7b | N/A | N/A | N/A | N/A |
| 8k/1k c32 PTP8x1/DTP8x1 4f9355 | N/A | N/A | N/A | N/A |
| 8k/1k c48 PTP8x1/DTP8x1 76d61a | N/A | N/A | N/A | N/A |
| 8k/1k c80 PTP8x1/DTP8x1 904311 | N/A | N/A | N/A | N/A |
| 8k/1k c480 PTP4x3/DTP16x1 b448ef | N/A | N/A | N/A | N/A |
| 8k/1k c768 PTP4x4/DTP16x1 1cc391 | N/A | N/A | N/A | N/A |
| 8k/1k c1280 PTP4x6/DTP16x1 6c259e | N/A | N/A | N/A | N/A |
| 8k/1k c1344 PTP4x7/DTP16x1 b8dcdd | N/A | N/A | N/A | N/A |
| 8k/1k c1920 PTP4x8/DTP16x1 1cff03 | N/A | N/A | N/A | N/A |
| 8k/1k c2304 PTP4x8/DTP16x1 31080f | N/A | N/A | N/A | N/A |

**Note:** All rows: unavailable.

| Eval | Score ↑ | Samples |
| --- | ---: | ---: |
| gsm8k/em_strict · c80 | 96.97% | 1,319 |
| gsm8k/em_strict · c480 | 96.59% | 1,319 |
| gsm8k/em_strict · c768 | 96.82% | 1,319 |
| gsm8k/em_strict · c1280 | 96.89% | 1,319 |
| gsm8k/em_strict · c1344 | 96.51% | 1,319 |
| gsm8k/em_strict · c2304 | 97.04% | 1,319 |

<details>
<summary>中文</summary>

**目标：**将 SGLang 镜像从 `lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3` 更新为 `lmsysorg/sglang:v0.5.19-cu130@sha256:d6e7288627be8b02be88e4bba38e73f6d50e2826869f753c13a4c4385ab3eda9`。  
**基线：**2026-07-26 · `lmsysorg/sglang:v0.5.14-cu130@sha256:5027e95bf6ec536856b1b52a91d1f35ff5c564ab83e8a94758a169ff09bb8df3`  
平均延迟 · 来源： [API 1](https://inferencex.semianalysis.com/api/v1/benchmarks?model=Qwen-3.5-397B-A17B&date=2026-07-26&exact=true), [API 2](https://inferencex.semianalysis.com/api/v1/workflow-info?date=2026-07-26), [API 3](https://inferencex.semianalysis.com/api/v1/evaluations?model=Qwen-3.5-397B-A17B)；数值及异常说明见上表。

</details>
<!-- /klaud-baseline-body -->