### PR TITLE
[AMD][Qwen3.5] Bump MI355X MXFP4 AgentX to sglang-rocm 20260912

### DIFF
--- a/benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh
+++ b/benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh
@@ -14,7 +14,7 @@ check_env_vars \
     MODEL TP CONC EP_SIZE KV_OFFLOADING \
     TOTAL_CPU_DRAM_GB RESULT_DIR DURATION
 
-SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-30}
+SCHEDULER_RECV_INTERVAL=${SCHEDULER_RECV_INTERVAL:-60}
 
 if [[ -n "${SLURM_JOB_ID:-}" ]]; then
     echo "JOB $SLURM_JOB_ID running on ${SLURMD_NODENAME:-unknown}"
@@ -58,8 +58,8 @@ CACHE_ARGS=()
 if require_agentic_kv_offload_backend hicache; then
     HICACHE_RATIO="${HICACHE_RATIO:-1.5}"
     HICACHE_WRITE_POLICY="${HICACHE_WRITE_POLICY:-write_through}"
-    HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-direct}"
-    HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first_direct}"
+    HICACHE_IO_BACKEND="${HICACHE_IO_BACKEND:-kernel}"
+    HICACHE_MEM_LAYOUT="${HICACHE_MEM_LAYOUT:-page_first}"
     echo "HiCache CPU tier: ratio=$HICACHE_RATIO, write_policy=$HICACHE_WRITE_POLICY, io_backend=$HICACHE_IO_BACKEND, mem_layout=$HICACHE_MEM_LAYOUT, dram_budget=${TOTAL_CPU_DRAM_GB} GB, tp=$TP"
     CACHE_ARGS=(
         --enable-hierarchical-cache
@@ -90,7 +90,7 @@ export SGLANG_USE_AITER=1
 export SGLANG_USE_AITER_UNIFIED_ATTN=1
 export AITER_FLYDSL_FORCE=1
 export SGLANG_MAMBA_SSM_DTYPE=bfloat16
-export ROCM_QUICK_REDUCE_QUANTIZATION=INT8
+export ROCM_QUICK_REDUCE_QUANTIZATION=INT4
 export SGLANG_TIMEOUT_KEEP_ALIVE=1800
 
 if [ "${EVAL_ONLY:-false}" != "true" ]; then
@@ -113,7 +113,7 @@ SGLANG_CMD=(
     --watchdog-timeout 1200
     --page-size 16
     --kv-cache-dtype fp8_e4m3
-    --cuda-graph-max-bs "$CUDA_GRAPH_MAX_BS"
+    --cuda-graph-max-bs-decode "$CUDA_GRAPH_MAX_BS"
     --max-running-requests "$MAX_RUNNING_REQUESTS"
     --max-prefill-tokens 16384
     --chunked-prefill-size 16384

--- a/configs/amd-master.yaml
+++ b/configs/amd-master.yaml
@@ -361,7 +361,7 @@ qwen3.5-fp4-mi355x-sglang-mtp:
       - { tp: 4, conc-start: 4, conc-end: 16, spec-decoding: mtp }
 
 qwen3.5-fp4-mi355x-sglang-agentic-mtp:
-  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908
+  image: lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260912
   model: amd/Qwen3.5-397B-A17B-MXFP4
   model-prefix: qwen3.5
   runner: cluster:mi355x-amds
@@ -372,10 +372,9 @@ qwen3.5-fp4-mi355x-sglang-agentic-mtp:
     agentic-coding:
     - dram-utilization: 0.80
       search-space:
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20, 24, 28, 32, 40] }
+      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16] }
       - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: none, conc-list: [1, 4, 8, 12, 16, 20] }
-      - { tp: 4, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [40, 48, 56, 64] }
-      - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [20, 24, 28, 32] }
+      - { tp: 2, ep: 1, spec-decoding: mtp, kv-offloading: dram, kv-offload-backend: { name: hicache }, conc-list: [20, 24, 28, 32, 36, 40] }
 
 qwen3.5-fp4-mi355x-sglang-disagg:
   image: lmsysorg/sglang-rocm:v0.5.12.post1-rocm720-mi35x-20260523

--- a/perf-changelog.yaml
+++ b/perf-changelog.yaml
@@ -7428,3 +7428,15 @@
     - "Add representative AMD coverage for fixed-sequence request diagnostics and multinode concurrency filename processing; shared processor changes also affect unlisted fixed-sequence recipes."
     - "增加固定序列请求诊断与多节点并发文件名处理的代表性 AMD 覆盖；共享处理器变更也影响未列出的固定序列配置。"
   pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3026
+
+- config-keys:
+    - qwen3.5-fp4-mi355x-sglang-agentic-mtp
+  scenario-type:
+    - agentic-coding
+  description:
+    - "Bump the MI355X Qwen3.5 MXFP4 AgentX image from lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260908 to lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260912."
+    - "Default HiCache CPU-tier to kernel / page_first (ratio 1.5, write_through unchanged)."
+    - "Rename --cuda-graph-max-bs to --cuda-graph-max-bs-decode for sglang 0.5.19."
+    - "Prefill allreduce INT4; scheduler-recv-interval default 60."
+    - "Trim AgentX search space to TP4 none [1,4,8,12,16], TP2 none [1,4,8,12,16,20], TP2 HiCache [20,24,28,32,36,40]; drop the TP4 HiCache arm."
+  pr-link: https://github.com/SemiAnalysisAI/InferenceX/pull/3062


### PR DESCRIPTION
## Summary

- Bump `qwen3.5-fp4-mi355x-sglang-agentic-mtp` to `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260912` (Docker Hub tag check returned 200).
- Keep the AgentX launch knobs that 0.5.19 needs: `--cuda-graph-max-bs-decode`, `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, and `SCHEDULER_RECV_INTERVAL` default 60.
- Default HiCache CPU-tier to `kernel` / `page_first` (ratio 1.5 and `write_through` unchanged). Trim the search space to TP4 none `[1, 4, 8, 12, 16]`, TP2 none `[1, 4, 8, 12, 16, 20]`, TP2 HiCache `[20, 24, 28, 32, 36, 40]`; drop the TP4 HiCache arm.

## Details

This is a new PR off `main` (image on `main` is still `v0.5.19-rocm720-mi35x-20260908`). It does not reuse the still-open #2972 branch.

The recipe rename `--cuda-graph-max-bs` → `--cuda-graph-max-bs-decode` is required for sglang 0.5.19. Prefill allreduce stays INT4 and scheduler recv-interval stays 60 so the 20260912 sweep matches the knobs already measured locally.

HiCache env overrides `HICACHE_IO_BACKEND` and `HICACHE_MEM_LAYOUT` still work.

No local GPU sweep is attached; CI `full-sweep-fail-fast` is the accuracy and performance gate.

## Test plan

- [ ] Docker Hub tag `lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260912` resolves (already 200).
- [ ] `full-sweep-fail-fast` AgentX matrix for `qwen3.5-fp4-mi355x-sglang-agentic-mtp` passes.
- [ ] Eval path still uses real target-model verification (`EVAL_ONLY`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and YAML recipe changes only; no application runtime code, though new launch defaults will shift CI sweep results versus the prior image.
> 
> **Overview**
> Updates the **MI355X Qwen3.5 MXFP4 AgentX** recipe (`qwen3.5-fp4-mi355x-sglang-agentic-mtp`) to **`lmsysorg/sglang-rocm:v0.5.19-rocm720-mi35x-20260912`** and aligns the launch script with sglang **0.5.19**: **`--cuda-graph-max-bs-decode`** (replacing `--cuda-graph-max-bs`), default **`SCHEDULER_RECV_INTERVAL=60`**, prefill allreduce **`ROCM_QUICK_REDUCE_QUANTIZATION=INT4`**, and HiCache CPU-tier defaults **`kernel` / `page_first`** (was `direct` / `page_first_direct`).
> 
> The **agentic-coding search space** is narrowed: TP4 GPU-resident concurrency stops at 16 (drops 20–40), the **TP4 HiCache arm is removed**, and TP2 HiCache extends through **40**. **`perf-changelog.yaml`** documents the image bump and knob changes for PR #3062.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94646d525979be29377aa6646b1d98c343e671b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->